### PR TITLE
Fix invalid invalidation paths from master builds

### DIFF
--- a/.buildkite/scripts/publish.sh
+++ b/.buildkite/scripts/publish.sh
@@ -4,5 +4,5 @@ echo "🎋 Publishing to ${DOMAIN}${BASE_PATH}" \
   && aws s3 sync --delete site/public "s3://${DOMAIN}${BASE_PATH}" \
   && aws cloudfront create-invalidation \
       --distribution-id "${DISTRIBUTION}" \
-      --paths "${BASE_PATH}*" \
+      --paths "${BASE_PATH:-/}*" \
       --output text


### PR DESCRIPTION
`BASE_PATH` is not defined when publishing from master, but an invalidation path of `*` alone is illegal.