### PR TITLE
Make build artifact extraction flag more explicit

### DIFF
--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -7,7 +7,7 @@ extract-artifact() {
 }
 
 main() {
-  if [[ $BUILDKITE_LABEL == *Publish* ]]; then
+  if [[ -n $EXTRACT_ARTIFACTS ]]; then
     extract-artifact "site.tar.gz"
     extract-artifact "storybook.tar.gz"
   fi

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -66,6 +66,7 @@ steps:
     command: ".buildkite/scripts/publish.sh"
     branches: "!master"
     env:
+      EXTRACT_ARTIFACTS: true
       DOMAIN: "${DEVELOPMENT_DOMAIN}"
       DISTRIBUTION: "${DEVELOPMENT_DISTRIBUTION}"
       BASE_PATH: "${DEVELOPMENT_BASE_PATH}"
@@ -82,6 +83,7 @@ steps:
     command: ".buildkite/scripts/publish.sh"
     branches: "master"
     env:
+      EXTRACT_ARTIFACTS: true
       DOMAIN: "${PRODUCTION_DOMAIN}"
       DISTRIBUTION: "${PRODUCTION_DISTRIBUTION}"
     <<: *defaults


### PR DESCRIPTION
Previously this was matching against the step name.