### PR TITLE
ci: Add release validation step to branch pipeline

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -67,3 +67,8 @@ steps:
       - docker#v3.3.0:
           image: "node:10.16.3-alpine"
           <<: *common-env
+
+  - name: ":vertical_traffic_light: Validate release"
+    command: ".buildkite/scripts/validate.sh"
+    branches: "!master"
+    <<: *defaults

--- a/.buildkite/scripts/validate.sh
+++ b/.buildkite/scripts/validate.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+set -e
+
+echo
+echo "Installing git..."
+apk add --no-cache --no-progress git
+
+echo
+echo "Installing lerna..."
+npm config set unsafe-perm true
+npm install --global --no-audit --no-progress lerna
+
+echo
+echo "Validating release..."
+# Check that lerna isn't reporting errors
+lerna list
+# Count the number of modified non-private packages
+changed=$(lerna --loglevel=error changed || echo "") 
+changed_count=$(echo "$changed" | wc -l)
+
+echo
+echo "Modified packages:"
+echo "${changed:-"(none)"}"
+
+if [ "$changed_count" -gt 1 ]; then
+  echo
+  echo "Branches may not release (modify) more than one non-private package."
+  exit 1
+fi
+
+echo
+echo "All checks passed."


### PR DESCRIPTION
Checks that the number of modified non-private packages is <= 1, and therefore that we can interpret a conventional PR title as being scoped to that package.