### PR TITLE
ci: Stop versioning/tagging private packages

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -4,6 +4,6 @@
     "**/*.{stories,spec,test}.{js,jsx,ts,tsx}",
     "**/*.{md,mdx}"
   ],
-  "npmClient": "yarn",
-  "useWorkspaces": true
+  "npmClient": "npm",
+  "packages": ["packages/*"]
 }

--- a/site/package.json
+++ b/site/package.json
@@ -1,6 +1,6 @@
 {
   "name": "site",
-  "version": "1.0.2",
+  "version": "0.0.0-private",
   "private": true,
   "dependencies": {
     "@babel/core": "^7.6.0",


### PR DESCRIPTION
Because lerna was getting its packages from yarn workspaces, we were pushing tags for all updates to the site. This was creating a lot of noise in the git history and the releases page.

By separating lerna packages and workspaces, we can exclude the site from being versioned.