### PR TITLE
docs: Order Components nav items with Overview at top

### DIFF
--- a/site/src/components/MainNav.tsx
+++ b/site/src/components/MainNav.tsx
@@ -2,7 +2,7 @@ import {
   Link as NavLink,
   NavigationBar,
 } from "@cultureamp/kaizen-component-library"
-import { graphql, useStaticQuery, withPrefix } from "gatsby"
+import { withPrefix } from "gatsby"
 import * as React from "react"
 
 type MainNavProps = {
@@ -10,21 +10,6 @@ type MainNavProps = {
 }
 
 const MainNav: React.SFC<MainNavProps> = ({ currentPath = "" }) => {
-  const data = useStaticQuery(graphql`
-    query MainNavComponentsQuery {
-      allMdx(filter: { fields: { slug: { regex: "^/components/" } } }) {
-        edges {
-          node {
-            fields {
-              slug
-            }
-          }
-        }
-      }
-    }
-  `)
-  const firstComponentPath = data.allMdx!.edges[0]!.node!.fields!.slug
-
   const currentPathStartsWith = (path: string) =>
     currentPath.startsWith(withPrefix(path))
 
@@ -42,7 +27,7 @@ const MainNav: React.SFC<MainNavProps> = ({ currentPath = "" }) => {
       />
       <NavLink
         text="Components"
-        href={withPrefix(firstComponentPath)}
+        href={withPrefix("/components/overview")}
         active={currentPathStartsWith("/components")}
       />
       <NavLink

--- a/site/src/templates/componentPage.tsx
+++ b/site/src/templates/componentPage.tsx
@@ -13,11 +13,34 @@ import {
   SidebarSection,
   SidebarTab,
 } from "../components/SidebarAndContent"
+import { sortSidebarTabs, stripTrailingSlash } from "./util"
+
+const renderSidebarTabs = (pages, currentPath) => {
+  return pages.map((node, i) => (
+    <SidebarTab
+      href={node!.node!.fields!.slug}
+      active={
+        stripTrailingSlash(node!.node!.fields!.slug) ===
+        stripTrailingSlash(currentPath)
+      }
+      key={`sidebarTab-${i}`}
+    >
+      {node!.node!.frontmatter!.navTitle}
+    </SidebarTab>
+  ))
+}
 
 export default ({ data, pageContext, location }) => {
   const md = data.mdx
   const allPages = data.allMdx.edges
   const currentPath = location.pathname
+
+  const overviewPage = allPages.filter(
+    el => el.node.frontmatter.navTitle === "Overview"
+  )
+  const pagesWithoutOverview = sortSidebarTabs(
+    allPages.filter(el => el.node.frontmatter.navTitle !== "Overview")
+  )
 
   const ComponentPageHeader = (
     <PageHeader
@@ -37,18 +60,8 @@ export default ({ data, pageContext, location }) => {
       <SidebarAndContent>
         <Sidebar>
           <SidebarSection>
-            {allPages.map((node, i) => {
-              if (!node!.node!.frontmatter!.navTitle) return undefined
-              return (
-                <SidebarTab
-                  href={node!.node!.fields!.slug}
-                  active={node!.node!.fields!.slug === currentPath}
-                  key={`sidebarTab-${i}`}
-                >
-                  {node!.node!.frontmatter!.title}
-                </SidebarTab>
-              )
-            })}
+            {renderSidebarTabs(overviewPage, currentPath)}
+            {renderSidebarTabs(pagesWithoutOverview, currentPath)}
           </SidebarSection>
         </Sidebar>
         <Content>

--- a/site/src/templates/guidelinePage.tsx
+++ b/site/src/templates/guidelinePage.tsx
@@ -13,15 +13,7 @@ import {
   SidebarSection,
   SidebarTab,
 } from "../components/SidebarAndContent"
-
-const stripTrailingSlash = (str: string) => str.replace(/\/$/, "")
-
-const sortSidebarTabs = tabs => {
-  const newTabs = [...tabs].sort((a, b) =>
-    a.node.frontmatter.navTitle > b.node.frontmatter.navTitle ? 1 : -1
-  )
-  return newTabs
-}
+import { sortSidebarTabs, stripTrailingSlash } from "./util"
 
 const renderSidebarTabs = (pages, currentPath, sectionName) => {
   return pages.map((node, i) => (

--- a/site/src/templates/util.ts
+++ b/site/src/templates/util.ts
@@ -1,0 +1,8 @@
+export const stripTrailingSlash = (str: string) => str.replace(/\/$/, "")
+
+export const sortSidebarTabs = tabs => {
+  const newTabs = [...tabs].sort((a, b) =>
+    a.node.frontmatter.navTitle > b.node.frontmatter.navTitle ? 1 : -1
+  )
+  return newTabs
+}


### PR DESCRIPTION
We're already sorting the GraphQL data for the nav items on the Guidelines page; this PR does the same for Components (slightly different as they don't need to be in separate sections in the sidebar).