### PR TITLE
chore: Add binary-assets package

### DIFF
--- a/packages/binary-assets/README.md
+++ b/packages/binary-assets/README.md
@@ -1,0 +1,18 @@
+# Kaizen Binary Assets
+
+Binary asset management for Culture Amp's Kaizen Design System.
+
+## API
+
+### `assetUrl(path)`
+
+Returns the full URL of the asset at `path` managed by the
+`kaizen-design-system-assets` service.
+
+```ts
+assetUrl("some/blob.png") // -> "https://<origin>/some/blob.png"
+```
+
+## See also
+
+- [cultureamp/kaizen-design-system-assets](https://github.com/cultureamp/kaizen-design-system-assets/)

--- a/packages/binary-assets/lib/index.ts
+++ b/packages/binary-assets/lib/index.ts
@@ -1,0 +1,12 @@
+const ORIGIN_BASE_URL = "https://kaizen-assets.s3-us-west-2.amazonaws.com"
+
+/**
+ * Returns the full URL of the asset at `path` managed by the
+ * `kaizen-design-system-assets` service.
+ *
+ * @example
+ * assetUrl("some/blob.png") -> "https://<origin>/some/blob.png"
+ *
+ * @see https://github.com/cultureamp/kaizen-design-system-assets/
+ */
+export const assetUrl = (path: string) => [ORIGIN_BASE_URL, path].join("/")

--- a/packages/binary-assets/package.json
+++ b/packages/binary-assets/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@cultureamp/kaizen-binary-assets",
+  "version": "0.0.0",
+  "description": "Binary asset management for Culture Amp's Kaizen Design System.",
+  "homepage": "https://github.com/cultureamp/kaizen-design-system/packages/binary-asset#readme",
+  "license": "MIT",
+  "main": "lib",
+  "directories": {
+    "lib": "lib"
+  },
+  "files": [
+    "lib"
+  ],
+  "publishConfig": {
+    "registry": "https://registry.yarnpkg.com"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/cultureamp/kaizen-design-system.git"
+  },
+  "bugs": {
+    "url": "https://github.com/cultureamp/kaizen-design-system/issues"
+  }
+}


### PR DESCRIPTION
Release the `@cultureamp/kaizen-binary-assets` package, using it's current S3 assets URL.

(This will be updated to a cloudfront for http2 support, but the S3 URLs will remain available for backwards-compatibility.)