### PR TITLE
ci: Switch lerna npm client back to yarn

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -4,6 +4,6 @@
     "**/*.{stories,spec,test}.{js,jsx,ts,tsx}",
     "**/*.{md,mdx}"
   ],
-  "npmClient": "npm",
+  "npmClient": "yarn",
   "packages": ["packages/*"]
 }


### PR DESCRIPTION
Something since the first package release has broken the release pipeline (lerna is unable to authenticate with the npm registry), and this seems like the most likely candidate.

This change was introduced in #55 but was not necessary for the purpose of that PR.