### PR TITLE
chore: Stop overriding registry in the binary-assets package

### DIFF
--- a/packages/binary-assets/package.json
+++ b/packages/binary-assets/package.json
@@ -11,9 +11,6 @@
   "files": [
     "lib"
   ],
-  "publishConfig": {
-    "registry": "https://registry.yarnpkg.com"
-  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/cultureamp/kaizen-design-system.git"


### PR DESCRIPTION
This is suspected to be causing authentication problems in the release pipeline.