### PR TITLE
ci: Make all changes eligible for versioning and release

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,5 @@
 {
   "version": "independent",
-  "ignoreChanges": ["**/*.{stories,spec,test}.{js,jsx,ts,tsx}"],
   "npmClient": "yarn",
   "packages": ["packages/*"]
 }

--- a/lerna.json
+++ b/lerna.json
@@ -1,9 +1,6 @@
 {
   "version": "independent",
-  "ignoreChanges": [
-    "**/*.{stories,spec,test}.{js,jsx,ts,tsx}",
-    "**/*.{md,mdx}"
-  ],
+  "ignoreChanges": ["**/*.{stories,spec,test}.{js,jsx,ts,tsx}"],
   "npmClient": "yarn",
   "packages": ["packages/*"]
 }


### PR DESCRIPTION
Markdown changes had previously been ignored by lerna, but this was causing issues with the changelog when docs were updated in packages.

Updates to tests and stories would encounter the same issues.

This change makes it so that the release step will now depend on the conventional commit alone to determine appropriate bumps, and group all previous unreleased changes in the next package release.