### PR TITLE
docs: Create dos and don'ts components

### DIFF
--- a/site/src/docs-components/Do.tsx
+++ b/site/src/docs-components/Do.tsx
@@ -1,0 +1,12 @@
+import classnames from "classnames"
+import * as React from "react"
+import WhenUse from "./WhenUse"
+
+const styles = require("./DosAndDonts.scss")
+
+export default ({ children }) => (
+  <div className={classnames(styles.card, styles.do)}>
+    <WhenUse variant="do" />
+    {children}
+  </div>
+)

--- a/site/src/docs-components/Dont.tsx
+++ b/site/src/docs-components/Dont.tsx
@@ -1,0 +1,12 @@
+import classnames from "classnames"
+import * as React from "react"
+import WhenUse from "./WhenUse"
+
+const styles = require("./DosAndDonts.scss")
+
+export default ({ children }) => (
+  <div className={classnames(styles.card, styles.dont)}>
+    <WhenUse variant="dont" />
+    {children}
+  </div>
+)

--- a/site/src/docs-components/DosAndDonts.scss
+++ b/site/src/docs-components/DosAndDonts.scss
@@ -1,0 +1,48 @@
+@import "~@cultureamp/kaizen-component-library/styles/color";
+
+.container {
+  display: flex;
+  justify-content: space-between;
+}
+
+.card {
+  margin-top: var(--ca-grid);
+  width: 48%;
+  padding: var(--ca-grid);
+  box-sizing: border-box;
+  border: 1px solid $ca-border-color;
+  box-shadow: 0px 1px 1px rgba(0, 0, 0, 0.19);
+  border-radius: 3px;
+  border-top-width: 7px;
+  border-top-style: solid;
+
+  :global(.md-ul.md-ul) {
+    padding-left: 1.25rem;
+  }
+
+  :global(.md-li.md-li) {
+    font-size: 0.875rem;
+    line-height: 1.5;
+    margin-top: 0.75rem;
+  }
+
+  :global(.md-strong.md-strong) {
+    font-weight: 500;
+  }
+
+  :global(.md-a.md-a) {
+    text-decoration: underline;
+
+    &:hover {
+      text-decoration: none;
+    }
+  }
+}
+
+.do {
+  border-top-color: $ca-palette-seedling;
+}
+
+.dont {
+  border-top-color: $ca-palette-coral;
+}

--- a/site/src/docs-components/DosAndDonts.scss
+++ b/site/src/docs-components/DosAndDonts.scss
@@ -1,8 +1,13 @@
 @import "~@cultureamp/kaizen-component-library/styles/color";
+@import "~@cultureamp/kaizen-component-library/styles/responsive";
 
 .container {
   display: flex;
   justify-content: space-between;
+
+  @include ca-media-mobile() {
+    flex-direction: column;
+  }
 }
 
 .card {
@@ -15,6 +20,10 @@
   border-radius: 3px;
   border-top-width: 7px;
   border-top-style: solid;
+
+  @include ca-media-mobile() {
+    width: 100%;
+  }
 
   :global(.md-ul.md-ul) {
     padding-left: 1.25rem;

--- a/site/src/docs-components/DosAndDonts.tsx
+++ b/site/src/docs-components/DosAndDonts.tsx
@@ -1,0 +1,8 @@
+import classnames from "classnames"
+import * as React from "react"
+
+const styles = require("./DosAndDonts.scss")
+
+export default ({ children }) => (
+  <div className={styles.container}>{children}</div>
+)

--- a/site/src/docs-components/WhenUse.scss
+++ b/site/src/docs-components/WhenUse.scss
@@ -1,0 +1,35 @@
+@import "~@cultureamp/kaizen-component-library/styles/color";
+
+.container {
+  color: $ca-palette-lapis;
+  display: inline-flex;
+  height: 1.75rem;
+  align-items: center;
+  border-radius: 2rem;
+  padding: 0 0.75rem 0 0.25rem;
+  font-size: 0.8333rem;
+  font-weight: 400;
+}
+
+.icon {
+  display: flex;
+  margin-right: 0.25rem;
+}
+
+.do {
+  background: add-tint($ca-palette-seedling, 90%);
+  border: 1px solid add-tint($ca-palette-seedling, 40%);
+
+  .icon {
+    color: $ca-palette-seedling;
+  }
+}
+
+.dont {
+  background: add-tint($ca-palette-coral, 90%);
+  border: 1px solid add-tint($ca-palette-coral, 40%);
+
+  .icon {
+    color: $ca-palette-coral;
+  }
+}

--- a/site/src/docs-components/WhenUse.tsx
+++ b/site/src/docs-components/WhenUse.tsx
@@ -1,0 +1,33 @@
+import { Icon } from "@cultureamp/kaizen-component-library"
+import classnames from "classnames"
+
+import * as React from "react"
+
+const success = require("@cultureamp/kaizen-component-library/icons/success-white.icon.svg")
+  .default
+const exclamation = require("@cultureamp/kaizen-component-library/icons/exclamation-white.icon.svg")
+  .default
+const styles = require("./WhenUse.scss")
+
+type WhenUseProps = {
+  variant: "do" | "dont"
+}
+
+const getIcon = variant => {
+  if (variant === "do") return success
+  if (variant === "dont") return exclamation
+}
+
+const getText = variant => {
+  if (variant === "do") return "When to use"
+  if (variant === "dont") return "When not to use"
+}
+
+export default ({ variant }) => (
+  <div className={classnames(styles.container, styles[variant])}>
+    <span className={styles.icon}>
+      <Icon icon={getIcon(variant)} role="presentation" />
+    </span>
+    {getText(variant)}
+  </div>
+)

--- a/site/src/docs-components/WhenUse.tsx
+++ b/site/src/docs-components/WhenUse.tsx
@@ -9,21 +9,31 @@ const exclamation = require("@cultureamp/kaizen-component-library/icons/exclamat
   .default
 const styles = require("./WhenUse.scss")
 
+type Variant = "do" | "dont"
+
 type WhenUseProps = {
-  variant: "do" | "dont"
+  variant: Variant
 }
 
-const getIcon = variant => {
-  if (variant === "do") return success
-  if (variant === "dont") return exclamation
+const getIcon = (variant: Variant) => {
+  switch (variant) {
+    case "do":
+      return success
+    case "dont":
+      return exclamation
+  }
 }
 
-const getText = variant => {
-  if (variant === "do") return "When to use"
-  if (variant === "dont") return "When not to use"
+const getText = (variant: Variant) => {
+  switch (variant) {
+    case "do":
+      return "When to use"
+    case "dont":
+      return "When not to use"
+  }
 }
 
-export default ({ variant }) => (
+export default ({ variant }: WhenUseProps) => (
   <div className={classnames(styles.container, styles[variant])}>
     <span className={styles.icon}>
       <Icon icon={getIcon(variant)} role="presentation" />

--- a/yarn.lock
+++ b/yarn.lock
@@ -7659,16 +7659,16 @@ eslint-scope@^4.0.0, eslint-scope@^4.0.3:
     estraverse "^4.1.1"
 
 eslint-utils@^1.3.1:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-1.4.0.tgz#e2c3c8dba768425f897cf0f9e51fe2e241485d4c"
-  integrity sha512-7ehnzPaP5IIEh1r1tkjuIrxqhNkzUJa9z3R92tLJdZIVdWaczEhr3EbhGtsMrVxi1KeR8qA7Off6SWc5WNQqyQ==
+  version "1.4.3"
+  resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-1.4.3.tgz#74fec7c54d0776b6f67e0251040b5806564e981f"
+  integrity sha512-fbBN5W2xdY45KulGXmLHZ3c3FHfVYmKg0IrAKGOkT/464PQsx2UeIzfz1RmEci+KLm1bBaAzZAh8+/E+XAeZ8Q==
   dependencies:
-    eslint-visitor-keys "^1.0.0"
+    eslint-visitor-keys "^1.1.0"
 
-eslint-visitor-keys@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#3f3180fb2e291017716acb4c9d6d5b5c34a6a81d"
-  integrity sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==
+eslint-visitor-keys@^1.0.0, eslint-visitor-keys@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz#e2a82cea84ff246ad6fb57f9bde5b46621459ec2"
+  integrity sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==
 
 eslint@^5.16.0:
   version "5.16.0"


### PR DESCRIPTION
This PR allows docs contributors to add dos + don'ts components like this:

![image](https://user-images.githubusercontent.com/6406263/67451889-605bae00-f66d-11e9-87f1-90a3a2803968.png)

Note that MDX doesn't seem to allow named imports like `import { Do, Dont, DosAndDonts }`.