### PR TITLE
chore: update codeowners to ping the DST for any new packages

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -6,7 +6,7 @@
 /packages/ @cultureamp/design-systems
 
 # Exclude modifications to existing packages by assigning it to no one
-/packages/component-library/ @ghost
+/packages/component-library @ghost
 /packages/binary-assets @ghost
 
 # Pipelines are maintained by Delivery Engineering:

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,8 +1,13 @@
 # CODEOWNERS
 # https://help.github.com/articles/about-code-owners/
 
-# Require Design Systems Team approval to modify this file:
+# Require Design Systems Team approval for any new packages or this file
 /CODEOWNERS @cultureamp/design-systems
+/packages/ @cultureamp/design-systems
+
+# Exclude modifications to existing packages by assigning it to no one
+/packages/component-library/ @ghost
+/packages/binary-assets @ghost
 
 # Pipelines are maintained by Delivery Engineering:
 /.buildkite/ @cultureamp/delivery-engineering


### PR DESCRIPTION
Props to @zioroboco for the suggestion 👍 

This essentially adds us as an owner for any new packages in this repo. It will need to be updated once draft components are split out of the Design System. 