### PR TITLE
fix: fix visibility of Elm Select's selected item text

### DIFF
--- a/packages/component-library/draft/Kaizen/Select/styles.elm.scss
+++ b/packages/component-library/draft/Kaizen/Select/styles.elm.scss
@@ -16,7 +16,6 @@
   position: absolute;
   transform: translateY(-50%);
   box-sizing: border-box;
-  opacity: $input-placeholder-opacity;
 }
 .container {
   position: relative;
@@ -68,6 +67,7 @@
 
 .placeholder {
   @extend .basePlaceholder;
+  opacity: $input-placeholder-opacity;
 }
 
 .faded {


### PR DESCRIPTION
Before:

![Screen Shot 2019-10-31 at 10 15 00 am](https://user-images.githubusercontent.com/4900094/67905989-53880e80-fbc7-11e9-9149-5c4cc8b599ef.png)

After:

![Screen Shot 2019-10-31 at 10 14 56 am](https://user-images.githubusercontent.com/4900094/67905988-53880e80-fbc7-11e9-8649-48d91538a56e.png)
