### PR TITLE
fix: revert select content alignment in ie11 off (#86)

### DIFF
--- a/packages/component-library/draft/Kaizen/Select/styles.elm.scss
+++ b/packages/component-library/draft/Kaizen/Select/styles.elm.scss
@@ -30,7 +30,6 @@
   flex-wrap: wrap;
   justify-content: space-between;
   min-height: 48px;
-  height: 48px;
   position: relative;
   box-sizing: border-box;
   border: solid 1px $ca-border-color;


### PR DESCRIPTION
Reverts cultureamp/kaizen-design-system#86