### PR TITLE
fix: Fix shifting text when expanding and collapsing table rows

### DIFF
--- a/packages/component-library/draft/Kaizen/Table/styles.scss
+++ b/packages/component-library/draft/Kaizen/Table/styles.scss
@@ -1,3 +1,4 @@
+@import "~@cultureamp/kaizen-component-library/styles/animation";
 @import "~@cultureamp/kaizen-component-library/styles/border";
 @import "~@cultureamp/kaizen-component-library/styles/color";
 @import "~@cultureamp/kaizen-component-library/styles/type";
@@ -60,7 +61,9 @@ $row-height: 60px;
   background: $white;
   border: solid 1px $ca-border-color;
   box-shadow: $ca-box-shadow;
-  transition: box-shadow 0.2s, border-color 0.2s, margin 0.2s, padding 0.2s;
+  transition: box-shadow $ca-duration-rapid, border-color $ca-duration-rapid,
+    margin $ca-duration-rapid, padding $ca-duration-rapid,
+    width $ca-duration-rapid;
   // These css properties are required for when the rows are anchor elements
   text-decoration: none;
   color: $ca-palette-ink;
@@ -86,7 +89,7 @@ $row-height: 60px;
   }
 
   &:hover {
-    will-change: box-shadow, border-color, margin, padding;
+    will-change: box-shadow, border-color, margin, padding, width;
   }
 
   &.well {

--- a/packages/component-library/stories/Table.stories.tsx
+++ b/packages/component-library/stories/Table.stories.tsx
@@ -170,105 +170,146 @@ storiesOf("Table", module)
       </TableContainer>
     </Container>
   ))
-  .add("Expanded", () => (
-    <Container>
-      <TableContainer>
-        <TableHeader>
-          <ExampleTableHeaderRow checkable />
-        </TableHeader>
-        <TableCard onClick={() => alert("expand!")}>
-          <ExampleTableRow />
-        </TableCard>
-        <TableCard expanded onClick={() => alert("unexpand!")}>
-          <ExampleTableRow expanded />
-          <TableContainer>
-            <TableCard>
-              <ExampleTableRow expandable={false} />
-            </TableCard>
-            <TableCard>
-              <ExampleTableRow expandable={false} />
-            </TableCard>
-          </TableContainer>
-        </TableCard>
-        <TableCard onClick={() => alert("expand!")}>
-          <ExampleTableRow />
-        </TableCard>
-      </TableContainer>
-    </Container>
-  ))
-  .add("Expanded popout", () => (
-    <Container>
-      <TableContainer>
-        <TableHeader>
-          <ExampleTableHeaderRow checkable />
-        </TableHeader>
-        <TableCard onClick={() => alert("expand!")}>
-          <ExampleTableRow />
-        </TableCard>
-        <TableCard
-          expanded
-          expandedStyle="popout"
-          onClick={() => alert("unexpand!")}
-        >
-          <ExampleTableRow expanded />
-          <div>
-            <div className={styles.popoutExpandedBody}>
-              <div className={styles.customExpandedHeader}>
-                <Text tag="div" style="label">
-                  Overall progress
-                </Text>
-              </div>
-              <Text tag="p">We are making good progress towards our goal!</Text>
-            </div>
-            <div className={styles.popoutExpandedFooter}>
-              <Text tag="div" style="body-bold">
-                Created on: July 12, 2017
-              </Text>
-            </div>
-          </div>
-        </TableCard>
-        <TableCard onClick={() => alert("expand!")}>
-          <ExampleTableRow />
-        </TableCard>
-      </TableContainer>
-    </Container>
-  ))
-  .add("Expanded with custom content", () => (
-    <Container>
-      <TableContainer>
-        <TableHeader>
-          <ExampleTableHeaderRow checkable />
-        </TableHeader>
-        <TableCard onClick={() => alert("expand!")}>
-          <ExampleTableRow />
-        </TableCard>
-        <TableCard expanded>
-          <div className={styles.customExpandedHeader}>
-            <Text tag="div" style="label">
-              Overall progress
-            </Text>
-          </div>
-          <TableContainer>
-            <TableCard onClick={() => alert("unexpand!")}>
-              <ExampleTableRow expanded />
-            </TableCard>
-          </TableContainer>
-          <TableContainer>
-            <ExampleTableHeaderRow />
-            <TableCard>
-              <ExampleTableRow expandable={false} />
-            </TableCard>
-            <TableCard>
-              <ExampleTableRow expandable={false} />
-            </TableCard>
-          </TableContainer>
-        </TableCard>
-        <TableCard onClick={() => alert("expand!")}>
-          <ExampleTableRow />
-        </TableCard>
-      </TableContainer>
-    </Container>
-  ))
+  .add("Expanded", () => {
+    const [expandedId, setExpandedId] = React.useState<string | null>("second")
+    const toggleExpanded = id => {
+      if (expandedId === id) {
+        setExpandedId(null)
+        return
+      }
+      setExpandedId(id)
+    }
+    return (
+      <Container>
+        <TableContainer>
+          <TableHeader>
+            <ExampleTableHeaderRow checkable />
+          </TableHeader>
+          {["first", "second", "third"].map(id => {
+            const expanded = expandedId === id
+            return (
+              <TableCard expanded={expanded} onClick={() => toggleExpanded(id)}>
+                <ExampleTableRow expanded={expanded} />
+                {expanded && (
+                  <TableContainer>
+                    <TableCard>
+                      <ExampleTableRow expandable={false} />
+                    </TableCard>
+                    <TableCard>
+                      <ExampleTableRow expandable={false} />
+                    </TableCard>
+                  </TableContainer>
+                )}
+              </TableCard>
+            )
+          })}
+        </TableContainer>
+      </Container>
+    )
+  })
+  .add("Expanded popout", () => {
+    const [expandedId, setExpandedId] = React.useState<string | null>("second")
+    const toggleExpanded = id => {
+      if (expandedId === id) {
+        setExpandedId(null)
+        return
+      }
+      setExpandedId(id)
+    }
+    return (
+      <Container>
+        <TableContainer>
+          <TableHeader>
+            <ExampleTableHeaderRow checkable />
+          </TableHeader>
+          {["first", "second", "third"].map(id => {
+            const expanded = expandedId === id
+            return (
+              <TableCard
+                key={id}
+                expandedStyle="popout"
+                expanded={expanded}
+                onClick={() => toggleExpanded(id)}
+              >
+                <ExampleTableRow expanded={expanded} />
+                {expanded && (
+                  <div>
+                    <div className={styles.popoutExpandedBody}>
+                      <div className={styles.customExpandedHeader}>
+                        <Text tag="div" style="label">
+                          Overall progress
+                        </Text>
+                      </div>
+                      <Text tag="p">
+                        We are making good progress towards our goal!
+                      </Text>
+                    </div>
+                    <div className={styles.popoutExpandedFooter}>
+                      <Text tag="div" style="body-bold">
+                        Created on: July 12, 2017
+                      </Text>
+                    </div>
+                  </div>
+                )}
+              </TableCard>
+            )
+          })}
+        </TableContainer>
+      </Container>
+    )
+  })
+  .add("Expanded with custom content", () => {
+    const [expandedId, setExpandedId] = React.useState<string | null>("second")
+    const toggleExpanded = id => {
+      if (expandedId === id) {
+        setExpandedId(null)
+        return
+      }
+      setExpandedId(id)
+    }
+    return (
+      <Container>
+        <TableContainer>
+          <TableHeader>
+            <ExampleTableHeaderRow checkable />
+          </TableHeader>
+          {["first", "second", "third"].map(id => {
+            const expanded = expandedId === id
+            return (
+              <>
+                <TableCard onClick={() => toggleExpanded(id)}>
+                  <ExampleTableRow />
+                </TableCard>
+                {expanded && (
+                  <TableCard expanded={expanded}>
+                    <div className={styles.customExpandedHeader}>
+                      <Text tag="div" style="label">
+                        Overall progress
+                      </Text>
+                    </div>
+                    <TableContainer>
+                      <TableCard onClick={() => toggleExpanded(id)}>
+                        <ExampleTableRow expanded={expanded} />
+                      </TableCard>
+                    </TableContainer>
+                    <TableContainer>
+                      <ExampleTableHeaderRow />
+                      <TableCard>
+                        <ExampleTableRow expandable={false} />
+                      </TableCard>
+                      <TableCard>
+                        <ExampleTableRow expandable={false} />
+                      </TableCard>
+                    </TableContainer>
+                  </TableCard>
+                )}
+              </>
+            )
+          })}
+        </TableContainer>
+      </Container>
+    )
+  })
   .add("No header", () => (
     <Container>
       <TableContainer>


### PR DESCRIPTION
Storybook:
https://dev.cultureamp.design/lijuenc/fix-table-animations/storybook-static/?path=/story/table--expanded-popout

This PR fixes some unexpected shifting layout and text when expanding and collapsing table rows.

This problem was also not obvious in the storybook because the examples were just static. There was no way to toggle the expanding and collapsing of rows so I only came across this issue in real use. To fix that, I've also updated the stories to make them interactive.

Before (notice that the text shifts to the right, then back to the left):

![janky](https://user-images.githubusercontent.com/4900094/68257744-68ade300-0088-11ea-9b1c-f88972143b40.gif)

After:

![smooth](https://user-images.githubusercontent.com/4900094/68257745-68ade300-0088-11ea-9c4c-4bca42a9cfbe.gif)
