### PR TITLE
ci: Increase agent size for storybook build

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -44,6 +44,7 @@ steps:
     command: ".buildkite/scripts/build-storybook.sh"
     artifact_paths: "./storybook.tar.gz"
     <<: *defaults
+    agent_query_rules: ["queue=build-unrestricted-large"]
 
   - wait: ~
     continue_on_failure: true


### PR DESCRIPTION
Storybook builds were a bit slow! This PR requests large agents for this step, knocking about a minute off the build time under ideal conditions.