### PR TITLE
fix: Fix Tag not constraining its width to its content

### DIFF
--- a/packages/component-library/draft/Kaizen/Tag/Tag.elm
+++ b/packages/component-library/draft/Kaizen/Tag/Tag.elm
@@ -258,10 +258,12 @@ view (Config config) value =
                 ++ resolveVariantStyle
             )
         ]
-        [ resolveValidationIcon
-        , viewTextContent config value
-        , resolveClear
-        , resolveIndicatorIcon
+        [ div [ styles.class .layoutContainer ]
+            [ resolveValidationIcon
+            , viewTextContent config value
+            , resolveClear
+            , resolveIndicatorIcon
+            ]
         ]
 
 
@@ -333,6 +335,7 @@ viewClear config =
 styles =
     css "@cultureamp/kaizen-component-library/draft/Kaizen/Tag/Tag.scss"
         { root = "root"
+        , layoutContainer = "layoutContainer"
         , default = "default"
         , sentimentPositive = "sentimentPositive"
         , sentimentNeutral = "sentimentNeutral"

--- a/packages/component-library/draft/Kaizen/Tag/Tag.scss
+++ b/packages/component-library/draft/Kaizen/Tag/Tag.scss
@@ -10,12 +10,17 @@ $small: $ca-grid;
   @include ca-inherit-baseline;
   @include ca-margin($end: $ca-grid * 0.5);
   color: $ca-palette-lapis;
-  display: flex;
-  align-items: center;
+  display: inline-block;
   border: 1px solid transparent;
   border-radius: $ca-grid * 0.75;
   padding: 0 $ca-grid * 0.4;
   cursor: default;
+}
+
+.layoutContainer {
+  height: 100%;
+  display: flex;
+  align-items: center;
 }
 
 .validationIcon {

--- a/packages/component-library/draft/Kaizen/Tag/Tag.tsx
+++ b/packages/component-library/draft/Kaizen/Tag/Tag.tsx
@@ -82,7 +82,7 @@ const Tag = (props: Props) => {
         [styles.dismissible]: dismissible,
       })}
     >
-      <>
+      <div className={styles.layoutContainer}>
         {canShowIcon &&
           (() => {
             if (successIconVariants.includes(variant)) {
@@ -100,18 +100,16 @@ const Tag = (props: Props) => {
               )
             }
           })()}
-      </>
-      <span
-        className={classNames(styles.textContent, {
-          [styles.truncate]: isTruncated,
-        })}
-        style={{
-          maxWidth: isTruncated ? truncateWidth : undefined,
-        }}
-      >
-        {children}
-      </span>
-      <>
+        <span
+          className={classNames(styles.textContent, {
+            [styles.truncate]: isTruncated,
+          })}
+          style={{
+            maxWidth: isTruncated ? truncateWidth : undefined,
+          }}
+        >
+          {children}
+        </span>
         {dismissible && (
           <span
             className={styles.dismissIcon}
@@ -122,12 +120,12 @@ const Tag = (props: Props) => {
             <Icon icon={clearIcon} inheritSize role="img" title="Dismiss" />
           </span>
         )}
-      </>
-      {variant === "statusLive" && (
-        <span className={styles.pulse}>
-          <span className={styles.pulseRing} />
-        </span>
-      )}
+        {variant === "statusLive" && (
+          <span className={styles.pulse}>
+            <span className={styles.pulseRing} />
+          </span>
+        )}
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
The root element of the Tag component is currently `display: flex` when it should be `display: inline-block`.

This resulted in an issue where the Tag would stretch to fill the width of its container.

![Screen Shot 2019-11-13 at 1 38 15 pm](https://user-images.githubusercontent.com/4900094/68728247-dcb53180-061a-11ea-8732-45a134a595ad.png)
