### PR TITLE
feat: passing optional prop to disable submit button on edit modal

### DIFF
--- a/packages/component-library/draft/Kaizen/Modal/presets/InputEditModal.tsx
+++ b/packages/component-library/draft/Kaizen/Modal/presets/InputEditModal.tsx
@@ -22,6 +22,7 @@ interface Props {
   readonly submitLabel?: string
   readonly dismissLabel?: string
   readonly children: React.ReactNode
+  readonly submitDisabled?: boolean
 }
 
 type InputEditModal = React.FunctionComponent<Props>
@@ -35,6 +36,7 @@ const InputEditModal = ({
   submitLabel = "Submit",
   dismissLabel = "Cancel",
   children,
+  submitDisabled = false,
 }: Props) => (
   <GenericModal
     isOpen={isOpen}
@@ -56,7 +58,7 @@ const InputEditModal = ({
       </ModalBody>
       <ModalFooter
         actions={[
-          { label: submitLabel, action: onSubmit },
+          { label: submitLabel, action: onSubmit, disabled: submitDisabled },
           { label: dismissLabel, action: onDismiss },
         ]}
         appearance={type === "negative" ? "destructive" : "primary"}


### PR DESCRIPTION
Creating optional prop, `submitDisabled`, which can disable the submit button on an editModal.

The prop is passed through to the `modalFooter`, which accepts a `disabled` prop for each type of button.

Naturally, the default value is false.