### PR TITLE
chore: remove sidebar background color

### DIFF
--- a/packages/component-library/components/Layout/_styles.scss
+++ b/packages/component-library/components/Layout/_styles.scss
@@ -79,7 +79,6 @@
 }
 
 %sidebar {
-  background-color: $ca-palette-stone;
   width: $ca-layout-sidebar-width;
   padding: $ca-grid 0;
   overflow: visible;


### PR DESCRIPTION
This is unnecessary, as everywhere the sidebar is used should already have a background.
If we wanted this sidebar to be used on a different colour background like white, it wouldn't work
in it's current implementation anyway (there's no padding, so there'd be a harsh transition from
the side of the sidebar to the white background)