### PR TITLE
fix: Design token package.json was referencing old folder structure

### DIFF
--- a/packages/design-tokens/package.json
+++ b/packages/design-tokens/package.json
@@ -12,11 +12,8 @@
   },
   "files": [
     "tokens",
-    "lib"
+    "sass"
   ],
-  "directories": {
-    "lib": "./lib"
-  },
   "private": false,
   "license": "MIT",
   "scripts": {


### PR DESCRIPTION
Changes files from lib->sass

I also removed `directories` as it's not something that's supported now. 
https://docs.npmjs.com/files/package.json#directories