### PR TITLE
fix: Ensure that sticky TitleBlock's navigation bar gets a background when scrolling

### DIFF
--- a/packages/component-library/draft/Kaizen/TitleBlock/TitleBlock.scss
+++ b/packages/component-library/draft/Kaizen/TitleBlock/TitleBlock.scss
@@ -318,7 +318,7 @@
   }
 
   .navContainer {
-    background: transparent;
+    background-color: transparent;
 
     @include ca-media-mobile {
       border-bottom: 1px solid #fff;
@@ -328,43 +328,92 @@
 
 .reverseColorLapis {
   @include ca-media-tablet-and-up {
-    background-color: $ca-palette-lapis;
+    .titleBlock {
+      background-color: $ca-palette-lapis;
+    }
+  }
+  @include ca-media-mobile {
+    .navContainer {
+      background-color: $ca-palette-lapis;
+    }
   }
 }
 
 .reverseColorOcean {
   @include ca-media-tablet-and-up {
-    background-color: $ca-palette-ocean;
+    .titleBlock {
+      background-color: $ca-palette-ocean;
+    }
+  }
+  @include ca-media-mobile {
+    .navContainer {
+      background-color: $ca-palette-ocean;
+    }
   }
 }
 
 .reverseColorPeach {
   @include ca-media-tablet-and-up {
-    background-color: $ca-palette-peach;
+    .titleBlock {
+      background-color: $ca-palette-peach;
+    }
+  }
+  @include ca-media-mobile {
+    .navContainer {
+      background-color: $ca-palette-peach;
+    }
   }
 }
 
 .reverseColorSeedling {
   @include ca-media-tablet-and-up {
-    background-color: $ca-palette-seedling;
+    .titleBlock {
+      background-color: $ca-palette-seedling;
+    }
+  }
+  @include ca-media-mobile {
+    .navContainer {
+      background-color: $ca-palette-seedling;
+    }
   }
 }
 
 .reverseColorWisteria {
   @include ca-media-tablet-and-up {
-    background-color: $ca-palette-wisteria;
+    .titleBlock {
+      background-color: $ca-palette-wisteria;
+    }
+  }
+  @include ca-media-mobile {
+    .navContainer {
+      background-color: $ca-palette-wisteria;
+    }
   }
 }
 
 .reverseColorYuzu {
   @include ca-media-tablet-and-up {
-    background-color: $ca-palette-yuzu;
+    .titleBlock {
+      background-color: $ca-palette-yuzu;
+    }
+  }
+  @include ca-media-mobile {
+    .navContainer {
+      background-color: $ca-palette-yuzu;
+    }
   }
 }
 
 .reverseColorTransparent {
   @include ca-media-tablet-and-up {
-    background-color: transparent;
+    .titleBlock {
+      background-color: transparent;
+    }
+  }
+  @include ca-media-mobile {
+    .navContainer {
+      background-color: transparent;
+    }
   }
 }
 
@@ -403,42 +452,91 @@
 
 .stickyColorLapis {
   @include ca-media-tablet-and-up {
-    background-color: add-tint($ca-palette-lapis, 20%);
+    .titleBlock {
+      background-color: add-tint($ca-palette-lapis, 20%);
+    }
+  }
+  @include ca-media-mobile {
+    .navContainer {
+      background-color: add-tint($ca-palette-lapis, 20%);
+    }
   }
 }
 
 .stickyColorOcean {
   @include ca-media-tablet-and-up {
-    background-color: add-tint($ca-palette-ocean, 20%);
+    .titleBlock {
+      background-color: add-tint($ca-palette-ocean, 20%);
+    }
+  }
+  @include ca-media-mobile {
+    .navContainer {
+      background-color: add-tint($ca-palette-ocean, 20%);
+    }
   }
 }
 
 .stickyColorPeach {
   @include ca-media-tablet-and-up {
-    background-color: add-tint($ca-palette-peach, 20%);
+    .titleBlock {
+      background-color: add-tint($ca-palette-peach, 20%);
+    }
+  }
+  @include ca-media-mobile {
+    .navContainer {
+      background-color: add-tint($ca-palette-peach, 20%);
+    }
   }
 }
 
 .stickyColorSeedling {
   @include ca-media-tablet-and-up {
-    background-color: add-tint($ca-palette-seedling, 20%);
+    .titleBlock {
+      background-color: add-tint($ca-palette-seedling, 20%);
+    }
+  }
+  @include ca-media-mobile {
+    .navContainer {
+      background-color: add-tint($ca-palette-seedling, 20%);
+    }
   }
 }
 
 .stickyColorWisteria {
   @include ca-media-tablet-and-up {
-    background-color: add-tint($ca-palette-wisteria, 20%);
+    .titleBlock {
+      background-color: add-tint($ca-palette-wisteria, 20%);
+    }
+  }
+  @include ca-media-mobile {
+    .navContainer {
+      background-color: add-tint($ca-palette-wisteria, 20%);
+    }
   }
 }
 
 .stickyColorYuzu {
   @include ca-media-tablet-and-up {
-    background-color: add-tint($ca-palette-yuzu, 20%);
+    .titleBlock {
+      background-color: add-tint($ca-palette-yuzu, 20%);
+    }
+  }
+  @include ca-media-mobile {
+    .navContainer {
+      background-color: add-tint($ca-palette-yuzu, 20%);
+    }
   }
 }
 
 .stickyColorTransparent {
   @include ca-media-tablet-and-up {
-    background-color: transparent;
+    .titleBlock {
+      background-color: transparent;
+    }
+  }
+  @include ca-media-mobile {
+    .navContainer {
+      background-color: transparent;
+    }
   }
 }

--- a/packages/component-library/draft/Kaizen/TitleBlock/TitleBlock.tsx
+++ b/packages/component-library/draft/Kaizen/TitleBlock/TitleBlock.tsx
@@ -172,16 +172,14 @@ class TitleBlock extends React.Component<Props, State> {
       <div
         className={classNames(styles.titleBlockContainer, {
           [styles.reversed]: reversed,
+          [styles[`reverseColor${reverseColor}`]]: reverseColor,
           [styles.sticky]: sticky,
           [styles.compact]: useCompactSize,
+          [styles[`stickyColor${stickyColor}`]]: useCompactSize && stickyColor,
         })}
       >
         <div
-          className={classNames(styles.titleBlock, {
-            [styles[`reverseColor${reverseColor}`]]: reverseColor,
-            [styles[`stickyColor${stickyColor}`]]:
-              useCompactSize && stickyColor,
-          })}
+          className={classNames(styles.titleBlock)}
           data-automation-id="TitleBlock__TitleBlock"
         >
           <div className={styles.titleBlockInner}>

--- a/packages/component-library/stories/TitleBlock.stories.scss
+++ b/packages/component-library/stories/TitleBlock.stories.scss
@@ -1,0 +1,3 @@
+body {
+  margin: 0;
+}

--- a/packages/component-library/stories/TitleBlock.stories.tsx
+++ b/packages/component-library/stories/TitleBlock.stories.tsx
@@ -3,6 +3,8 @@ import { TitleBlock } from "@cultureamp/kaizen-component-library/draft"
 import { storiesOf } from "@storybook/react"
 import * as React from "react"
 
+require("./TitleBlock.stories.scss")
+
 const navigationButtons = [
   {
     buttonText: "Dashboard",


### PR DESCRIPTION
Current issue:

![image](https://user-images.githubusercontent.com/4900094/69290595-8b2d2800-0c54-11ea-8619-026a5579cfed.png)

When scrolling, the sticky TitleBlock's navigation bar should get the same background color as its `stickyColor`.