### PR TITLE
feat: make mobile version of navigation bar menu optional

### DIFF
--- a/packages/component-library/components/NavigationBar/NavigationBar.tsx
+++ b/packages/component-library/components/NavigationBar/NavigationBar.tsx
@@ -25,7 +25,6 @@ type Props = {
   colorScheme?: "cultureamp" | "kaizen"
   badgeHref?: string
   footerComponent?: React.ReactNode
-  mobileEnabled?: boolean
 }
 
 export default class NavigationBar extends React.Component<Props> {
@@ -37,15 +36,10 @@ export default class NavigationBar extends React.Component<Props> {
     loading: false,
     colorScheme: "cultureamp",
     badgeHref: "/",
-    mobileEnabled: true,
   }
 
   render() {
-    const {
-      children,
-      colorScheme = "cultureamp",
-      mobileEnabled = true,
-    } = this.props
+    const { children, colorScheme = "cultureamp" } = this.props
     const links: React.ReactElement<LinkProps>[] = []
     const otherChildren: React.ReactElement<MenuProps>[] = []
 
@@ -78,7 +72,7 @@ export default class NavigationBar extends React.Component<Props> {
     return (
       <Media query={MOBILE_QUERY}>
         {(matches: boolean) =>
-          mobileEnabled && matches ? (
+          matches ? (
             <ControlledOffCanvas
               headerComponent={this.renderBadge()}
               footerComponent={this.props.footerComponent}

--- a/packages/component-library/components/NavigationBar/NavigationBar.tsx
+++ b/packages/component-library/components/NavigationBar/NavigationBar.tsx
@@ -25,6 +25,7 @@ type Props = {
   colorScheme?: "cultureamp" | "kaizen"
   badgeHref?: string
   footerComponent?: React.ReactNode
+  mobileEnabled?: boolean
 }
 
 export default class NavigationBar extends React.Component<Props> {
@@ -36,10 +37,15 @@ export default class NavigationBar extends React.Component<Props> {
     loading: false,
     colorScheme: "cultureamp",
     badgeHref: "/",
+    mobileEnabled: true,
   }
 
   render() {
-    const { children, colorScheme = "cultureamp" } = this.props
+    const {
+      children,
+      colorScheme = "cultureamp",
+      mobileEnabled = true,
+    } = this.props
     const links: React.ReactElement<LinkProps>[] = []
     const otherChildren: React.ReactElement<MenuProps>[] = []
 
@@ -72,7 +78,7 @@ export default class NavigationBar extends React.Component<Props> {
     return (
       <Media query={MOBILE_QUERY}>
         {(matches: boolean) =>
-          matches ? (
+          mobileEnabled && matches ? (
             <ControlledOffCanvas
               headerComponent={this.renderBadge()}
               footerComponent={this.props.footerComponent}

--- a/packages/component-library/components/NavigationBar/components/Menu.tsx
+++ b/packages/component-library/components/NavigationBar/components/Menu.tsx
@@ -23,6 +23,7 @@ export type MenuProps = {
   items: MenuItem[]
   automationId?: string
   heading: string
+  mobileEnabled?: boolean
 }
 
 type State = {
@@ -35,17 +36,18 @@ export default class Menu extends React.Component<MenuProps, State> {
   static displayName = "Menu"
   static defaultProps = {
     items: [],
+    mobileEnabled: true,
   }
 
   state = { open: false }
 
   render() {
-    const { children, automationId, heading } = this.props
+    const { children, automationId, heading, mobileEnabled } = this.props
 
     return (
       <Media query={MOBILE_QUERY}>
         {(matches: boolean) =>
-          matches ? (
+          mobileEnabled && matches ? (
             <React.Fragment>
               <OffCanvasContext.Consumer>
                 {({ toggleVisibleMenu }) => (


### PR DESCRIPTION
The freemium version of the navbar menu in murmur is already mobile friendly and hence does not need to change shape at lower resolutions.