### PR TITLE
feat: revert Use Zen colours for NavigationBar

### DIFF
--- a/packages/component-library/components/NavigationBar/NavigationBar.module.scss
+++ b/packages/component-library/components/NavigationBar/NavigationBar.module.scss
@@ -66,6 +66,10 @@
   }
 }
 
-.kaizen .active {
-  background-color: add-shade($ca-palette-wisteria, 25%);
+.active {
+  background-color: add-alpha($ca-palette-ink, 80%);
+
+  .kaizen & {
+    background-color: add-shade($ca-palette-wisteria, 25%);
+  }
 }

--- a/packages/component-library/components/NavigationBar/_styles.scss
+++ b/packages/component-library/components/NavigationBar/_styles.scss
@@ -6,8 +6,7 @@ $ca-navigation-bar__height: 2.5 * $ca-grid;
 %ca-navigation-bar {
   display: flex;
   flex-direction: row;
-  background-color: #4b4d68; // DST-TODO: Replace this with $kz-color-wisteria-700 once kaizen-design-tokens is installed
-  color: #fff;
+  background-color: add-shade($ca-palette-ink, 20%);
   height: $ca-navigation-bar__height;
   width: 100%;
   position: fixed;
@@ -27,7 +26,7 @@ $ca-navigation-bar__height: 2.5 * $ca-grid;
     // show custom focus ring when :focus-visible
     &:global(.focus-visible) {
       color: #fff;
-      outline: 2px solid #0168b3; // DST-TODO: Replace this with $kz-color-cluny-500 once kaizen-design-tokens is installed
+      outline: 2px solid $ca-palette-ocean;
     }
   }
 }

--- a/packages/component-library/components/NavigationBar/components/Badge.module.scss
+++ b/packages/component-library/components/NavigationBar/components/Badge.module.scss
@@ -3,7 +3,7 @@
 @import "../styles";
 
 .badge {
-  background-color: $ca-palette-coral; // DST-TODO: change this to $kz-color-coral-500 once kaizen-design-tokens is installed
+  background-color: $ca-palette-coral;
   color: #fff;
   font-weight: $ca-weight-medium;
   text-decoration: none;
@@ -51,6 +51,6 @@
   }
 
   &.local {
-    background-color: #99c3e1; // DST-TODO: change this to $kz-color-cluny-300 once kaizen-design-tokens is installed
+    background-color: add-tint($ca-palette-ocean, 50%);
   }
 }

--- a/packages/component-library/components/NavigationBar/components/Link.module.scss
+++ b/packages/component-library/components/NavigationBar/components/Link.module.scss
@@ -31,7 +31,7 @@ $link-margin: $ca-grid / 4;
 
   border-radius: $ca-border-radius;
 
-  color: #c4c5d4; // DST-TODO: change this to $kz-color-wisteria-300 once kaizen-design-tokens is installed
+  color: add-tint($ca-palette-ink, 70%);
   padding: 0;
   text-decoration: none;
 
@@ -175,6 +175,6 @@ $link-margin: $ca-grid / 4;
   @include ca-type-ideal-small-bold;
   @include ca-inherit-baseline;
   border-radius: $ca-grid;
-  background-color: #bce3dc; // DST-TODO: Replace with $kz-color-seedling-200 once kaizen-design-tokens is installed
-  color: #35374a; // DST-TODO: Replace with $kz-color-wisteria-800 once kaizen-design-tokens is installed
+  background-color: add-tint($ca-palette-seedling, 80%);
+  color: $ca-palette-lapis;
 }

--- a/packages/component-library/components/NavigationBar/components/Menu.module.scss
+++ b/packages/component-library/components/NavigationBar/components/Menu.module.scss
@@ -55,7 +55,7 @@ $menu__square-size: $ca-grid * 2;
     right: calc(#{$menu__square-size / 2} - #{$menu__arrow-size});
     border: $menu__arrow-size solid transparent;
     border-top-width: 0;
-    border-bottom-color: #35374a; // DST-TODO: Replace this with $kz-color-wisteria-800 once kaizen-design-tokens is installed
+    border-bottom-color: add-shade($ca-palette-ink, 20%);
   }
 
   [dir="rtl"] &::before {
@@ -65,7 +65,7 @@ $menu__square-size: $ca-grid * 2;
 
   > * {
     color: #fff;
-    background-color: #35374a; // DST-TODO: Replace this with $kz-color-wisteria-800 once kaizen-design-tokens is installed
+    background-color: add-shade($ca-palette-ink, 20%);
     border-radius: $ca-border-radius;
     padding: $ca-border-radius 0;
     white-space: nowrap;
@@ -111,6 +111,6 @@ $menu__square-size: $ca-grid * 2;
   }
 
   &:hover {
-    background-color: #4b4d68; // DST-TODO: Replace this with $kz-color-wisteria-700 once kaizen-design-tokens is installed
+    background-color: add-tint($ca-palette-ink, 10%);
   }
 }


### PR DESCRIPTION
Reverts cultureamp/kaizen-design-system#140

This couldn't be used in murmur until we are ready for the Zen colour rollout in Murmur. As such, we are blocking an important fix that needs to be released. So, we will revert for now, and re-introduce when we are ready.