### PR TITLE
feat: Include svg mock in published package

### DIFF
--- a/packages/component-library/package.json
+++ b/packages/component-library/package.json
@@ -17,7 +17,6 @@
     "!**/*.spec.*",
     "!**/*.snap",
     "!draft-templates",
-    "!mocks",
     "!stories",
     "!tsconfig.dist.json"
   ],


### PR DESCRIPTION
This mock is useful to consumers of Kaizen components.