### PR TITLE
docs: Add Pagination and Infinite Scroll documentation

### DIFF
--- a/site/docs/components/infinite-scroll.mdx
+++ b/site/docs/components/infinite-scroll.mdx
@@ -4,7 +4,7 @@ navTitle: Infinite Scroll (not built)
 summaryParagraph: Infinite Scroll separates large bodies of content into separate sections. You can access each extra section via a "View more" button.
 tags: ["Infinite scrolling", "Continuous scroll", "Load more", "Async loading"]
 needToKnow:
-  - Perform usability testing to decide where to split content into pages.
+  - Perform usability testing to decide where to split content into pages (that is, how much content to show per page).
   - This has been designed but not built.
 ---
 
@@ -28,6 +28,10 @@ Traditionally, Infinite Scroll loads and presents more results as you scroll wit
     - Amount of content in each entry
     - Screen real estate
     - How many items a person may need to compare at once
+- After someone has tapped "view more" several times, it might end up becoming a long page:
+    - You might consider helping users keep context by using, for example, a sticky header, such as when you have long [Collapsible](/components/collapsible) sections.
+    - You might consider giving users a method to efficiently exit the stream, such as letting them collapse a sticky [Collapsible](/components/collapsible) section or provide a persistent link to access the next action they must perform.
+    - Be mindful of performance for extremely long pages on browsers and devices with fewer resources.
 
 ## When to use and when not to use
 

--- a/site/docs/components/infinite-scroll.mdx
+++ b/site/docs/components/infinite-scroll.mdx
@@ -1,0 +1,70 @@
+---
+title: Infinite Scroll with a “View more” button
+navTitle: Infinite Scroll (not built)
+summaryParagraph: Infinite Scroll separates large bodies of content into separate sections. You can access each extra section via a "View more" button.
+tags: ["Infinite scrolling", "Continuous scroll", "Load more", "Async loading"]
+needToKnow:
+  - Perform usability testing to decide where to split content into pages.
+  - This has been designed but not built.
+---
+
+import DosAndDonts from "docs-components/DosAndDonts"
+import Do from "docs-components/Do"
+import Dont from "docs-components/Dont"
+
+## To keep in mind
+
+Traditionally, Infinite Scroll loads and presents more results as you scroll without interruption, in a single stream. To minimize some drawbacks of this, however, we use a "View more" [Button](/components/button) that a user must click to progressively disclose only as much content as they want.
+
+- Compare [Pagination and Infinite Scroll](/guidelines/pagination-infinite-scroll).
+- Show a [Loading Spinner](/components/loading-spinner) below the list to indicate that items have been requested, either in the "View more" button or in the space they'll load.
+- Button text:
+    - Instead of "load more", which describes what the system is doing, use "View more" to describe what the person is doing.
+    - Where appropriate, specify the object to further clarify what the action will do. For example, use "View more comments" when loading more comments.
+    - Where appropriate, indicate how many additional items will be loaded, such as "View 50 more comments". Where possible, pluralize it correctly so that it says "View 1 more comment" when there's only 1 comment remaining.
+- Consider if you need to keep the person's place in the loaded content when they refresh their browser page or navigate backwards and forwards through browser history.
+- To decide where to split content into sections, consider:
+    - Page and data load time
+    - Amount of content in each entry
+    - Screen real estate
+    - How many items a person may need to compare at once
+
+## When to use and when not to use
+
+<DosAndDonts>
+<Do>
+
+- Use "View more" when someone may want to see every item and compare them at the same time.
+- Use "View more" when we want and expect people to read more than 1 page worth of content without disrupting the experience with a page load.
+- On small and touch devices, "View more" can feel more efficient than pagination.
+
+</Do>
+<Dont>
+
+- Use [Pagination](/components/pagination) when people are unlikely to need to see ALL the content.
+- Use [Pagination](/components/pagination) when the first page is enough.
+- Use [Pagination](/components/pagination) when bookmarking a specific page is important.
+- Consider using [Pagination](/components/pagination) when there's lot of screen real estate.
+- Consider using [Pagination](/components/pagination) when a list contains more than 50 items of a single line of text each.
+
+</Dont>
+</DosAndDonts>
+
+## Research insights
+
+In the Comments report, we saw a sharp drop off from page 1 to page 2 when we used pagination. When we introduced question grouping and a "View more" button, we saw more viewers viewing page 2.
+
+## See also
+
+- [Pagination](/components/pagination).
+- [Pagination and Infinite Scroll](/guidelines/pagination-infinite-scroll).
+- [Button](/components/button).
+
+## External links
+
+Here are some examples of "View more" in existing design systems:
+
+- [Ant Design: list load more](https://ant.design/components/list/#components-list-demo-loadmore).
+- [Carbon: load more](https://www.carbondesignsystem.com/patterns/loading/#load-more).
+- [UIPatterns.io: continuous scrolling, load more](http://uipatterns.io/continuous-scrolling).
+

--- a/site/docs/components/pagination.mdx
+++ b/site/docs/components/pagination.mdx
@@ -4,7 +4,7 @@ navTitle: Pagination (not built)
 summaryParagraph: Pagination separates large bodies of content into separate pages. You can access each page via a shared index of links.
 tags: ["Pages"]
 needToKnow:
-  - Perform usability testing to decide where to split content into pages.
+  - Perform usability testing to decide where to split content into pages (that is, how much content to show per page).
   - This has been designed but not built.
 ---
 
@@ -18,7 +18,7 @@ import Dont from "docs-components/Dont"
 
 - Place Pagination at the bottom of the long list of content that has been split up into pages.
 - Let people navigate to the Previous and Next set of items in the paged list.
-- Show when people are on the first or the last page by disabling the its pagination link.
+- Indicate to users when they are on the first or last page by disabling the Previous or Next link.
 - Where possible, load each set of items without reloading the whole page.
 - Highlight the Current page as well as available pages in Pagination, such as the total number of results.
 - To decide where to split content into pages, consider:
@@ -44,7 +44,7 @@ import Dont from "docs-components/Dont"
 <Dont>
 
 - Avoid pagination when seeing every item and comparing them at the same time is important to the task.
-- Manual pagination may be less efficient than [Infinite Scroll](/components/infinite-scroll) because it requires additional user interaction to click or tap a link to navigate to the next page as well as cognitive load to choose a page number or pagination button.
+- Manual pagination may be less efficient than [Infinite Scroll](/components/infinite-scroll) because it may require additional cognitive load to choose a page number or pagination button.
 - When we want and expect people to read more than 1 page worth of content, pagination may be disruptive to the reading experience. You might consider a "View more" button instead.
 - On small and touch devices, consider using [Infinite Scroll](/components/infinite-scroll) instead to avoid interrupting the flow with the need to tap a button as people scroll.
 

--- a/site/docs/components/pagination.mdx
+++ b/site/docs/components/pagination.mdx
@@ -1,0 +1,86 @@
+---
+title: Pagination
+navTitle: Pagination (not built)
+summaryParagraph: Pagination separates large bodies of content into separate pages. You can access each page via a shared index of links.
+tags: ["Pages"]
+needToKnow:
+  - Perform usability testing to decide where to split content into pages.
+  - This has been designed but not built.
+---
+
+import DosAndDonts from "docs-components/DosAndDonts"
+import Do from "docs-components/Do"
+import Dont from "docs-components/Dont"
+
+## To keep in mind
+
+<iframe style="border: none;" width="744" height="450" src="https://www.figma.com/embed?embed_host=share&url=https%3A%2F%2Fwww.figma.com%2Ffile%2Fe3TyAOZKfLg9cA01Iy1Mgm%2FKaizen-Site-embed%3Fnode-id%3D4332%253A26712" allowfullscreen></iframe>
+
+- Place Pagination at the bottom of the long list of content that has been split up into pages.
+- Let people navigate to the Previous and Next set of items in the paged list.
+- Show when people are on the first or the last page by disabling the its pagination link.
+- Where possible, load each set of items without reloading the whole page.
+- Highlight the Current page as well as available pages in Pagination, such as the total number of results.
+- To decide where to split content into pages, consider:
+    - Page and data load time
+    - Amount of content in each entry
+    - Screen real estate available
+    - How many items a person may need to compare at once
+- Compare [Pagination and Infinite Scroll](/guidelines/pagination-infinite-scroll) with a "View more" button.
+
+<DosAndDonts>
+<Do>
+
+- Use Pagination when people are unlikely to need to see **all** the content.
+- Use Pagination when the first page is enough to make a decision.
+- Use Pagination when loading all the content at once would not be possible technically or not be performant. If it takes more than 10 seconds to load all the content, paginate.
+- Use Pagination when keeping your place is important or you want to bookmark a specific page.
+- Use Pagination when there's lot of screen real estate.
+- Consider using pagination when a list contains more than 50 items of a single line of text each.
+
+</Do>
+<Dont>
+
+- Avoid pagination when seeing every item and comparing them at the same time is important to the task.
+- Manual pagination may be less efficient than [Infinite Scroll](/components/infinite-scroll) because it requires additional user interaction to click or tap a link to navigate to the next page as well as cognitive load to choose a page number or pagination button.
+- When we want and expect people to read more than 1 page worth of content, pagination may be disruptive to the reading experience. You might consider a "View more" button instead.
+- On small and touch devices, consider using [Infinite Scroll](/components/infinite-scroll) instead to avoid interrupting the flow with the need to tap a button as people scroll.
+
+</Dont>
+</DosAndDonts>
+
+
+## When to use
+
+- Use pagination when people are unlikely to need to see **all** the content.
+- Use pagination when the first page is enough to make a decision.
+- Use pagination when loading all the content at once would not be possible technically or not be performant. If it takes more than 10 seconds to load all the content, paginate.
+- Use pagination when keeping your place is important or you want to bookmark a specific page.
+- Use pagination when there's lot of screen real estate.
+- Consider using pagination when a list contains more than 50 items of a single line of text each.
+
+## When not to use
+
+- Avoid pagination when seeing every item and comparing them at the same time is important to the task.
+- Manual pagination may be less efficient than infinite scroll because it requires additional user interaction to click or tap a link to navigate to the next page as well as cognitive load to choose a page number or pagination button.
+- When we want and expect people to read more than 1 page worth of content, pagination may be disruptive to the reading experience. You might consider a "View more" button instead.
+- On small and touch devices, consider using infinite scroll instead to avoid interrupting the flow with the need to tap a button as people scroll.
+
+## Research insights
+
+In the Comments report, we saw a sharp drop off from page 1 to page 2 when we used pagination. When we introduced question grouping and a "View more" button, we saw more viewers viewing page 2.
+
+## See also
+
+- [Pagination and Infinite Scroll](/guidelines/pagination-infinite-scroll).
+
+## External links
+
+Here are some examples of existing design systems:
+
+- [Polaris: pagination](https://polaris.shopify.com/components/navigation/pagination).
+- [Ant Design: pagination](https://ant.design/components/pagination/#header).
+- [Atlassian: pagination](https://www.atlassian.design/guidelines/product/components/pagination).
+- [Material Design: data table pagination](https://material.io/components/data-tables/#behavior).
+- [Lonely Plant: pagination](https://rizzo.lonelyplanet.com/styleguide/ui-components/pagination).
+

--- a/site/docs/components/pagination.mdx
+++ b/site/docs/components/pagination.mdx
@@ -28,6 +28,8 @@ import Dont from "docs-components/Dont"
     - How many items a person may need to compare at once
 - Compare [Pagination and Infinite Scroll](/guidelines/pagination-infinite-scroll) with a "View more" button.
 
+## When to use and when not to use
+
 <DosAndDonts>
 <Do>
 
@@ -48,23 +50,6 @@ import Dont from "docs-components/Dont"
 
 </Dont>
 </DosAndDonts>
-
-
-## When to use
-
-- Use pagination when people are unlikely to need to see **all** the content.
-- Use pagination when the first page is enough to make a decision.
-- Use pagination when loading all the content at once would not be possible technically or not be performant. If it takes more than 10 seconds to load all the content, paginate.
-- Use pagination when keeping your place is important or you want to bookmark a specific page.
-- Use pagination when there's lot of screen real estate.
-- Consider using pagination when a list contains more than 50 items of a single line of text each.
-
-## When not to use
-
-- Avoid pagination when seeing every item and comparing them at the same time is important to the task.
-- Manual pagination may be less efficient than infinite scroll because it requires additional user interaction to click or tap a link to navigate to the next page as well as cognitive load to choose a page number or pagination button.
-- When we want and expect people to read more than 1 page worth of content, pagination may be disruptive to the reading experience. You might consider a "View more" button instead.
-- On small and touch devices, consider using infinite scroll instead to avoid interrupting the flow with the need to tap a button as people scroll.
 
 ## Research insights
 

--- a/site/docs/guidelines/pagination-infinite-scroll.mdx
+++ b/site/docs/guidelines/pagination-infinite-scroll.mdx
@@ -4,7 +4,7 @@ navTitle: Pagination and Infinite Scroll
 summaryParagraph: Pagination separates large bodies of content into separate pages accessed via a shared index of links while Infinite Scroll separates large bodies of content into separate sections accessed via "View more" button.
 tags:
 needToKnow:
-  - 'Perform usability testing to decide where to split content into pages or sections.'
+  - 'Perform usability testing to decide where to split content into pages (that is, how much content to show per page).'
   - 'We never use infinite scroll without a "View more" button.'
 inComparingSection: true
 ---

--- a/site/docs/guidelines/pagination-infinite-scroll.mdx
+++ b/site/docs/guidelines/pagination-infinite-scroll.mdx
@@ -1,0 +1,50 @@
+---
+title: Pagination and Infinite Scroll
+navTitle: Pagination and Infinite Scroll
+summaryParagraph: Pagination separates large bodies of content into separate pages accessed via a shared index of links while Infinite Scroll separates large bodies of content into separate sections accessed via "View more" button.
+tags:
+needToKnow:
+  - 'Perform usability testing to decide where to split content into pages or sections.'
+  - 'We never use infinite scroll without a "View more" button.'
+inComparingSection: true
+---
+
+## To keep in mind
+
+<iframe style="border: none;" width="744" height="450" src="https://www.figma.com/embed?embed_host=share&url=https%3A%2F%2Fwww.figma.com%2Ffile%2Fe3TyAOZKfLg9cA01Iy1Mgm%2FKaizen-Site-embed%3Fnode-id%3D4332%253A26712" allowfullscreen></iframe>
+
+[Pagination](/components/pagination) can reduce results in large data sets down to easy-to-digest chunks. Each page has a link that can be bookmarked. The First, Current, and Last pages are always accessible, while other page links may be truncated when there’s too many to show at once. Pagination also has Previous and Next links.
+
+Traditionally, Infinite Scroll loads and presents more results as you scroll without interruption, in a single stream. To minimize some drawbacks of this, however, we use a "View more" [Button](/components/button) that a user must click to progressively disclose only as much content as they want.
+
+## When to use
+
+- Use [Pagination](/components/pagination) when people are unlikely to need to see **all** the content.
+- Use [Pagination](/components/pagination) when the first page is enough to make a decision.
+- Use [Pagination](/components/pagination) when loading all the content at once would not be possible technically or not be performant. If it takes more than 10 seconds to load all the content, paginate.
+- Use [Pagination](/components/pagination) when keeping your place is important or you want to bookmark a specific page.
+- Use [Pagination](/components/pagination) when there's lot of screen real estate.
+- Consider using [Pagination](/components/pagination) when a list contains more than 50 items of a single line of text each.
+- Use [Infinite Scroll](/components/infinite-scroll) with a "View more" button when someone may want to see every item and compare them at the same time.
+- Use [Infinite Scroll](/components/infinite-scroll) with a "View more" button when we want and expect people to read more than 1 page worth of content without disrupting the experience with a page load.
+- Use [Infinite Scroll](/components/infinite-scroll) with a "View more" button on small, touch devices if it feels more efficient to the user than pagination.
+
+## See also
+
+* [Pagination](/components/pagination).
+* [Infinite Scroll](/components/infinite-scroll).
+* [Button](/components/button).
+
+## External links
+
+Here are some examples of other existing design systems:
+
+- [Polaris: pagination](https://polaris.shopify.com/components/navigation/pagination).
+- [Ant Design: pagination](https://ant.design/components/pagination/#header).
+- [Atlassian: pagination](https://www.atlassian.design/guidelines/product/components/pagination).
+- [Material Design: data table pagination](https://material.io/components/data-tables/#behavior).
+- [Lonely Plant: pagination](https://rizzo.lonelyplanet.com/styleguide/ui-components/pagination).
+- [Ant Design: list load more](https://ant.design/components/list/#components-list-demo-loadmore).
+- [Carbon: load more](https://www.carbondesignsystem.com/patterns/loading/#load-more).
+- [UIPatterns.io: continuous scrolling, load more](http://uipatterns.io/continuous-scrolling).
+


### PR DESCRIPTION
Closes #77

Branch preview: <http://dev.cultureamp.design/add-pagination-documentation/guidelines/pagination-infinite-scroll>

* Adds [Pagination and Infinite Scroll](http://dev.cultureamp.design/add-pagination-documentation/guidelines/pagination-infinite-scroll) comparison guidelines, [pagination](http://dev.cultureamp.design/add-pagination-documentation/components/pagination/), and [infinite scroll](http://dev.cultureamp.design/add-pagination-documentation/components/infinite-scroll)
* Uses DOs and DONTs styling for "When to use and when not to use"
* Uses "( not built)" in nav titles as per [this issue to improve visibility](https://github.com/cultureamp/kaizen-design-system/issues/116)

Screenshot:
![image](https://user-images.githubusercontent.com/2476974/70584028-b4b5ef80-1c13-11ea-89c2-5c1fe938eaa8.png)

