### PR TITLE
docs: update tags on layout guidelines

### DIFF
--- a/site/docs/guidelines/layout-spacing-sizing-vertical-rhythm.mdx
+++ b/site/docs/guidelines/layout-spacing-sizing-vertical-rhythm.mdx
@@ -2,7 +2,7 @@
 title: "Layout, Spacing, Sizing, Vertical Rhythm, and Alignment"
 navTitle: "Layout, Spacing, Sizing, Vertical Rhythm, and Alignment"
 summaryParagraph: Explore our guidelines to learn how to design cohesive and predictable products for Culture Amp using Kaizen.
-tags: ["Guidelines", "Guide", "Design documentation"]
+tags:
 needToKnow:
   - 'Layout: familiar ways to lay out content or other elements on a page (and responsively at different screen sizes).'
   - 'Spacing: spacing details within a component or detailed User Interface, such as between checkbox and label.'


### PR DESCRIPTION
Remove default tags from Layout, Spacing, Sizing, Vertical Rhythm, and Alignment page

Branch preview: https://dev.cultureamp.design/update-tags-on-layout/guidelines/layout-spacing-sizing-vertical-rhythm/