### PR TITLE
feat: add noBottomMargin prop to inlineNotification

### DIFF
--- a/packages/component-library/components/Notification/InlineNotification.tsx
+++ b/packages/component-library/components/Notification/InlineNotification.tsx
@@ -13,6 +13,7 @@ type Props = {
   hideCloseIcon: boolean
   onHide?: () => void
   automationId?: string
+  noBottomMargin?: boolean
 }
 
 const InlineNotification = ({

--- a/packages/component-library/components/Notification/_styles.scss
+++ b/packages/component-library/components/Notification/_styles.scss
@@ -122,6 +122,12 @@ $ca-notification-slide-right: transform $ca-duration-slow ease-out;
       opacity: 1;
     }
   }
+
+  // Modifiers
+
+  &%ca-notification---noBottomMargin {
+    margin-bottom: 0;
+  }
 }
 
 %ca-notification__icon {

--- a/packages/component-library/components/Notification/components/GenericNotification.module.scss
+++ b/packages/component-library/components/Notification/components/GenericNotification.module.scss
@@ -71,3 +71,9 @@
 .negative {
   @extend %ca-notification---negative;
 }
+
+// Modifiers
+
+.noBottomMargin {
+  @extend %ca-notification---noBottomMargin;
+}

--- a/packages/component-library/components/Notification/components/GenericNotification.tsx
+++ b/packages/component-library/components/Notification/components/GenericNotification.tsx
@@ -28,6 +28,7 @@ type Props = {
   autohideDelay?: "short" | "long"
   onHide?: () => void
   automationId?: string
+  noBottomMargin?: boolean
 }
 
 type State = {
@@ -99,6 +100,7 @@ class GenericNotification extends React.Component<Props, State> {
       styles[this.props.style],
       {
         [styles.hidden]: this.state.hidden,
+        [styles.noBottomMargin]: this.props.noBottomMargin,
       }
     )
   }


### PR DESCRIPTION
I'm working on something where I could use this component but need to remove the margin-bottom.

![image](https://user-images.githubusercontent.com/1811583/70769519-faaeb700-1dbd-11ea-982f-f2241cf9a5e9.png)

This PR just adds a prop to the React version of `InlineNotification` to allow us to remove the bottom margin.