### PR TITLE
fix: Ensure that className prop also taken into account for Select

### DIFF
--- a/packages/component-library/draft/Kaizen/Select/Select.tsx
+++ b/packages/component-library/draft/Kaizen/Select/Select.tsx
@@ -29,7 +29,7 @@ const Select = (props: Props) => {
         ClearIndicator: null,
         IndicatorSeparator: null,
       }}
-      className={styles.container}
+      className={classNames(styles.container, props.className)}
     />
   )
 }


### PR DESCRIPTION
Enable the `className` prop to be enabled for the `Select` class names.

The primary purpose is to allow "needsclick" for the `React Select` component that breaks on mobile devices due to the `fastclick` library.