### PR TITLE
fix: Add scroll layer style to parent span

### DIFF
--- a/packages/component-library/draft/Kaizen/Modal/Primitives/GenericModal.elm
+++ b/packages/component-library/draft/Kaizen/Modal/Primitives/GenericModal.elm
@@ -42,7 +42,7 @@ default =
 
 view : Size -> List (Html msg) -> Config msg -> Html msg
 view size content (Config config) =
-    span []
+    span [ styles.class .scrollLayer ]
         [ div
             ([ styles.classList [ ( .scrollLayer, True ) ]
              , role "dialog"

--- a/packages/component-library/stories/ModalStories.elm
+++ b/packages/component-library/stories/ModalStories.elm
@@ -70,7 +70,7 @@ main =
     storybook
         [ storyOf "Generic" config <|
             \m ->
-                div [ style "width" "100%" ]
+                div []
                     [ Button.view (Button.primary |> Button.onClick SetModalContext) "Open Modal"
                     , case m.modalContext of
                         Just modalState ->
@@ -90,7 +90,7 @@ main =
                     ]
         , storyOf "Confirmation (Informative)" config <|
             \m ->
-                div [ style "width" "100%" ]
+                div []
                     [ Button.view (Button.primary |> Button.onClick SetModalContext) "Open Modal"
                     , case m.modalContext of
                         Just modalState ->


### PR DESCRIPTION
The scrollLayer style needs to be duplicated in the parent span in order for elm modal to not take up additional space. This differs from how React modal implements the style.