### PR TITLE
fix: Add missing flex styles for GenericModal

### DIFF
--- a/packages/component-library/draft/Kaizen/Modal/Primitives/GenericModal.scss
+++ b/packages/component-library/draft/Kaizen/Modal/Primitives/GenericModal.scss
@@ -47,6 +47,8 @@
 // TODO: unify margin top styling
 .elmGenericModal {
   @extend .genericModal;
+  display: flex;
+  flex-direction: column;
   margin-top: 150px;
   margin-left: auto;
   margin-right: auto;

--- a/packages/component-library/draft/Kaizen/Modal/Primitives/ModalBody.elm
+++ b/packages/component-library/draft/Kaizen/Modal/Primitives/ModalBody.elm
@@ -1,4 +1,11 @@
-module Kaizen.Modal.Primitives.ModalBody exposing (fillVerticalSpace, layout, scrollable, view)
+module Kaizen.Modal.Primitives.ModalBody exposing
+    ( BackgroundColor(..)
+    , background
+    , fillVerticalSpace
+    , layout
+    , scrollable
+    , view
+    )
 
 import CssModules exposing (css)
 import Html exposing (Html, section, text)
@@ -75,6 +82,11 @@ defaults =
 scrollable : Bool -> Config msg -> Config msg
 scrollable predicate (Config config) =
     Config { config | scrollable = predicate }
+
+
+background : BackgroundColor -> Config msg -> Config msg
+background color (Config config) =
+    Config { config | background = color }
 
 
 

--- a/packages/component-library/draft/Kaizen/Modal/Primitives/ModalFooter.elm
+++ b/packages/component-library/draft/Kaizen/Modal/Primitives/ModalFooter.elm
@@ -41,7 +41,7 @@ view (Config config) =
 
         filler content =
             if useFiller then
-                fillerBox content
+                fillerBox config content
 
             else
                 []
@@ -71,9 +71,18 @@ layoutBox content config =
     ]
 
 
-fillerBox : List (Html msg) -> List (Html msg)
-fillerBox content =
-    [ div [ styles.classList [ ( .filler, True ), ( .footerWrap, True ) ] ] content ]
+fillerBox : Configuration msg -> List (Html msg) -> List (Html msg)
+fillerBox config content =
+    [ div
+        [ styles.classList
+            [ ( .filler, True )
+            , ( .footerWrap, True )
+            , ( .border, config.border )
+            , ( .padded, config.padded )
+            ]
+        ]
+        content
+    ]
 
 
 actionButton : Html msg -> Html msg

--- a/packages/component-library/stories/ModalStories.elm
+++ b/packages/component-library/stories/ModalStories.elm
@@ -77,8 +77,16 @@ main =
                             Modal.view <|
                                 (Modal.generic
                                     [ ModalHeader.view <| ModalHeader.layout [ div [] [ text "Generic header" ] ]
-                                    , ModalBody.view <| (ModalBody.layout [ div [] [ text "Generic body" ] ] |> ModalBody.fillVerticalSpace True)
-                                    , ModalFooter.view <| (ModalFooter.layout [ div [] [ text "Generic footer" ] ] |> ModalFooter.fixed True)
+                                    , ModalBody.view <|
+                                        (ModalBody.layout [ div [] [ text "Generic body" ] ]
+                                            |> ModalBody.fillVerticalSpace True
+                                            |> ModalBody.background ModalBody.Stone
+                                        )
+                                    , ModalFooter.view <|
+                                        (ModalFooter.layout [ div [] [ text "Generic footer" ] ]
+                                            |> ModalFooter.fixed True
+                                            |> ModalFooter.padded True
+                                        )
                                     ]
                                     ( 800, 640 )
                                     |> Modal.modalState modalState


### PR DESCRIPTION
## Flex Styles
When combining styles with the react modal some key css was removed from the elm version that actually needs to remain.

These relate to how the modal is laid out using flex.