### PR TITLE
fix: Disable fastclick so mobile devices don't require double click

### DIFF
--- a/packages/component-library/draft/Kaizen/Form/Primitives/Checkbox/Checkbox.tsx
+++ b/packages/component-library/draft/Kaizen/Form/Primitives/Checkbox/Checkbox.tsx
@@ -4,6 +4,7 @@ const checkIcon = require("@cultureamp/kaizen-component-library/icons/check.icon
 const minusIcon = require("@cultureamp/kaizen-component-library/icons/minus.icon.svg")
   .default
 import * as React from "react"
+import classnames from "classnames"
 
 const styles = require("./styles.scss")
 
@@ -56,7 +57,8 @@ const Input: Input = ({
       data-automation-id={automationId}
       // This si only used as a handle for unit testing
       data-indeterminate={checkedStatus === "mixed"}
-      className={styles.checkbox}
+      // TODO - needsclick class disables fastclick on this element to prevent double tap on mobile. Remove when fastclick is removed from consuming repos
+      className={classnames(styles.checkbox, "needsclick")}
       checked={getCheckedFromStatus(checkedStatus)}
       onChange={onCheck}
       disabled={disabled}

--- a/packages/component-library/draft/Kaizen/Form/Primitives/Checkbox/Checkbox.tsx
+++ b/packages/component-library/draft/Kaizen/Form/Primitives/Checkbox/Checkbox.tsx
@@ -3,8 +3,8 @@ const checkIcon = require("@cultureamp/kaizen-component-library/icons/check.icon
   .default
 const minusIcon = require("@cultureamp/kaizen-component-library/icons/minus.icon.svg")
   .default
-import * as React from "react"
 import classnames from "classnames"
+import * as React from "react"
 
 const styles = require("./styles.scss")
 

--- a/packages/component-library/draft/Kaizen/Radio/Primitives/RadioInput.tsx
+++ b/packages/component-library/draft/Kaizen/Radio/Primitives/RadioInput.tsx
@@ -1,4 +1,5 @@
 import * as React from "react"
+import classnames from "classnames"
 
 const styles = require("./styles.scss")
 
@@ -38,7 +39,8 @@ const RadioInput: RadioInput = ({
       value={value}
       checked={selectedStatus}
       data-automation-id={automationId}
-      className={styles.radioInput}
+      // TODO - needsclick class disables fastclick on this element to prevent double tap on mobile. Remove when fastclick is removed from consuming repos
+      className={classnames(styles.radioInput, "needsclick")}
       onChange={onChange}
       disabled={disabled}
     />

--- a/packages/component-library/draft/Kaizen/Radio/Primitives/RadioInput.tsx
+++ b/packages/component-library/draft/Kaizen/Radio/Primitives/RadioInput.tsx
@@ -1,5 +1,5 @@
-import * as React from "react"
 import classnames from "classnames"
+import * as React from "react"
 
 const styles = require("./styles.scss")
 

--- a/packages/component-library/draft/Kaizen/RadioGroup/__snapshots__/RadioGroup.spec.tsx.snap
+++ b/packages/component-library/draft/Kaizen/RadioGroup/__snapshots__/RadioGroup.spec.tsx.snap
@@ -96,7 +96,7 @@ exports[`<RadioGroup />  snapshots renders RadioGroup with radios 1`] = `
     >
       <div>
         <input
-          class="radioInput"
+          class="radioInput needsclick"
           data-automation-id="radio-1-radio-input"
           id="radio-1"
           name="radio"
@@ -125,7 +125,7 @@ exports[`<RadioGroup />  snapshots renders RadioGroup with radios 1`] = `
     >
       <div>
         <input
-          class="radioInput"
+          class="radioInput needsclick"
           data-automation-id="radio-2-radio-input"
           id="radio-2"
           name="radio"


### PR DESCRIPTION
Hello! Ran into two more components this morning that fall victim to `fastclick` - not the worst outcome, but they require double tapping to select.

If this is the desired effect, please let me know! Gif attached. Might be hard to see, but you can see the first tap does not select anything (but some styles update) and requires a double click to activate. 

Not sure how the double tap impacts when it comes to those using features like `VoiceOver` but also worth considering. 

When I am off the simulator and using my device for QA swarm this afternoon, I will investigate the VoiceOver usage.

![double-clicking](https://user-images.githubusercontent.com/4946487/71132737-7a200880-224c-11ea-8a76-40ad71855f98.gif)
