### PR TITLE
feat: Add `boxOffset` property to the `Popover` component

### DIFF
--- a/packages/component-library/draft/Kaizen/Popover/Popover.tsx
+++ b/packages/component-library/draft/Kaizen/Popover/Popover.tsx
@@ -66,7 +66,7 @@ const Popover: Popover = forwardRef<HTMLDivElement, Props>(({
     <div className={mapVariantToBoxClass(variant)}>
       <div className={styles.header}>
         {variant !== "default" && (
-          <span className={styles.icon}>
+          <span className={classNames(styles.icon, mapVariantToIconClass(variant))}>
             <Icon role="presentation" icon={mapVariantToIcon(variant)} />
           </span>
         )}
@@ -128,6 +128,21 @@ const getArrowStyle = (boxOffset: number | undefined, side: Side) => {
         transform: `${translate}${rotate}`,
       }
     : undefined
+}
+
+const mapVariantToIconClass = (variant: Variant) => {
+  switch (variant) {
+    case "informative":
+      return styles.informativeIcon
+    case "positive":
+      return styles.positiveIcon
+    case "negative":
+      return styles.negativeIcon
+    case "cautionary":
+      return styles.cautionaryIcon
+    default:
+      return undefined
+  }
 }
 
 const mapVariantToIcon = (

--- a/packages/component-library/draft/Kaizen/Popover/Popover.tsx
+++ b/packages/component-library/draft/Kaizen/Popover/Popover.tsx
@@ -44,53 +44,65 @@ type Size = "small" | "large"
 
 type Popover = React.FunctionComponent<Props>
 
-const Popover: Popover = forwardRef<HTMLDivElement, Props>(({
-  id,
-  automationId,
-  children,
-  variant = "default",
-  side = "bottom",
-  size = "small",
-  position = "center",
-  heading,
-  dismissible = false,
-  onClose,
-  singleLine = false,
-  boxOffset,
-}, ref) => (
-  <div
-    className={classNames(styles.root, mapSizeToClass(size))}
-    style={getRootStyle(boxOffset)}
-    ref={ref}
-  >
-    <div className={mapVariantToBoxClass(variant)}>
-      <div className={styles.header}>
-        {variant !== "default" && (
-          <span className={classNames(styles.icon, mapVariantToIconClass(variant))}>
-            <Icon role="presentation" icon={mapVariantToIcon(variant)} />
-          </span>
-        )}
-        <div className={styles.singleLine}>{heading}</div>
-        {dismissible && (
-          <button className={styles.close} onClick={onClose}>
-            <Icon role="presentation" icon={closeIcon} />
-          </button>
-        )}
-      </div>
-      <div className={classNames(styles.container, mapLineVariant(singleLine))}>
-        {children}
-      </div>
-    </div>
+const Popover: Popover = forwardRef<HTMLDivElement, Props>(
+  (
+    {
+      id,
+      automationId,
+      children,
+      variant = "default",
+      side = "bottom",
+      size = "small",
+      position = "center",
+      heading,
+      dismissible = false,
+      onClose,
+      singleLine = false,
+      boxOffset,
+    },
+    ref
+  ) => (
     <div
-      className={classNames(
-        mapArrowVariantToClass(variant),
-        mapArrowSideToClass(side),
-        mapArrowPositionToClass(position)
-      )}
-      style={getArrowStyle(boxOffset, side)}
-    />
-  </div>
-))
+      className={classNames(styles.root, mapSizeToClass(size))}
+      style={getRootStyle(boxOffset)}
+      ref={ref}
+    >
+      <div className={mapVariantToBoxClass(variant)}>
+        <div className={styles.header}>
+          {variant !== "default" && (
+            <span
+              className={classNames(
+                styles.icon,
+                mapVariantToIconClass(variant)
+              )}
+            >
+              <Icon role="presentation" icon={mapVariantToIcon(variant)} />
+            </span>
+          )}
+          <div className={styles.singleLine}>{heading}</div>
+          {dismissible && (
+            <button className={styles.close} onClick={onClose}>
+              <Icon role="presentation" icon={closeIcon} />
+            </button>
+          )}
+        </div>
+        <div
+          className={classNames(styles.container, mapLineVariant(singleLine))}
+        >
+          {children}
+        </div>
+      </div>
+      <div
+        className={classNames(
+          mapArrowVariantToClass(variant),
+          mapArrowSideToClass(side),
+          mapArrowPositionToClass(position)
+        )}
+        style={getArrowStyle(boxOffset, side)}
+      />
+    </div>
+  )
+)
 
 const getRootStyle = (boxOffset: number | undefined) => ({
   transform:

--- a/packages/component-library/draft/Kaizen/Popover/Popover.tsx
+++ b/packages/component-library/draft/Kaizen/Popover/Popover.tsx
@@ -55,12 +55,7 @@ const Popover: Popover = ({
   onClose,
   singleLine = false,
 }: Props) => (
-  <div
-    className={classNames(
-      mapVariantToRootClass(variant),
-      mapSizeToClass(size)
-    )}
-  >
+  <div className={classNames(styles.root, mapSizeToClass(size))}>
     <div
       className={classNames(
         mapArrowVariantToClass(variant),
@@ -68,37 +63,41 @@ const Popover: Popover = ({
         mapArrowPositionToClass(position),
       )}
     />
-    <div className={styles.header}>
-      {variant !== "default" && (
-        <span className={styles.icon}>
-          <Icon role="presentation" icon={mapVariantToIcon(variant)} />
-        </span>
-      )}
-      <div className={styles.singleLine}>{heading}</div>
-      {dismissible && (
-        <button className={styles.close} onClick={onClose}>
-          <Icon role="presentation" icon={closeIcon} />
-        </button>
-      )}
-    </div>
-    <div className={classNames(styles.container, mapLineVariant(singleLine))}>
-      {children}
+    <div
+      className={mapVariantToBoxClass(variant)}
+    >
+      <div className={styles.header}>
+        {variant !== "default" && (
+          <span className={styles.icon}>
+            <Icon role="presentation" icon={mapVariantToIcon(variant)} />
+          </span>
+        )}
+        <div className={styles.singleLine}>{heading}</div>
+        {dismissible && (
+          <button className={styles.close} onClick={onClose}>
+            <Icon role="presentation" icon={closeIcon} />
+          </button>
+        )}
+      </div>
+      <div className={classNames(styles.container, mapLineVariant(singleLine))}>
+        {children}
+      </div>
     </div>
   </div>
 )
 
-const mapVariantToRootClass = (variant: Variant): string => {
+const mapVariantToBoxClass = (variant: Variant): string => {
   switch (variant) {
     case "informative":
-      return styles.informative
+      return styles.informativeBox
     case "positive":
-      return styles.positive
+      return styles.positiveBox
     case "negative":
-      return styles.negative
+      return styles.negativeBox
     case "cautionary":
-      return styles.cautionary
+      return styles.cautionaryBox
     default:
-      return styles.default
+      return styles.defaultBox
   }
 }
 
@@ -137,9 +136,9 @@ const mapArrowVariantToClass = (variant: Variant): string => {
 const mapArrowPositionToClass = (position: Position): string => {
   switch (position) {
     case "start":
-      return styles.positionStart
+      return styles.arrowPositionStart
     case "end":
-      return styles.positionEnd
+      return styles.arrowPositionEnd
     default:
       return ""
   }
@@ -148,7 +147,7 @@ const mapArrowPositionToClass = (position: Position): string => {
 const mapArrowSideToClass = (side: Side): string => {
   switch (side) {
     case "top":
-      return styles.sideTop
+      return styles.arrowSideTop
     default:
       return ""
   }

--- a/packages/component-library/draft/Kaizen/Popover/Popover.tsx
+++ b/packages/component-library/draft/Kaizen/Popover/Popover.tsx
@@ -35,7 +35,7 @@ type Variant =
   | "negative"
   | "cautionary"
 
-type Side = "top" | "bottom" | "left" | "right"
+type Side = "top" | "bottom" // | "left" | "right" - not yet implemented
 
 type Position = "start" | "center" | "end"
 
@@ -57,18 +57,11 @@ const Popover: Popover = ({
   singleLine = false,
   boxOffset,
 }: Props) => (
-  <div className={classNames(styles.root, mapSizeToClass(size))}>
-    <div
-      className={classNames(
-        mapArrowVariantToClass(variant),
-        mapArrowSideToClass(side),
-        mapArrowPositionToClass(position),
-      )}
-    />
-    <div
-      className={mapVariantToBoxClass(variant)}
-      style={getBoxOffsetStyles(boxOffset)}
-    >
+  <div
+    className={classNames(styles.root, mapSizeToClass(size))}
+    style={getRootStyle(boxOffset)}
+  >
+    <div className={mapVariantToBoxClass(variant)}>
       <div className={styles.header}>
         {variant !== "default" && (
           <span className={styles.icon}>
@@ -86,8 +79,23 @@ const Popover: Popover = ({
         {children}
       </div>
     </div>
+    <div
+      className={classNames(
+        mapArrowVariantToClass(variant),
+        mapArrowSideToClass(side),
+        mapArrowPositionToClass(position)
+      )}
+      style={getArrowStyle(boxOffset, side)}
+    />
   </div>
 )
+
+const getRootStyle = (boxOffset: number | undefined) => ({
+  transform:
+    boxOffset == null
+      ? `translateX(-50%)`
+      : `translateX(calc(-50% + ${boxOffset}px)`,
+})
 
 const mapVariantToBoxClass = (variant: Variant): string => {
   switch (variant) {
@@ -104,10 +112,21 @@ const mapVariantToBoxClass = (variant: Variant): string => {
   }
 }
 
-const getBoxOffsetStyles = (boxOffset: number | undefined) =>
-  boxOffset == null
-    ? undefined
-    : { transform: `translateX(${boxOffset}px)` }
+const getArrowStyle = (boxOffset: number | undefined, side: Side) => {
+  const rotate = side === "top" ? "rotate(180deg)" : ""
+  const translate =
+    boxOffset == null
+      ? ""
+      : // Because we shifted the popover in the parent, we need to readjust the
+        // arrow back to where it was.
+        `translateX(${boxOffset * -1}px)`
+
+  return rotate || translate
+    ? {
+        transform: `${translate}${rotate}`,
+      }
+    : undefined
+}
 
 const mapVariantToIcon = (
   variant: Variant

--- a/packages/component-library/draft/Kaizen/Popover/Popover.tsx
+++ b/packages/component-library/draft/Kaizen/Popover/Popover.tsx
@@ -9,6 +9,7 @@ const positiveIcon = require("@cultureamp/kaizen-component-library/icons/success
   .default
 import classNames from "classnames"
 import * as React from "react"
+import { forwardRef } from "react"
 
 const styles = require("./styles.scss")
 
@@ -43,7 +44,7 @@ type Size = "small" | "large"
 
 type Popover = React.FunctionComponent<Props>
 
-const Popover: Popover = ({
+const Popover: Popover = forwardRef<HTMLDivElement, Props>(({
   id,
   automationId,
   children,
@@ -56,10 +57,11 @@ const Popover: Popover = ({
   onClose,
   singleLine = false,
   boxOffset,
-}: Props) => (
+}, ref) => (
   <div
     className={classNames(styles.root, mapSizeToClass(size))}
     style={getRootStyle(boxOffset)}
+    ref={ref}
   >
     <div className={mapVariantToBoxClass(variant)}>
       <div className={styles.header}>
@@ -88,7 +90,7 @@ const Popover: Popover = ({
       style={getArrowStyle(boxOffset, side)}
     />
   </div>
-)
+))
 
 const getRootStyle = (boxOffset: number | undefined) => ({
   transform:

--- a/packages/component-library/draft/Kaizen/Popover/Popover.tsx
+++ b/packages/component-library/draft/Kaizen/Popover/Popover.tsx
@@ -58,11 +58,16 @@ const Popover: Popover = ({
   <div
     className={classNames(
       mapVariantToRootClass(variant),
-      mapSideToClass(side),
-      mapPositionToClass(position),
       mapSizeToClass(size)
     )}
   >
+    <div
+      className={classNames(
+        mapArrowVariantToClass(variant),
+        mapArrowSideToClass(side),
+        mapArrowPositionToClass(position),
+      )}
+    />
     <div className={styles.header}>
       {variant !== "default" && (
         <span className={styles.icon}>
@@ -114,23 +119,38 @@ const mapVariantToIcon = (
   }
 }
 
-const mapPositionToClass = (position: Position): string => {
+const mapArrowVariantToClass = (variant: Variant): string => {
+  switch (variant) {
+    case "informative":
+      return styles.informativeArrow
+    case "positive":
+      return styles.positiveArrow
+    case "negative":
+      return styles.negativeArrow
+    case "cautionary":
+      return styles.cautionaryArrow
+    default:
+      return styles.defaultArrow
+  }
+}
+
+const mapArrowPositionToClass = (position: Position): string => {
   switch (position) {
     case "start":
       return styles.positionStart
     case "end":
       return styles.positionEnd
     default:
-      return "center"
+      return ""
   }
 }
 
-const mapSideToClass = (side: Side): string => {
+const mapArrowSideToClass = (side: Side): string => {
   switch (side) {
     case "top":
       return styles.sideTop
     default:
-      return "bottom"
+      return ""
   }
 }
 

--- a/packages/component-library/draft/Kaizen/Popover/Popover.tsx
+++ b/packages/component-library/draft/Kaizen/Popover/Popover.tsx
@@ -25,6 +25,7 @@ export interface Props {
   readonly dismissible?: boolean
   readonly singleLine?: boolean
   readonly children: React.ReactNode
+  readonly boxOffset?: number
 }
 
 type Variant =
@@ -54,6 +55,7 @@ const Popover: Popover = ({
   dismissible = false,
   onClose,
   singleLine = false,
+  boxOffset,
 }: Props) => (
   <div className={classNames(styles.root, mapSizeToClass(size))}>
     <div
@@ -65,6 +67,7 @@ const Popover: Popover = ({
     />
     <div
       className={mapVariantToBoxClass(variant)}
+      style={getBoxOffsetStyles(boxOffset)}
     >
       <div className={styles.header}>
         {variant !== "default" && (
@@ -100,6 +103,11 @@ const mapVariantToBoxClass = (variant: Variant): string => {
       return styles.defaultBox
   }
 }
+
+const getBoxOffsetStyles = (boxOffset: number | undefined) =>
+  boxOffset == null
+    ? undefined
+    : { transform: `translateX(${boxOffset}px)` }
 
 const mapVariantToIcon = (
   variant: Variant

--- a/packages/component-library/draft/Kaizen/Popover/styles.scss
+++ b/packages/component-library/draft/Kaizen/Popover/styles.scss
@@ -139,7 +139,6 @@ $large: 450px;
 .icon {
   display: inherit;
   margin-right: $ca-grid / 4;
-
 }
 
 .informativeIcon {

--- a/packages/component-library/draft/Kaizen/Popover/styles.scss
+++ b/packages/component-library/draft/Kaizen/Popover/styles.scss
@@ -68,7 +68,6 @@ $large: 450px;
   }
 }
 
-.root,
 %root {
   width: 220px;
   background: #fff;
@@ -84,7 +83,9 @@ $large: 450px;
 
 .default {
   @extend %root;
+}
 
+.defaultArrow {
   @include arrow(#fff, add-tint($ca-palette-ink, 80%));
 }
 
@@ -92,7 +93,9 @@ $large: 450px;
   @extend %root;
   background: add-tint($ca-palette-ocean, 90%);
   border-color: add-tint($ca-palette-ocean, 60%);
+}
 
+.informativeArrow {
   @include arrow(
     add-tint($ca-palette-ocean, 90%),
     add-tint($ca-palette-ocean, 60%)
@@ -103,7 +106,9 @@ $large: 450px;
   @extend %root;
   background: add-tint($ca-palette-seedling, 90%);
   border-color: add-tint($ca-palette-seedling, 60%);
+}
 
+.positiveArrow {
   @include arrow(
     add-tint($ca-palette-seedling, 90%),
     add-tint($ca-palette-seedling, 60%)
@@ -114,7 +119,9 @@ $large: 450px;
   @extend %root;
   background: add-tint($ca-palette-coral, 95%);
   border-color: add-tint($ca-palette-coral, 60%);
+}
 
+.negativeArrow {
   @include arrow(
     add-tint($ca-palette-coral, 95%),
     add-tint($ca-palette-coral, 60%)
@@ -125,7 +132,9 @@ $large: 450px;
   @extend %root;
   background: add-tint($ca-palette-yuzu, 90%);
   border-color: add-tint($ca-palette-yuzu, 40%);
+}
 
+.cautionaryArrow {
   @include arrow(
     add-tint($ca-palette-yuzu, 90%),
     add-tint($ca-palette-yuzu, 40%)
@@ -178,7 +187,7 @@ $large: 450px;
   color: add-alpha(#000, 50%);
 }
 
-.sideTop {
+.arrowSideTop {
   &::before,
   &::after {
     top: 0;
@@ -190,7 +199,7 @@ $large: 450px;
   }
 }
 
-.positionStart {
+.arrowPositionStart {
   &::before,
   &::after {
     left: $ca-grid;
@@ -198,7 +207,7 @@ $large: 450px;
   }
 }
 
-.positionEnd {
+.arrowPositionEnd {
   &::before,
   &::after {
     right: $ca-grid;

--- a/packages/component-library/draft/Kaizen/Popover/styles.scss
+++ b/packages/component-library/draft/Kaizen/Popover/styles.scss
@@ -73,6 +73,13 @@ $large: 450px;
   position: absolute;
   left: 50%;
   transform: translateX(-50%);
+
+  // If we set the box offset property, there will be an invisible div that block the content behind it.
+  // So we set the pointer events to none, and turn them back on immediately afterwards.
+  pointer-events: none;
+  & > * {
+    pointer-events: initial;
+  }
 }
 
 %box {

--- a/packages/component-library/draft/Kaizen/Popover/styles.scss
+++ b/packages/component-library/draft/Kaizen/Popover/styles.scss
@@ -18,7 +18,6 @@ $large: 450px;
   position: absolute;
   top: 100%;
   left: 50%;
-  margin-left: -$size;
 
   &::before,
   &::after {

--- a/packages/component-library/draft/Kaizen/Popover/styles.scss
+++ b/packages/component-library/draft/Kaizen/Popover/styles.scss
@@ -10,21 +10,24 @@
 $default-size: 8px;
 $large: 450px;
 
-@mixin arrow(
-  $background-color,
-  $border-color,
-  $size: $default-size,
-  $side: bottom,
-  $position: center
-) {
+// Suggestion: with this implementation, the anchor point of the popover is at the base of the triangle. But,
+// we would ideally want it at the tip of the triangle. Otherwise, when using the popover, the consumer needs to manually
+// add something like a `margin-top: 8px` to get the popover properly positioned.
+// I didn't update this, as I didn't want to introduce a breaking change.
+@mixin arrow($background-color, $border-color, $size: $default-size) {
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  margin-left: -$size;
+
   &::before,
   &::after {
     content: "";
     position: absolute;
     border-left: $size solid transparent;
     border-right: $size solid transparent;
-    top: 100%;
-    left: 50%;
+    top: 0;
+    left: 0;
     margin-left: -$size;
   }
 
@@ -38,48 +41,13 @@ $large: 450px;
     margin-top: -1px;
     z-index: 1;
   }
-
-  /* Side modifiers */
-  @if $side == top {
-    &::before,
-    &::after {
-      top: 0;
-      transform: rotate(180deg) translateY(100%);
-    }
-
-    &::after {
-      margin-top: 1px;
-    }
-  }
-
-  /* Position modifiers */
-  @if $position == start {
-    &::before,
-    &::after {
-      left: $ca-grid;
-      right: auto;
-    }
-  } @else if $position == end {
-    &::before,
-    &::after {
-      right: $ca-grid;
-      left: auto;
-    }
-  }
 }
 
 .root {
   width: 220px;
   position: absolute;
   left: 50%;
-  transform: translateX(-50%);
-
-  // If we set the box offset property, there will be an invisible div that block the content behind it.
-  // So we set the pointer events to none, and turn them back on immediately afterwards.
-  pointer-events: none;
-  & > * {
-    pointer-events: initial;
-  }
+  // also see the component file under getRootStyle, which will transform the element
 }
 
 %box {
@@ -198,31 +166,20 @@ $large: 450px;
 }
 
 .arrowSideTop {
-  &::before,
-  &::after {
-    top: 0;
-    transform: rotate(180deg) translateY(100%);
-  }
-
-  &::after {
-    margin-top: 1px;
-  }
+  top: initial;
+  bottom: 100%;
+  margin-top: 1px;
+  // Also see getArrowStyle in the component file, which will rotate the arrow 180 degrees
 }
 
 .arrowPositionStart {
-  &::before,
-  &::after {
-    left: $ca-grid;
-    right: auto;
-  }
+  left: $ca-grid;
+  right: auto;
 }
 
 .arrowPositionEnd {
-  &::before,
-  &::after {
-    right: $ca-grid;
-    left: auto;
-  }
+  right: $ca-grid;
+  left: auto;
 }
 
 .large {

--- a/packages/component-library/draft/Kaizen/Popover/styles.scss
+++ b/packages/component-library/draft/Kaizen/Popover/styles.scss
@@ -140,21 +140,22 @@ $large: 450px;
   display: inherit;
   margin-right: $ca-grid / 4;
 
-  .informative & {
-    color: add-tint($ca-palette-ocean, 30%);
-  }
+}
 
-  .positive & {
-    color: add-tint($ca-palette-seedling, 30%);
-  }
+.informativeIcon {
+  color: add-tint($ca-palette-ocean, 30%);
+}
 
-  .negative & {
-    color: $ca-palette-coral;
-  }
+.positiveIcon {
+  color: add-tint($ca-palette-seedling, 30%);
+}
 
-  .cautionary & {
-    color: $ca-palette-yuzu;
-  }
+.negativeIcon {
+  color: $ca-palette-coral;
+}
+
+.cautionaryIcon {
+  color: $ca-palette-yuzu;
 }
 
 .close {

--- a/packages/component-library/draft/Kaizen/Popover/styles.scss
+++ b/packages/component-library/draft/Kaizen/Popover/styles.scss
@@ -68,29 +68,32 @@ $large: 450px;
   }
 }
 
-%root {
+.root {
   width: 220px;
+  position: absolute;
+  left: 50%;
+  transform: translateX(-50%);
+}
+
+%box {
   background: #fff;
   border: 1px solid add-tint($ca-palette-ink, 80%);
   filter: drop-shadow(0 0 7px rgba(0, 0, 0, 0.1));
   border-radius: $ca-border-radius;
   color: $ca-palette-lapis;
-  position: absolute;
-  left: 50%;
-  transform: translateX(-50%);
   text-align: left;
 }
 
-.default {
-  @extend %root;
+.defaultBox {
+  @extend %box;
 }
 
 .defaultArrow {
   @include arrow(#fff, add-tint($ca-palette-ink, 80%));
 }
 
-.informative {
-  @extend %root;
+.informativeBox {
+  @extend %box;
   background: add-tint($ca-palette-ocean, 90%);
   border-color: add-tint($ca-palette-ocean, 60%);
 }
@@ -102,8 +105,8 @@ $large: 450px;
   );
 }
 
-.positive {
-  @extend %root;
+.positiveBox {
+  @extend %box;
   background: add-tint($ca-palette-seedling, 90%);
   border-color: add-tint($ca-palette-seedling, 60%);
 }
@@ -115,8 +118,8 @@ $large: 450px;
   );
 }
 
-.negative {
-  @extend %root;
+.negativeBox {
+  @extend %box;
   background: add-tint($ca-palette-coral, 95%);
   border-color: add-tint($ca-palette-coral, 60%);
 }
@@ -128,8 +131,8 @@ $large: 450px;
   );
 }
 
-.cautionary {
-  @extend %root;
+.cautionaryBox {
+  @extend %box;
   background: add-tint($ca-palette-yuzu, 90%);
   border-color: add-tint($ca-palette-yuzu, 40%);
 }

--- a/packages/component-library/stories/Popover.stories.tsx
+++ b/packages/component-library/stories/Popover.stories.tsx
@@ -96,13 +96,23 @@ storiesOf("Popover", module)
   .add("Box offset", () => (
     <>
       <div style={{ marginTop: "1.5rem", height: 200 }}>
-        <Popover heading="Box offset" position="center" side="top" boxOffset={-50}>
+        <Popover
+          heading="Box offset"
+          position="center"
+          side="top"
+          boxOffset={-50}
+        >
           Popover body that explains something useful, is optional, and not
           critical to completing a task.
         </Popover>
       </div>
       <div style={{ marginTop: "1.5rem", height: 200 }}>
-        <Popover heading="Box offset" position="end" side="bottom" boxOffset={20}>
+        <Popover
+          heading="Box offset"
+          position="center"
+          side="bottom"
+          boxOffset={50}
+        >
           Popover body that explains something useful, is optional, and not
           critical to completing a task.
         </Popover>

--- a/packages/component-library/stories/Popover.stories.tsx
+++ b/packages/component-library/stories/Popover.stories.tsx
@@ -93,6 +93,22 @@ storiesOf("Popover", module)
       </Popover>
     </div>
   ))
+  .add("Box offset", () => (
+    <>
+      <div style={{ marginTop: "1.5rem", height: 200 }}>
+        <Popover heading="Box offset" position="center" side="top" boxOffset={-50}>
+          Popover body that explains something useful, is optional, and not
+          critical to completing a task.
+        </Popover>
+      </div>
+      <div style={{ marginTop: "1.5rem", height: 200 }}>
+        <Popover heading="Box offset" position="end" side="bottom" boxOffset={20}>
+          Popover body that explains something useful, is optional, and not
+          critical to completing a task.
+        </Popover>
+      </div>
+    </>
+  ))
 
 loadElmStories("Popover (Elm)", module, require("./PopoverStories.elm"), [
   "Default",


### PR DESCRIPTION
Add `boxOffset` property to the `Popover` component. It will shift the popover box a specified amount, without moving the popover arrow.

![image](https://user-images.githubusercontent.com/4495057/71139166-81054600-2261-11ea-8e8d-8e6133d03e0f.png)

*(the snapshot above is slightly off centre, but that has now been fixed)*

This task links to a requirement of ticket CORE-348 in perform. We needed to show a popover, have the popover arrow centered to the sibling button, but the box to not go past the main body margin. This new property will give us the flexibility to achieve this.

Side updates:
* Removal of some dead scss code in the `arrow` mixin
* Removal of the `position` `left` and `right` options, since they aren't yet implemented.
* Separate the popover arrow to its own element, as to give more flexibility on how it is positioned.

Notes:
One of the ugly things that I've introduced is some fragmentation of styling. Because we now allow for manually updating the position via javascript, we are forced to have some styling in javascript, and some in scss. I'm not sure the best way to get around this, other than going all in on javascript styles (which I would be very happy to do 😛).

I've gone through all of the storybook stories, to make sure there are no visual regressions, and it all looks good on my end.
