### PR TITLE
docs: update contributing docs the steps to add elm stories

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -101,6 +101,22 @@ You can also clean up generated files:
 
 `yarn clean`
 
+### Elm components stories
+Besides creating your Elm story on an Elm file, there is an extra step in order to make it appear on the storybook. 
+You have to refer it on the component's JS story.
+
+```
+-- MyComponent.tsx
+import { loadElmStories } from "@cultureamp/elm-storybook"
+
+// JS stories
+
+loadElmStories("MyComponent (Elm)", module, require("./MyComponent.elm"), [
+  "Your new story #1",
+  "Your new story #2",
+])
+```
+
 ## Releasing packages
 
 Automated releases to the npm public registry are triggered for all pull requests containing modifications to one or more npm packages (found in the `/packages/` directory). The information required to determine the version update for each release is taken from the title and content of the pull request.


### PR DESCRIPTION
I recently added elm stories, but couldn't see them showing on the storybook. I spent a while troubleshooting, digging docs, without success. I was only able to fix the issue after talking to an old contributor.
This PR documents an extra step you have to do after adding an elm story.