### PR TITLE
docs: Fix styles for inline code on Kaizen Site

### DIFF
--- a/site/src/styles/global.scss
+++ b/site/src/styles/global.scss
@@ -39,3 +39,10 @@ pre {
   padding: $ca-grid;
   line-height: 1.5;
 }
+
+code {
+  line-height: inherit;
+  background-color: $kz-color-stone;
+  padding: 0.25em;
+  border-radius: 0.25em;
+}

--- a/site/src/styles/markdown.scss
+++ b/site/src/styles/markdown.scss
@@ -166,12 +166,12 @@ $link-icon-margin: 12px;
     font-weight: $ca-weight-light;
   }
 
-  :global(.md-code) {
-    line-height: inherit;
-    background-color: $kz-color-wisteria-800;
-    // color: #fff;
-    padding: 0.25em;
-    border-radius: 0.25em;
+  :global(.md-pre) {
+    background-color: $kz-color-stone;
+
+    & :global(.md-code) {
+      padding: 0;
+    }
   }
 
   // :global(.md-lede) {


### PR DESCRIPTION
Before:

![image](https://user-images.githubusercontent.com/2476974/71391083-dc1aac80-2656-11ea-96c5-76461191004c.png)

After:

![image](https://user-images.githubusercontent.com/2476974/71391098-ec328c00-2656-11ea-85c3-a60955d16818.png)

Branch previews of pages with code blocks (and inline code):

- http://dev.cultureamp.design/di/fix-illegible-code-blocks/guidelines/animation/
- http://dev.cultureamp.design/di/fix-illegible-code-blocks/guidelines/layout/

This PR does:

- Move background color from `code` to `pre` for code blocks and updates the color value to make text legible again.
- Fix padding on `code` inside `pre`
- Move `code` styles from `.md-code {}` scope to `code {}` scope because
`md-code` class isn't being applied to `code` elements at this time.