### PR TITLE
docs: improve visibility of unbuilt components

### DIFF
--- a/site/docs/components/badge.mdx
+++ b/site/docs/components/badge.mdx
@@ -1,6 +1,6 @@
 ---
 title: Badge
-navTitle: Badge
+navTitle: Badge (not built)
 summaryParagraph: Badges show the count of some adjacent data. A dot badge notifies the user that something is new or updated without showing a count.
 tags: ["Tag", "Chip", "Label", "Pill", "Lozenge"]
 needToKnow:

--- a/site/docs/components/button-group.mdx
+++ b/site/docs/components/button-group.mdx
@@ -1,6 +1,6 @@
 ---
 title: Button Group
-navTitle: Button Group
+navTitle: Button Group (not built)
 summaryParagraph: Button Groups contain buttons that perform related actions.
 tags: ["Toggle Buttons", "Radio Button Groups", "Switchers"]
 needToKnow:

--- a/site/docs/components/card.mdx
+++ b/site/docs/components/card.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Card"
-navTitle: "Card"
+navTitle: "Card (not built)"
 summaryParagraph: Cards are a structural component to contain primary content.
 tags: ["Wells", "Panels", "Slats", "Rows", "List Rows", "Tiles", "Container", "Content area", "Box", "Rectangle"]
 needToKnow:

--- a/site/docs/components/divider.mdx
+++ b/site/docs/components/divider.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Divider"
-navTitle: "Divider"
+navTitle: "Divider (not built)"
 summaryParagraph: Dividers are thin lines that group content in lists and layouts, or separate blocks of content.
 tags: ["Horizontal rules", "HR", "Lines", "Stroke"]
 needToKnow:

--- a/site/docs/components/loading-skeleton.mdx
+++ b/site/docs/components/loading-skeleton.mdx
@@ -1,6 +1,6 @@
 ---
 title: Loading Skeleton
-navTitle: Loading Skeleton
+navTitle: Loading Skeleton (not built)
 summaryParagraph: A collection of loading placeholders that display a non-interactive preview of the app’s actual UI to visually communicate that content is in the process of loading.
 tags: ["Skeleton", "Stencil", "Loading Placeholders", "Placeholder UI"]
 needToKnow:

--- a/site/docs/components/loading-spinner.mdx
+++ b/site/docs/components/loading-spinner.mdx
@@ -1,6 +1,6 @@
 ---
 title: Loading Spinner
-navTitle: Loading Spinner
+navTitle: Loading Spinner (not built)
 summaryParagraph: An animated element that indicates loading is in process and where it will appear when loading data is slow.
 tags: ["Spinner", "Loader", "Progress indicators", "Circular indicators", "Indeterminate indicators"]
 needToKnow:

--- a/site/docs/components/tile.mdx
+++ b/site/docs/components/tile.mdx
@@ -1,6 +1,6 @@
 ---
 title: Tile
-navTitle: Tile
+navTitle: Tile (not built)
 summaryParagraph: A visually interesting item in a list consisting of a card, visual, title metadata, and call to action.
 tags: ["Card", "Grid item", "Featured item"]
 needToKnow:

--- a/site/src/components/SidebarAndContent.scss
+++ b/site/src/components/SidebarAndContent.scss
@@ -76,11 +76,11 @@ $sidebar-width: $ca-grid * 10;
   display: flex;
   align-items: center;
   box-sizing: border-box;
-  font-size: 20px;
+  font-size: 18px;
   line-height: 24px;
 
   a {
-    padding: $ca-grid / 2.5 $ca-grid / 2;
+    padding: $ca-grid * 0.25 $ca-grid / 2;
     width: 100%;
     text-decoration: none;
     color: inherit;

--- a/site/src/components/SidebarAndContent.scss
+++ b/site/src/components/SidebarAndContent.scss
@@ -54,7 +54,7 @@ $sidebar-width: $ca-grid * 10;
 
 .sidebar {
   grid-area: sidebar;
-  margin-top: $ca-grid;
+  margin-top: $ca-grid * 1.5;
 }
 
 .sidebarSectionTitle {

--- a/site/src/styles/global.scss
+++ b/site/src/styles/global.scss
@@ -5,7 +5,7 @@
 
 :root {
   --ca-grid: #{$ca-grid};
-  --content-card-top-offset: calc(var(--ca-grid) * 2);
+  --content-card-top-offset: calc(var(--ca-grid) * 2.5);
   --sidebar-content-gap: calc(var(--ca-grid) * 2);
   --content-top-and-bottom-margin: calc(var(--ca-grid) * 4);
   --content-side-margin: calc(var(--ca-grid) * 6);


### PR DESCRIPTION
This PR:

- Adds “not built” to component nav titles for components that haven't been built
- Adjusts sizing for sidebar tabs for longer names
- Adjusts the layout so the sidebar aligns with "Need to know" heading

![image](https://user-images.githubusercontent.com/2476974/71611371-6d0bfd80-2bec-11ea-92c6-913bc8a845d6.png)

Branch previews:

- https://dev.cultureamp.design/di/improve-visibility-of-unbuilt-components/components/badge
- https://dev.cultureamp.design/di/improve-visibility-of-unbuilt-components/components/button-group
- https://dev.cultureamp.design/di/improve-visibility-of-unbuilt-components/components/card
- https://dev.cultureamp.design/di/improve-visibility-of-unbuilt-components/components/divider
- https://dev.cultureamp.design/di/improve-visibility-of-unbuilt-components/components/loading-skeleton
- https://dev.cultureamp.design/di/improve-visibility-of-unbuilt-components/components/loading-spinner
- https://dev.cultureamp.design/di/improve-visibility-of-unbuilt-components/components/tile

Fixes: #116 