### PR TITLE
fix: TableRowCell style to make it work on IE11

### DIFF
--- a/packages/component-library/draft/Kaizen/Table/styles.scss
+++ b/packages/component-library/draft/Kaizen/Table/styles.scss
@@ -68,6 +68,7 @@ $row-height: 60px;
   text-decoration: none;
   color: $ca-palette-ink;
   display: block;
+
   &:hover,
   &:active,
   &:focus {
@@ -141,4 +142,9 @@ $row-height: 60px;
   padding: 0 $ca-grid * 0.8;
   display: flex;
   align-items: center;
+
+  // IE11 don't like aling items when a min-height. 
+  &:after {
+    min-height: inherit;
+  }
 }

--- a/packages/component-library/draft/Kaizen/Table/styles.scss
+++ b/packages/component-library/draft/Kaizen/Table/styles.scss
@@ -143,7 +143,7 @@ $row-height: 60px;
   display: flex;
   align-items: center;
 
-  // IE11 don't like aling items when a min-height. 
+  // IE11 don't like aling items when a min-height.
   &:after {
     min-height: inherit;
   }


### PR DESCRIPTION
## Objective
On IE11 the content of the `TableRowCell` is not center aligned. 
Add style necessary to make content be centered.

### Context
We have a layout issue on `Performance` when displaying the `Table` component on `IE11`.
The style behind the `TableRowCell` is: 
```
.rowCell {
  min-height: $row-height;
  padding: 0 $ca-grid * 0.8;
  display: flex;
  align-items: center;
}
```
making the content of the row look like this (lightCoral background is the content)
![image](https://user-images.githubusercontent.com/3228237/71682428-7624d800-2d6e-11ea-9433-4f90b39d2e79.png)

Investigating a little bit seems that `IE11` don't like flex more specific the combination of `align-items: center` and `min-height: xxx` 
• https://stackoverflow.com/questions/19371626/flexbox-not-centering-vertically-in-ie
• https://github.com/philipwalton/flexbugs/issues/231

### Changes
Add an `:after` with `min-height: inherit;` as workaround.

![image](https://user-images.githubusercontent.com/3228237/71683149-79b95e80-2d70-11ea-9382-d8afba17f495.png)

### Notes
Tried the other workaround that found: Set a fixed `height` less than `min-height` this was making row cell don't expand on multiline table. 👎 

Was getting issues trying to run storybook locally on IE11 and also trying to link kaizen with `performance-ui`  so to test this i updated the code locally on perform and run it on IE11 to be sure fix is working. 
Unfortunately couldn't test the storybook on IE11 =[ 

Like i said, this is a workaround, not sure if is the best solution. 

**Slack conversations:** https://cultureamp.slack.com/archives/CETLTFG9G/p1577132688040100

