### PR TITLE
Make storybook work in ie11

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   },
   "babel": {
     "presets": [
+      "@babel/preset-env",
       "@babel/preset-typescript",
       "@babel/preset-react"
     ],


### PR DESCRIPTION
This PR allows storybook to run in ie11 by adding preset-env to babel-loader's list of presets