### PR TITLE
fix: Specify ie11 for @babel/preset-env

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,14 @@
   },
   "babel": {
     "presets": [
-      "@babel/preset-env",
+      [
+        "@babel/preset-env",
+        {
+          "targets": {
+            "ie": "11"
+          }
+        }
+      ],
       "@babel/preset-typescript",
       "@babel/preset-react"
     ],

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   },
   "babel": {
     "presets": [
+      "@babel/preset-env",
       "@babel/preset-typescript",
       "@babel/preset-react"
     ],

--- a/site/gatsby-node.js
+++ b/site/gatsby-node.js
@@ -37,7 +37,14 @@ exports.onCreateWebpackConfig = ({ actions, loaders }) => {
 exports.onCreateBabelConfig = ({ actions }, options) => {
   const { presets, plugins } = require("../package.json").babel
   presets.forEach(preset => {
-    actions.setBabelPreset({ name: require.resolve(preset), options })
+    actions.setBabelPreset(
+      Array.isArray(preset)
+        ? {
+            name: require.resolve(preset[0]),
+            options: preset[1],
+          }
+        : { name: require.resolve(preset), options }
+    )
   })
   plugins.forEach(plugin => {
     actions.setBabelPlugin({ name: require.resolve(plugin), options })


### PR DESCRIPTION
This PR adds makes storybook work in ie11 by adding @babel/preset-env.

In a previous PR (https://github.com/cultureamp/kaizen-design-system/pull/198), I added the name of the preset only, and this led to a break when running `yarn gatsby develop` (Which uses setBabelPreset to add an options object with a `plugins` field to each preset - which @babel/preset-env doesn't accept)

To address this break, this PR also adds a specific options object to @babel/preset-env (specifying ie11), and some logic in gatsby-node.js to check if a preset already has it's own options (and use that instead if it exists)