### PR TITLE
feat: add focus events to TextField

### DIFF
--- a/packages/component-library/draft/Kaizen/Form/Primitives/Input/Input.tsx
+++ b/packages/component-library/draft/Kaizen/Form/Primitives/Input/Input.tsx
@@ -21,6 +21,8 @@ export type InputProps = {
   startIconAdornment?: React.ReactNode
   endIconAdornment?: React.ReactNode
   onChange?: (event: React.ChangeEvent<HTMLInputElement>) => any
+  onBlur?: (event: React.FocusEvent<HTMLInputElement>) => any
+  onFocus?: (event: React.FocusEvent<HTMLInputElement>) => any
 }
 
 type Input = React.FunctionComponent<InputProps>
@@ -40,6 +42,8 @@ const Input: Input = ({
   startIconAdornment,
   endIconAdornment,
   onChange,
+  onBlur,
+  onFocus,
 }) => (
   <div
     className={classnames(styles.wrapper, {
@@ -62,6 +66,8 @@ const Input: Input = ({
       aria-describedby={ariaDescribedBy}
       placeholder={placeholder}
       onChange={onChange}
+      onBlur={onBlur}
+      onFocus={onFocus}
       disabled={disabled}
       className={classnames(
         styles.input,

--- a/packages/component-library/draft/Kaizen/Form/TextField/TextField.tsx
+++ b/packages/component-library/draft/Kaizen/Form/TextField/TextField.tsx
@@ -31,6 +31,8 @@ type TextField = React.FunctionComponent<{
   validationMessage?: string
   description?: string
   onChange: (event: React.ChangeEvent<HTMLInputElement>) => any
+  onBlur?: (event: React.FocusEvent<HTMLInputElement>) => any
+  onFocus?: (event: React.FocusEvent<HTMLInputElement>) => any
   name?: string
 }>
 
@@ -48,6 +50,8 @@ const TextField: TextField = ({
   status,
   icon,
   onChange,
+  onBlur,
+  onFocus,
   name,
 }) => {
   const validationMessageAria = validationMessage
@@ -88,6 +92,8 @@ const TextField: TextField = ({
         inputValue={inputValue}
         placeholder={placeholder}
         onChange={onChange}
+        onBlur={onBlur}
+        onFocus={onFocus}
         disabled={disabled}
         reversed={reversed}
         status={status}

--- a/packages/component-library/stories/TextField.stories.tsx
+++ b/packages/component-library/stories/TextField.stories.tsx
@@ -387,6 +387,28 @@ storiesOf("TextField", module)
       />
     </ExampleContainer>
   ))
+  .add("Default with Focus/Blur events", () => (
+    <ExampleContainer>
+      <TextField
+        id="email"
+        inputType="email"
+        inputValue=""
+        labelText={
+          <div>
+            This is a label with a{" "}
+            <a href="http://google.com" target="_blank">
+              link
+            </a>
+          </div>
+        }
+        placeholder="Please enter your email"
+        onFocus={action("onFocus fired")}
+        onBlur={action("onBlur fired")}
+        onChange={action("user input")}
+        description="Valid email addresses must have an @ and a suffix."
+      />
+    </ExampleContainer>
+  ))
 
 loadElmStories("TextField (Elm)", module, require("./TextFieldStories.elm"), [
   "Default",


### PR DESCRIPTION
Enable focus events (onBlur, onFocus) for the `TextField`.

Required for:

1. Analytics (event measurements required for event focus/blur).
2. Alignment with what we state in our guidelines (https://cultureamp.design/components/text-field/): `Most of the time, we validate text fields on "blur" (when leaving the text fields) or on form submission as needed. We don’t validate on key strokes.`

Added:

1. Optional focus events to types + component.
2. Example Story with events firing.

Note that this aligns to `open/closed` principle and should only be a minor update as the API is backwards compatible.