### PR TITLE
docs: Add initial guide for HeroCard

### DIFF
--- a/packages/component-library/draft/Kaizen/HeroCard/README.mdx
+++ b/packages/component-library/draft/Kaizen/HeroCard/README.mdx
@@ -1,0 +1,31 @@
+---
+title: HeroCard
+navTitle: HeroCard
+summaryParagraph: HeroCards are a large structural component to organise primary content.
+tags: ["Panel", "Card", "Container", "Box", "Table"]
+needToKnow:
+- The badge contains a number, ideally 1 character, showing a micro bit of information such as a step.
+- For image use a graphic illustration that supports what's going on in the rest of the card.
+- With title aim for 1 line of text.
+demoStoryId: herocard--default
+---
+
+## Visuals
+Coming soon.
+
+## When to use
+
+* To organize information that needs to be prominent and inviting.
+* When you have enough content to fill the space effectively. If you only have a little bit of information, use a
+guidance block or a [Card](/components/card) component.
+* When it's the primary feature of the page.
+* For "at a glance" information that focuses the user's attention on one thing.
+
+## When not to use
+
+*   When there's long form content underneath, such as high density data in a [Table](/components/table), consider using
+ a less prominent component, such as a guidance block or a [Card](/components/card) component.
+
+## See also
+
+*   [Card component](/components/card/)

--- a/packages/component-library/draft/Kaizen/HeroCard/README.mdx
+++ b/packages/component-library/draft/Kaizen/HeroCard/README.mdx
@@ -1,12 +1,12 @@
 ---
-title: HeroCard
-navTitle: HeroCard
-summaryParagraph: HeroCards are a large structural component to organise primary content.
+title: Hero Card
+navTitle: Hero Card
+summaryParagraph: Hero Cards are a large structural component for organizing primary content. They are used to create visual interest and draw attention.
 tags: ["Panel", "Card", "Container", "Box", "Table"]
 needToKnow:
 - The badge contains a number, ideally 1 character, showing a micro bit of information such as a step.
-- For image use a graphic illustration that supports what's going on in the rest of the card.
-- With title aim for 1 line of text.
+- For the image, use a graphic illustration that supports what's going on in the rest of the card.
+- For the title, aim for 1 line of text.
 demoStoryId: herocard--default
 ---
 


### PR DESCRIPTION
This adds an accompanying guide for the Hero Card component, which already exists in kaizen.

**Branch preview:** https://dev.cultureamp.design/pex/add-hero-card-guideline/