### PR TITLE
feat: Remove header divider if no heading prop is provided

### DIFF
--- a/packages/component-library/draft/Kaizen/Popover/Popover.tsx
+++ b/packages/component-library/draft/Kaizen/Popover/Popover.tsx
@@ -68,24 +68,26 @@ const Popover: Popover = forwardRef<HTMLDivElement, Props>(
       ref={ref}
     >
       <div className={mapVariantToBoxClass(variant)}>
-        <div className={styles.header}>
-          {variant !== "default" && (
-            <span
-              className={classNames(
-                styles.icon,
-                mapVariantToIconClass(variant)
-              )}
-            >
-              <Icon role="presentation" icon={mapVariantToIcon(variant)} />
-            </span>
-          )}
-          <div className={styles.singleLine}>{heading}</div>
-          {dismissible && (
-            <button className={styles.close} onClick={onClose}>
-              <Icon role="presentation" icon={closeIcon} />
-            </button>
-          )}
-        </div>
+        {heading && (
+          <div className={styles.header}>
+            {variant !== "default" && (
+              <span
+                className={classNames(
+                  styles.icon,
+                  mapVariantToIconClass(variant)
+                )}
+              >
+                <Icon role="presentation" icon={mapVariantToIcon(variant)} />
+              </span>
+            )}
+            <div className={styles.singleLine}>{heading}</div>
+            {dismissible && (
+              <button className={styles.close} onClick={onClose}>
+                <Icon role="presentation" icon={closeIcon} />
+              </button>
+            )}
+          </div>
+        )}
         <div
           className={classNames(styles.container, mapLineVariant(singleLine))}
         >

--- a/packages/component-library/stories/Popover.stories.tsx
+++ b/packages/component-library/stories/Popover.stories.tsx
@@ -10,6 +10,12 @@ storiesOf("Popover", module)
       to completing a task.
     </Popover>
   ))
+  .add("Default without heading", () => (
+    <Popover>
+      Popover body that explains something useful, is optional, and not critical
+      to completing a task.
+    </Popover>
+  ))
   .add("Informative", () => (
     <Popover heading="Informative" variant="informative">
       Popover body that explains something useful, is optional, and not critical


### PR DESCRIPTION
Hello DST 👋 

In Perform, we're in the need of a `Popover` that doesn't have a heading. If that prop isn't provided, the current `Popover` component still displays the header divider line and looks a bit out of place.

![image](https://user-images.githubusercontent.com/1225563/71912515-8f15fa80-316d-11ea-893c-b8231734173b.png)

What I did is to render the header (divider included) only if the `heading` prop is passed. The downside of this is that the dismiss button lives within the header, so with this change there's no way to have a dismissable, headerless popover. Is that ok?