### PR TITLE
fix: IE11 fixes for HeroCard

### DIFF
--- a/packages/component-library/draft/Kaizen/HeroCard/HeroCard.scss
+++ b/packages/component-library/draft/Kaizen/HeroCard/HeroCard.scss
@@ -57,6 +57,7 @@ $badge__height: 80px;
   border-radius: 50%;
   background-color: rgba(255, 255, 255, 0.1);
   align-self: flex-start;
+  line-height: 80px;
   min-width: 80px;
   min-height: 80px;
   align-items: center;


### PR DESCRIPTION
- Fixes an issue where number wasn't centred inside `HeroCard` badge

Before:
![IE11_-_Step_number_in_content_area_floats_high](https://user-images.githubusercontent.com/13988803/72121478-40f03980-33af-11ea-8ea1-c24f084b6193.png)
After:
<img width="175" alt="Screen Shot 2020-01-10 at 1 44 10 pm" src="https://user-images.githubusercontent.com/13988803/72121490-49e10b00-33af-11ea-8367-1ddfa35c79f7.png">

