### PR TITLE
feat: HeroCard enhancements

### DIFF
--- a/packages/component-library/draft/Kaizen/HeroCard/HeroCard.scss
+++ b/packages/component-library/draft/Kaizen/HeroCard/HeroCard.scss
@@ -3,7 +3,7 @@
 @import "~@cultureamp/kaizen-component-library/styles/color";
 @import "~@cultureamp/kaizen-component-library/styles/layout";
 
-$left-content__width: 221px;
+$left-content__width: 33%;
 $badge__height: 80px;
 
 .root {
@@ -24,7 +24,7 @@ $badge__height: 80px;
   border-radius: 5px 0 0 5px;
   background-color: $kz-color-wisteria-700;
   color: $kz-color-white;
-  min-width: $left-content__width;
+  width: $left-content__width;
   padding: ($ca-grid / 2) ($ca-grid * 2);
   flex-direction: column;
   align-items: flex-start;
@@ -37,10 +37,16 @@ $badge__height: 80px;
 
 .right {
   border-radius: 0 5px 5px 0;
+  display: flex;
+  flex-direction: column;
   padding: 51px;
   background-color: $kz-color-white;
-  flex: 2 2 auto;
+  flex: 1;
   color: $kz-color-wisteria-800;
+}
+
+.rightContent {
+  height: 100%;
 }
 
 .title {

--- a/packages/component-library/draft/Kaizen/HeroCard/HeroCard.scss
+++ b/packages/component-library/draft/Kaizen/HeroCard/HeroCard.scss
@@ -3,8 +3,8 @@
 @import "~@cultureamp/kaizen-component-library/styles/color";
 @import "~@cultureamp/kaizen-component-library/styles/layout";
 
-$left-content__width: 33%;
 $badge__height: 80px;
+$left-content__width: 221px;
 
 .root {
   @include ca-type-ideal-body;
@@ -24,11 +24,16 @@ $badge__height: 80px;
   border-radius: 5px 0 0 5px;
   background-color: $kz-color-wisteria-700;
   color: $kz-color-white;
-  width: $left-content__width;
   padding: ($ca-grid / 2) ($ca-grid * 2);
   flex-direction: column;
   align-items: flex-start;
   position: relative;
+  width: $left-content__width;
+
+  .fullWidth & {
+    width: 33%;
+    max-width: 450px;
+  }
 }
 
 .withBadge {
@@ -41,7 +46,6 @@ $badge__height: 80px;
   flex-direction: column;
   padding: 51px;
   background-color: $kz-color-white;
-  flex: 1;
   color: $kz-color-wisteria-800;
 }
 

--- a/packages/component-library/draft/Kaizen/HeroCard/HeroCard.scss
+++ b/packages/component-library/draft/Kaizen/HeroCard/HeroCard.scss
@@ -26,6 +26,7 @@ $left-content__width: 221px;
   color: $kz-color-white;
   padding: ($ca-grid / 2) ($ca-grid * 2);
   flex-direction: column;
+  flex-shrink: 0;
   align-items: flex-start;
   position: relative;
   width: $left-content__width;
@@ -47,6 +48,10 @@ $left-content__width: 221px;
   padding: 51px;
   background-color: $kz-color-white;
   color: $kz-color-wisteria-800;
+
+  .fullWidth & {
+    width: 66%;
+  }
 }
 
 .rightContent {

--- a/packages/component-library/draft/Kaizen/HeroCard/HeroCard.scss
+++ b/packages/component-library/draft/Kaizen/HeroCard/HeroCard.scss
@@ -65,12 +65,3 @@ $badge__height: 80px;
   top: $ca-grid;
   left: $ca-grid * 1.2;
 }
-
-.image {
-  width: $left-content__width + 128px;
-  height: auto;
-  position: absolute;
-  bottom: -128px;
-  left: 50%;
-  transform: translateX(-50%);
-}

--- a/packages/component-library/draft/Kaizen/HeroCard/HeroCard.tsx
+++ b/packages/component-library/draft/Kaizen/HeroCard/HeroCard.tsx
@@ -10,6 +10,7 @@ interface Props {
   readonly image?: React.ReactNode
   readonly badgeText?: String
   readonly fullWidth?: Boolean
+  readonly minHeight?: string
 }
 
 type HeroCard = React.FunctionComponent<Props>
@@ -20,6 +21,7 @@ const HeroCard: HeroCard = ({
   title,
   image,
   badgeText,
+  minHeight = "none",
   fullWidth = false,
 }: Props) => {
   return (
@@ -28,7 +30,7 @@ const HeroCard: HeroCard = ({
         [styles.fullWidth]: fullWidth,
       })}
     >
-      <div className={styles.left}>
+      <div style={{ minHeight }} className={styles.left}>
         {badgeText && <div className={styles.badge}>{badgeText}</div>}
         {leftContent && (
           <div
@@ -43,7 +45,7 @@ const HeroCard: HeroCard = ({
       </div>
       <div className={styles.right}>
         {title && <h1 className={styles.title}>{title}</h1>}
-        {children}
+        <div className={styles.rightContent}>{children}</div>
       </div>
     </div>
   )

--- a/packages/component-library/draft/Kaizen/HeroCard/HeroCard.tsx
+++ b/packages/component-library/draft/Kaizen/HeroCard/HeroCard.tsx
@@ -39,7 +39,7 @@ const HeroCard: HeroCard = ({
             {leftContent}
           </div>
         )}
-        {image && <div className={styles.image}>{image}</div>}
+        {image}
       </div>
       <div className={styles.right}>
         {title && <h1 className={styles.title}>{title}</h1>}

--- a/packages/component-library/stories/HeroCard.stories.tsx
+++ b/packages/component-library/stories/HeroCard.stories.tsx
@@ -53,7 +53,18 @@ storiesOf("HeroCard", module)
       <HeroCard
         title="Preview the survey questions"
         badgeText="1"
-        image={<img src={surveyIllustration} alt="survey-preview-image" />}
+        image={
+          <img
+            src={surveyIllustration}
+            alt="survey-preview-image"
+            style={{
+              position: "absolute",
+              bottom: "15px",
+              left: "0",
+              width: "100%",
+            }}
+          />
+        }
       >
         {renderContent()}
       </HeroCard>


### PR DESCRIPTION
### HeroCard Enhancements
- Removed image wrapper - allows for more granular control of image placement from outside of the component
- Made left column 1/3 to align with designs
- Made content under title stretch to fill rest of card
- Allow for `minHeight` attribute to set minimum height of the card from outside the card. (For IE11 compatibility) - known IE11 flex bug.