### PR TITLE
docs: Updated references of Ocean to Cluny

### DIFF
--- a/site/docs/guidelines/color.mdx
+++ b/site/docs/guidelines/color.mdx
@@ -50,7 +50,7 @@ Used for links (Cluny 500), control actions, guidance and onboarding.
 
 ### Links
 
-To indicate links and on-page actions, use Ocean.
+To indicate links and on-page actions, use Cluny.
 
 ### Primary action
 
@@ -68,7 +68,7 @@ To indicate Sentiment, use:
 
 ## When to use
 
-- Colors can help to create visual patterns that the user can recall (for example, links are always Ocean colored or negative favorability scores, errors, and destructive actions are always Coral).
+- Colors can help to create visual patterns that the user can recall (for example, links are always Cluny colored or negative favorability scores, errors, and destructive actions are always Coral).
 - Use colors to create visual hierarchy.
 - Colors can help to determine the level of severity.
 - Add tone and contrast to define areas and guide or call out certain information.


### PR DESCRIPTION
Fixes: #217 

Changed references to Ocean (below) to Cluny:

- To indicate links and on-page actions, use Ocean.
- Colors can help to create visual patterns that the user can recall (for example, links are always Ocean colored or negative favorability scores, errors, and destructive actions are always Coral).