### PR TITLE
feat: Add ability to specify if elm popover has variable height and apply relevant styles

### DIFF
--- a/packages/component-library/draft/Kaizen/Popover/Popover.elm
+++ b/packages/component-library/draft/Kaizen/Popover/Popover.elm
@@ -14,10 +14,12 @@ module Kaizen.Popover.Popover exposing
     , withContent
     , withHeading
     , withTipPosition
+    , withVariableHeight
     )
 
 import CssModules exposing (css)
 import Html exposing (Html, button, div, span, text)
+import Html.Attributes
 import Html.Events exposing (onClick)
 import Icon.Icon as Icon
 import Icon.SvgAsset exposing (svgAsset)
@@ -40,6 +42,7 @@ type alias ConfigValue msg =
     , heading : Maybe String
     , variant : Variant
     , tipPosition : ( Side, Position )
+    , forVariableHeight : Bool
     }
 
 
@@ -53,6 +56,7 @@ defaults =
     , heading = Nothing
     , variant = Default
     , tipPosition = ( Bottom, Center )
+    , forVariableHeight = False
     }
 
 
@@ -150,6 +154,11 @@ withPosition value (Config config) =
     Config { config | tipPosition = ( value, Center ) }
 
 
+withVariableHeight : Bool -> Config msg -> Config msg
+withVariableHeight value (Config config) =
+    Config { config | forVariableHeight = value }
+
+
 
 -- VIEW
 
@@ -174,12 +183,14 @@ view (Config config) =
             mapPositionToClass config.tipPosition
     in
     div
-        [ styles.classList
+        ([ styles.classList
             [ ( mapVariantToRootClass config.variant, True )
             , ( sideClass, True )
             , ( positionClass, True )
             ]
-        ]
+         ]
+            ++ mapVariableHeightToAttribute config.forVariableHeight config.tipPosition
+        )
         [ case config.heading of
             Just heading ->
                 div [ styles.class .header ]
@@ -211,6 +222,8 @@ styles =
         , positionStart = "positionStart"
         , positionCenter = "positionCenter"
         , positionEnd = "positionEnd"
+        , bottomAttribute = "bottomAttribute"
+        , topAttribute = "topAttribute"
         }
 
 
@@ -293,3 +306,21 @@ mapPositionToClass tipPosition =
 
         ( _, _ ) ->
             ( .sideBottom, .positionCenter )
+
+
+mapVariableHeightToAttribute : Bool -> ( Side, Position ) -> List (Html.Attribute msg)
+mapVariableHeightToAttribute value ( side, position ) =
+    case value of
+        True ->
+            case side of
+                Bottom ->
+                    [ styles.class .bottomAttribute ]
+
+                Top ->
+                    [ styles.class .topAttribute ]
+
+                _ ->
+                    []
+
+        False ->
+            []

--- a/packages/component-library/draft/Kaizen/Popover/styles.scss
+++ b/packages/component-library/draft/Kaizen/Popover/styles.scss
@@ -192,3 +192,11 @@ $large: 450px;
   white-space: nowrap;
   overflow: hidden;
 }
+
+.bottomAttribute {
+  bottom: 100%;
+}
+
+.topAttribute {
+  top: 100%;
+}

--- a/packages/component-library/stories/Popover.stories.tsx
+++ b/packages/component-library/stories/Popover.stories.tsx
@@ -136,4 +136,5 @@ loadElmStories("Popover (Elm)", module, require("./PopoverStories.elm"), [
   "Arrow above",
   "Arrow start",
   "Arrow end",
+  "With Variable Height",
 ])

--- a/packages/component-library/stories/PopoverStories.elm
+++ b/packages/component-library/stories/PopoverStories.elm
@@ -82,4 +82,11 @@ main =
                         |> Popover.withTipPosition ( Popover.Top, Popover.End )
                     )
                 ]
+        , statelessStoryOf "With Variable Height" <|
+            Popover.view
+                (Popover.default
+                    |> Popover.withHeading "With-Variable-Height"
+                    |> Popover.withContent placeholderContent
+                    |> Popover.withVariableHeight True
+                )
         ]


### PR DESCRIPTION
## Context
https://cultureamp.slack.com/archives/CETLTFG9G/p1578874817025300

TLDR: 
Popover’s styles prevent it from being positioned above an element when the contents of the popover have an unpredictable height.

We've decided to put it behind a prop for now because doing a major release means we have to update all existing implementations of Popover which will take a bit of time.

Example screenshots:
<img width="389" alt="Screen Shot 2020-01-13 at 10 23 32 am" src="https://user-images.githubusercontent.com/39490942/72316862-9730e580-36eb-11ea-94d6-069a2fc711ff.png">
<img width="332" alt="Screen Shot 2020-01-13 at 10 23 26 am" src="https://user-images.githubusercontent.com/39490942/72316863-9730e580-36eb-11ea-9cbf-282404ea1a55.png">


## Changes in this PR
I've added the ability for us to set a `withVariableHeight` as `True` and get the css attribute we need. This defaults to `False` and shouldn't affect any existing usages of Popover.elm.