### PR TITLE
feat: Add AsyncSelect component

### DIFF
--- a/packages/component-library/draft/Kaizen/Select/Select.tsx
+++ b/packages/component-library/draft/Kaizen/Select/Select.tsx
@@ -1,6 +1,8 @@
 import classNames from "classnames"
 import * as React from "react"
 import ReactSelect, { components } from "react-select"
+import Async from "react-select/async"
+import { AsyncProps as ReactAsyncSelectProps } from "react-select/src/Async"
 import { Props as ReactSelectProps } from "react-select/src/Select"
 
 import { Icon } from "@cultureamp/kaizen-component-library"
@@ -13,9 +15,32 @@ const styles = require("./styles.react.scss")
 
 interface Props extends ReactSelectProps {}
 
-const Select = (props: Props) => {
+export const Select = (props: Props) => {
   return (
     <ReactSelect
+      {...props}
+      components={{
+        Control,
+        Placeholder,
+        DropdownIndicator,
+        Menu,
+        Option,
+        NoOptionsMessage,
+        SingleValue,
+        MultiValue,
+        ClearIndicator: null,
+        IndicatorSeparator: null,
+      }}
+      className={classNames(styles.container, props.className)}
+    />
+  )
+}
+
+interface AsyncProps extends ReactAsyncSelectProps<any>, ReactSelectProps {}
+
+export const AsyncSelect = (props: AsyncProps) => {
+  return (
+    <Async
       {...props}
       components={{
         Control,
@@ -87,5 +112,3 @@ const SingleValue: typeof components.SingleValue = props => (
 const MultiValue: typeof components.MultiValue = props => (
   <components.MultiValue {...props} className={styles.multiValue} />
 )
-
-export default Select

--- a/packages/component-library/draft/Kaizen/Select/Select.tsx
+++ b/packages/component-library/draft/Kaizen/Select/Select.tsx
@@ -6,7 +6,6 @@ import { AsyncProps as ReactAsyncSelectProps } from "react-select/src/Async"
 import { Props as ReactSelectProps } from "react-select/src/Select"
 
 import { Icon } from "@cultureamp/kaizen-component-library"
-import { Tag } from "@cultureamp/kaizen-component-library/draft"
 
 const chevronDownIcon = require("@cultureamp/kaizen-component-library/icons/chevron-down.icon.svg")
   .default

--- a/packages/component-library/draft/Kaizen/Select/index.ts
+++ b/packages/component-library/draft/Kaizen/Select/index.ts
@@ -1,1 +1,1 @@
-export { default as Select } from "./Select"
+export { Select, AsyncSelect } from "./Select"

--- a/packages/component-library/stories/Select.stories.tsx
+++ b/packages/component-library/stories/Select.stories.tsx
@@ -1,5 +1,5 @@
 import { loadElmStories } from "@cultureamp/elm-storybook"
-import { Select } from "@cultureamp/kaizen-component-library/draft"
+import { AsyncSelect, Select } from "@cultureamp/kaizen-component-library/draft"
 import { storiesOf } from "@storybook/react"
 import * as React from "react"
 
@@ -23,6 +23,40 @@ const options = [
   { value: "Nick", label: "Nick" },
 ]
 
+const asyncOptions = [
+  { value: "Mindy", label: "Mindy" },
+  { value: "Jaime", label: "Jaime" },
+  { value: "Rafa", label: "Rafa" },
+  { value: "Elaine", label: "Elaine" },
+  { value: "Julio", label: "Julio" },
+  { value: "Priyanka", label: "Priyanka" },
+  { value: "Prince", label: "Prince" },
+  { value: "Charith", label: "Charith" },
+  { value: "Nick", label: "Nick" },
+  { value: "Marc", label: "Marc" },
+  { value: "Victor", label: "Victor" },
+  { value: "Nicholas", label: "Nicholas" },
+  { value: "Juan", label: "Juan" },
+  { value: "Pedro", label: "Pedro" },
+  { value: "Jack", label: "Jack" },
+  { value: "Michael", label: "Michael" },
+  { value: "Melisa", label: "Melisa" },
+  { value: "Roberto", label: "Roberto" },
+]
+
+const filterNames = (inputValue: string) => {
+  return asyncOptions.filter(i =>
+    i.label.toLowerCase().includes(inputValue.toLowerCase())
+  )
+}
+
+const promiseOptions = inputValue =>
+  new Promise(resolve => {
+    setTimeout(() => {
+      resolve(filterNames(inputValue))
+    }, 1000)
+  })
+
 storiesOf("Select", module)
   .add("Single", () => (
     <StoryContainer>
@@ -43,6 +77,27 @@ storiesOf("Select", module)
   .add("Multi-Select Searchable", () => (
     <WideStoryContainer>
       <Select options={options} placeholder="Placeholder" isMulti={true} />
+    </WideStoryContainer>
+  ))
+
+  .add("Async Searchable", () => (
+    <WideStoryContainer>
+      <AsyncSelect
+        loadOptions={promiseOptions}
+        defaultOptions={options}
+        placeholder="Placeholder"
+      />
+    </WideStoryContainer>
+  ))
+
+  .add("Multi-Async Searchable", () => (
+    <WideStoryContainer>
+      <AsyncSelect
+        loadOptions={promiseOptions}
+        defaultOptions={options}
+        placeholder="Placeholder"
+        isMulti={true}
+      />
     </WideStoryContainer>
   ))
 


### PR DESCRIPTION
## Objective
Add `AsyncSelect` component into Kaizen. 
This components expose the `Async` component from `react-select`. A couple of props of this component gave us the ability to search asynchronously when the user is typing.
   
### Changes
Inside the `Select.tsx` added a new component called `AsyncSelect` that basically render the `Async` component from `react-select/async` --> [more info here](https://react-select.com/async).
Decided to add it here since we reuse all the components created for the `Select` component like `Control` `Placeholder` `Dropdownindicator` etc.
Created a separate component since react-select exposes it as a separate component as well. 

In the `index.ts` export the `Select` and `AsyncSelect`

Included a couple of stories inside the `Select.stories.tsx` as well.
At least for now only used the `loadOptions` and `defaultOptions` props. 

### Notes
Wondering if should I move all the Async stuff to another different file. Now on storybooks appear inside the Select three. 

![image](https://user-images.githubusercontent.com/3228237/72356007-40b1b000-36c7-11ea-99cb-4532351c3860.png)

At the moment i'm using the default loader when typing, i'm open to update this also if is necessary.

Here attach a little gif to see how it looks the `AsyncSelect` component and how it looks the loader when typing.
📹 http://g.recordit.co/9m1jKTU2aG.gif
 