### PR TITLE
docs: update story titles for clarity

### DIFF
--- a/packages/component-library/components/Button/README.mdx
+++ b/packages/component-library/components/Button/README.mdx
@@ -6,7 +6,7 @@ tags: ["Link button", "Primary action", "Secondary action", "Default action", "D
 needToKnow:
 - Buttons perform actions.
 - If it needs to navigate somewhere and can be opened in a new tab, use a link instead.
-demoStoryId: button--default
+demoStoryId: button-react--default-kaizen-site-demo
 ---
 
 ## Visuals

--- a/packages/component-library/draft/Kaizen/CheckboxGroup/README.mdx
+++ b/packages/component-library/draft/Kaizen/CheckboxGroup/README.mdx
@@ -7,7 +7,8 @@ needToKnow:
 - Prefer vertical (stacked) checkboxes to easily scan and compare options.
 - When choices are mutually exclusive, use a radio instead.
 - For settings that are immediately applied, consider using a toggle switch instead.
-demoStoryId: checkboxgroup--interactive
+demoStoryId: checkboxgroup-react--interactive-kaizen-site-demo
+
 ---
 
 ## Visuals

--- a/packages/component-library/draft/Kaizen/Collapsible/README.mdx
+++ b/packages/component-library/draft/Kaizen/Collapsible/README.mdx
@@ -6,7 +6,7 @@ tags: ["Expandable", "Accordion", "Show and hide", "Reveal", "Disclosure"]
 needToKnow:
   - "We usually start collapsibles in a collapsed position by default so that users can see what's available."
   - "We often avoid accordions, which are a specific type of collapsible that allows only 1 section open at a time and is often an annoying constraint on user interaction."
-demoStoryId: collapsible--single-collapsible
+demoStoryId: collapsible-react--single-collapsible-kaizen-site-demo
 ---
 
 ## Options

--- a/packages/component-library/draft/Kaizen/EmptyState/README.mdx
+++ b/packages/component-library/draft/Kaizen/EmptyState/README.mdx
@@ -6,7 +6,7 @@ tags: ["Zero State", "Empty well", "Starter content", "Educational content"]
 needToKnow:
 - Empty states communicate the current state, allowing users to feel in control of the system, take appropriate actions to reach their goal, and ultimately trust the brand.
 - Without an empty state, people are confused about what to do next.
-demoStoryId: emptystate--default
+demoStoryId: emptystate-react--default-kaizen-site-demo
 ---
 
 ## Visuals

--- a/packages/component-library/draft/Kaizen/Form/CheckboxField/README.mdx
+++ b/packages/component-library/draft/Kaizen/Form/CheckboxField/README.mdx
@@ -5,7 +5,7 @@ summaryParagraph: A checkbox field includes a checkable input and its label. Che
 tags: ["Checkbox", "Tick box", "Check item", "Option button", "Choice", "Selection"]
 needToKnow:
 - Lets a user choose to select or unselect a single item. When used in a Checkbox Group, a checkbox lets a user select zero or more items from a set, which are all visible at the same time.
-demoStoryId: checkboxfield--interactive
+demoStoryId: checkboxfield-react--interactive-kaizen-site-demo
 ---
 
 ## Visuals

--- a/packages/component-library/draft/Kaizen/Form/TextField/README.mdx
+++ b/packages/component-library/draft/Kaizen/Form/TextField/README.mdx
@@ -4,7 +4,7 @@ navTitle: Text Field
 summaryParagraph: A text field includes a label and an input field you can type text into.
 tags: ["Input", "Form field", "Text input", "Email input", "Password"]
 needToKnow:
-demoStoryId: 
+demoStoryId: textfield--default
 ---
 
 ## Visuals

--- a/packages/component-library/draft/Kaizen/Form/TextField/README.mdx
+++ b/packages/component-library/draft/Kaizen/Form/TextField/README.mdx
@@ -5,7 +5,7 @@ summaryParagraph: A text field includes a label and an input field you can type 
 tags: ["Input", "Form field", "Text input", "Email input", "Password"]
 needToKnow:
 - "Pre-fill the Text Field input with good defaults wherever possible."
-demoStoryId: textfield--default
+demoStoryId: textfield-react--default-kaizen-site-demo
 ---
 
 ## Visuals

--- a/packages/component-library/draft/Kaizen/Form/TextField/README.mdx
+++ b/packages/component-library/draft/Kaizen/Form/TextField/README.mdx
@@ -4,6 +4,7 @@ navTitle: Text Field
 summaryParagraph: A text field includes a label and an input field you can type text into.
 tags: ["Input", "Form field", "Text input", "Email input", "Password"]
 needToKnow:
+- "Pre-fill the Text Field input with good defaults wherever possible."
 demoStoryId: textfield--default
 ---
 
@@ -19,9 +20,9 @@ demoStoryId: textfield--default
 
 * Most of the time, we validate text fields on “blur” (when leaving the text fields) or on form submission as needed. We don’t validate on key strokes.
 * As a rule of thumb, generally use “ (optional)” to indicate optional fields instead of “`*`” to indicate required fields.
-* Consider if a more specific `type` of is needed as an `email` type for email addresses.
+* Consider if a more specific `type` is needed as an `email` type for email addresses.
 * When displaying a validation messages, such as an error, use a `aria-describedby` attribute to associate the text field with the element containing the validation message.
-* Pre-fill the field with good defaults wherever possible.
+* Pre-fill the Text Field input with good defaults wherever possible.
 
 ## When to use
 

--- a/packages/component-library/draft/Kaizen/Form/ToggleSwitchField/README.mdx
+++ b/packages/component-library/draft/Kaizen/Form/ToggleSwitchField/README.mdx
@@ -6,7 +6,7 @@ tags: ["Toggle button", "Switch", "Toggle"]
 needToKnow:
 - Toggle Switch labels must include a verb. E.g. Show translations
 - The label should never be on both sides (e.g. On/Off).
-demoStoryId: toggleswitchfield--on
+demoStoryId: toggleswitchfield-react--on-kaizen-site-demo
 ---
 
 ## Visuals

--- a/packages/component-library/draft/Kaizen/HeroCard/README.mdx
+++ b/packages/component-library/draft/Kaizen/HeroCard/README.mdx
@@ -7,7 +7,7 @@ needToKnow:
 - The badge contains a number, ideally 1 character, showing a micro bit of information such as a step.
 - For the image, use a graphic illustration that supports what's going on in the rest of the card.
 - For the title, aim for 1 line of text.
-demoStoryId: herocard--default
+demoStoryId: herocard-react--default-kaizen-site-demo
 ---
 
 ## Visuals

--- a/packages/component-library/draft/Kaizen/LoadingPlaceholder/README.mdx
+++ b/packages/component-library/draft/Kaizen/LoadingPlaceholder/README.mdx
@@ -5,7 +5,7 @@ summaryParagraph: A single loading placeholder element used in a loading skeleto
 tags: ["Skeleton", "Stencil", "Placeholder UI"]
 needToKnow:
   - "Only use loading placeholders with loading skeletons"
-demoStoryId: loadingplaceholder--basic-block
+demoStoryId: loadingplaceholder-react--basic-block-kaizen-site-demo
 ---
 
 ## Visuals

--- a/packages/component-library/draft/Kaizen/LoadingPlaceholder/README.mdx
+++ b/packages/component-library/draft/Kaizen/LoadingPlaceholder/README.mdx
@@ -5,7 +5,7 @@ summaryParagraph: A single loading placeholder element used in a loading skeleto
 tags: ["Skeleton", "Stencil", "Placeholder UI"]
 needToKnow:
   - "Only use loading placeholders with loading skeletons"
-demoStoryId: loadingplaceholder-react--basic-block-kaizen-site-demo
+demoStoryId: loadingplaceholder-react--default-multiple-kaizen-site-demo
 ---
 
 ## Visuals

--- a/packages/component-library/draft/Kaizen/Modal/README.mdx
+++ b/packages/component-library/draft/Kaizen/Modal/README.mdx
@@ -8,7 +8,7 @@ needToKnow:
 - "Modals need an overlay behind them and over the page."
 - "Choose your type (confirmation, informative, etc.)."
 - "Use sparingly."
-demoStoryId: modal--confirmation-positive
+demoStoryId: modal-react--confirmation-positive-kaizen-site-demo
 ---
 
 ## Visuals

--- a/packages/component-library/draft/Kaizen/Popover/README.mdx
+++ b/packages/component-library/draft/Kaizen/Popover/README.mdx
@@ -8,7 +8,7 @@ needToKnow:
 - Unlike a tooltip, a user can interact with popover content.
 - Trigger popovers from Interactive elements (Buttons, Links, Icon buttons) or Non-interactive elements (Icons, Abbreviations, Truncated text)—be mindful of keyboard accessibility
 - Use sparingly.
-demoStoryId: popover--default
+demoStoryId: popover-react--default-kaizen-site-demo
 ---
 
 ## Visuals

--- a/packages/component-library/draft/Kaizen/Radio/README.mdx
+++ b/packages/component-library/draft/Kaizen/Radio/README.mdx
@@ -5,7 +5,7 @@ summaryParagraph: A radio includes a radio input and its label. Radios are used 
 tags: ["Radio button", "Radio group", "Option button", "Choice", "Selection", "Disc", "Radio input"]
 needToKnow:
 - Radios are only used in radio groups to let people select exactly one option from a set.
-demoStoryId: radio--interactive
+demoStoryId: radio-react--interactive-kaizen-site-demo
 ---
 
 ## Visuals

--- a/packages/component-library/draft/Kaizen/RadioGroup/README.mdx
+++ b/packages/component-library/draft/Kaizen/RadioGroup/README.mdx
@@ -7,7 +7,7 @@ needToKnow:
 - Prefer vertical (stacked) radios to easily scan and compare options.
 - When there’s only two options, consider if a single checkbox would be better.
 - For settings that are immediately applied, consider using a toggle switch instead.
-demoStoryId: radiogroup-react--standard-kaizen-site-demo
+demoStoryId: radiogroup-react--default-kaizen-site-demo
 ---
 
 ## Visuals

--- a/packages/component-library/draft/Kaizen/RadioGroup/README.mdx
+++ b/packages/component-library/draft/Kaizen/RadioGroup/README.mdx
@@ -7,7 +7,7 @@ needToKnow:
 - Prefer vertical (stacked) radios to easily scan and compare options.
 - When there’s only two options, consider if a single checkbox would be better.
 - For settings that are immediately applied, consider using a toggle switch instead.
-demoStoryId: radiogroup--standard
+demoStoryId: radiogroup-react--standard-kaizen-site-demo
 ---
 
 ## Visuals

--- a/packages/component-library/draft/Kaizen/Select/README.mdx
+++ b/packages/component-library/draft/Kaizen/Select/README.mdx
@@ -5,7 +5,7 @@ summaryParagraph: A select lets you choose options from an option menu. A single
 tags: ["Select", "Select menu", "Select dropdown", "Dropdown", "Select input"]
 needToKnow:
 - Use for 4+ options when you need to conserve space and provide a pre-selected good default. There are single- and multi-select variants.
-demoStoryId: select-elm--single
+demoStoryId: select-elm--single-kaizen-site-demo
 ---
 
 ## Visuals

--- a/packages/component-library/draft/Kaizen/Table/README.mdx
+++ b/packages/component-library/draft/Kaizen/Table/README.mdx
@@ -6,7 +6,7 @@ tags: ["Select menu", "Select dropdown", "Multi-select", "Select input"]
 needToKnow:
 - All tables have headers, rows, and columns.
 - Don’t use a table when you can use a data visualization.
-demoStoryId: table--default
+demoStoryId: table-react--default-kaizen-site-demo
 ---
 
 ## Visuals

--- a/packages/component-library/draft/Kaizen/Tag/README.mdx
+++ b/packages/component-library/draft/Kaizen/Tag/README.mdx
@@ -7,7 +7,7 @@ tags: ['Badge', 'Pill', 'Chip', 'Label', 'Lozenge', 'Input tag']
 needToKnow:
   - Tags help categorize and organize
   - Use sentiment labels only for sentiment or other employee feedback data
-demoStoryId: 
+demoStoryId: tag-react--default-medium-kaizen-site-demo
 ---
 
 ## Visuals

--- a/packages/component-library/draft/Kaizen/Tooltip/README.mdx
+++ b/packages/component-library/draft/Kaizen/Tooltip/README.mdx
@@ -9,7 +9,7 @@ needToKnow:
 - Tooltips must be accessible via hover, focus or click.
 - Trigger tooltips from Interactive elements (Buttons, Links, Icon buttons) or Non-interactive elements (Icons, Abbreviations, Truncated text)—be mindful of keyboard accessibility
 - Use sparingly. Tooltips innately hide information. Consider exposing it immediately without a tooltip or removing it completely.
-demoStoryId: tooltip--default-below
+demoStoryId: tooltip-react--default-below-kaizen-site-demo
 ---
 
 ## Visuals

--- a/packages/component-library/draft/Kaizen/Well/README.mdx
+++ b/packages/component-library/draft/Kaizen/Well/README.mdx
@@ -6,7 +6,7 @@ tags: ["Placeholder", "Content area", "Frame", "Card", "Group", "Box", "Containe
 needToKnow:
 - "For primary content, use a Card instead."
 - "Usually, wells are used in other components, such as Empty States and drag and drop file upload, instead of independently."
-demoStoryId: well--default-with-solid-border
+demoStoryId: well-react--default-with-solid-border-kaizen-site-demo
 ---
 
 ## Visuals

--- a/packages/component-library/stories/Button.stories.tsx
+++ b/packages/component-library/stories/Button.stories.tsx
@@ -8,6 +8,51 @@ import * as React from "react"
 
 storiesOf("Button (React)", module)
   .add("Default (Kaizen Site Demo)", () => <Button label="Label" />)
+  .add("Default, Disabled", () => <Button label="Label" disabled={true} />)
+  .add("Primary", () => <Button label="Label" primary={true} />)
+  .add("Primary, Disabled", () => (
+    <Button label="Label" primary={true} disabled={true} />
+  ))
+  .add("Destructive", () => <Button label="Label" destructive={true} />)
+  .add("Destructive, Disabled", () => (
+    <Button label="Label" destructive={true} disabled={true} />
+  ))
+  .add("Secondary", () => <Button label="Label" secondary={true} />)
+  .add("Secondary, Disabled", () => (
+    <Button label="Label" secondary={true} disabled={true} />
+  ))
+  .add("Secondary w/ Icon", () => (
+    <Button label="Configure" icon={configureIcon} secondary={true} />
+  ))
+  .add("Secondary w/ Icon, Disabled", () => (
+    <Button
+      label="Configure"
+      icon={configureIcon}
+      secondary={true}
+      disabled={true}
+    />
+  ))
+  .add("Secondary, Destructive (not yet implemented)", () => (
+    <Button
+      label="Delete"
+      secondary={true}
+      disabled={false}
+      destructive={true}
+    />
+  ))
+  .add("Secondary w/ Icon, Destructive (not yet implemented)", () => (
+    <Button
+      label="Delete"
+      icon={configureIcon}
+      secondary={true}
+      disabled={false}
+      destructive={true}
+    />
+  ))
+  .add("Icon + Label", () => <Button label="Configure" icon={configureIcon} />)
+  .add("Label + Icon", () => (
+    <Button label="Configure" icon={configureIcon} iconPosition="end" />
+  ))
   .add("Full Width", () => <Button label="Label" fullWidth={true} />)
   .add("Full Width + Icon", () => (
     <Button label="Label" fullWidth={true} icon={configureIcon} />
@@ -20,11 +65,151 @@ storiesOf("Button (React)", module)
       onClick={action("I am an onClick handler")}
     />
   ))
-  .add("Icon + Label", () => <Button label="Configure" icon={configureIcon} />)
-  .add("Label + Icon", () => (
-    <Button label="Configure" icon={configureIcon} iconPosition="end" />
+  .add("Reversed, Default", () => <Button label="Label" reversed={true} />)
+  .add("Reversed, Default, Disabled", () => (
+    <Button label="Label" reversed={true} disabled={true} />
   ))
-  .add("Overflowing text", () => (
+  .add("Reversed, Primary", () => (
+    <Button label="Label" primary={true} disabled={false} reversed={true} />
+  ))
+  .add("Reversed, Primary, Disabled", () => (
+    <Button label="Label" primary={true} reversed={true} disabled={true} />
+  ))
+  .add("Reversed, Color, Lapis", () => (
+    <Button
+      label="Label"
+      primary={true}
+      disabled={false}
+      reversed={true}
+      reverseColor="lapis"
+    />
+  ))
+  .add("Reversed, Primary, Disabled, Color, Lapis", () => (
+    <Button
+      label="Label"
+      primary={true}
+      disabled={true}
+      reversed={true}
+      reverseColor="lapis"
+    />
+  ))
+  .add("Reversed, Primary, Color, Ocean", () => (
+    <Button
+      label="Label"
+      primary={true}
+      disabled={false}
+      reversed={true}
+      reverseColor="ocean"
+    />
+  ))
+  .add("Reversed, Primary, Disabled, Color, Ocean", () => (
+    <Button
+      label="Label"
+      primary={true}
+      disabled={true}
+      reversed={true}
+      reverseColor="ocean"
+    />
+  ))
+  .add("Reversed, Primary, Color, Peach", () => (
+    <Button
+      label="Label"
+      primary={true}
+      disabled={false}
+      reversed={true}
+      reverseColor="peach"
+    />
+  ))
+  .add("Reversed, Primary, Disabled, Color, Peach", () => (
+    <Button
+      label="Label"
+      primary={true}
+      disabled={true}
+      reversed={true}
+      reverseColor="peach"
+    />
+  ))
+  .add("Reversed, Primary, Color, Seedling", () => (
+    <Button
+      label="Label"
+      primary={true}
+      disabled={false}
+      reversed={true}
+      reverseColor="seedling"
+    />
+  ))
+  .add("Reversed, Primary, Disabled, Color, Seedling", () => (
+    <Button
+      label="Label"
+      primary={true}
+      disabled={true}
+      reversed={true}
+      reverseColor="seedling"
+    />
+  ))
+  .add("Reversed, Primary, Color, Wisteria", () => (
+    <Button
+      label="Label"
+      primary={true}
+      disabled={false}
+      reversed={true}
+      reverseColor="wisteria"
+    />
+  ))
+  .add("Reversed, Primary, Disabled, Color, Wisteria", () => (
+    <Button
+      label="Label"
+      primary={true}
+      disabled={true}
+      reversed={true}
+      reverseColor="wisteria"
+    />
+  ))
+  .add("Reversed, Primary, Color, Yuzu", () => (
+    <Button
+      label="Label"
+      primary={true}
+      disabled={false}
+      reversed={true}
+      reverseColor="yuzu"
+    />
+  ))
+  .add("Reversed, Primary, Disabled, Color, Yuzu", () => (
+    <Button
+      label="Label"
+      primary={true}
+      disabled={true}
+      reversed={true}
+      reverseColor="yuzu"
+    />
+  ))
+  .add("Reversed, Secondary", () => (
+    <Button label="Label" secondary={true} reversed={true} />
+  ))
+  .add("Reversed, Secondary, Disabled", () => (
+    <Button label="Label" secondary={true} reversed={true} disabled={true} />
+  ))
+  .add("Reversed, Secondary w/ Icon", () => (
+    <Button
+      label="Configure"
+      secondary={true}
+      reversed={true}
+      icon={configureIcon}
+    />
+  ))
+  .add("Reversed, Secondary w/ Icon, Disabled", () => (
+    <Button
+      label="Configure"
+      secondary={true}
+      reversed={true}
+      disabled={true}
+      icon={configureIcon}
+    />
+  ))
+  .add("Type, Submit", () => <Button label="Label" type="submit" />)
+  .add("Type, Reset", () => <Button label="Label" type="reset" />)
+  .add("Form", () => <Button label="Label" form={true} />)
+  .add("Overflowing text, Icon + Label (test case)", () => (
     <div style={{ width: 120 }}>
       <Button
         icon={configureIcon}
@@ -33,7 +218,7 @@ storiesOf("Button (React)", module)
       />
     </div>
   ))
-  .add("Form (Overflowing text)", () => (
+  .add("Overflowing text, Form (test case)", () => (
     <div style={{ width: 120 }}>
       <Button
         form
@@ -43,191 +228,6 @@ storiesOf("Button (React)", module)
       />
     </div>
   ))
-  .add("Disabled", () => <Button label="Label" disabled={true} />)
-  .add("Form", () => <Button label="Label" form={true} />)
-  .add("Primary", () => <Button label="Label" primary={true} />)
-  .add("Primary Disabled", () => (
-    <Button label="Label" primary={true} disabled={true} />
-  ))
-  .add("Secondary", () => <Button label="Label" secondary={true} />)
-  .add("Secondary Disabled", () => (
-    <Button label="Label" secondary={true} disabled={true} />
-  ))
-  .add("Secondary w/ Icon", () => (
-    <Button label="Configure" icon={configureIcon} secondary={true} />
-  ))
-  .add("Secondary Disabled w/ Icon", () => (
-    <Button
-      label="Configure"
-      icon={configureIcon}
-      secondary={true}
-      disabled={true}
-    />
-  ))
-  .add("Secondary Destructive (not yet implemented)", () => (
-    <Button
-      label="Delete"
-      secondary={true}
-      disabled={false}
-      destructive={true}
-    />
-  ))
-  .add("Secondary Destructive w/ Icon (not yet implemented)", () => (
-    <Button
-      label="Delete"
-      icon={configureIcon}
-      secondary={true}
-      disabled={false}
-      destructive={true}
-    />
-  ))
-  .add("Destructive", () => <Button label="Label" destructive={true} />)
-  .add("Destructive Disabled", () => (
-    <Button label="Label" destructive={true} disabled={true} />
-  ))
-  .add("Reversed", () => <Button label="Label" reversed={true} />)
-  .add("Reversed Disabled", () => (
-    <Button label="Label" reversed={true} disabled={true} />
-  ))
-  .add("Primary Reversed", () => (
-    <Button label="Label" primary={true} disabled={false} reversed={true} />
-  ))
-  .add("Primary Reversed Disabled", () => (
-    <Button label="Label" primary={true} reversed={true} disabled={true} />
-  ))
-  .add("Primary Reversed Color Lapis", () => (
-    <Button
-      label="Label"
-      primary={true}
-      disabled={false}
-      reversed={true}
-      reverseColor="lapis"
-    />
-  ))
-  .add("Primary Reversed Disabled Color Lapis", () => (
-    <Button
-      label="Label"
-      primary={true}
-      disabled={true}
-      reversed={true}
-      reverseColor="lapis"
-    />
-  ))
-  .add("Primary Reversed Color Ocean", () => (
-    <Button
-      label="Label"
-      primary={true}
-      disabled={false}
-      reversed={true}
-      reverseColor="ocean"
-    />
-  ))
-  .add("Primary Reversed Disabled Color Ocean", () => (
-    <Button
-      label="Label"
-      primary={true}
-      disabled={true}
-      reversed={true}
-      reverseColor="ocean"
-    />
-  ))
-  .add("Primary Reversed Color Peach", () => (
-    <Button
-      label="Label"
-      primary={true}
-      disabled={false}
-      reversed={true}
-      reverseColor="peach"
-    />
-  ))
-  .add("Primary Reversed Disabled Color Peach", () => (
-    <Button
-      label="Label"
-      primary={true}
-      disabled={true}
-      reversed={true}
-      reverseColor="peach"
-    />
-  ))
-  .add("Primary Reversed Color Seedling", () => (
-    <Button
-      label="Label"
-      primary={true}
-      disabled={false}
-      reversed={true}
-      reverseColor="seedling"
-    />
-  ))
-  .add("Primary Reversed Disabled Color Seedling", () => (
-    <Button
-      label="Label"
-      primary={true}
-      disabled={true}
-      reversed={true}
-      reverseColor="seedling"
-    />
-  ))
-  .add("Primary Reversed Color Wisteria", () => (
-    <Button
-      label="Label"
-      primary={true}
-      disabled={false}
-      reversed={true}
-      reverseColor="wisteria"
-    />
-  ))
-  .add("Primary Reversed Disabled Color Wisteria", () => (
-    <Button
-      label="Label"
-      primary={true}
-      disabled={true}
-      reversed={true}
-      reverseColor="wisteria"
-    />
-  ))
-  .add("Primary Reversed Color Yuzu", () => (
-    <Button
-      label="Label"
-      primary={true}
-      disabled={false}
-      reversed={true}
-      reverseColor="yuzu"
-    />
-  ))
-  .add("Primary Reversed Disabled Color Yuzu", () => (
-    <Button
-      label="Label"
-      primary={true}
-      disabled={true}
-      reversed={true}
-      reverseColor="yuzu"
-    />
-  ))
-  .add("Secondary Reversed", () => (
-    <Button label="Label" secondary={true} reversed={true} />
-  ))
-  .add("Secondary Reversed Disabled", () => (
-    <Button label="Label" secondary={true} reversed={true} disabled={true} />
-  ))
-  .add("Secondary Reversed w/ Icon", () => (
-    <Button
-      label="Configure"
-      secondary={true}
-      reversed={true}
-      icon={configureIcon}
-    />
-  ))
-  .add("Secondary Reversed Disabled w/ Icon", () => (
-    <Button
-      label="Configure"
-      secondary={true}
-      reversed={true}
-      disabled={true}
-      icon={configureIcon}
-    />
-  ))
-  .add("Type Submit", () => <Button label="Label" type="submit" />)
-  .add("Type Reset", () => <Button label="Label" type="reset" />)
   .add("Multiple Buttons", () => (
     <div>
       <Button label="Save" primary automationId="demo-button-1" />

--- a/packages/component-library/stories/Button.stories.tsx
+++ b/packages/component-library/stories/Button.stories.tsx
@@ -208,7 +208,7 @@ storiesOf("Button (React)", module)
   ))
   .add("Type, Submit", () => <Button label="Label" type="submit" />)
   .add("Type, Reset", () => <Button label="Label" type="reset" />)
-  .add("Form", () => <Button label="Label" form={true} />)
+  .add("Form (discouraged)", () => <Button label="Label" form={true} />)
   .add("Overflowing text, Icon + Label (test case)", () => (
     <div style={{ width: 120 }}>
       <Button

--- a/packages/component-library/stories/Button.stories.tsx
+++ b/packages/component-library/stories/Button.stories.tsx
@@ -7,7 +7,7 @@ import { storiesOf } from "@storybook/react"
 import * as React from "react"
 
 storiesOf("Button (React)", module)
-  .add("Default", () => <Button label="Label" />)
+  .add("Default (Kaizen Site Demo)", () => <Button label="Label" />)
   .add("Full Width", () => <Button label="Label" fullWidth={true} />)
   .add("Full Width + Icon", () => (
     <Button label="Label" fullWidth={true} icon={configureIcon} />

--- a/packages/component-library/stories/Button.stories.tsx
+++ b/packages/component-library/stories/Button.stories.tsx
@@ -75,7 +75,7 @@ storiesOf("Button (React)", module)
   .add("Reversed, Primary, Disabled", () => (
     <Button label="Label" primary={true} reversed={true} disabled={true} />
   ))
-  .add("Reversed, Color, Lapis", () => (
+  .add("Reversed, Color, Lapis (discouraged)", () => (
     <Button
       label="Label"
       primary={true}
@@ -84,7 +84,7 @@ storiesOf("Button (React)", module)
       reverseColor="lapis"
     />
   ))
-  .add("Reversed, Primary, Disabled, Color, Lapis", () => (
+  .add("Reversed, Primary, Disabled, Color, Lapis (discouraged)", () => (
     <Button
       label="Label"
       primary={true}
@@ -93,7 +93,7 @@ storiesOf("Button (React)", module)
       reverseColor="lapis"
     />
   ))
-  .add("Reversed, Primary, Color, Ocean", () => (
+  .add("Reversed, Primary, Color, Ocean (discouraged)", () => (
     <Button
       label="Label"
       primary={true}
@@ -102,7 +102,7 @@ storiesOf("Button (React)", module)
       reverseColor="ocean"
     />
   ))
-  .add("Reversed, Primary, Disabled, Color, Ocean", () => (
+  .add("Reversed, Primary, Disabled, Color, Ocean (discouraged)", () => (
     <Button
       label="Label"
       primary={true}
@@ -111,7 +111,7 @@ storiesOf("Button (React)", module)
       reverseColor="ocean"
     />
   ))
-  .add("Reversed, Primary, Color, Peach", () => (
+  .add("Reversed, Primary, Color, Peach (discouraged)", () => (
     <Button
       label="Label"
       primary={true}
@@ -120,7 +120,7 @@ storiesOf("Button (React)", module)
       reverseColor="peach"
     />
   ))
-  .add("Reversed, Primary, Disabled, Color, Peach", () => (
+  .add("Reversed, Primary, Disabled, Color, Peach (discouraged)", () => (
     <Button
       label="Label"
       primary={true}
@@ -129,7 +129,7 @@ storiesOf("Button (React)", module)
       reverseColor="peach"
     />
   ))
-  .add("Reversed, Primary, Color, Seedling", () => (
+  .add("Reversed, Primary, Color, Seedling (discouraged)", () => (
     <Button
       label="Label"
       primary={true}
@@ -138,7 +138,7 @@ storiesOf("Button (React)", module)
       reverseColor="seedling"
     />
   ))
-  .add("Reversed, Primary, Disabled, Color, Seedling", () => (
+  .add("Reversed, Primary, Disabled, Color, Seedling (discouraged)", () => (
     <Button
       label="Label"
       primary={true}
@@ -147,7 +147,7 @@ storiesOf("Button (React)", module)
       reverseColor="seedling"
     />
   ))
-  .add("Reversed, Primary, Color, Wisteria", () => (
+  .add("Reversed, Primary, Color, Wisteria (discouraged)", () => (
     <Button
       label="Label"
       primary={true}
@@ -156,7 +156,7 @@ storiesOf("Button (React)", module)
       reverseColor="wisteria"
     />
   ))
-  .add("Reversed, Primary, Disabled, Color, Wisteria", () => (
+  .add("Reversed, Primary, Disabled, Color, Wisteria (discouraged)", () => (
     <Button
       label="Label"
       primary={true}
@@ -165,7 +165,7 @@ storiesOf("Button (React)", module)
       reverseColor="wisteria"
     />
   ))
-  .add("Reversed, Primary, Color, Yuzu", () => (
+  .add("Reversed, Primary, Color, Yuzu (discouraged)", () => (
     <Button
       label="Label"
       primary={true}
@@ -174,7 +174,7 @@ storiesOf("Button (React)", module)
       reverseColor="yuzu"
     />
   ))
-  .add("Reversed, Primary, Disabled, Color, Yuzu", () => (
+  .add("Reversed, Primary, Disabled, Color, Yuzu (discouraged)", () => (
     <Button
       label="Label"
       primary={true}

--- a/packages/component-library/stories/Button.stories.tsx
+++ b/packages/component-library/stories/Button.stories.tsx
@@ -6,7 +6,7 @@ import { action } from "@storybook/addon-actions"
 import { storiesOf } from "@storybook/react"
 import * as React from "react"
 
-storiesOf("Button", module)
+storiesOf("Button (React)", module)
   .add("Default", () => <Button label="Label" />)
   .add("Full Width", () => <Button label="Label" fullWidth={true} />)
   .add("Full Width + Icon", () => (

--- a/packages/component-library/stories/CheckboxField.stories.tsx
+++ b/packages/component-library/stories/CheckboxField.stories.tsx
@@ -48,7 +48,7 @@ class CheckboxFieldExample extends React.Component<Props> {
 }
 
 storiesOf("CheckboxField (React)", module)
-  .add("Interactive", () => (
+  .add("Interactive (Kaizen Site Demo)", () => (
     <CheckboxFieldExample
       render={({ checkedStatus, onCheckHandler }) => (
         <CheckboxField

--- a/packages/component-library/stories/CheckboxField.stories.tsx
+++ b/packages/component-library/stories/CheckboxField.stories.tsx
@@ -47,7 +47,7 @@ class CheckboxFieldExample extends React.Component<Props> {
   }
 }
 
-storiesOf("CheckboxField", module)
+storiesOf("CheckboxField (React)", module)
   .add("Interactive", () => (
     <CheckboxFieldExample
       render={({ checkedStatus, onCheckHandler }) => (

--- a/packages/component-library/stories/CheckboxGroup.stories.tsx
+++ b/packages/component-library/stories/CheckboxGroup.stories.tsx
@@ -45,7 +45,7 @@ export default class CheckboxGroupExample extends React.Component<Props> {
   }
 }
 storiesOf("CheckboxGroup (React)", module)
-  .add("Interactive", () => (
+  .add("Interactive (Kaizen Site Demo)", () => (
     <div>
       <CheckboxGroup labelText="Checkbox Group Label">
         <CheckboxGroupExample

--- a/packages/component-library/stories/CheckboxGroup.stories.tsx
+++ b/packages/component-library/stories/CheckboxGroup.stories.tsx
@@ -44,7 +44,7 @@ export default class CheckboxGroupExample extends React.Component<Props> {
     )
   }
 }
-storiesOf("CheckboxGroup", module)
+storiesOf("CheckboxGroup (React)", module)
   .add("Interactive", () => (
     <div>
       <CheckboxGroup labelText="Checkbox Group Label">

--- a/packages/component-library/stories/Collapsible.stories.tsx
+++ b/packages/component-library/stories/Collapsible.stories.tsx
@@ -24,7 +24,7 @@ magna nisl, in cursus urna hendrerit et. Aenean semper, est non
 feugiat sodales, nisl ligula aliquet lorem, sit amet scelerisque
 arcu quam a sapien. Donec in viverra urna.`
 
-storiesOf("Collapsible", module)
+storiesOf("Collapsible (React)", module)
   .add("Single collapsible", () => (
     <div style={{ margin: "1rem", width: "40rem" }}>
       <Collapsible id="collapsible-single" open title="Single collapsible">

--- a/packages/component-library/stories/Collapsible.stories.tsx
+++ b/packages/component-library/stories/Collapsible.stories.tsx
@@ -25,7 +25,7 @@ feugiat sodales, nisl ligula aliquet lorem, sit amet scelerisque
 arcu quam a sapien. Donec in viverra urna.`
 
 storiesOf("Collapsible (React)", module)
-  .add("Single collapsible", () => (
+  .add("Single collapsible (Kaizen Site Demo)", () => (
     <div style={{ margin: "1rem", width: "40rem" }}>
       <Collapsible id="collapsible-single" open title="Single collapsible">
         <Text tag="p">{lipsum}</Text>

--- a/packages/component-library/stories/Dropdown.stories.tsx
+++ b/packages/component-library/stories/Dropdown.stories.tsx
@@ -60,7 +60,7 @@ const Menu: React.FunctionComponent = () => (
     <MenuItem action="https://www.cultureamp.com/">Link label</MenuItem>
   </MenuList>
 )
-storiesOf("Dropdown", module)
+storiesOf("Dropdown (React)", module)
   .add("Default (Meatball)", () => (
     <Dropdown>
       <Menu />

--- a/packages/component-library/stories/EmptyState.stories.elm
+++ b/packages/component-library/stories/EmptyState.stories.elm
@@ -4,6 +4,7 @@ import Button.Button as Button
 import CssModules exposing (css)
 import ElmStorybook exposing (statelessStoryOf, storybook)
 import Html exposing (Html, div, text)
+import Html.Attributes exposing (dir)
 import Icon.SvgAsset exposing (svgAsset)
 import Kaizen.EmptyState.EmptyState as EmptyState
 
@@ -16,6 +17,13 @@ sidebarAndContentLayout children =
             children
         ]
 
+sidebarAndContentLayoutRTL : List (Html msg) -> Html msg
+sidebarAndContentLayoutRTL children =
+    div [ styles.class .container, dir "rtl"  ]
+        [ div [ styles.class .sidebar ] []
+        , div [ styles.class .content ]
+            children
+        ]
 
 contentOnlyLayout : List (Html msg) -> Html msg
 contentOnlyLayout children =
@@ -57,24 +65,6 @@ main =
                         |> EmptyState.illustrationType EmptyState.Positive
                     )
                 ]
-        , statelessStoryOf "Neutral" <|
-            sidebarAndContentLayout
-                [ EmptyState.view
-                    (EmptyState.default
-                        |> EmptyState.headingText "Empty state title"
-                        |> EmptyState.bodyText (EmptyState.BodyText "This preset only passes in the headingText and bodyText props, and leaves the rest to fallbacks.")
-                        |> EmptyState.illustrationType EmptyState.Neutral
-                    )
-                ]
-        , statelessStoryOf "Negative" <|
-            sidebarAndContentLayout
-                [ EmptyState.view
-                    (EmptyState.default
-                        |> EmptyState.headingText "Empty state title"
-                        |> EmptyState.bodyText (EmptyState.BodyText "This preset only passes in the headingText and bodyText props, and leaves the rest to fallbacks.")
-                        |> EmptyState.illustrationType EmptyState.Negative
-                    )
-                ]
         , statelessStoryOf "Informative" <|
             sidebarAndContentLayout
                 [ EmptyState.view
@@ -93,7 +83,7 @@ main =
                         |> EmptyState.illustrationType EmptyState.Action
                     )
                 ]
-        , statelessStoryOf "Action with button" <|
+        , statelessStoryOf "Action, button" <|
             sidebarAndContentLayout
                 [ EmptyState.view
                     (EmptyState.default
@@ -112,13 +102,40 @@ main =
                             ]
                     )
                 ]
-        , statelessStoryOf "Content-only layout" <|
+        , statelessStoryOf "Neutral" <|
+            sidebarAndContentLayout
+                [ EmptyState.view
+                    (EmptyState.default
+                        |> EmptyState.headingText "Empty state title"
+                        |> EmptyState.bodyText (EmptyState.BodyText "This preset only passes in the headingText and bodyText props, and leaves the rest to fallbacks.")
+                        |> EmptyState.illustrationType EmptyState.Neutral
+                    )
+                ]
+        , statelessStoryOf "Negative" <|
+            sidebarAndContentLayout
+                [ EmptyState.view
+                    (EmptyState.default
+                        |> EmptyState.headingText "Empty state title"
+                        |> EmptyState.bodyText (EmptyState.BodyText "This preset only passes in the headingText and bodyText props, and leaves the rest to fallbacks.")
+                        |> EmptyState.illustrationType EmptyState.Negative
+                    )
+                ]
+        , statelessStoryOf "Layout, Content-only" <|
             contentOnlyLayout
                 [ EmptyState.view
                     (EmptyState.default
                         |> EmptyState.headingText "Empty state title"
                         |> EmptyState.bodyText (EmptyState.BodyText "This is an example of the content-only layout (no sidebar).")
                         |> EmptyState.layoutContext EmptyState.ContentOnly
+                    )
+                ]
+        , statelessStoryOf "RTL, Action" <|
+            sidebarAndContentLayoutRTL
+                [ EmptyState.view
+                    (EmptyState.default
+                        |> EmptyState.headingText "Empty state title"
+                        |> EmptyState.bodyText (EmptyState.BodyText "This preset only passes in the headingText and bodyText props, and leaves the rest to fallbacks.")
+                        |> EmptyState.illustrationType EmptyState.Action
                     )
                 ]
         ]

--- a/packages/component-library/stories/EmptyState.stories.elm
+++ b/packages/component-library/stories/EmptyState.stories.elm
@@ -17,13 +17,15 @@ sidebarAndContentLayout children =
             children
         ]
 
+
 sidebarAndContentLayoutRTL : List (Html msg) -> Html msg
 sidebarAndContentLayoutRTL children =
-    div [ styles.class .container, dir "rtl"  ]
+    div [ styles.class .container, dir "rtl" ]
         [ div [ styles.class .sidebar ] []
         , div [ styles.class .content ]
             children
         ]
+
 
 contentOnlyLayout : List (Html msg) -> Html msg
 contentOnlyLayout children =

--- a/packages/component-library/stories/EmptyState.stories.tsx
+++ b/packages/component-library/stories/EmptyState.stories.tsx
@@ -39,7 +39,7 @@ storiesOf("EmptyState (React)", module)
       />
     </SidebarAndContentLayout>
   ))
-  .add("Sidebar + Content layout", () => (
+  .add("Layout, Sidebar + Content", () => (
     <SidebarAndContentLayout>
       <EmptyState
         headingText="Empty state title"
@@ -49,7 +49,7 @@ storiesOf("EmptyState (React)", module)
       />
     </SidebarAndContentLayout>
   ))
-  .add("Content-only layout", () => (
+  .add("Layout, Content-only", () => (
     <ContentOnlyLayout>
       <EmptyState
         headingText="Empty state title"
@@ -66,35 +66,6 @@ storiesOf("EmptyState (React)", module)
         bodyText="If providing further actions, include a link to an action or use a
           Default or Primary action."
         illustrationType="positive"
-      >
-        <div className={styles.buttonContainer}>
-          <Button
-            label="Label"
-            icon={chevronRight}
-            iconPosition="end"
-            fullWidth
-          />
-        </div>
-      </EmptyState>
-    </SidebarAndContentLayout>
-  ))
-  .add("Neutral", () => (
-    <SidebarAndContentLayout>
-      <EmptyState
-        headingText="Neutral empty state"
-        bodyText="If providing further actions, include a link to an action or use a
-          Default or Primary action."
-        illustrationType="neutral"
-      />
-    </SidebarAndContentLayout>
-  ))
-  .add("Negative", () => (
-    <SidebarAndContentLayout>
-      <EmptyState
-        headingText="Negative empty state"
-        bodyText="If providing further actions, include a link to an action or use a
-          Default or Primary action."
-        illustrationType="negative"
       >
         <div className={styles.buttonContainer}>
           <Button
@@ -136,7 +107,7 @@ storiesOf("EmptyState (React)", module)
       </EmptyState>
     </SidebarAndContentLayout>
   ))
-  .add("Action + primary button", () => (
+  .add("Action, Button", () => (
     <SidebarAndContentLayout>
       <EmptyState
         headingText="Action empty state"
@@ -160,7 +131,36 @@ storiesOf("EmptyState (React)", module)
       </EmptyState>
     </SidebarAndContentLayout>
   ))
-  .add("RTL", () => (
+  .add("Neutral", () => (
+    <SidebarAndContentLayout>
+      <EmptyState
+        headingText="Neutral empty state"
+        bodyText="If providing further actions, include a link to an action or use a
+          Default or Primary action."
+        illustrationType="neutral"
+      />
+    </SidebarAndContentLayout>
+  ))
+  .add("Negative", () => (
+    <SidebarAndContentLayout>
+      <EmptyState
+        headingText="Negative empty state"
+        bodyText="If providing further actions, include a link to an action or use a
+          Default or Primary action."
+        illustrationType="negative"
+      >
+        <div className={styles.buttonContainer}>
+          <Button
+            label="Label"
+            icon={chevronRight}
+            iconPosition="end"
+            fullWidth
+          />
+        </div>
+      </EmptyState>
+    </SidebarAndContentLayout>
+  ))
+  .add("RTL, Action", () => (
     <div dir="rtl">
       <SidebarAndContentLayout>
         <EmptyState
@@ -209,12 +209,13 @@ loadElmStories(
   [
     "Default",
     "Default (minimal props)",
-    "Content-only layout",
+    "Layout, Content-only",
     "Positive",
-    "Neutral",
-    "Negative",
     "Informative",
     "Action",
-    "Action with button",
+    "Action, button",
+    "Neutral",
+    "Negative",
+    "RTL, Action",
   ]
 )

--- a/packages/component-library/stories/EmptyState.stories.tsx
+++ b/packages/component-library/stories/EmptyState.stories.tsx
@@ -30,7 +30,7 @@ const ContentOnlyLayout = ({ children }: { children: React.ReactNode }) => (
 )
 
 storiesOf("EmptyState (React)", module)
-  .add("Default", () => (
+  .add("Default (Kaizen Site Demo)", () => (
     <SidebarAndContentLayout>
       <EmptyState
         headingText="Empty state title"

--- a/packages/component-library/stories/EmptyState.stories.tsx
+++ b/packages/component-library/stories/EmptyState.stories.tsx
@@ -29,7 +29,7 @@ const ContentOnlyLayout = ({ children }: { children: React.ReactNode }) => (
   </div>
 )
 
-storiesOf("EmptyState", module)
+storiesOf("EmptyState (React)", module)
   .add("Default", () => (
     <SidebarAndContentLayout>
       <EmptyState

--- a/packages/component-library/stories/GlobalNotification.stories.elm
+++ b/packages/component-library/stories/GlobalNotification.stories.elm
@@ -9,7 +9,7 @@ import Text.Text as Text
 
 main =
     storybook
-        [ statelessStoryOf "Affirmative" <|
+        [ statelessStoryOf "Positive" <|
             Notification.view
                 (Notification.global [ text "New user data, imported by mackenzie@hooli.com has successfully uploaded. ", a [ href "/" ] [ text "Manage users is now available" ] ]
                     |> Notification.notificationType Notification.Affirmative

--- a/packages/component-library/stories/GlobalNotification.stories.tsx
+++ b/packages/component-library/stories/GlobalNotification.stories.tsx
@@ -5,7 +5,7 @@ import * as React from "react"
 import { GlobalNotification } from "@cultureamp/kaizen-component-library"
 
 storiesOf("GlobalNotification (React)", module)
-  .add("Affirmative", () => (
+  .add("Affirmative (Kaizen Site Demo)", () => (
     <GlobalNotification type="affirmative" automationId="notification1">
       New user data, imported by mackenzie@hooli.com has successfully uploaded.
       <a href="/">Manage users is now available</a>

--- a/packages/component-library/stories/GlobalNotification.stories.tsx
+++ b/packages/component-library/stories/GlobalNotification.stories.tsx
@@ -4,7 +4,7 @@ import * as React from "react"
 
 import { GlobalNotification } from "@cultureamp/kaizen-component-library"
 
-storiesOf("GlobalNotification", module)
+storiesOf("GlobalNotification (React)", module)
   .add("Affirmative", () => (
     <GlobalNotification type="affirmative" automationId="notification1">
       New user data, imported by mackenzie@hooli.com has successfully uploaded.

--- a/packages/component-library/stories/GlobalNotification.stories.tsx
+++ b/packages/component-library/stories/GlobalNotification.stories.tsx
@@ -5,7 +5,7 @@ import * as React from "react"
 import { GlobalNotification } from "@cultureamp/kaizen-component-library"
 
 storiesOf("GlobalNotification (React)", module)
-  .add("Affirmative (Kaizen Site Demo)", () => (
+  .add("Positive (Kaizen Site Demo)", () => (
     <GlobalNotification type="affirmative" automationId="notification1">
       New user data, imported by mackenzie@hooli.com has successfully uploaded.
       <a href="/">Manage users is now available</a>
@@ -64,7 +64,7 @@ loadElmStories(
   module,
   require("./GlobalNotification.stories.elm"),
   [
-    "Affirmative",
+    "Positive",
     "Informative",
     "Cautionary",
     "Negative",

--- a/packages/component-library/stories/HeroCard.stories.tsx
+++ b/packages/component-library/stories/HeroCard.stories.tsx
@@ -26,7 +26,7 @@ const renderContent = () => (
 )
 
 storiesOf("HeroCard (React)", module)
-  .add("Default", () => (
+  .add("Default (Kaizen Site Demo)", () => (
     <Container>
       <HeroCard>{renderContent()}</HeroCard>
     </Container>

--- a/packages/component-library/stories/HeroCard.stories.tsx
+++ b/packages/component-library/stories/HeroCard.stories.tsx
@@ -25,7 +25,7 @@ const renderContent = () => (
   </div>
 )
 
-storiesOf("HeroCard", module)
+storiesOf("HeroCard (React)", module)
   .add("Default", () => (
     <Container>
       <HeroCard>{renderContent()}</HeroCard>

--- a/packages/component-library/stories/Icon.stories.tsx
+++ b/packages/component-library/stories/Icon.stories.tsx
@@ -7,7 +7,7 @@ const configureIcon = require("@cultureamp/kaizen-component-library/icons/config
   .default
 
 storiesOf("Icon (React)", module)
-  .add("Meaningful", () => (
+  .add("Meaningful (Kaizen Site Demo)", () => (
     <Icon
       icon={configureIcon}
       title="Warning"

--- a/packages/component-library/stories/Icon.stories.tsx
+++ b/packages/component-library/stories/Icon.stories.tsx
@@ -24,7 +24,7 @@ storiesOf("Icon (React)", module)
     </div>
   ))
 
-loadElmStories("Icon(Elm)", module, require("./Icon.stories.elm"), [
+loadElmStories("Icon (Elm)", module, require("./Icon.stories.elm"), [
   "Meaningful",
   "Presentational",
   "Inherit Size",

--- a/packages/component-library/stories/Icon.stories.tsx
+++ b/packages/component-library/stories/Icon.stories.tsx
@@ -6,7 +6,7 @@ import { Icon } from "@cultureamp/kaizen-component-library"
 const configureIcon = require("@cultureamp/kaizen-component-library/icons/configure.icon.svg")
   .default
 
-storiesOf("Icon", module)
+storiesOf("Icon (React)", module)
   .add("Meaningful", () => (
     <Icon
       icon={configureIcon}

--- a/packages/component-library/stories/IconButton.stories.tsx
+++ b/packages/component-library/stories/IconButton.stories.tsx
@@ -26,7 +26,7 @@ storiesOf("IconButton (React)", module)
   .add("Destructive", () => (
     <IconButton icon={configureIcon} label="Label" destructive={true} />
   ))
-  .add("Destructive Disabled", () => (
+  .add("Destructive, Disabled", () => (
     <IconButton
       icon={configureIcon}
       label="Label"
@@ -37,7 +37,7 @@ storiesOf("IconButton (React)", module)
   .add("Reversed", () => (
     <IconButton icon={configureIcon} label="Label" reversed />
   ))
-  .add("Reversed Disabled", () => (
+  .add("Reversed, Disabled", () => (
     <IconButton
       icon={configureIcon}
       label="Label"

--- a/packages/component-library/stories/IconButton.stories.tsx
+++ b/packages/component-library/stories/IconButton.stories.tsx
@@ -5,7 +5,7 @@ import { action } from "@storybook/addon-actions"
 import { storiesOf } from "@storybook/react"
 import * as React from "react"
 
-storiesOf("IconButton", module)
+storiesOf("IconButton (React)", module)
   .add("Default", () => (
     <IconButton icon={configureIcon} label="Label" automationId="demo-button" />
   ))

--- a/packages/component-library/stories/IconButton.stories.tsx
+++ b/packages/component-library/stories/IconButton.stories.tsx
@@ -23,9 +23,6 @@ storiesOf("IconButton (React)", module)
   .add("Disabled", () => (
     <IconButton icon={configureIcon} label="Label" disabled={true} />
   ))
-  .add("Form", () => (
-    <IconButton icon={configureIcon} label="Label" form={true} />
-  ))
   .add("Destructive", () => (
     <IconButton icon={configureIcon} label="Label" destructive={true} />
   ))
@@ -47,4 +44,7 @@ storiesOf("IconButton (React)", module)
       reversed={true}
       disabled={true}
     />
+  ))
+  .add("Form (discouraged)", () => (
+    <IconButton icon={configureIcon} label="Label" form={true} />
   ))

--- a/packages/component-library/stories/InlineNotification.stories.elm
+++ b/packages/component-library/stories/InlineNotification.stories.elm
@@ -19,35 +19,49 @@ multiline =
 
 main =
     storybook
-        [ statelessStoryOf "Affirmative" <|
+        [ statelessStoryOf "Dismissible, Positive" <|
             Notification.view
                 (Notification.inline "Success!" [ text "New user data, imported by mackenzie@hooli.com has successfully uploaded. ", a [ href "/" ] [ text "Manage users is now available" ] ] False
                     |> Notification.notificationType Notification.Affirmative
                 )
                 (Notification.Manual Notification.Visible)
                 (always "")
-        , statelessStoryOf "Informative" <|
+        , statelessStoryOf "Dismissible, Informative" <|
             Notification.view
                 (Notification.inline "Informative" [ text "New user data is currently being processed. We'll let you know when the process is completed. ", a [ href "/" ] [ text "Manage users" ] ] False
                     |> Notification.notificationType Notification.Informative
                 )
                 (Notification.Manual Notification.Visible)
                 (always "")
-        , statelessStoryOf "Cautionary" <|
+        , statelessStoryOf "Dismissible, Cautionary" <|
             Notification.view
                 (Notification.inline "Cautionary" [ text "New user data, imported by mackenzie@hooli.com has uploaded with some minor issues. ", a [ href "/" ] [ text "View issues" ] ] False
                     |> Notification.notificationType Notification.Cautionary
                 )
                 (Notification.Manual Notification.Visible)
                 (always "")
-        , statelessStoryOf "Negative" <|
+        , statelessStoryOf "Dismissible, Negative" <|
             Notification.view
                 (Notification.inline "Negative" [ text "Check your connection and try again. ", a [ href "/" ] [ text "Refresh" ] ] False
                     |> Notification.notificationType Notification.Negative
                 )
                 (Notification.Manual Notification.Visible)
                 (always "")
-        , statelessStoryOf "Persistent, Affirmative" <|
+        , statelessStoryOf "Dismissible, Multiline" <|
+            Notification.view
+                (Notification.inline "Negative" multiline False
+                    |> Notification.notificationType Notification.Negative
+                )
+                (Notification.Manual Notification.Visible)
+                (always "")
+        , statelessStoryOf "Dismissible, Slim" <|
+            Notification.view
+                (Notification.inline "Success!" [ a [ href "/" ] [ text "Manage users is now available" ] ] False
+                    |> Notification.notificationType Notification.Affirmative
+                )
+                (Notification.Manual Notification.Visible)
+                (always "")
+        , statelessStoryOf "Persistent, Positive" <|
             Notification.view
                 (Notification.inline "Success!" [ text "New user data, imported by mackenzie@hooli.com has successfully uploaded. ", a [ href "/" ] [ text "Manage users is now available" ] ] True
                     |> Notification.notificationType Notification.Affirmative
@@ -75,24 +89,10 @@ main =
                 )
                 (Notification.Manual Notification.Visible)
                 (always "")
-        , statelessStoryOf "Multiline" <|
-            Notification.view
-                (Notification.inline "Negative" multiline False
-                    |> Notification.notificationType Notification.Negative
-                )
-                (Notification.Manual Notification.Visible)
-                (always "")
         , statelessStoryOf "Persistent, Multiline" <|
             Notification.view
                 (Notification.inline "Negative" multiline True
                     |> Notification.notificationType Notification.Negative
-                )
-                (Notification.Manual Notification.Visible)
-                (always "")
-        , statelessStoryOf "Slim" <|
-            Notification.view
-                (Notification.inline "Success!" [ a [ href "/" ] [ text "Manage users is now available" ] ] False
-                    |> Notification.notificationType Notification.Affirmative
                 )
                 (Notification.Manual Notification.Visible)
                 (always "")

--- a/packages/component-library/stories/InlineNotification.stories.tsx
+++ b/packages/component-library/stories/InlineNotification.stories.tsx
@@ -5,7 +5,7 @@ import * as React from "react"
 import { InlineNotification } from "@cultureamp/kaizen-component-library"
 
 storiesOf("InlineNotification (React)", module)
-  .add("Affirmative", () => (
+  .add("Affirmative (Kaizen Site Demo)", () => (
     <InlineNotification
       type="affirmative"
       title="Success!"

--- a/packages/component-library/stories/InlineNotification.stories.tsx
+++ b/packages/component-library/stories/InlineNotification.stories.tsx
@@ -4,7 +4,7 @@ import * as React from "react"
 
 import { InlineNotification } from "@cultureamp/kaizen-component-library"
 
-storiesOf("InlineNotification", module)
+storiesOf("InlineNotification (React)", module)
   .add("Affirmative", () => (
     <InlineNotification
       type="affirmative"

--- a/packages/component-library/stories/InlineNotification.stories.tsx
+++ b/packages/component-library/stories/InlineNotification.stories.tsx
@@ -5,7 +5,7 @@ import * as React from "react"
 import { InlineNotification } from "@cultureamp/kaizen-component-library"
 
 storiesOf("InlineNotification (React)", module)
-  .add("Affirmative (Kaizen Site Demo)", () => (
+  .add("Dismissible, Positive (Kaizen Site Demo)", () => (
     <InlineNotification
       type="affirmative"
       title="Success!"
@@ -15,7 +15,7 @@ storiesOf("InlineNotification (React)", module)
       <a href="/">Manage users is now available</a>
     </InlineNotification>
   ))
-  .add("Affirmative, Autohide", () => (
+  .add("Dismissible, Positive, Autohide", () => (
     <InlineNotification
       type="affirmative"
       title="Success!"
@@ -26,7 +26,7 @@ storiesOf("InlineNotification (React)", module)
       <a href="/">Manage users is now available</a>
     </InlineNotification>
   ))
-  .add("Affirmative, Autohide, Hide Close Icon", () => (
+  .add("Dismissible, Positive, Autohide, Hide Close Icon", () => (
     <InlineNotification
       type="affirmative"
       title="Success!"
@@ -38,7 +38,7 @@ storiesOf("InlineNotification (React)", module)
       <a href="/">Manage users is now available</a>
     </InlineNotification>
   ))
-  .add("Informative", () => (
+  .add("Dismissible, Informative", () => (
     <InlineNotification
       type="informative"
       title="Informative"
@@ -48,7 +48,7 @@ storiesOf("InlineNotification (React)", module)
       process is completed. <a href="/">Manage users</a>
     </InlineNotification>
   ))
-  .add("Cautionary", () => (
+  .add("Dismissible, Cautionary", () => (
     <InlineNotification
       type="cautionary"
       title="Warning"
@@ -58,7 +58,7 @@ storiesOf("InlineNotification (React)", module)
       minor issues. <a href="/">View issues</a>
     </InlineNotification>
   ))
-  .add("Negative", () => (
+  .add("Dismissible, Negative", () => (
     <InlineNotification
       type="negative"
       title="No network connection"
@@ -67,7 +67,28 @@ storiesOf("InlineNotification (React)", module)
       Check your connection and try again. <a href="/">Refresh</a>.
     </InlineNotification>
   ))
-  .add("Persistent, Affirmative", () => (
+  .add("Dismissible, Multiline", () => (
+    <InlineNotification
+      type="negative"
+      title="Error"
+      automationId="notification1"
+    >
+      There’s a problem connecting to your HRIS. Check your HRIS is working and
+      check your <a href="/">integration settings</a>, or if you require more
+      assistance please <a href="/">contact support</a>.
+    </InlineNotification>
+  ))
+  .add("Dismissible, Slim", () => (
+    <InlineNotification
+      type="affirmative"
+      title="Success!"
+      automationId="notification1"
+    >
+      <a href="/">Manage users is now available</a>
+    </InlineNotification>
+  ))
+
+  .add("Persistent, Positive", () => (
     <InlineNotification
       type="affirmative"
       title="Success!"
@@ -109,17 +130,6 @@ storiesOf("InlineNotification (React)", module)
       Check your connection and try again. <a href="/">Refresh</a>.
     </InlineNotification>
   ))
-  .add("Multiline", () => (
-    <InlineNotification
-      type="negative"
-      title="Error"
-      automationId="notification1"
-    >
-      There’s a problem connecting to your HRIS. Check your HRIS is working and
-      check your <a href="/">integration settings</a>, or if you require more
-      assistance please <a href="/">contact support</a>.
-    </InlineNotification>
-  ))
 
   .add("Persistent, Multiline", () => (
     <InlineNotification
@@ -131,16 +141,6 @@ storiesOf("InlineNotification (React)", module)
       There’s a problem connecting to your HRIS. Check your HRIS is working and
       check your <a href="/">integration settings</a>, or if you require more
       assistance please <a href="/">contact support</a>.
-    </InlineNotification>
-  ))
-
-  .add("Slim", () => (
-    <InlineNotification
-      type="affirmative"
-      title="Success!"
-      automationId="notification1"
-    >
-      <a href="/">Manage users is now available</a>
     </InlineNotification>
   ))
 
@@ -199,17 +199,17 @@ loadElmStories(
   module,
   require("./InlineNotification.stories.elm"),
   [
-    "Affirmative",
-    "Informative",
-    "Cautionary",
-    "Negative",
-    "Persistent, Affirmative",
+    "Dismissible, Positive",
+    "Dismissible, Informative",
+    "Dismissible, Cautionary",
+    "Dismissible, Negative",
+    "Dismissible, Multiline",
+    "Dismissible, Slim",
+    "Persistent, Positive",
     "Persistent, Informative",
     "Persistent, Cautionary",
     "Persistent, Negative",
-    "Multiline",
     "Persistent, Multiline",
-    "Slim",
     "Persistent, Slim",
     "Multiple Notification",
   ]

--- a/packages/component-library/stories/Layout.stories.tsx
+++ b/packages/component-library/stories/Layout.stories.tsx
@@ -18,7 +18,7 @@ const caMonogramIcon = require("@cultureamp/kaizen-component-library/icons/ca-mo
 const supportIcon = require("@cultureamp/kaizen-component-library/icons/support.icon.svg")
   .default
 
-storiesOf("Layout", module).add("Default", () => (
+storiesOf("Layout (React)", module).add("Default", () => (
   <div
     style={{
       flexGrow: 1,

--- a/packages/component-library/stories/LoadingPlaceholder.stories.elm
+++ b/packages/component-library/stories/LoadingPlaceholder.stories.elm
@@ -74,13 +74,24 @@ reversedOceanPlaceholder =
 
 main =
     storybook
-        [ statelessStoryOf "Basic block" <|
+        [ statelessStoryOf "Default, Multiple" <|
             storyContainer
                 ([ paragraph ]
                     ++ List.repeat 5
                         defaultPlaceholder
                 )
-        , statelessStoryOf "Variable width block" <|
+        , statelessStoryOf "Default, Multiple, Inline" <|
+            storyContainer
+                [ paragraph
+                , div []
+                    [ div [] (List.repeat 3 (inlinePlaceholder 30))
+                    , div [] (List.repeat 3 (inlinePlaceholder 30))
+                    , div [] (List.repeat 3 (inlinePlaceholder 30))
+                    , div [] (List.repeat 3 (inlinePlaceholder 30))
+                    , div [] (List.repeat 3 (inlinePlaceholder 30))
+                    ]
+                ]
+        , statelessStoryOf "Default, Multiple, Variable width" <|
             storyContainer
                 [ paragraph
                 , variableWidthPlaceholder 90
@@ -89,7 +100,7 @@ main =
                 , variableWidthPlaceholder 85
                 , variableWidthPlaceholder 80
                 ]
-        , statelessStoryOf "Variable width block (centred)" <|
+        , statelessStoryOf "Default, Multiple, Variable width, Centered" <|
             storyContainer
                 [ div [ style "text-align" "center" ] [ paragraph ]
                 , LoadingPlaceholder.view
@@ -117,45 +128,7 @@ main =
                         |> LoadingPlaceholder.width 60
                     )
                 ]
-        , statelessStoryOf "Heading" <|
-            storyContainer
-                ([ paragraph ]
-                    ++ List.repeat 5 tallPlaceholder
-                )
-        , statelessStoryOf "Inline" <|
-            storyContainer
-                [ paragraph
-                , div []
-                    [ div [] (List.repeat 3 (inlinePlaceholder 30))
-                    , div [] (List.repeat 3 (inlinePlaceholder 30))
-                    , div [] (List.repeat 3 (inlinePlaceholder 30))
-                    , div [] (List.repeat 3 (inlinePlaceholder 30))
-                    , div [] (List.repeat 3 (inlinePlaceholder 30))
-                    ]
-                ]
-        , statelessStoryOf "Without bottom margin" <|
-            storyContainer
-                [ LoadingPlaceholder.view
-                    (LoadingPlaceholder.default
-                        |> LoadingPlaceholder.noBottomMargin
-                    )
-                , Text.view (Text.p |> Text.inline True) [ text "These loading placeholders have no bottom margin." ]
-                , LoadingPlaceholder.view
-                    (LoadingPlaceholder.default
-                        |> LoadingPlaceholder.noBottomMargin
-                    )
-                ]
-        , statelessStoryOf "Inherit baseline" <|
-            storyContainer
-                [ div [ class .flexbox ]
-                    [ Text.view (Text.h2 |> Text.inheritBaseline True) [ text "Inheriting baseline" ]
-                    , LoadingPlaceholder.view
-                        (LoadingPlaceholder.default
-                            |> LoadingPlaceholder.inheritBaseline
-                        )
-                    ]
-                ]
-        , statelessStoryOf "Combined block and inline" <|
+        , statelessStoryOf "Default, Multiple, Combined block and inline" <|
             storyContainer
                 [ paragraph
                 , div []
@@ -169,7 +142,34 @@ main =
                 , div [] (List.repeat 3 (inlinePlaceholder 30))
                 , div [] (List.repeat 3 (inlinePlaceholder 30))
                 ]
-        , statelessStoryOf "Reversed Default" <|
+        , statelessStoryOf "Default, Without bottom margin" <|
+            storyContainer
+                [ LoadingPlaceholder.view
+                    (LoadingPlaceholder.default
+                        |> LoadingPlaceholder.noBottomMargin
+                    )
+                , Text.view (Text.p |> Text.inline True) [ text "These loading placeholders have no bottom margin." ]
+                , LoadingPlaceholder.view
+                    (LoadingPlaceholder.default
+                        |> LoadingPlaceholder.noBottomMargin
+                    )
+                ]
+        , statelessStoryOf "Default, Inherit baseline" <|
+            storyContainer
+                [ div [ class .flexbox ]
+                    [ Text.view (Text.h2 |> Text.inheritBaseline True) [ text "Inheriting baseline" ]
+                    , LoadingPlaceholder.view
+                        (LoadingPlaceholder.default
+                            |> LoadingPlaceholder.inheritBaseline
+                        )
+                    ]
+                ]
+        , statelessStoryOf "Heading" <|
+            storyContainer
+                ([ paragraph ]
+                    ++ List.repeat 5 tallPlaceholder
+                )
+        , statelessStoryOf "Reversed, Default" <|
             storyContainer
                 [ div
                     [ class .reversedDefault ]

--- a/packages/component-library/stories/LoadingPlaceholder.stories.elm
+++ b/packages/component-library/stories/LoadingPlaceholder.stories.elm
@@ -117,7 +117,7 @@ main =
                         |> LoadingPlaceholder.width 60
                     )
                 ]
-        , statelessStoryOf "Tall" <|
+        , statelessStoryOf "Heading" <|
             storyContainer
                 ([ paragraph ]
                     ++ List.repeat 5 tallPlaceholder

--- a/packages/component-library/stories/LoadingPlaceholder.stories.tsx
+++ b/packages/component-library/stories/LoadingPlaceholder.stories.tsx
@@ -74,7 +74,7 @@ storiesOf("LoadingPlaceholder (React)", module)
     </StoryContainer>
   ))
 
-  .add("Tall", () => (
+  .add("Heading", () => (
     <StoryContainer>
       <div>
         <Text tag="p">
@@ -308,7 +308,7 @@ loadElmStories(
     "Basic block",
     "Variable width block",
     "Variable width block (centred)",
-    "Tall",
+    "Heading",
     "Inline",
     "Without bottom margin",
     "Inherit baseline",

--- a/packages/component-library/stories/LoadingPlaceholder.stories.tsx
+++ b/packages/component-library/stories/LoadingPlaceholder.stories.tsx
@@ -10,7 +10,7 @@ const StoryContainer: React.FunctionComponent<{}> = ({ children }) => {
   return <div className={styles.storyContainer}>{children}</div>
 }
 
-storiesOf("LoadingPlaceholder", module)
+storiesOf("LoadingPlaceholder (React)", module)
   .add("Basic block", () => (
     <StoryContainer>
       <Text tag="p">

--- a/packages/component-library/stories/LoadingPlaceholder.stories.tsx
+++ b/packages/component-library/stories/LoadingPlaceholder.stories.tsx
@@ -306,15 +306,15 @@ loadElmStories(
   module,
   require("./LoadingPlaceholder.stories.elm"),
   [
-    "Basic block",
-    "Variable width block",
-    "Variable width block (centred)",
+    "Default, Multiple",
+    "Default, Multiple, Inline",
+    "Default, Multiple, Variable width",
+    "Default, Multiple, Variable width, Centered",
+    "Default, Multiple, Combined block and inline",
+    "Default, Without bottom margin",
+    "Default, Inherit baseline",
     "Heading",
-    "Inline",
-    "Without bottom margin",
-    "Inherit baseline",
-    "Combined block and inline",
-    "Reversed Default",
+    "Reversed, Default",
     "In the wild",
   ]
 )

--- a/packages/component-library/stories/LoadingPlaceholder.stories.tsx
+++ b/packages/component-library/stories/LoadingPlaceholder.stories.tsx
@@ -177,7 +177,6 @@ storiesOf("LoadingPlaceholder (React)", module)
     </StoryContainer>
   ))
 
-
   .add("Heading", () => (
     <StoryContainer>
       <div>

--- a/packages/component-library/stories/LoadingPlaceholder.stories.tsx
+++ b/packages/component-library/stories/LoadingPlaceholder.stories.tsx
@@ -11,7 +11,7 @@ const StoryContainer: React.FunctionComponent<{}> = ({ children }) => {
 }
 
 storiesOf("LoadingPlaceholder (React)", module)
-  .add("Basic block", () => (
+  .add("Basic block (Kaizen Site Demo)", () => (
     <StoryContainer>
       <Text tag="p">
         Dr. Brené Brown, author of Daring Greatly, is a research professor from

--- a/packages/component-library/stories/LoadingPlaceholder.stories.tsx
+++ b/packages/component-library/stories/LoadingPlaceholder.stories.tsx
@@ -11,7 +11,7 @@ const StoryContainer: React.FunctionComponent<{}> = ({ children }) => {
 }
 
 storiesOf("LoadingPlaceholder (React)", module)
-  .add("Basic block (Kaizen Site Demo)", () => (
+  .add("Default, Multiple (Kaizen Site Demo)", () => (
     <StoryContainer>
       <Text tag="p">
         Dr. Brené Brown, author of Daring Greatly, is a research professor from
@@ -31,7 +31,50 @@ storiesOf("LoadingPlaceholder (React)", module)
     </StoryContainer>
   ))
 
-  .add("Variable width block", () => (
+  .add("Default, Multiple, Inline", () => (
+    <StoryContainer>
+      <div>
+        <Text tag="p">
+          Dr. Brené Brown, author of Daring Greatly, is a research professor
+          from the University of Houston who studies human emotions, including
+          shame and vulnerability. In a March 2012 TED talk, she said,
+          “Vulnerability is not weakness, and that myth is profoundly
+          dangerous.” She went on to say that after 12 years of research, she
+          has actually determined that vulnerability is “our most accurate
+          measurement of courage.”
+        </Text>
+      </div>
+      <>
+        <div>
+          <LoadingPlaceholder inline width={30} />
+          <LoadingPlaceholder inline width={30} />
+          <LoadingPlaceholder inline width={30} />
+        </div>
+        <div>
+          <LoadingPlaceholder inline width={30} />
+          <LoadingPlaceholder inline width={30} />
+          <LoadingPlaceholder inline width={30} />
+        </div>
+        <div>
+          <LoadingPlaceholder inline width={30} />
+          <LoadingPlaceholder inline width={30} />
+          <LoadingPlaceholder inline width={30} />
+        </div>
+        <div>
+          <LoadingPlaceholder inline width={30} />
+          <LoadingPlaceholder inline width={30} />
+          <LoadingPlaceholder inline width={30} />
+        </div>
+        <div>
+          <LoadingPlaceholder inline width={30} />
+          <LoadingPlaceholder inline width={30} />
+          <LoadingPlaceholder inline width={30} />
+        </div>
+      </>
+    </StoryContainer>
+  ))
+
+  .add("Default, Multiple, Variable width", () => (
     <StoryContainer>
       <Text tag="p">
         Dr. Brené Brown, author of Daring Greatly, is a research professor from
@@ -51,7 +94,7 @@ storiesOf("LoadingPlaceholder (React)", module)
     </StoryContainer>
   ))
 
-  .add("Variable width block (centred)", () => (
+  .add("Default, Multiple, Variable width, Centered", () => (
     <StoryContainer>
       <div style={{ textAlign: "center" }}>
         <Text tag="p">
@@ -74,95 +117,7 @@ storiesOf("LoadingPlaceholder (React)", module)
     </StoryContainer>
   ))
 
-  .add("Heading", () => (
-    <StoryContainer>
-      <div>
-        <Text tag="p">
-          Dr. Brené Brown, author of Daring Greatly, is a research professor
-          from the University of Houston who studies human emotions, including
-          shame and vulnerability. In a March 2012 TED talk, she said,
-          “Vulnerability is not weakness, and that myth is profoundly
-          dangerous.” She went on to say that after 12 years of research, she
-          has actually determined that vulnerability is “our most accurate
-          measurement of courage.”
-        </Text>
-      </div>
-      <>
-        <LoadingPlaceholder tall />
-        <LoadingPlaceholder tall />
-        <LoadingPlaceholder tall />
-        <LoadingPlaceholder tall />
-        <LoadingPlaceholder tall />
-      </>
-    </StoryContainer>
-  ))
-
-  .add("Inline", () => (
-    <StoryContainer>
-      <div>
-        <Text tag="p">
-          Dr. Brené Brown, author of Daring Greatly, is a research professor
-          from the University of Houston who studies human emotions, including
-          shame and vulnerability. In a March 2012 TED talk, she said,
-          “Vulnerability is not weakness, and that myth is profoundly
-          dangerous.” She went on to say that after 12 years of research, she
-          has actually determined that vulnerability is “our most accurate
-          measurement of courage.”
-        </Text>
-      </div>
-      <>
-        <div>
-          <LoadingPlaceholder inline width={30} />
-          <LoadingPlaceholder inline width={30} />
-          <LoadingPlaceholder inline width={30} />
-        </div>
-        <div>
-          <LoadingPlaceholder inline width={30} />
-          <LoadingPlaceholder inline width={30} />
-          <LoadingPlaceholder inline width={30} />
-        </div>
-        <div>
-          <LoadingPlaceholder inline width={30} />
-          <LoadingPlaceholder inline width={30} />
-          <LoadingPlaceholder inline width={30} />
-        </div>
-        <div>
-          <LoadingPlaceholder inline width={30} />
-          <LoadingPlaceholder inline width={30} />
-          <LoadingPlaceholder inline width={30} />
-        </div>
-        <div>
-          <LoadingPlaceholder inline width={30} />
-          <LoadingPlaceholder inline width={30} />
-          <LoadingPlaceholder inline width={30} />
-        </div>
-      </>
-    </StoryContainer>
-  ))
-
-  .add("Without bottom margin", () => (
-    <StoryContainer>
-      <LoadingPlaceholder noBottomMargin />
-      <Text tag="p" inline>
-        These loading placeholders have no bottom margin.
-      </Text>
-
-      <LoadingPlaceholder noBottomMargin />
-    </StoryContainer>
-  ))
-
-  .add("Inherit baseline", () => (
-    <StoryContainer>
-      <div className={styles.flexbox}>
-        <Text tag="h2" inheritBaseline>
-          Inheriting baseline
-        </Text>
-        <LoadingPlaceholder inheritBaseline />
-      </div>
-    </StoryContainer>
-  ))
-
-  .add("Combined block and inline", () => (
+  .add("Default, Multiple, Combined block and inline", () => (
     <StoryContainer>
       <div>
         <Text tag="p">
@@ -200,7 +155,53 @@ storiesOf("LoadingPlaceholder (React)", module)
     </StoryContainer>
   ))
 
-  .add("Reversed Default", () => {
+  .add("Default, Without bottom margin", () => (
+    <StoryContainer>
+      <LoadingPlaceholder noBottomMargin />
+      <Text tag="p" inline>
+        These loading placeholders have no bottom margin.
+      </Text>
+
+      <LoadingPlaceholder noBottomMargin />
+    </StoryContainer>
+  ))
+
+  .add("Default, Inherit baseline", () => (
+    <StoryContainer>
+      <div className={styles.flexbox}>
+        <Text tag="h2" inheritBaseline>
+          Inheriting baseline
+        </Text>
+        <LoadingPlaceholder inheritBaseline />
+      </div>
+    </StoryContainer>
+  ))
+
+
+  .add("Heading", () => (
+    <StoryContainer>
+      <div>
+        <Text tag="p">
+          Dr. Brené Brown, author of Daring Greatly, is a research professor
+          from the University of Houston who studies human emotions, including
+          shame and vulnerability. In a March 2012 TED talk, she said,
+          “Vulnerability is not weakness, and that myth is profoundly
+          dangerous.” She went on to say that after 12 years of research, she
+          has actually determined that vulnerability is “our most accurate
+          measurement of courage.”
+        </Text>
+      </div>
+      <>
+        <LoadingPlaceholder tall />
+        <LoadingPlaceholder tall />
+        <LoadingPlaceholder tall />
+        <LoadingPlaceholder tall />
+        <LoadingPlaceholder tall />
+      </>
+    </StoryContainer>
+  ))
+
+  .add("Reversed, Default", () => {
     return (
       <StoryContainer>
         <div className={styles.reversedDefault}>

--- a/packages/component-library/stories/MenuList.stories.tsx
+++ b/packages/component-library/stories/MenuList.stories.tsx
@@ -11,7 +11,7 @@ import {
 const caMonogramIcon = require("@cultureamp/kaizen-component-library/icons/ca-monogram.icon.svg")
   .default
 
-storiesOf("MenuList", module)
+storiesOf("MenuList (React)", module)
   .add("Default", () => (
     <MenuList>
       <MenuHeader title="Contextual Select Menu" />

--- a/packages/component-library/stories/Modal.stories.tsx
+++ b/packages/component-library/stories/Modal.stories.tsx
@@ -44,7 +44,7 @@ class ModalStateContainer extends React.Component<
   }
 }
 
-storiesOf("Modal", module)
+storiesOf("Modal (React)", module)
   .add("Confirmation (positive)", () => (
     <ModalStateContainer isInitiallyOpen={true}>
       {({ open, close, isOpen }) => (

--- a/packages/component-library/stories/Modal.stories.tsx
+++ b/packages/component-library/stories/Modal.stories.tsx
@@ -45,7 +45,7 @@ class ModalStateContainer extends React.Component<
 }
 
 storiesOf("Modal (React)", module)
-  .add("Confirmation (positive)", () => (
+  .add("Confirmation (positive) (Kaizen Site Demo)", () => (
     <ModalStateContainer isInitiallyOpen={true}>
       {({ open, close, isOpen }) => (
         <div>

--- a/packages/component-library/stories/Modal.stories.tsx
+++ b/packages/component-library/stories/Modal.stories.tsx
@@ -164,7 +164,7 @@ storiesOf("Modal (React)", module)
                 <TextField
                   id="email"
                   inputType="email"
-                  inputValue="rod.leviton@cultureamp.com"
+                  inputValue="mackenzie@example.com"
                   labelText="Email"
                   placeholder="Please enter your email"
                   onChange={action("user input")}
@@ -216,7 +216,7 @@ storiesOf("Modal (React)", module)
                 <TextField
                   id="email"
                   inputType="email"
-                  inputValue="rod.leviton@cultureamp.com"
+                  inputValue="mackenzie@example.com"
                   labelText="Email"
                   placeholder="Please enter your email"
                   onChange={action("user input")}
@@ -267,7 +267,7 @@ storiesOf("Modal (React)", module)
                 <TextField
                   id="email"
                   inputType="email"
-                  inputValue="rod.leviton@cultureamp.com"
+                  inputValue="mackenzie@example.com"
                   labelText="Email"
                   placeholder="Please enter your email"
                   onChange={action("user input")}

--- a/packages/component-library/stories/NavigationBar.stories.tsx
+++ b/packages/component-library/stories/NavigationBar.stories.tsx
@@ -14,7 +14,7 @@ const caMonogramIcon = require("@cultureamp/kaizen-component-library/icons/ca-mo
 const supportIcon = require("@cultureamp/kaizen-component-library/icons/support.icon.svg")
   .default
 
-storiesOf("NavigationBar", module)
+storiesOf("NavigationBar (React)", module)
   .add("Default", () => (
     <NavigationBar>
       <Link text="Home" href="/" active />

--- a/packages/component-library/stories/Popover.stories.tsx
+++ b/packages/component-library/stories/Popover.stories.tsx
@@ -3,7 +3,7 @@ import { Popover } from "@cultureamp/kaizen-component-library/draft"
 import { storiesOf } from "@storybook/react"
 import * as React from "react"
 
-storiesOf("Popover", module)
+storiesOf("Popover (React)", module)
   .add("Default", () => (
     <Popover heading="Default">
       Popover body that explains something useful, is optional, and not critical

--- a/packages/component-library/stories/Popover.stories.tsx
+++ b/packages/component-library/stories/Popover.stories.tsx
@@ -4,7 +4,7 @@ import { storiesOf } from "@storybook/react"
 import * as React from "react"
 
 storiesOf("Popover (React)", module)
-  .add("Default", () => (
+  .add("Default (Kaizen Site Demo)", () => (
     <Popover heading="Default">
       Popover body that explains something useful, is optional, and not critical
       to completing a task.

--- a/packages/component-library/stories/Radio.stories.tsx
+++ b/packages/component-library/stories/Radio.stories.tsx
@@ -48,7 +48,7 @@ class RadioFieldExample extends React.Component<Props> {
     )
   }
 }
-storiesOf("Radio", module)
+storiesOf("Radio (React)", module)
   .add("Interactive", () => (
     <RadioFieldExample
       render={({ selectedStatus, onChangeHandler }) => (

--- a/packages/component-library/stories/Radio.stories.tsx
+++ b/packages/component-library/stories/Radio.stories.tsx
@@ -49,7 +49,7 @@ class RadioFieldExample extends React.Component<Props> {
   }
 }
 storiesOf("Radio (React)", module)
-  .add("Interactive", () => (
+  .add("Interactive (Kaizen Site Demo)", () => (
     <RadioFieldExample
       render={({ selectedStatus, onChangeHandler }) => (
         <Radio

--- a/packages/component-library/stories/RadioGroup.stories.tsx
+++ b/packages/component-library/stories/RadioGroup.stories.tsx
@@ -38,7 +38,7 @@ export default class RadioGroupExample extends React.Component<Props> {
 }
 
 storiesOf("RadioGroup (React)", module)
-  .add("Standard (Kaizen Site Demo)", () => (
+  .add("Default (Kaizen Site Demo)", () => (
     <RadioGroupExample
       render={({ selectedOption, onChangeHandler }) => (
         <RadioGroup labelText="Radio group label">

--- a/packages/component-library/stories/RadioGroup.stories.tsx
+++ b/packages/component-library/stories/RadioGroup.stories.tsx
@@ -38,7 +38,7 @@ export default class RadioGroupExample extends React.Component<Props> {
 }
 
 storiesOf("RadioGroup (React)", module)
-  .add("Standard", () => (
+  .add("Standard (Kaizen Site Demo)", () => (
     <RadioGroupExample
       render={({ selectedOption, onChangeHandler }) => (
         <RadioGroup labelText="Radio group label">

--- a/packages/component-library/stories/RadioGroup.stories.tsx
+++ b/packages/component-library/stories/RadioGroup.stories.tsx
@@ -37,7 +37,7 @@ export default class RadioGroupExample extends React.Component<Props> {
   }
 }
 
-storiesOf("RadioGroup", module)
+storiesOf("RadioGroup (React)", module)
   .add("Standard", () => (
     <RadioGroupExample
       render={({ selectedOption, onChangeHandler }) => (

--- a/packages/component-library/stories/Select.stories.tsx
+++ b/packages/component-library/stories/Select.stories.tsx
@@ -102,7 +102,7 @@ storiesOf("Select (React)", module)
   ))
 
 loadElmStories("Select (Elm)", module, require("./SelectStories.elm"), [
-  "Single",
+  "Single (Kaizen Site Demo)",
   "Single Searchable",
   "Multi-Select Searchable",
 ])

--- a/packages/component-library/stories/Select.stories.tsx
+++ b/packages/component-library/stories/Select.stories.tsx
@@ -57,7 +57,7 @@ const promiseOptions = inputValue =>
     }, 1000)
   })
 
-storiesOf("Select", module)
+storiesOf("Select (React)", module)
   .add("Single", () => (
     <StoryContainer>
       <Select

--- a/packages/component-library/stories/SelectStories.elm
+++ b/packages/component-library/stories/SelectStories.elm
@@ -73,7 +73,7 @@ main =
             }
     in
     storybook
-        [ storyOf "Single" config <|
+        [ storyOf "Single (Kaizen Site Demo)" config <|
             \m ->
                 Html.map SelectMsg <|
                     div [ style "width" "300px", style "margin-top" "12px" ]

--- a/packages/component-library/stories/SplitButton.stories.tsx
+++ b/packages/component-library/stories/SplitButton.stories.tsx
@@ -10,7 +10,7 @@ const editIcon = require("@cultureamp/kaizen-component-library/icons/edit.icon.s
   .default
 
 storiesOf("SplitButton (React)", module)
-  .add("Default", () => (
+  .add("Default (Kaizen Site Demo)", () => (
     <SplitButton
       label="Edit"
       onClick={() => action("Button clicked")}

--- a/packages/component-library/stories/SplitButton.stories.tsx
+++ b/packages/component-library/stories/SplitButton.stories.tsx
@@ -9,7 +9,7 @@ const duplicateIcon = require("@cultureamp/kaizen-component-library/icons/duplic
 const editIcon = require("@cultureamp/kaizen-component-library/icons/edit.icon.svg")
   .default
 
-storiesOf("SplitButton", module)
+storiesOf("SplitButton (React)", module)
   .add("Default", () => (
     <SplitButton
       label="Edit"

--- a/packages/component-library/stories/Table.stories.tsx
+++ b/packages/component-library/stories/Table.stories.tsx
@@ -106,7 +106,7 @@ const ExampleTableRow = ({
   </TableRow>
 )
 
-storiesOf("Table", module)
+storiesOf("Table (React)", module)
   .add("Default", () => (
     <Container>
       <TableContainer>

--- a/packages/component-library/stories/Table.stories.tsx
+++ b/packages/component-library/stories/Table.stories.tsx
@@ -107,7 +107,7 @@ const ExampleTableRow = ({
 )
 
 storiesOf("Table (React)", module)
-  .add("Default", () => (
+  .add("Default (Kaizen Site Demo)", () => (
     <Container>
       <TableContainer>
         <TableHeader>

--- a/packages/component-library/stories/Tabs.stories.tsx
+++ b/packages/component-library/stories/Tabs.stories.tsx
@@ -6,7 +6,7 @@ import { Tabs } from "@cultureamp/kaizen-component-library/draft"
 
 import { storiesOf } from "@storybook/react"
 
-storiesOf("Tabs", module)
+storiesOf("Tabs (React)", module)
   .add("Default", () => {
     const tabs = [
       { label: "One" },

--- a/packages/component-library/stories/Tag.stories.tsx
+++ b/packages/component-library/stories/Tag.stories.tsx
@@ -9,7 +9,7 @@ const StoryContainer = ({ children }: { children: React.ReactNode }) => (
   </div>
 )
 
-storiesOf("Tag", module)
+storiesOf("Tag (React)", module)
   .add("Default - Medium", () => (
     <StoryContainer>
       <Tag variant="default">Default</Tag>

--- a/packages/component-library/stories/Tag.stories.tsx
+++ b/packages/component-library/stories/Tag.stories.tsx
@@ -10,7 +10,7 @@ const StoryContainer = ({ children }: { children: React.ReactNode }) => (
 )
 
 storiesOf("Tag (React)", module)
-  .add("Default - Medium", () => (
+  .add("Default - Medium (Kaizen Site Demo)", () => (
     <StoryContainer>
       <Tag variant="default">Default</Tag>
       <Tag variant="default" dismissible>

--- a/packages/component-library/stories/Text.stories.tsx
+++ b/packages/component-library/stories/Text.stories.tsx
@@ -3,7 +3,7 @@ import { Text } from "@cultureamp/kaizen-component-library"
 import { storiesOf } from "@storybook/react"
 import * as React from "react"
 
-storiesOf("Text", module)
+storiesOf("Text (React)", module)
   .add("H1", () => <Text tag="h1">This is a Page Title (H1)</Text>)
 
   .add("H1 (inherit baseline)", () => (

--- a/packages/component-library/stories/TextField.stories.tsx
+++ b/packages/component-library/stories/TextField.stories.tsx
@@ -14,7 +14,7 @@ const ExampleContainer: React.FunctionComponent = ({ children }) => (
 )
 
 storiesOf("TextField (React)", module)
-  .add("Default", () => (
+  .add("Default (Kaizen Site Demo)", () => (
     <ExampleContainer>
       <TextField
         id="email"

--- a/packages/component-library/stories/TextField.stories.tsx
+++ b/packages/component-library/stories/TextField.stories.tsx
@@ -161,7 +161,7 @@ storiesOf("TextField (React)", module)
       <TextField
         id="email"
         inputType="email"
-        inputValue="rod.leviton@cultureamp.com"
+        inputValue="mackenzie@example.com"
         labelText="Email"
         placeholder="Please enter your email"
         onChange={action("user input")}
@@ -184,7 +184,7 @@ storiesOf("TextField (React)", module)
         id="email"
         status="error"
         inputType="email"
-        inputValue="rod.leviton@cultureamp.com"
+        inputValue="mackenzie@example.com"
         labelText="Email"
         placeholder="Please enter your email"
         onChange={action("user input")}
@@ -340,7 +340,7 @@ storiesOf("TextField (React)", module)
       <TextField
         id="email"
         inputType="email"
-        inputValue="rod.leviton@cultureamp.com"
+        inputValue="mackenzie@example.com"
         labelText="Email"
         placeholder="Please enter your email"
         onChange={action("user input")}
@@ -365,7 +365,7 @@ storiesOf("TextField (React)", module)
         id="email"
         status="error"
         inputType="email"
-        inputValue="rod.leviton@cultureamp.com"
+        inputValue="mackenzie@example.com"
         labelText="Email"
         placeholder="Please enter your email"
         onChange={action("user input")}

--- a/packages/component-library/stories/TextField.stories.tsx
+++ b/packages/component-library/stories/TextField.stories.tsx
@@ -13,7 +13,7 @@ const ExampleContainer: React.FunctionComponent = ({ children }) => (
   <div style={{ width: "100%", margin: 10 }}>{children}</div>
 )
 
-storiesOf("TextField", module)
+storiesOf("TextField (React)", module)
   .add("Default", () => (
     <ExampleContainer>
       <TextField

--- a/packages/component-library/stories/TextField.stories.tsx
+++ b/packages/component-library/stories/TextField.stories.tsx
@@ -34,7 +34,7 @@ storiesOf("TextField (React)", module)
       />
     </ExampleContainer>
   ))
-  .add("Default w/ inline", () => (
+  .add("Default, Inline", () => (
     <ExampleContainer>
       <TextField
         id="email"
@@ -48,7 +48,7 @@ storiesOf("TextField (React)", module)
       />
     </ExampleContainer>
   ))
-  .add("Default w/ Icon", () => (
+  .add("Default, Icon", () => (
     <ExampleContainer>
       <TextField
         id="email"
@@ -61,7 +61,7 @@ storiesOf("TextField (React)", module)
       />
     </ExampleContainer>
   ))
-  .add("Default Disabled", () => (
+  .add("Default, Disabled", () => (
     <ExampleContainer>
       <TextField
         id="email"
@@ -74,7 +74,7 @@ storiesOf("TextField (React)", module)
       />
     </ExampleContainer>
   ))
-  .add("Default Disabled w/ value", () => (
+  .add("Default, Disabled w/ value", () => (
     <ExampleContainer>
       <TextField
         id="email"
@@ -87,7 +87,7 @@ storiesOf("TextField (React)", module)
       />
     </ExampleContainer>
   ))
-  .add("Default Disabled + Icon", () => (
+  .add("Default, Disabled + Icon", () => (
     <ExampleContainer>
       <TextField
         id="email"
@@ -101,7 +101,7 @@ storiesOf("TextField (React)", module)
       />
     </ExampleContainer>
   ))
-  .add("Default w/ Success", () => (
+  .add("Default, Success", () => (
     <ExampleContainer>
       <TextField
         id="email"
@@ -114,7 +114,7 @@ storiesOf("TextField (React)", module)
       />
     </ExampleContainer>
   ))
-  .add("Default w/ Success + Icon", () => (
+  .add("Default, Success + Icon", () => (
     <ExampleContainer>
       <TextField
         id="email"
@@ -128,7 +128,7 @@ storiesOf("TextField (React)", module)
       />
     </ExampleContainer>
   ))
-  .add("Default w/ Error", () => (
+  .add("Default, Error", () => (
     <ExampleContainer>
       <TextField
         id="email"
@@ -142,7 +142,7 @@ storiesOf("TextField (React)", module)
       />
     </ExampleContainer>
   ))
-  .add("Default w/ Error + Icon", () => (
+  .add("Default, Error + Icon", () => (
     <ExampleContainer>
       <TextField
         id="email"
@@ -156,7 +156,7 @@ storiesOf("TextField (React)", module)
       />
     </ExampleContainer>
   ))
-  .add("Default Multiple Fields", () => (
+  .add("Default, Multiple Fields", () => (
     <ExampleContainer>
       <TextField
         id="email"
@@ -178,7 +178,7 @@ storiesOf("TextField (React)", module)
       />
     </ExampleContainer>
   ))
-  .add("Default Multiple Fields w/ Error", () => (
+  .add("Default, Multiple Fields, Error", () => (
     <ExampleContainer>
       <TextField
         id="email"
@@ -217,7 +217,7 @@ storiesOf("TextField (React)", module)
       />
     </ExampleContainer>
   ))
-  .add("Reversed w/ Icon", () => (
+  .add("Reversed, Icon", () => (
     <ExampleContainer>
       <TextField
         id="email"
@@ -231,7 +231,7 @@ storiesOf("TextField (React)", module)
       />
     </ExampleContainer>
   ))
-  .add("Reversed Disabled", () => (
+  .add("Reversed, Disabled", () => (
     <ExampleContainer>
       <TextField
         id="email"
@@ -245,7 +245,7 @@ storiesOf("TextField (React)", module)
       />
     </ExampleContainer>
   ))
-  .add("Reversed Disabled w/ value", () => (
+  .add("Reversed, Disabled w/ value", () => (
     <ExampleContainer>
       <TextField
         id="email"
@@ -259,7 +259,7 @@ storiesOf("TextField (React)", module)
       />
     </ExampleContainer>
   ))
-  .add("Reversed Disabled + Icon", () => (
+  .add("Reversed, Disabled + Icon", () => (
     <ExampleContainer>
       <TextField
         id="email"
@@ -274,7 +274,7 @@ storiesOf("TextField (React)", module)
       />
     </ExampleContainer>
   ))
-  .add("Reversed w/ Success", () => (
+  .add("Reversed,  Success", () => (
     <ExampleContainer>
       <TextField
         id="email"
@@ -288,7 +288,7 @@ storiesOf("TextField (React)", module)
       />
     </ExampleContainer>
   ))
-  .add("Reversed w/ Success + Icon", () => (
+  .add("Reversed, Success + Icon", () => (
     <ExampleContainer>
       <TextField
         id="email"
@@ -304,7 +304,7 @@ storiesOf("TextField (React)", module)
     </ExampleContainer>
   ))
 
-  .add("Reversed w/ Error", () => (
+  .add("Reversed, Error", () => (
     <ExampleContainer>
       <TextField
         id="email"
@@ -319,7 +319,7 @@ storiesOf("TextField (React)", module)
       />
     </ExampleContainer>
   ))
-  .add("Reversed w/ Error + Icon", () => (
+  .add("Reversed, Error + Icon", () => (
     <ExampleContainer>
       <TextField
         id="email"
@@ -335,7 +335,7 @@ storiesOf("TextField (React)", module)
       />
     </ExampleContainer>
   ))
-  .add("Reversed Multiple Fields", () => (
+  .add("Reversed, Multiple Fields", () => (
     <ExampleContainer>
       <TextField
         id="email"
@@ -359,7 +359,7 @@ storiesOf("TextField (React)", module)
       />
     </ExampleContainer>
   ))
-  .add("Reversed Multiple Fields w/ Error", () => (
+  .add("Reversed, Multiple Fields w/ Error", () => (
     <ExampleContainer>
       <TextField
         id="email"
@@ -387,7 +387,7 @@ storiesOf("TextField (React)", module)
       />
     </ExampleContainer>
   ))
-  .add("Default with Focus/Blur events", () => (
+  .add("Default, Focus/Blur events", () => (
     <ExampleContainer>
       <TextField
         id="email"

--- a/packages/component-library/stories/TitleBlock.stories.tsx
+++ b/packages/component-library/stories/TitleBlock.stories.tsx
@@ -30,7 +30,7 @@ const stickyContainerStyle = {
   background: "lightgrey",
 }
 
-storiesOf("TitleBlock", module)
+storiesOf("TitleBlock (React)", module)
   .add("with Title", () => <TitleBlock title="Reports" />)
   .add("with subtitle", () => (
     <TitleBlock title="Home" subtitle="Subtitle goes here" />

--- a/packages/component-library/stories/ToastNotification.stories.elm
+++ b/packages/component-library/stories/ToastNotification.stories.elm
@@ -9,7 +9,7 @@ import Text.Text as Text
 
 main =
     storybook
-        [ statelessStoryOf "Affirmative" <|
+        [ statelessStoryOf "Positive" <|
             Notification.view
                 (Notification.toast "Success!" [ text "New user data, imported by mackenzie@hooli.com has successfully uploaded. ", a [ href "/" ] [ text "Manage users is now available" ] ] False
                     |> Notification.notificationType Notification.Affirmative

--- a/packages/component-library/stories/ToastNotification.stories.tsx
+++ b/packages/component-library/stories/ToastNotification.stories.tsx
@@ -5,7 +5,7 @@ import * as React from "react"
 import { ToastNotification } from "@cultureamp/kaizen-component-library"
 
 storiesOf("ToastNotification (React)", module)
-  .add("Affirmative (Kaizen Site Demo)", () => (
+  .add("Positive (Kaizen Site Demo)", () => (
     <ToastNotification
       type="affirmative"
       title="Success!"
@@ -15,7 +15,7 @@ storiesOf("ToastNotification (React)", module)
       <a href="/">Manage users is now available</a>
     </ToastNotification>
   ))
-  .add("Affirmative, Autohide", () => (
+  .add("Positive, Autohide", () => (
     <ToastNotification
       type="affirmative"
       title="Success!"
@@ -26,7 +26,7 @@ storiesOf("ToastNotification (React)", module)
       <a href="/">Manage users is now available</a>
     </ToastNotification>
   ))
-  .add("Affirmative, Autohide, Hide Close Icon", () => (
+  .add("Positive, Autohide, Hide Close Icon", () => (
     <ToastNotification
       automationId="notification1"
       type="affirmative"
@@ -117,7 +117,7 @@ loadElmStories(
   module,
   require("./ToastNotification.stories.elm"),
   [
-    "Affirmative",
+    "Positive",
     "Informative",
     "Cautionary",
     "Negative",

--- a/packages/component-library/stories/ToastNotification.stories.tsx
+++ b/packages/component-library/stories/ToastNotification.stories.tsx
@@ -4,7 +4,7 @@ import * as React from "react"
 
 import { ToastNotification } from "@cultureamp/kaizen-component-library"
 
-storiesOf("ToastNotification", module)
+storiesOf("ToastNotification (React)", module)
   .add("Affirmative", () => (
     <ToastNotification
       type="affirmative"

--- a/packages/component-library/stories/ToastNotification.stories.tsx
+++ b/packages/component-library/stories/ToastNotification.stories.tsx
@@ -5,7 +5,7 @@ import * as React from "react"
 import { ToastNotification } from "@cultureamp/kaizen-component-library"
 
 storiesOf("ToastNotification (React)", module)
-  .add("Affirmative", () => (
+  .add("Affirmative (Kaizen Site Demo)", () => (
     <ToastNotification
       type="affirmative"
       title="Success!"

--- a/packages/component-library/stories/ToggleSwitchField.stories.tsx
+++ b/packages/component-library/stories/ToggleSwitchField.stories.tsx
@@ -37,7 +37,7 @@ const RtlContainer = ({ children }: { children: React.ReactNode }) => (
   <div dir="rtl">{children}</div>
 )
 
-storiesOf("ToggleSwitchField", module)
+storiesOf("ToggleSwitchField (React)", module)
   .add("On", () => (
     <ToggleStateContainer initialToggledStatus={ToggledStatus.ON}>
       {({ toggledStatus, toggle }) => (

--- a/packages/component-library/stories/ToggleSwitchField.stories.tsx
+++ b/packages/component-library/stories/ToggleSwitchField.stories.tsx
@@ -38,7 +38,7 @@ const RtlContainer = ({ children }: { children: React.ReactNode }) => (
 )
 
 storiesOf("ToggleSwitchField (React)", module)
-  .add("On", () => (
+  .add("On (Kaizen Site Demo)", () => (
     <ToggleStateContainer initialToggledStatus={ToggledStatus.ON}>
       {({ toggledStatus, toggle }) => (
         <ToggleSwitchField

--- a/packages/component-library/stories/Tooltip.stories.tsx
+++ b/packages/component-library/stories/Tooltip.stories.tsx
@@ -6,7 +6,7 @@ import { Tag } from "@cultureamp/kaizen-component-library/draft"
 import { Tooltip } from "@cultureamp/kaizen-component-library/draft"
 
 storiesOf("Tooltip (React)", module)
-  .add("Default - Below", () => (
+  .add("Default - Below (Kaizen Site Demo)", () => (
     <div style={{ display: "flex", justifyContent: "center" }}>
       <Tooltip position="below" text="This is below the tooltip">
         <Tag>Below</Tag>

--- a/packages/component-library/stories/Tooltip.stories.tsx
+++ b/packages/component-library/stories/Tooltip.stories.tsx
@@ -5,7 +5,7 @@ import * as React from "react"
 import { Tag } from "@cultureamp/kaizen-component-library/draft"
 import { Tooltip } from "@cultureamp/kaizen-component-library/draft"
 
-storiesOf("Tooltip", module)
+storiesOf("Tooltip (React)", module)
   .add("Default - Below", () => (
     <div style={{ display: "flex", justifyContent: "center" }}>
       <Tooltip position="below" text="This is below the tooltip">

--- a/packages/component-library/stories/VerticalProgressIndicator.stories.tsx
+++ b/packages/component-library/stories/VerticalProgressIndicator.stories.tsx
@@ -16,7 +16,7 @@ const StoryContainer = ({ children }: { children: React.ReactNode }) => (
   </div>
 )
 
-storiesOf("VerticalProgressIndicator", module)
+storiesOf("VerticalProgressIndicator (React)", module)
   .add("Start-Upcoming", () => (
     <StoryContainer>
       <VerticalProgressIndicator position="start" completion="upcoming" />

--- a/packages/component-library/stories/VerticalProgressStep.stories.tsx
+++ b/packages/component-library/stories/VerticalProgressStep.stories.tsx
@@ -15,7 +15,7 @@ const StoryContainer = ({ children }: { children: React.ReactNode }) => (
   </div>
 )
 
-storiesOf("VerticalProgressStep", module)
+storiesOf("VerticalProgressStep (React)", module)
   .add("current step actionable", () => (
     <StoryContainer>
       <VerticalProgressStep.CurrentStep

--- a/packages/component-library/stories/Well.stories.tsx
+++ b/packages/component-library/stories/Well.stories.tsx
@@ -21,7 +21,7 @@ const ExampleContent = () => (
   </div>
 )
 
-storiesOf("Well", module)
+storiesOf("Well (React)", module)
   .add("Default with solid border", () => (
     <Well>
       <ExampleContent />

--- a/packages/component-library/stories/Well.stories.tsx
+++ b/packages/component-library/stories/Well.stories.tsx
@@ -22,7 +22,7 @@ const ExampleContent = () => (
 )
 
 storiesOf("Well (React)", module)
-  .add("Default with solid border", () => (
+  .add("Default with solid border (Kaizen Site Demo)", () => (
     <Well>
       <ExampleContent />
     </Well>

--- a/packages/component-library/stories/Well.stories.tsx
+++ b/packages/component-library/stories/Well.stories.tsx
@@ -68,7 +68,7 @@ storiesOf("Well (React)", module)
     </Well>
   ))
 
-loadElmStories("Well(Elm)", module, require("./Well.stories.elm"), [
+loadElmStories("Well (Elm)", module, require("./Well.stories.elm"), [
   "Default with solid border",
   "Default with dashed border",
   "Default without border",

--- a/site/docs/components/global-notification.mdx
+++ b/site/docs/components/global-notification.mdx
@@ -5,7 +5,7 @@ summaryParagraph: A global notification is a message object used for system-leve
 tags: ["Banner", "Confirmation", "Acknowledgment", "Message", "Alert"]
 needToKnow:
 - A Global notification is always positioned at the top of the screen (above the Navigation Bar) and stretches the full width of the viewport.
-demoStoryId: globalnotification--affirmative
+demoStoryId: globalnotification-react--affirmative-kaizen-site-demo
 ---
 
 ## Visuals

--- a/site/docs/components/global-notification.mdx
+++ b/site/docs/components/global-notification.mdx
@@ -5,7 +5,7 @@ summaryParagraph: A global notification is a message object used for system-leve
 tags: ["Banner", "Confirmation", "Acknowledgment", "Message", "Alert"]
 needToKnow:
 - A Global notification is always positioned at the top of the screen (above the Navigation Bar) and stretches the full width of the viewport.
-demoStoryId: globalnotification-react--affirmative-kaizen-site-demo
+demoStoryId: globalnotification-react--positive-kaizen-site-demo
 ---
 
 ## Visuals

--- a/site/docs/components/inline-notification.mdx
+++ b/site/docs/components/inline-notification.mdx
@@ -5,7 +5,7 @@ summaryParagraph: An inline notification is a message object that presents timel
 tags: ["Banner", "Confirmation", "Acknowledgement", "Message", "Alert"]
 needToKnow: 
 - An inline notification is a message object that presents timely information within content areas as close as possible to the thing that it’s about.
-demoStoryId: inlinenotification-react--affirmative-kaizen-site-demo
+demoStoryId: inlinenotification-react--dismissible-positive-kaizen-site-demo
 ---
 
 ## Visuals

--- a/site/docs/components/inline-notification.mdx
+++ b/site/docs/components/inline-notification.mdx
@@ -5,7 +5,7 @@ summaryParagraph: An inline notification is a message object that presents timel
 tags: ["Banner", "Confirmation", "Acknowledgement", "Message", "Alert"]
 needToKnow: 
 - An inline notification is a message object that presents timely information within content areas as close as possible to the thing that it’s about.
-demoStoryId: inlinenotification--affirmative
+demoStoryId: inlinenotification-react--affirmative-kaizen-site-demo
 ---
 
 ## Visuals

--- a/site/docs/components/split-button.mdx
+++ b/site/docs/components/split-button.mdx
@@ -7,6 +7,7 @@ needToKnow:
 - Avoid split buttons where separated buttons and icon buttons will do.
 - Only include related actions in the dropdown.
 - Don’t use links in the dropdown.
+demoStoryId: splitbutton-react--default-kaizen-site-demo
 ---
 
 ## Visuals

--- a/site/docs/components/toast-notification.mdx
+++ b/site/docs/components/toast-notification.mdx
@@ -5,7 +5,7 @@ summaryParagraph: A toast notification is a message object that presents timely 
 tags: ["Toasts", "Snackbars", "Pop-up notifications", "Drawer notification", "Banner", "Confirmation", "Acknowledgement", "Message", "Alert"]
 needToKnow:
 - Use toast notifications immediately after a specific event such as a user action that does not relate to an object on the page.
-demoStoryId: toastnotification-react--affirmative-kaizen-site-demo
+demoStoryId: toastnotification-react--positive-kaizen-site-demo
 ---
 
 ## Visuals
@@ -75,7 +75,7 @@ When you are notifying a user of the outcome of an action they have taken, provi
 
 *   **Global Notification: **A [Global Notification](/components/global-notification) is a message object used for system-level notifications that inform the user about system status such as logging in and background processes like data imports.
 
-*   **Confirmation Modal:** The [confirmation modal](/components/modal) confirms the end result of an action such as Destructive / Irreversible actions / Affirmative actions.
+*   **Confirmation Modal:** The [confirmation modal](/components/modal) confirms the end result of an action such as Destructive / Irreversible actions / Positive actions.
 
 ## External Links
 

--- a/site/docs/components/toast-notification.mdx
+++ b/site/docs/components/toast-notification.mdx
@@ -5,7 +5,7 @@ summaryParagraph: A toast notification is a message object that presents timely 
 tags: ["Toasts", "Snackbars", "Pop-up notifications", "Drawer notification", "Banner", "Confirmation", "Acknowledgement", "Message", "Alert"]
 needToKnow:
 - Use toast notifications immediately after a specific event such as a user action that does not relate to an object on the page.
-demoStoryId: toastnotification--affirmative
+demoStoryId: toastnotification-react--affirmative-kaizen-site-demo
 ---
 
 ## Visuals


### PR DESCRIPTION
This PR aims to update story titles to increase clarity for designers and engineers because we've seen confusion understanding them. For example, it's not clear what is a 'blessed' component that shows ideal use vs edge cases we want to test for but discourage (e.g. too much text in a button).

Branch previews: 

- Storybook: https://dev.cultureamp.design/di/story-names/storybook/
- An updated component page: https://dev.cultureamp.design/di/story-names/components/tag/

Changes:

* Add " (React)" to React story titles so you can filter stories by React or Elm using Storybook search.
* Add " (Kaizen Site Demo)" to stories used on site so that people are prompted to review any changes to that story on the site, including where changed story titles change story IDs and disappear from the site.
* Add demo story for Text Field, Tag, Split Button, Icon.
* docs: Update TextField docs with a Need to know.
* Renaming, reordering, and updating story titles. This aids scanning groups with lots of stories and learnability through consistency.
* Add " (discouraged)" to "Form" button story and Icon Button Form story.
* Add Elm RTL story.
* Rename "Tall" to "Heading" in Loading Placeholder story to reflect design intention.
* Change "affirmative" to "positive" to reflect design intention for [Moods](https://cultureamp.design/guidelines/moods/).
* Change Culture Amp email address to example email address in some stories.