### PR TITLE
ci: Minor refactors to Buildkite scripts

### DIFF
--- a/.buildkite/scripts/build-site.sh
+++ b/.buildkite/scripts/build-site.sh
@@ -1,7 +1,8 @@
 #!/bin/sh
+set -e
 
 export GATSBY_TELEMETRY_DISABLED=true
 
-yarn setup \
-  && yarn gatsby build --prefix-paths \
-  && tar -czf ./site.tar.gz ./site/public
+yarn install --frozen-lockfile
+yarn gatsby build --prefix-paths
+tar -czf ./site.tar.gz ./site/public

--- a/.buildkite/scripts/build-storybook.sh
+++ b/.buildkite/scripts/build-storybook.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
+set -e
 
-yarn setup \
-  && yarn storybook:build \
-  && tar -czf ./storybook.tar.gz ./storybook/public
+yarn install --frozen-lockfile
+yarn storybook:build
+tar -czf ./storybook.tar.gz ./storybook/public

--- a/.buildkite/scripts/compile.sh
+++ b/.buildkite/scripts/compile.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+set -e
 
-yarn setup \
-  && yarn tsc
+yarn install --frozen-lockfile
+yarn tsc

--- a/.buildkite/scripts/lint.sh
+++ b/.buildkite/scripts/lint.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+set -e
 
-yarn setup \
-  && yarn lint
+yarn install --frozen-lockfile
+yarn lint

--- a/.buildkite/scripts/publish.sh
+++ b/.buildkite/scripts/publish.sh
@@ -1,11 +1,17 @@
 #!/bin/sh
+set -e
 
-echo "Publishing to ${KAIZEN_DOMAIN_NAME}${KAIZEN_BASE_PATH}" \
-  && aws s3 sync --delete \
-      site/public "s3://${KAIZEN_DOMAIN_NAME}${KAIZEN_BASE_PATH}" \
-  && aws s3 sync --delete \
-      storybook/public "s3://${KAIZEN_DOMAIN_NAME}${KAIZEN_BASE_PATH}/storybook-static" \
-  && aws cloudfront create-invalidation \
-      --distribution-id "${KAIZEN_DISTRIBUTION_ID}" \
-      --paths "${KAIZEN_BASE_PATH:-/}*" \
-      --output text
+echo "Publishing to ${KAIZEN_DOMAIN_NAME}${KAIZEN_BASE_PATH}"
+
+aws s3 sync --delete \
+    "site/public" \
+    "s3://${KAIZEN_DOMAIN_NAME}${KAIZEN_BASE_PATH}"
+
+aws s3 sync --delete \
+    "storybook/public" \
+    "s3://${KAIZEN_DOMAIN_NAME}${KAIZEN_BASE_PATH}/storybook-static"
+
+aws cloudfront create-invalidation \
+    --distribution-id "${KAIZEN_DISTRIBUTION_ID}" \
+    --paths "${KAIZEN_BASE_PATH:-/}*" \
+    --output text

--- a/.buildkite/scripts/test.sh
+++ b/.buildkite/scripts/test.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+set -e
 
-yarn setup \
-  && yarn test --ci
+yarn install --frozen-lockfile
+yarn test --ci

--- a/package.json
+++ b/package.json
@@ -19,8 +19,7 @@
     "lint": "elm-format --validate packages && yarn tslint && yarn prettier",
     "lint:fix": "elm-format --yes packages && yarn tslint --fix && yarn prettier --write",
     "clean": "lerna run clean && yarn gatsby clean && rm -rf elm-stuff storybook/public",
-    "reset": "yarn clean && yarn setup --force",
-    "setup": "yarn install --frozen-lockfile"
+    "reset": "yarn clean && yarn install --force"
   },
   "babel": {
     "presets": [


### PR DESCRIPTION
Includes adding `set -e` to exit on first error — equivalent to the existing behaviour, except that all scripts previously were only a single line.