### PR TITLE
fix: toggle switch field positioning bug

### DIFF
--- a/packages/component-library/draft/Kaizen/Form/Primitives/ToggleSwitch/styles.scss
+++ b/packages/component-library/draft/Kaizen/Form/Primitives/ToggleSwitch/styles.scss
@@ -16,6 +16,7 @@ $animation-timing: $ca-duration-immediate $ca-linear;
   border: 1px solid $kz-color-wisteria-300;
   background-color: $kz-color-ash;
   border-radius: $ca-grid;
+  box-sizing: content-box;
   width: ($ca-grid * 1.05) * 2;
   height: ($ca-grid * 1.25);
   padding: 0 $ca-grid * 0.15;
@@ -40,6 +41,7 @@ $animation-timing: $ca-duration-immediate $ca-linear;
 .thumb {
   background-color: $kz-color-white;
   border: 1px solid transparent;
+  box-sizing: content-box;
   width: $ca-grid * 0.9;
   height: $ca-grid * 0.9;
   border-radius: $ca-grid;

--- a/packages/component-library/draft/Kaizen/Form/Primitives/ToggleSwitch/styles.scss
+++ b/packages/component-library/draft/Kaizen/Form/Primitives/ToggleSwitch/styles.scss
@@ -55,8 +55,8 @@ $animation-timing: $ca-duration-immediate $ca-linear;
     background-color: $kz-color-seedling-500;
 
     &.freemium {
-      background-color: add-shade($ca-freemium-green, 10%);
-      border-color: add-shade($ca-freemium-green, 10%);
+      background-color: $kz-color-seedling-400;
+      border-color: $kz-color-seedling-400;
     }
   }
 


### PR DESCRIPTION
A recent change to the toggle positioning broke the styling within freemium, this was due to it inheriting box-sizing from a parent. This fix explicitly sets the box-sizing to keep the thumb and track positioning of the toggle field consistent throughout.

This also updates the colour scheme for freemium to use kz colour tokens.