### PR TITLE
chore: Re-release as `@kaizen/component-library@1.0.0`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,9 +64,9 @@ To learn more about what browsers and devices we support in Kaizen Component Lib
 
 ### Local development with other front-end codebases
 
-To strengthen the Kaizen Design System, we encourage engineers to take a component-first development approach. By concentrating on developing Kaizen components in Storybook, we are likely to improve the API design and achieve good separation of concerns, avoiding components tightly coupled to specific applications. If, however, you want to test a component in the context of another front-end codebase, you can [yarn link](https://yarnpkg.com/lang/en/docs/cli/link/) your local version of `@cultureamp/kaizen-component-library` with your other front-end codebase.
+To strengthen the Kaizen Design System, we encourage engineers to take a component-first development approach. By concentrating on developing Kaizen components in Storybook, we are likely to improve the API design and achieve good separation of concerns, avoiding components tightly coupled to specific applications. If, however, you want to test a component in the context of another front-end codebase, you can [yarn link](https://yarnpkg.com/lang/en/docs/cli/link/) your local version of `@kaizen/component-library` with your other front-end codebase.
 
-**Step 1**: Make your local copy of `@cultureamp/kaizen-component-library` available.
+**Step 1**: Make your local copy of `@kaizen/component-library` available.
 
 ```sh
 # Navigate to code source
@@ -79,14 +79,14 @@ $ yarn link
 $ yarn build:watch
 ```
 
-**Step 2**: Link `@cultureamp/kaizen-component-library` to your other front-end codebase.
+**Step 2**: Link `@kaizen/component-library` to your other front-end codebase.
 
 ```sh
 # Navigate to code source
 $ cd <your_code>/cultureamp/YOUR_FRONT_END_CODEBASE
 
 # Link repo to locally registered package
-$ yarn link @cultureamp/kaizen-component-library
+$ yarn link @kaizen/component-library
 ```
 
 Your local Kaizen changes will now show in your other front-end codebase.
@@ -95,7 +95,7 @@ Your local Kaizen changes will now show in your other front-end codebase.
 
 When you are done, unlink the package:
 
-`yarn unlink @cultureamp/kaizen-component-library`
+`yarn unlink @kaizen/component-library`
 
 You can also clean up generated files:
 
@@ -185,7 +185,7 @@ Note that in the case that a pull request touches files from more than one packa
 
 ## Using new package releases
 
-To use a newly released version of the Kaizen Component Library (or any other package) in a front-end codebase, run `yarn upgrade --latest <scoped package name>` (e.g. `yarn upgrade --latest @cultureamp/kaizen-component-library`).
+To use a newly released version of the Kaizen Component Library (or any other package) in a front-end codebase, run `yarn upgrade --latest <scoped package name>` (e.g. `yarn upgrade --latest @kaizen/component-library`).
 
 Remember to always check the CHANGELOG (e.g. [`/packages/component-library/CHANGELOG.md`](./packages/component-library/CHANGELOG.md) or the [releases page](https://github.com/cultureamp/kaizen-design-system/releases)) for any package you wish to upgrade, paying extra attention to any breaking changes which have been introduced since the last version used in your project.
 

--- a/elm.json
+++ b/elm.json
@@ -2,9 +2,9 @@
     "type": "application",
     "source-directories": [
         ".",
-        "./node_modules/@cultureamp/kaizen-component-library/components",
-        "./node_modules/@cultureamp/kaizen-component-library/draft",
-        "./node_modules/@cultureamp/kaizen-component-library/stories",
+        "./node_modules/@kaizen/component-library/components",
+        "./node_modules/@kaizen/component-library/draft",
+        "./node_modules/@kaizen/component-library/stories",
         "./node_modules/@cultureamp/elm-storybook/src",
         "./node_modules/elm-upgrade-shims/lib-0.19"
     ],

--- a/jest.config.js
+++ b/jest.config.js
@@ -6,7 +6,7 @@ module.exports = {
     "\\.(jpe?g|png)$": "jest-static-stubs/$1",
     "\\.s?css$": "identity-obj-proxy",
     "\\.svg$": require.resolve(
-      "@cultureamp/kaizen-component-library/mocks/svgMock"
+      "@kaizen/component-library/mocks/svgMock"
     ),
   },
 }

--- a/jest.config.js
+++ b/jest.config.js
@@ -5,8 +5,6 @@ module.exports = {
   moduleNameMapper: {
     "\\.(jpe?g|png)$": "jest-static-stubs/$1",
     "\\.s?css$": "identity-obj-proxy",
-    "\\.svg$": require.resolve(
-      "@kaizen/component-library/mocks/svgMock"
-    ),
+    "\\.svg$": require.resolve("@kaizen/component-library/mocks/svgMock"),
   },
 }

--- a/packages/component-library/README.md
+++ b/packages/component-library/README.md
@@ -2,10 +2,10 @@
 
 ## Add to a project
 
-Kaizen Component Library is already included in our main product repositories. If it's needed in a new repo, add `@cultureamp/kaizen-component-library` to your `package.json` file:
+Kaizen Component Library is already included in our main product repositories. If it's needed in a new repo, add `@kaizen/component-library` to your `package.json` file:
 
 ```
-yarn add @cultureamp/kaizen-component-library
+yarn add @kaizen/component-library
 ```
 
 ## Usage
@@ -15,7 +15,7 @@ You can import a Kaizen Component Library package inside your application using 
 React import example:
 
 ```
-import { Button } from "@cultureamp/kaizen-component-library"
+import { Button } from "@kaizen/component-library"
 ```
 
 React usage example:
@@ -51,6 +51,6 @@ For Elm components, we have used Kaizen to namespace them because the source dir
 You can also import Kaizen styles into SCSS files:
 
 ```
-@import '~@cultureamp/kaizen-component-library/styles/type';
+@import '~@kaizen/component-library/styles/type';
 ```
 

--- a/packages/component-library/bin/design-uplift/import_mapping.py
+++ b/packages/component-library/bin/design-uplift/import_mapping.py
@@ -1,5 +1,5 @@
 import_mapping = {
-    "~@cultureamp/kaizen-design-tokens/sass/color": [
+    "~@kaizen/design-tokens/sass/color": [
         "$kz-color-wisteria-100",
         "$kz-color-wisteria-200",
         "$kz-color-wisteria-300",

--- a/packages/component-library/components/Button/Button.elm
+++ b/packages/component-library/components/Button/Button.elm
@@ -215,7 +215,7 @@ viewIconFor configValue forPosition =
 
 
 styles =
-    css "@cultureamp/kaizen-component-library/components/Button/components/GenericButton.module.scss"
+    css "@kaizen/component-library/components/Button/components/GenericButton.module.scss"
         { container = "container"
         , button = "button"
         , primary = "primary"

--- a/packages/component-library/components/Button/styles.scss
+++ b/packages/component-library/components/Button/styles.scss
@@ -2,7 +2,7 @@
 @import "../../styles/color";
 @import "../../styles/type";
 @import "../../styles/layout";
-@import "~@cultureamp/kaizen-design-tokens/sass/color";
+@import "~@kaizen/design-tokens/sass/color";
 
 $caButton-border-width: 1px;
 $caButton-focus-border-width: 2px;

--- a/packages/component-library/components/Dropdown/Dropdown.tsx
+++ b/packages/component-library/components/Dropdown/Dropdown.tsx
@@ -1,7 +1,7 @@
-import { Icon } from "@cultureamp/kaizen-component-library"
-const chevronDownIcon = require("@cultureamp/kaizen-component-library/icons/chevron-down.icon.svg")
+import { Icon } from "@kaizen/component-library"
+const chevronDownIcon = require("@kaizen/component-library/icons/chevron-down.icon.svg")
   .default
-const ellipsisIcon = require("@cultureamp/kaizen-component-library/icons/ellipsis.icon.svg")
+const ellipsisIcon = require("@kaizen/component-library/icons/ellipsis.icon.svg")
   .default
 import classNames from "classnames"
 import * as React from "react"

--- a/packages/component-library/components/Icon/Icon.elm
+++ b/packages/component-library/components/Icon/Icon.elm
@@ -24,7 +24,7 @@ view : Config -> SvgAsset -> Html Never
 view ((Config configValue) as config) svgAsset =
     let
         { toString } =
-            css "@cultureamp/kaizen-component-library/components/Icon/Icon.module.scss"
+            css "@kaizen/component-library/components/Icon/Icon.module.scss"
                 { icon = "icon"
                 , inheritSize = "inheritSize"
                 }

--- a/packages/component-library/components/Icon/Icon.spec.tsx
+++ b/packages/component-library/components/Icon/Icon.spec.tsx
@@ -1,7 +1,7 @@
 import { cleanup, render } from "@testing-library/react"
 import * as React from "react"
 
-import { Icon } from "@cultureamp/kaizen-component-library"
+import { Icon } from "@kaizen/component-library"
 
 afterEach(cleanup)
 

--- a/packages/component-library/components/Layout/Layout.module.scss
+++ b/packages/component-library/components/Layout/Layout.module.scss
@@ -1,5 +1,5 @@
 @import "./styles";
-@import "~@cultureamp/kaizen-component-library/styles/utils";
+@import "~@kaizen/component-library/styles/utils";
 
 .root {
   @extend %root;

--- a/packages/component-library/components/MenuList/Menu.module.scss
+++ b/packages/component-library/components/MenuList/Menu.module.scss
@@ -1,10 +1,10 @@
-@import "~@cultureamp/kaizen-design-tokens/sass/color";
+@import "~@kaizen/design-tokens/sass/color";
 @import "../../styles/type";
 @import "../../styles/color";
 @import "../../styles/border";
 @import "../../styles/layers";
 @import "../../styles/animation";
-@import "~@cultureamp/kaizen-component-library/styles/layout";
+@import "~@kaizen/component-library/styles/layout";
 
 $side-padding: 3/4 * $ca-grid;
 

--- a/packages/component-library/components/NavigationBar/NavigationBar.module.scss
+++ b/packages/component-library/components/NavigationBar/NavigationBar.module.scss
@@ -1,4 +1,4 @@
-@import "~@cultureamp/kaizen-design-tokens/sass/color";
+@import "~@kaizen/design-tokens/sass/color";
 @import "./styles";
 @import "../../styles/color";
 @import "../../styles/type";

--- a/packages/component-library/components/NavigationBar/NavigationBar.tsx
+++ b/packages/component-library/components/NavigationBar/NavigationBar.tsx
@@ -1,4 +1,4 @@
-import { ControlledOffCanvas } from "@cultureamp/kaizen-component-library"
+import { ControlledOffCanvas } from "@kaizen/component-library"
 import classNames from "classnames"
 import * as React from "react"
 import Media from "react-media"

--- a/packages/component-library/components/NavigationBar/_styles.scss
+++ b/packages/component-library/components/NavigationBar/_styles.scss
@@ -1,4 +1,4 @@
-@import "~@cultureamp/kaizen-design-tokens/sass/color";
+@import "~@kaizen/design-tokens/sass/color";
 @import "../../styles/color";
 @import "../../styles/type";
 

--- a/packages/component-library/components/NavigationBar/components/Badge.module.scss
+++ b/packages/component-library/components/NavigationBar/components/Badge.module.scss
@@ -1,4 +1,4 @@
-@import "~@cultureamp/kaizen-design-tokens/sass/color";
+@import "~@kaizen/design-tokens/sass/color";
 @import "../../../styles/color";
 @import "../../../styles/type";
 @import "../styles";

--- a/packages/component-library/components/NavigationBar/components/Badge.tsx
+++ b/packages/component-library/components/NavigationBar/components/Badge.tsx
@@ -1,7 +1,7 @@
-import { Icon } from "@cultureamp/kaizen-component-library"
-const caMonogramIcon = require("@cultureamp/kaizen-component-library/icons/ca-monogram.icon.svg")
+import { Icon } from "@kaizen/component-library"
+const caMonogramIcon = require("@kaizen/component-library/icons/ca-monogram.icon.svg")
   .default
-const spinnerIcon = require("@cultureamp/kaizen-component-library/icons/spinner.icon.svg")
+const spinnerIcon = require("@kaizen/component-library/icons/spinner.icon.svg")
   .default
 import classNames from "classnames"
 import * as React from "react"

--- a/packages/component-library/components/NavigationBar/components/Link.module.scss
+++ b/packages/component-library/components/NavigationBar/components/Link.module.scss
@@ -1,4 +1,4 @@
-@import "~@cultureamp/kaizen-design-tokens/sass/color";
+@import "~@kaizen/design-tokens/sass/color";
 @import "../styles";
 @import "../../../styles/border";
 @import "../../../styles/type";

--- a/packages/component-library/components/NavigationBar/components/Link.tsx
+++ b/packages/component-library/components/NavigationBar/components/Link.tsx
@@ -1,5 +1,5 @@
-import { Icon } from "@cultureamp/kaizen-component-library"
-const chevronRightIcon = require("@cultureamp/kaizen-component-library/icons/chevron-right.icon.svg")
+import { Icon } from "@kaizen/component-library"
+const chevronRightIcon = require("@kaizen/component-library/icons/chevron-right.icon.svg")
   .default
 import classNames from "classnames"
 import * as React from "react"

--- a/packages/component-library/components/NavigationBar/components/Menu.module.scss
+++ b/packages/component-library/components/NavigationBar/components/Menu.module.scss
@@ -1,4 +1,4 @@
-@import "~@cultureamp/kaizen-design-tokens/sass/color";
+@import "~@kaizen/design-tokens/sass/color";
 @import "../styles";
 @import "../../../styles/border";
 @import "../../../styles/color";

--- a/packages/component-library/components/NavigationBar/components/Menu.tsx
+++ b/packages/component-library/components/NavigationBar/components/Menu.tsx
@@ -2,8 +2,8 @@ import {
   IconButton,
   OffCanvas,
   OffCanvasContext,
-} from "@cultureamp/kaizen-component-library"
-const arrowLeftIcon = require("@cultureamp/kaizen-component-library/icons/arrow-left.icon.svg")
+} from "@kaizen/component-library"
+const arrowLeftIcon = require("@kaizen/component-library/icons/arrow-left.icon.svg")
   .default
 import * as React from "react"
 import Media from "react-media"

--- a/packages/component-library/components/Notification/Notification.elm
+++ b/packages/component-library/components/Notification/Notification.elm
@@ -223,16 +223,16 @@ icon : NotificationType -> Icon.SvgAsset.SvgAsset
 icon type_ =
     case type_ of
         Affirmative ->
-            svgAsset "@cultureamp/kaizen-component-library/icons/success.icon.svg"
+            svgAsset "@kaizen/component-library/icons/success.icon.svg"
 
         Cautionary ->
-            svgAsset "@cultureamp/kaizen-component-library/icons/exclamation.icon.svg"
+            svgAsset "@kaizen/component-library/icons/exclamation.icon.svg"
 
         Negative ->
-            svgAsset "@cultureamp/kaizen-component-library/icons/exclamation.icon.svg"
+            svgAsset "@kaizen/component-library/icons/exclamation.icon.svg"
 
         Informative ->
-            svgAsset "@cultureamp/kaizen-component-library/icons/information.icon.svg"
+            svgAsset "@kaizen/component-library/icons/information.icon.svg"
 
 
 viewTitle : Config msg -> Html msg
@@ -283,14 +283,14 @@ viewCancelButton (Config { persistent, variant }) state onStateChange =
                 [ -- We are using a hidden span and Icon.presentation rather than the usual Icon.img to avoid this components API requiring a unique ID.
                   span [ styles.class .cancelLabel ] [ text "close notification" ]
                 , Icon.view Icon.presentation
-                    (svgAsset "@cultureamp/kaizen-component-library/icons/close.icon.svg")
+                    (svgAsset "@kaizen/component-library/icons/close.icon.svg")
                     |> Html.map never
                 ]
             ]
 
 
 styles =
-    css "@cultureamp/kaizen-component-library/components/Notification/components/GenericNotification.module.scss"
+    css "@kaizen/component-library/components/Notification/components/GenericNotification.module.scss"
         { notification = "notification"
         , icon = "icon"
         , textContainer = "textContainer"

--- a/packages/component-library/components/Notification/_styles.scss
+++ b/packages/component-library/components/Notification/_styles.scss
@@ -1,4 +1,4 @@
-@import "~@cultureamp/kaizen-design-tokens/sass/color";
+@import "~@kaizen/design-tokens/sass/color";
 @import "../../styles/color";
 @import "../../styles/type";
 @import "../../styles/border";

--- a/packages/component-library/components/Notification/components/GenericNotification.tsx
+++ b/packages/component-library/components/Notification/components/GenericNotification.tsx
@@ -1,11 +1,11 @@
-import { Icon } from "@cultureamp/kaizen-component-library"
-const closeIcon = require("@cultureamp/kaizen-component-library/icons/close.icon.svg")
+import { Icon } from "@kaizen/component-library"
+const closeIcon = require("@kaizen/component-library/icons/close.icon.svg")
   .default
-const exclamationIcon = require("@cultureamp/kaizen-component-library/icons/exclamation.icon.svg")
+const exclamationIcon = require("@kaizen/component-library/icons/exclamation.icon.svg")
   .default
-const informationIcon = require("@cultureamp/kaizen-component-library/icons/information.icon.svg")
+const informationIcon = require("@kaizen/component-library/icons/information.icon.svg")
   .default
-const successIcon = require("@cultureamp/kaizen-component-library/icons/success.icon.svg")
+const successIcon = require("@kaizen/component-library/icons/success.icon.svg")
   .default
 import classnames from "classnames"
 import * as React from "react"

--- a/packages/component-library/components/OffCanvas/OffCanvas.module.scss
+++ b/packages/component-library/components/OffCanvas/OffCanvas.module.scss
@@ -1,4 +1,4 @@
-@import "~@cultureamp/kaizen-design-tokens/sass/color";
+@import "~@kaizen/design-tokens/sass/color";
 @import "../../styles/color";
 @import "../../styles/type";
 @import "../../styles/animation";

--- a/packages/component-library/components/OffCanvas/components/Header.module.scss
+++ b/packages/component-library/components/OffCanvas/components/Header.module.scss
@@ -1,4 +1,4 @@
-@import "~@cultureamp/kaizen-design-tokens/sass/color";
+@import "~@kaizen/design-tokens/sass/color";
 @import "../../../styles/type";
 @import "../../../styles/color";
 

--- a/packages/component-library/components/OffCanvas/components/Header.tsx
+++ b/packages/component-library/components/OffCanvas/components/Header.tsx
@@ -1,4 +1,4 @@
-const closeIcon = require("@cultureamp/kaizen-component-library/icons/close.icon.svg")
+const closeIcon = require("@kaizen/component-library/icons/close.icon.svg")
   .default
 import * as React from "react"
 import IconButton from "../../Button/IconButton"

--- a/packages/component-library/components/OffCanvas/components/Menu.module.scss
+++ b/packages/component-library/components/OffCanvas/components/Menu.module.scss
@@ -1,4 +1,4 @@
-@import "~@cultureamp/kaizen-design-tokens/sass/color";
+@import "~@kaizen/design-tokens/sass/color";
 @import "../../../styles/color";
 @import "../../../styles/type";
 

--- a/packages/component-library/components/Text/Text.elm
+++ b/packages/component-library/components/Text/Text.elm
@@ -109,7 +109,7 @@ className tag typeStyle shouldInheritBaseline shouldInline =
 
 
 styles =
-    css "@cultureamp/kaizen-component-library/components/Text/Text.module.scss"
+    css "@kaizen/component-library/components/Text/Text.module.scss"
         { defaultStyle = "defaultStyle"
         , pageTitle = "pageTitle"
         , title = "title"

--- a/packages/component-library/draft-templates/ComponentName.elm
+++ b/packages/component-library/draft-templates/ComponentName.elm
@@ -80,6 +80,6 @@ view (Config config) =
 
 
 styles =
-    css "@cultureamp/kaizen-component-library/draft/ComponentName/styles.scss"
+    css "@kaizen/component-library/draft/ComponentName/styles.scss"
         { container = "container"
         }

--- a/packages/component-library/draft-templates/ComponentName.tsx
+++ b/packages/component-library/draft-templates/ComponentName.tsx
@@ -1,7 +1,7 @@
 import * as React from "react"
 
-// import { Icon } from "@cultureamp/kaizen-component-library"
-// const minusIcon = require("@cultureamp/kaizen-component-library/icons/minus.icon.svg").default
+// import { Icon } from "@kaizen/component-library"
+// const minusIcon = require("@kaizen/component-library/icons/minus.icon.svg").default
 
 const styles = require("./styles.scss")
 

--- a/packages/component-library/draft/Kaizen/CheckboxGroup/CheckboxGroup.tsx
+++ b/packages/component-library/draft/Kaizen/CheckboxGroup/CheckboxGroup.tsx
@@ -1,7 +1,7 @@
 import classnames from "classnames"
 import * as React from "react"
 
-import { Label } from "@cultureamp/kaizen-component-library/draft"
+import { Label } from "@kaizen/component-library/draft"
 
 const styles = require("./styles.scss")
 

--- a/packages/component-library/draft/Kaizen/CheckboxGroup/styles.scss
+++ b/packages/component-library/draft/Kaizen/CheckboxGroup/styles.scss
@@ -1,5 +1,5 @@
-@import "~@cultureamp/kaizen-component-library/styles/color";
-@import "~@cultureamp/kaizen-component-library/styles/type";
+@import "~@kaizen/component-library/styles/color";
+@import "~@kaizen/component-library/styles/type";
 
 .checkboxGroupLabel {
   margin-bottom: $ca-grid / 2;

--- a/packages/component-library/draft/Kaizen/Collapsible/Collapsible.tsx
+++ b/packages/component-library/draft/Kaizen/Collapsible/Collapsible.tsx
@@ -1,4 +1,4 @@
-import { Icon, Text } from "@cultureamp/kaizen-component-library"
+import { Icon, Text } from "@kaizen/component-library"
 import classnames from "classnames"
 import * as React from "react"
 import AnimateHeight from "react-animate-height"
@@ -6,9 +6,9 @@ import AnimateHeight from "react-animate-height"
 import { Sticky } from "./CollapsibleGroup"
 
 const styles = require("./styles.scss")
-const chevronUp = require("@cultureamp/kaizen-component-library/icons/chevron-up.icon.svg")
+const chevronUp = require("@kaizen/component-library/icons/chevron-up.icon.svg")
   .default
-const chevronDown = require("@cultureamp/kaizen-component-library/icons/chevron-down.icon.svg")
+const chevronDown = require("@kaizen/component-library/icons/chevron-down.icon.svg")
   .default
 
 export type Props = {

--- a/packages/component-library/draft/Kaizen/Collapsible/styles.scss
+++ b/packages/component-library/draft/Kaizen/Collapsible/styles.scss
@@ -1,8 +1,8 @@
-@import "~@cultureamp/kaizen-design-tokens/sass/color";
-@import "~@cultureamp/kaizen-component-library/styles/layout";
-@import "~@cultureamp/kaizen-component-library/styles/border";
-@import "~@cultureamp/kaizen-component-library/styles/color";
-@import "~@cultureamp/kaizen-component-library/styles/animation";
+@import "~@kaizen/design-tokens/sass/color";
+@import "~@kaizen/component-library/styles/layout";
+@import "~@kaizen/component-library/styles/border";
+@import "~@kaizen/component-library/styles/color";
+@import "~@kaizen/component-library/styles/animation";
 
 $heading-active-color: $kz-color-wisteria-100;
 

--- a/packages/component-library/draft/Kaizen/DropdownMenu/DropdownMenu.elm
+++ b/packages/component-library/draft/Kaizen/DropdownMenu/DropdownMenu.elm
@@ -77,7 +77,7 @@ view args state =
             , span
                 [ styles.class .chevronIcon ]
                 [ Icon.view Icon.presentation
-                    (svgAsset "@cultureamp/kaizen-component-library/icons/chevron-down.icon.svg")
+                    (svgAsset "@kaizen/component-library/icons/chevron-down.icon.svg")
                     |> Html.map never
                 ]
             ]
@@ -102,7 +102,7 @@ onClickWithStopAndPrevent msg =
 
 
 styles =
-    css "@cultureamp/kaizen-component-library/draft/Kaizen/DropdownMenu/DropdownMenu.scss"
+    css "@kaizen/component-library/draft/Kaizen/DropdownMenu/DropdownMenu.scss"
         { dropdown = "dropdown"
         , dropdownControlAction = "dropdownControlAction"
         , buttonReset = "buttonReset"

--- a/packages/component-library/draft/Kaizen/DropdownMenu/DropdownMenu.scss
+++ b/packages/component-library/draft/Kaizen/DropdownMenu/DropdownMenu.scss
@@ -1,9 +1,9 @@
-@import "~@cultureamp/kaizen-design-tokens/sass/color";
-@import "~@cultureamp/kaizen-component-library/styles/color";
-@import "~@cultureamp/kaizen-component-library/styles/type";
-@import "~@cultureamp/kaizen-component-library/styles/layout";
-@import "~@cultureamp/kaizen-component-library/styles/border";
-@import "~@cultureamp/kaizen-component-library/styles/mixins/forms";
+@import "~@kaizen/design-tokens/sass/color";
+@import "~@kaizen/component-library/styles/color";
+@import "~@kaizen/component-library/styles/type";
+@import "~@kaizen/component-library/styles/layout";
+@import "~@kaizen/component-library/styles/border";
+@import "~@kaizen/component-library/styles/mixins/forms";
 
 .dropdown {
   position: relative;

--- a/packages/component-library/draft/Kaizen/EmptyState/EmptyState.elm
+++ b/packages/component-library/draft/Kaizen/EmptyState/EmptyState.elm
@@ -70,27 +70,27 @@ defaults =
 
 actionIllustrationUrl : WebpackAsset.AssetUrl
 actionIllustrationUrl =
-    assetUrl "@cultureamp/kaizen-component-library/draft/Kaizen/EmptyState/illustrations/action.png"
+    assetUrl "@kaizen/component-library/draft/Kaizen/EmptyState/illustrations/action.png"
 
 
 informativeIllustrationUrl : WebpackAsset.AssetUrl
 informativeIllustrationUrl =
-    assetUrl "@cultureamp/kaizen-component-library/draft/Kaizen/EmptyState/illustrations/informative.png"
+    assetUrl "@kaizen/component-library/draft/Kaizen/EmptyState/illustrations/informative.png"
 
 
 negativeIllustrationUrl : WebpackAsset.AssetUrl
 negativeIllustrationUrl =
-    assetUrl "@cultureamp/kaizen-component-library/draft/Kaizen/EmptyState/illustrations/negative.png"
+    assetUrl "@kaizen/component-library/draft/Kaizen/EmptyState/illustrations/negative.png"
 
 
 neutralIllustrationUrl : WebpackAsset.AssetUrl
 neutralIllustrationUrl =
-    assetUrl "@cultureamp/kaizen-component-library/draft/Kaizen/EmptyState/illustrations/neutral.png"
+    assetUrl "@kaizen/component-library/draft/Kaizen/EmptyState/illustrations/neutral.png"
 
 
 positiveIllustrationUrl : WebpackAsset.AssetUrl
 positiveIllustrationUrl =
-    assetUrl "@cultureamp/kaizen-component-library/draft/Kaizen/EmptyState/illustrations/positive.png"
+    assetUrl "@kaizen/component-library/draft/Kaizen/EmptyState/illustrations/positive.png"
 
 
 
@@ -216,7 +216,7 @@ view (Config config) =
 
 
 styles =
-    css "@cultureamp/kaizen-component-library/draft/Kaizen/EmptyState/styles.scss"
+    css "@kaizen/component-library/draft/Kaizen/EmptyState/styles.scss"
         { container = "container"
         , illustrationSide = "illustrationSide"
         , textSide = "textSide"

--- a/packages/component-library/draft/Kaizen/EmptyState/responsive.scss
+++ b/packages/component-library/draft/Kaizen/EmptyState/responsive.scss
@@ -1,4 +1,4 @@
-@import "~@cultureamp/kaizen-component-library/styles/layout";
+@import "~@kaizen/component-library/styles/layout";
 
 $small: 300px;
 $medium: 720px;

--- a/packages/component-library/draft/Kaizen/EmptyState/styles.scss
+++ b/packages/component-library/draft/Kaizen/EmptyState/styles.scss
@@ -1,7 +1,7 @@
-@import "~@cultureamp/kaizen-design-tokens/sass/color";
-@import "~@cultureamp/kaizen-component-library/styles/color";
-@import "~@cultureamp/kaizen-component-library/styles/border";
-@import "~@cultureamp/kaizen-component-library/styles/type";
+@import "~@kaizen/design-tokens/sass/color";
+@import "~@kaizen/component-library/styles/color";
+@import "~@kaizen/component-library/styles/border";
+@import "~@kaizen/component-library/styles/type";
 @import "./responsive";
 
 .container {

--- a/packages/component-library/draft/Kaizen/Form/CheckboxField/CheckboxField.elm
+++ b/packages/component-library/draft/Kaizen/Form/CheckboxField/CheckboxField.elm
@@ -21,7 +21,7 @@ import Kaizen.Form.Primitives.Label.Label as Label
 
 
 styles =
-    css "@cultureamp/kaizen-component-library/draft/Kaizen/Form/CheckboxField/styles.scss"
+    css "@kaizen/component-library/draft/Kaizen/Form/CheckboxField/styles.scss"
         { withDisabled = "withDisabled"
         , inline = "inline"
         , container = "container"

--- a/packages/component-library/draft/Kaizen/Form/CheckboxField/CheckboxField.tsx
+++ b/packages/component-library/draft/Kaizen/Form/CheckboxField/CheckboxField.tsx
@@ -1,9 +1,9 @@
 import {
   Checkbox,
   CheckedStatus,
-} from "@cultureamp/kaizen-component-library/draft"
-import { FieldGroup } from "@cultureamp/kaizen-component-library/draft"
-import { Label } from "@cultureamp/kaizen-component-library/draft"
+} from "@kaizen/component-library/draft"
+import { FieldGroup } from "@kaizen/component-library/draft"
+import { Label } from "@kaizen/component-library/draft"
 import classnames from "classnames"
 import * as React from "react"
 

--- a/packages/component-library/draft/Kaizen/Form/CheckboxField/CheckboxField.tsx
+++ b/packages/component-library/draft/Kaizen/Form/CheckboxField/CheckboxField.tsx
@@ -1,7 +1,4 @@
-import {
-  Checkbox,
-  CheckedStatus,
-} from "@kaizen/component-library/draft"
+import { Checkbox, CheckedStatus } from "@kaizen/component-library/draft"
 import { FieldGroup } from "@kaizen/component-library/draft"
 import { Label } from "@kaizen/component-library/draft"
 import classnames from "classnames"

--- a/packages/component-library/draft/Kaizen/Form/CheckboxField/styles.scss
+++ b/packages/component-library/draft/Kaizen/Form/CheckboxField/styles.scss
@@ -1,7 +1,7 @@
-@import "~@cultureamp/kaizen-component-library/styles/type";
-@import "~@cultureamp/kaizen-component-library/styles/color";
-@import "~@cultureamp/kaizen-component-library/styles/mixins/forms";
-@import "~@cultureamp/kaizen-component-library/draft/Kaizen/Form/Primitives/Checkbox/styles";
+@import "~@kaizen/component-library/styles/type";
+@import "~@kaizen/component-library/styles/color";
+@import "~@kaizen/component-library/styles/mixins/forms";
+@import "~@kaizen/component-library/draft/Kaizen/Form/Primitives/Checkbox/styles";
 
 // -----------------------------------------------
 // Checkbox Field

--- a/packages/component-library/draft/Kaizen/Form/Primitives/Checkbox/Checkbox.elm
+++ b/packages/component-library/draft/Kaizen/Form/Primitives/Checkbox/Checkbox.elm
@@ -154,7 +154,7 @@ view (Config config) =
                 On ->
                     div [ styles.class .icon ]
                         [ Icon.view (Icon.presentation |> Icon.inheritSize True)
-                            (svgAsset "@cultureamp/kaizen-component-library/icons/check.icon.svg")
+                            (svgAsset "@kaizen/component-library/icons/check.icon.svg")
                             |> Html.map never
                         ]
 
@@ -164,7 +164,7 @@ view (Config config) =
                 Mixed ->
                     div [ styles.class .icon ]
                         [ Icon.view (Icon.presentation |> Icon.inheritSize True)
-                            (svgAsset "@cultureamp/kaizen-component-library/icons/minus.icon.svg")
+                            (svgAsset "@kaizen/component-library/icons/minus.icon.svg")
                             |> Html.map never
                         ]
 
@@ -189,7 +189,7 @@ view (Config config) =
 
 
 styles =
-    css "@cultureamp/kaizen-component-library/draft/Kaizen/Form/Primitives/Checkbox/styles.scss"
+    css "@kaizen/component-library/draft/Kaizen/Form/Primitives/Checkbox/styles.scss"
         { checkbox = "checkbox"
         , disabled = "disabled"
         , container = "container"

--- a/packages/component-library/draft/Kaizen/Form/Primitives/Checkbox/Checkbox.tsx
+++ b/packages/component-library/draft/Kaizen/Form/Primitives/Checkbox/Checkbox.tsx
@@ -1,7 +1,7 @@
-import { Icon } from "@cultureamp/kaizen-component-library"
-const checkIcon = require("@cultureamp/kaizen-component-library/icons/check.icon.svg")
+import { Icon } from "@kaizen/component-library"
+const checkIcon = require("@kaizen/component-library/icons/check.icon.svg")
   .default
-const minusIcon = require("@cultureamp/kaizen-component-library/icons/minus.icon.svg")
+const minusIcon = require("@kaizen/component-library/icons/minus.icon.svg")
   .default
 import classnames from "classnames"
 import * as React from "react"

--- a/packages/component-library/draft/Kaizen/Form/Primitives/Checkbox/styles.scss
+++ b/packages/component-library/draft/Kaizen/Form/Primitives/Checkbox/styles.scss
@@ -1,7 +1,7 @@
-@import "~@cultureamp/kaizen-design-tokens/sass/color";
-@import "~@cultureamp/kaizen-component-library/styles/color";
-@import "~@cultureamp/kaizen-component-library/styles/border";
-@import "~@cultureamp/kaizen-component-library/styles/mixins/forms";
+@import "~@kaizen/design-tokens/sass/color";
+@import "~@kaizen/component-library/styles/color";
+@import "~@kaizen/component-library/styles/border";
+@import "~@kaizen/component-library/styles/mixins/forms";
 
 $checkbox-size: 20px;
 $checkbox-border-width: 1px;

--- a/packages/component-library/draft/Kaizen/Form/Primitives/FieldGroup/FieldGroup.elm
+++ b/packages/component-library/draft/Kaizen/Form/Primitives/FieldGroup/FieldGroup.elm
@@ -6,7 +6,7 @@ import Html.Attributes
 
 
 styles =
-    css "@cultureamp/kaizen-component-library/draft/Kaizen/Form/Primitives/FieldGroup/styles.scss"
+    css "@kaizen/component-library/draft/Kaizen/Form/Primitives/FieldGroup/styles.scss"
         { group = "group"
         , inline = "inline"
         }

--- a/packages/component-library/draft/Kaizen/Form/Primitives/FieldGroup/styles.scss
+++ b/packages/component-library/draft/Kaizen/Form/Primitives/FieldGroup/styles.scss
@@ -1,4 +1,4 @@
-@import "~@cultureamp/kaizen-component-library/styles/type";
+@import "~@kaizen/component-library/styles/type";
 
 .group {
   // insert styles here

--- a/packages/component-library/draft/Kaizen/Form/Primitives/FieldMessage/FieldMessage.elm
+++ b/packages/component-library/draft/Kaizen/Form/Primitives/FieldMessage/FieldMessage.elm
@@ -6,7 +6,7 @@ import Html.Attributes
 
 
 styles =
-    css "@cultureamp/kaizen-component-library/draft/Kaizen/Form/Primitives/FieldMessage/styles.scss"
+    css "@kaizen/component-library/draft/Kaizen/Form/Primitives/FieldMessage/styles.scss"
         { error = "error"
         , default = "default"
         , reversed = "reversed"

--- a/packages/component-library/draft/Kaizen/Form/Primitives/FieldMessage/styles.scss
+++ b/packages/component-library/draft/Kaizen/Form/Primitives/FieldMessage/styles.scss
@@ -1,6 +1,6 @@
-@import "~@cultureamp/kaizen-design-tokens/sass/color";
-@import "~@cultureamp/kaizen-component-library/styles/color";
-@import "~@cultureamp/kaizen-component-library/styles/type";
+@import "~@kaizen/design-tokens/sass/color";
+@import "~@kaizen/component-library/styles/color";
+@import "~@kaizen/component-library/styles/type";
 
 $message-error-color: $kz-color-wisteria-800;
 $message-border-radius: 3px;

--- a/packages/component-library/draft/Kaizen/Form/Primitives/Input/Input.elm
+++ b/packages/component-library/draft/Kaizen/Form/Primitives/Input/Input.elm
@@ -32,7 +32,7 @@ import Kaizen.Events.Events as Events
 
 
 styles =
-    css "@cultureamp/kaizen-component-library/draft/Kaizen/Form/Primitives/Input/styles.scss"
+    css "@kaizen/component-library/draft/Kaizen/Form/Primitives/Input/styles.scss"
         { wrapper = "wrapper"
         , input = "input"
         , default = "default"

--- a/packages/component-library/draft/Kaizen/Form/Primitives/Input/styles.scss
+++ b/packages/component-library/draft/Kaizen/Form/Primitives/Input/styles.scss
@@ -1,9 +1,9 @@
-@import "~@cultureamp/kaizen-design-tokens/sass/color";
-@import "~@cultureamp/kaizen-component-library/styles/color";
-@import "~@cultureamp/kaizen-component-library/styles/animation";
-@import "~@cultureamp/kaizen-component-library/styles/layout";
-@import "~@cultureamp/kaizen-component-library/styles/border";
-@import "~@cultureamp/kaizen-component-library/styles/mixins/forms";
+@import "~@kaizen/design-tokens/sass/color";
+@import "~@kaizen/component-library/styles/color";
+@import "~@kaizen/component-library/styles/animation";
+@import "~@kaizen/component-library/styles/layout";
+@import "~@kaizen/component-library/styles/border";
+@import "~@kaizen/component-library/styles/mixins/forms";
 
 // -----------------------------------------------
 // Form Input Primitive

--- a/packages/component-library/draft/Kaizen/Form/Primitives/Label/Label.elm
+++ b/packages/component-library/draft/Kaizen/Form/Primitives/Label/Label.elm
@@ -24,7 +24,7 @@ type LabelProp msg
 
 
 styles =
-    css "@cultureamp/kaizen-component-library/draft/Kaizen/Form/Primitives/Label/styles.scss"
+    css "@kaizen/component-library/draft/Kaizen/Form/Primitives/Label/styles.scss"
         { label = "label"
         , reversed = "reversed"
         , text = "text"

--- a/packages/component-library/draft/Kaizen/Form/Primitives/Label/styles.scss
+++ b/packages/component-library/draft/Kaizen/Form/Primitives/Label/styles.scss
@@ -1,7 +1,7 @@
-@import "~@cultureamp/kaizen-design-tokens/sass/color";
-@import "~@cultureamp/kaizen-component-library/styles/color";
-@import "~@cultureamp/kaizen-component-library/styles/type";
-@import "~@cultureamp/kaizen-component-library/styles/layout";
+@import "~@kaizen/design-tokens/sass/color";
+@import "~@kaizen/component-library/styles/color";
+@import "~@kaizen/component-library/styles/type";
+@import "~@kaizen/component-library/styles/layout";
 
 $label-start-padding: 10px;
 

--- a/packages/component-library/draft/Kaizen/Form/Primitives/ToggleSwitch/styles.scss
+++ b/packages/component-library/draft/Kaizen/Form/Primitives/ToggleSwitch/styles.scss
@@ -1,10 +1,10 @@
-@import "~@cultureamp/kaizen-design-tokens/sass/color";
-@import "~@cultureamp/kaizen-component-library/styles/animation";
-@import "~@cultureamp/kaizen-component-library/styles/border";
-@import "~@cultureamp/kaizen-component-library/styles/color";
-@import "~@cultureamp/kaizen-component-library/styles/layout";
-@import "~@cultureamp/kaizen-component-library/styles/type";
-@import "~@cultureamp/kaizen-component-library/styles/mixins/forms";
+@import "~@kaizen/design-tokens/sass/color";
+@import "~@kaizen/component-library/styles/animation";
+@import "~@kaizen/component-library/styles/border";
+@import "~@kaizen/component-library/styles/color";
+@import "~@kaizen/component-library/styles/layout";
+@import "~@kaizen/component-library/styles/type";
+@import "~@kaizen/component-library/styles/mixins/forms";
 
 $animation-timing: $ca-duration-immediate $ca-linear;
 

--- a/packages/component-library/draft/Kaizen/Form/TextField/TextField.elm
+++ b/packages/component-library/draft/Kaizen/Form/TextField/TextField.elm
@@ -37,7 +37,7 @@ import Kaizen.Form.Primitives.Label.Label as Label
 
 
 styles =
-    css "@cultureamp/kaizen-component-library/draft/Kaizen/Form/TextField/styles.scss"
+    css "@kaizen/component-library/draft/Kaizen/Form/TextField/styles.scss"
         { withLabel = "withLabel"
         , withDisabled = "withDisabled"
         , withReversed = "withReversed"
@@ -254,7 +254,7 @@ view (Config config) =
                             [ ( .success, True )
                             ]
                         ]
-                        [ Icon.view Icon.presentation (svgAsset "@cultureamp/kaizen-component-library/icons/success.icon.svg") |> static ]
+                        [ Icon.view Icon.presentation (svgAsset "@kaizen/component-library/icons/success.icon.svg") |> static ]
                     ]
 
                 Error ->
@@ -263,7 +263,7 @@ view (Config config) =
                             [ ( .error, True )
                             ]
                         ]
-                        [ Icon.view Icon.presentation (svgAsset "@cultureamp/kaizen-component-library/icons/exclamation.icon.svg") |> static ]
+                        [ Icon.view Icon.presentation (svgAsset "@kaizen/component-library/icons/exclamation.icon.svg") |> static ]
                     ]
 
                 Default ->

--- a/packages/component-library/draft/Kaizen/Form/TextField/TextField.tsx
+++ b/packages/component-library/draft/Kaizen/Form/TextField/TextField.tsx
@@ -1,11 +1,7 @@
 import { Icon } from "@kaizen/component-library/components/Icon"
 import { FieldGroup } from "@kaizen/component-library/draft"
 import { FieldMessage } from "@kaizen/component-library/draft"
-import {
-  Input,
-  InputStatus,
-  InputType,
-} from "@kaizen/component-library/draft"
+import { Input, InputStatus, InputType } from "@kaizen/component-library/draft"
 import { Label } from "@kaizen/component-library/draft"
 const exclamationIcon = require("@kaizen/component-library/icons/exclamation.icon.svg")
   .default

--- a/packages/component-library/draft/Kaizen/Form/TextField/TextField.tsx
+++ b/packages/component-library/draft/Kaizen/Form/TextField/TextField.tsx
@@ -1,15 +1,15 @@
-import { Icon } from "@cultureamp/kaizen-component-library/components/Icon"
-import { FieldGroup } from "@cultureamp/kaizen-component-library/draft"
-import { FieldMessage } from "@cultureamp/kaizen-component-library/draft"
+import { Icon } from "@kaizen/component-library/components/Icon"
+import { FieldGroup } from "@kaizen/component-library/draft"
+import { FieldMessage } from "@kaizen/component-library/draft"
 import {
   Input,
   InputStatus,
   InputType,
-} from "@cultureamp/kaizen-component-library/draft"
-import { Label } from "@cultureamp/kaizen-component-library/draft"
-const exclamationIcon = require("@cultureamp/kaizen-component-library/icons/exclamation.icon.svg")
+} from "@kaizen/component-library/draft"
+import { Label } from "@kaizen/component-library/draft"
+const exclamationIcon = require("@kaizen/component-library/icons/exclamation.icon.svg")
   .default
-const successIcon = require("@cultureamp/kaizen-component-library/icons/success.icon.svg")
+const successIcon = require("@kaizen/component-library/icons/success.icon.svg")
   .default
 import classnames from "classnames"
 import * as React from "react"

--- a/packages/component-library/draft/Kaizen/Form/TextField/styles.scss
+++ b/packages/component-library/draft/Kaizen/Form/TextField/styles.scss
@@ -1,9 +1,9 @@
-@import "~@cultureamp/kaizen-component-library/styles/color";
-@import "~@cultureamp/kaizen-component-library/styles/animation";
-@import "~@cultureamp/kaizen-component-library/styles/layout";
-@import "~@cultureamp/kaizen-component-library/styles/type";
-@import "~@cultureamp/kaizen-component-library/styles/utils";
-@import "~@cultureamp/kaizen-component-library/styles/mixins/forms";
+@import "~@kaizen/component-library/styles/color";
+@import "~@kaizen/component-library/styles/animation";
+@import "~@kaizen/component-library/styles/layout";
+@import "~@kaizen/component-library/styles/type";
+@import "~@kaizen/component-library/styles/utils";
+@import "~@kaizen/component-library/styles/mixins/forms";
 
 // -----------------------------------------------
 // Text Field

--- a/packages/component-library/draft/Kaizen/Form/ToggleSwitchField/ToggleSwitchField.tsx
+++ b/packages/component-library/draft/Kaizen/Form/ToggleSwitchField/ToggleSwitchField.tsx
@@ -7,7 +7,7 @@ import {
   ToggledStatus,
   ToggleSwitch,
   ToggleTheme,
-} from "@cultureamp/kaizen-component-library/draft"
+} from "@kaizen/component-library/draft"
 
 const styles = require("./styles.scss")
 

--- a/packages/component-library/draft/Kaizen/Form/ToggleSwitchField/styles.scss
+++ b/packages/component-library/draft/Kaizen/Form/ToggleSwitchField/styles.scss
@@ -1,5 +1,5 @@
-@import "~@cultureamp/kaizen-component-library/styles/type";
-@import "~@cultureamp/kaizen-component-library/styles/color";
+@import "~@kaizen/component-library/styles/type";
+@import "~@kaizen/component-library/styles/color";
 
 .container {
   display: flex;

--- a/packages/component-library/draft/Kaizen/HeroCard/HeroCard.scss
+++ b/packages/component-library/draft/Kaizen/HeroCard/HeroCard.scss
@@ -1,7 +1,7 @@
-@import "~@cultureamp/kaizen-design-tokens/sass/color";
-@import "~@cultureamp/kaizen-component-library/styles/type";
-@import "~@cultureamp/kaizen-component-library/styles/color";
-@import "~@cultureamp/kaizen-component-library/styles/layout";
+@import "~@kaizen/design-tokens/sass/color";
+@import "~@kaizen/component-library/styles/type";
+@import "~@kaizen/component-library/styles/color";
+@import "~@kaizen/component-library/styles/layout";
 
 $badge__height: 80px;
 $left-content__width: 221px;

--- a/packages/component-library/draft/Kaizen/LoadingPlaceholder/LoadingPlaceholder.elm
+++ b/packages/component-library/draft/Kaizen/LoadingPlaceholder/LoadingPlaceholder.elm
@@ -147,7 +147,7 @@ class =
 
 
 styles =
-    css "@cultureamp/kaizen-component-library/draft/Kaizen/LoadingPlaceholder/styles.scss"
+    css "@kaizen/component-library/draft/Kaizen/LoadingPlaceholder/styles.scss"
         { base = "base"
         , animated = "animated"
         , centered = "centered"

--- a/packages/component-library/draft/Kaizen/LoadingPlaceholder/styles.scss
+++ b/packages/component-library/draft/Kaizen/LoadingPlaceholder/styles.scss
@@ -1,9 +1,9 @@
-@import "~@cultureamp/kaizen-design-tokens/sass/color";
-@import "~@cultureamp/kaizen-component-library/styles/animation";
-@import "~@cultureamp/kaizen-component-library/styles/border";
-@import "~@cultureamp/kaizen-component-library/styles/color";
-@import "~@cultureamp/kaizen-component-library/styles/layout";
-@import "~@cultureamp/kaizen-component-library/styles/type";
+@import "~@kaizen/design-tokens/sass/color";
+@import "~@kaizen/component-library/styles/animation";
+@import "~@kaizen/component-library/styles/border";
+@import "~@kaizen/component-library/styles/color";
+@import "~@kaizen/component-library/styles/layout";
+@import "~@kaizen/component-library/styles/type";
 
 .base {
   background-color: $kz-color-wisteria-100;

--- a/packages/component-library/draft/Kaizen/MenuList/MenuList.elm
+++ b/packages/component-library/draft/Kaizen/MenuList/MenuList.elm
@@ -34,7 +34,7 @@ item { onClickMsg, label } =
 
 menuListCss : CssModules.Helpers { menuList : String, menuItem : String } msg
 menuListCss =
-    css "@cultureamp/kaizen-component-library/draft/Kaizen/MenuList/MenuList.scss"
+    css "@kaizen/component-library/draft/Kaizen/MenuList/MenuList.scss"
         { menuList = "menuList"
         , menuItem = "menuItem"
         }

--- a/packages/component-library/draft/Kaizen/MenuList/MenuList.scss
+++ b/packages/component-library/draft/Kaizen/MenuList/MenuList.scss
@@ -1,11 +1,11 @@
-@import "~@cultureamp/kaizen-design-tokens/sass/color";
-@import "~@cultureamp/kaizen-component-library/styles/color";
-@import "~@cultureamp/kaizen-component-library/styles/type";
-@import "~@cultureamp/kaizen-component-library/styles/layout";
-@import "~@cultureamp/kaizen-component-library/styles/border";
-@import "~@cultureamp/kaizen-component-library/styles/layers";
-@import "~@cultureamp/kaizen-component-library/styles/animation";
-@import "~@cultureamp/kaizen-component-library/components/Icon/Icon.module";
+@import "~@kaizen/design-tokens/sass/color";
+@import "~@kaizen/component-library/styles/color";
+@import "~@kaizen/component-library/styles/type";
+@import "~@kaizen/component-library/styles/layout";
+@import "~@kaizen/component-library/styles/border";
+@import "~@kaizen/component-library/styles/layers";
+@import "~@kaizen/component-library/styles/animation";
+@import "~@kaizen/component-library/components/Icon/Icon.module";
 
 $side-padding: 3/4 * $ca-grid;
 

--- a/packages/component-library/draft/Kaizen/Modal/Modal.elm
+++ b/packages/component-library/draft/Kaizen/Modal/Modal.elm
@@ -244,7 +244,7 @@ defaultModalData =
 
 
 styles =
-    css "@cultureamp/kaizen-component-library/draft/Kaizen/Modal/Primitives/GenericModal.scss"
+    css "@kaizen/component-library/draft/Kaizen/Modal/Primitives/GenericModal.scss"
         { backdropLayer = "backdropLayer"
         , animatingElmEnter = "animatingElmEnter"
         , animatingElmExit = "animatingElmExit"

--- a/packages/component-library/draft/Kaizen/Modal/Presets/ConfirmationModal.elm
+++ b/packages/component-library/draft/Kaizen/Modal/Presets/ConfirmationModal.elm
@@ -108,7 +108,7 @@ header config =
             [ svg [ class <| styles.toString .iconBackground ] [ circle [ cx "75", cy "75", r "75" ] [] ]
             , div [ styles.class .icon ]
                 [ Icon.view Icon.presentation
-                    (svgAsset "@cultureamp/kaizen-component-library/icons/exclamation.icon.svg")
+                    (svgAsset "@kaizen/component-library/icons/exclamation.icon.svg")
                     |> Html.map never
                 ]
             ]
@@ -178,7 +178,7 @@ dismissLabel dismissString (Config config) =
 
 
 styles =
-    css "@cultureamp/kaizen-component-library/draft/Kaizen/Modal/Presets/ConfirmationModal.scss"
+    css "@kaizen/component-library/draft/Kaizen/Modal/Presets/ConfirmationModal.scss"
         { elmModal = "elmModal"
         , header = "header"
         , informativeHeader = "informativeHeader"

--- a/packages/component-library/draft/Kaizen/Modal/Presets/ConfirmationModal.scss
+++ b/packages/component-library/draft/Kaizen/Modal/Presets/ConfirmationModal.scss
@@ -1,7 +1,7 @@
-@import "~@cultureamp/kaizen-design-tokens/sass/color";
-@import "~@cultureamp/kaizen-component-library/styles/color";
-@import "~@cultureamp/kaizen-component-library/styles/layout";
-@import "~@cultureamp/kaizen-component-library/styles/responsive";
+@import "~@kaizen/design-tokens/sass/color";
+@import "~@kaizen/component-library/styles/color";
+@import "~@kaizen/component-library/styles/layout";
+@import "~@kaizen/component-library/styles/responsive";
 
 // override Murmur global styles :(
 .header h1 {

--- a/packages/component-library/draft/Kaizen/Modal/Presets/ConfirmationModal.tsx
+++ b/packages/component-library/draft/Kaizen/Modal/Presets/ConfirmationModal.tsx
@@ -1,12 +1,12 @@
 import classnames from "classnames"
 import * as React from "react"
 
-import { Icon, Text } from "@cultureamp/kaizen-component-library"
-const information = require("@cultureamp/kaizen-component-library/icons/information.icon.svg")
+import { Icon, Text } from "@kaizen/component-library"
+const information = require("@kaizen/component-library/icons/information.icon.svg")
   .default
-const success = require("@cultureamp/kaizen-component-library/icons/success.icon.svg")
+const success = require("@kaizen/component-library/icons/success.icon.svg")
   .default
-const exclamation = require("@cultureamp/kaizen-component-library/icons/exclamation.icon.svg")
+const exclamation = require("@kaizen/component-library/icons/exclamation.icon.svg")
   .default
 
 import {

--- a/packages/component-library/draft/Kaizen/Modal/Presets/InformationModal.scss
+++ b/packages/component-library/draft/Kaizen/Modal/Presets/InformationModal.scss
@@ -1,8 +1,8 @@
-@import "~@cultureamp/kaizen-design-tokens/sass/color";
-@import "~@cultureamp/kaizen-component-library/styles/border";
-@import "~@cultureamp/kaizen-component-library/styles/color";
-@import "~@cultureamp/kaizen-component-library/styles/responsive";
-@import "~@cultureamp/kaizen-component-library/styles/type";
+@import "~@kaizen/design-tokens/sass/color";
+@import "~@kaizen/component-library/styles/border";
+@import "~@kaizen/component-library/styles/color";
+@import "~@kaizen/component-library/styles/responsive";
+@import "~@kaizen/component-library/styles/type";
 
 .modal {
   composes: genericModal from "../Primitives/GenericModal.scss";

--- a/packages/component-library/draft/Kaizen/Modal/Presets/InformationModal.tsx
+++ b/packages/component-library/draft/Kaizen/Modal/Presets/InformationModal.tsx
@@ -1,6 +1,6 @@
 import * as React from "react"
 
-import { Text } from "@cultureamp/kaizen-component-library"
+import { Text } from "@kaizen/component-library"
 
 import {
   GenericModal,

--- a/packages/component-library/draft/Kaizen/Modal/Presets/InputEditModal.scss
+++ b/packages/component-library/draft/Kaizen/Modal/Presets/InputEditModal.scss
@@ -1,7 +1,7 @@
-@import "~@cultureamp/kaizen-design-tokens/sass/color";
-@import "~@cultureamp/kaizen-component-library/styles/border";
-@import "~@cultureamp/kaizen-component-library/styles/color";
-@import "~@cultureamp/kaizen-component-library/styles/type";
+@import "~@kaizen/design-tokens/sass/color";
+@import "~@kaizen/component-library/styles/border";
+@import "~@kaizen/component-library/styles/color";
+@import "~@kaizen/component-library/styles/type";
 
 .modal {
   composes: genericModal from "../Primitives/GenericModal.scss";

--- a/packages/component-library/draft/Kaizen/Modal/Presets/InputEditModal.tsx
+++ b/packages/component-library/draft/Kaizen/Modal/Presets/InputEditModal.tsx
@@ -1,7 +1,7 @@
 import classnames from "classnames"
 import * as React from "react"
 
-import { Text } from "@cultureamp/kaizen-component-library"
+import { Text } from "@kaizen/component-library"
 
 import {
   GenericModal,

--- a/packages/component-library/draft/Kaizen/Modal/Primitives/GenericModal.elm
+++ b/packages/component-library/draft/Kaizen/Modal/Primitives/GenericModal.elm
@@ -83,7 +83,7 @@ events msg (Config config) =
 
 
 styles =
-    css "@cultureamp/kaizen-component-library/draft/Kaizen/Modal/Primitives/GenericModal.scss"
+    css "@kaizen/component-library/draft/Kaizen/Modal/Primitives/GenericModal.scss"
         { scrollLayer = "scrollLayer"
         , elmGenericModal = "elmGenericModal"
         }

--- a/packages/component-library/draft/Kaizen/Modal/Primitives/GenericModal.scss
+++ b/packages/component-library/draft/Kaizen/Modal/Primitives/GenericModal.scss
@@ -1,9 +1,9 @@
-@import "~@cultureamp/kaizen-component-library/styles/animation";
-@import "~@cultureamp/kaizen-component-library/styles/border";
-@import "~@cultureamp/kaizen-component-library/styles/color";
-@import "~@cultureamp/kaizen-component-library/styles/layers";
-@import "~@cultureamp/kaizen-component-library/styles/layout";
-@import "~@cultureamp/kaizen-component-library/styles/responsive";
+@import "~@kaizen/component-library/styles/animation";
+@import "~@kaizen/component-library/styles/border";
+@import "~@kaizen/component-library/styles/color";
+@import "~@kaizen/component-library/styles/layers";
+@import "~@kaizen/component-library/styles/layout";
+@import "~@kaizen/component-library/styles/responsive";
 
 .backdropLayer {
   @include ca-position($start: 0, $end: 0, $top: 0, $bottom: 0);

--- a/packages/component-library/draft/Kaizen/Modal/Primitives/GenericModal.tsx
+++ b/packages/component-library/draft/Kaizen/Modal/Primitives/GenericModal.tsx
@@ -3,7 +3,7 @@ import { createPortal } from "react-dom"
 import FocusLock from "react-focus-lock"
 const { CSSTransition } = require("react-transition-group")
 
-import { warn } from "@cultureamp/kaizen-component-library/util/console"
+import { warn } from "@kaizen/component-library/util/console"
 import { ID_DESCRIBEDBY, ID_LABELLEDBY } from "./constants"
 
 const styles = require("./GenericModal.scss")

--- a/packages/component-library/draft/Kaizen/Modal/Primitives/GenericModalSection.scss
+++ b/packages/component-library/draft/Kaizen/Modal/Primitives/GenericModalSection.scss
@@ -1,4 +1,4 @@
-@import "~@cultureamp/kaizen-component-library/styles/type";
+@import "~@kaizen/component-library/styles/type";
 
 .padded {
   padding: $ca-grid;

--- a/packages/component-library/draft/Kaizen/Modal/Primitives/ModalBody.elm
+++ b/packages/component-library/draft/Kaizen/Modal/Primitives/ModalBody.elm
@@ -99,7 +99,7 @@ fillVerticalSpace predicate (Config config) =
 
 
 styles =
-    css "@cultureamp/kaizen-component-library/draft/Kaizen/Modal/Primitives/ModalBody.scss"
+    css "@kaizen/component-library/draft/Kaizen/Modal/Primitives/ModalBody.scss"
         { modalBody = "modalBody"
         , scrollable = "scrollable"
         , fillSpace = "fillSpace"

--- a/packages/component-library/draft/Kaizen/Modal/Primitives/ModalBody.scss
+++ b/packages/component-library/draft/Kaizen/Modal/Primitives/ModalBody.scss
@@ -1,5 +1,5 @@
-@import "~@cultureamp/kaizen-design-tokens/sass/color";
-@import "~@cultureamp/kaizen-component-library/styles/type";
+@import "~@kaizen/design-tokens/sass/color";
+@import "~@kaizen/component-library/styles/type";
 
 .modalBody {
   padding: $ca-grid $ca-grid $ca-grid $ca-grid;

--- a/packages/component-library/draft/Kaizen/Modal/Primitives/ModalFooter.elm
+++ b/packages/component-library/draft/Kaizen/Modal/Primitives/ModalFooter.elm
@@ -142,7 +142,7 @@ padded predicate (Config config) =
 
 
 styles =
-    css "@cultureamp/kaizen-component-library/draft/Kaizen/Modal/Primitives/ModalFooter.scss"
+    css "@kaizen/component-library/draft/Kaizen/Modal/Primitives/ModalFooter.scss"
         { footerWrap = "footerWrap"
         , center = "center"
         , border = "border"

--- a/packages/component-library/draft/Kaizen/Modal/Primitives/ModalFooter.scss
+++ b/packages/component-library/draft/Kaizen/Modal/Primitives/ModalFooter.scss
@@ -1,5 +1,5 @@
-@import "~@cultureamp/kaizen-component-library/styles/layout";
-@import "~@cultureamp/kaizen-component-library/styles/type";
+@import "~@kaizen/component-library/styles/layout";
+@import "~@kaizen/component-library/styles/type";
 
 .actions {
   display: flex;

--- a/packages/component-library/draft/Kaizen/Modal/Primitives/ModalFooter.tsx
+++ b/packages/component-library/draft/Kaizen/Modal/Primitives/ModalFooter.tsx
@@ -1,6 +1,6 @@
 import * as React from "react"
 
-import { Button } from "@cultureamp/kaizen-component-library"
+import { Button } from "@kaizen/component-library"
 import GenericModalSection from "./GenericModalSection"
 
 const styles = require("./ModalFooter.scss")

--- a/packages/component-library/draft/Kaizen/Modal/Primitives/ModalHeader.elm
+++ b/packages/component-library/draft/Kaizen/Modal/Primitives/ModalHeader.elm
@@ -59,7 +59,7 @@ layoutBox content config =
                     div [ styles.class .dismissButton, onClick onDismissMsg ]
                         [ Button.view
                             (Button.iconButton
-                                (svgAsset "@cultureamp/kaizen-component-library/icons/close.icon.svg")
+                                (svgAsset "@kaizen/component-library/icons/close.icon.svg")
                                 |> Button.reversed True
                             )
                             "Dismiss"
@@ -117,7 +117,7 @@ onDismiss msg (Config config) =
 
 
 styles =
-    css "@cultureamp/kaizen-component-library/draft/Kaizen/Modal/Primitives/ModalHeader.scss"
+    css "@kaizen/component-library/draft/Kaizen/Modal/Primitives/ModalHeader.scss"
         { layout = "layout"
         , filler = "filler"
         , fixed = "fixed"

--- a/packages/component-library/draft/Kaizen/Modal/Primitives/ModalHeader.scss
+++ b/packages/component-library/draft/Kaizen/Modal/Primitives/ModalHeader.scss
@@ -1,6 +1,6 @@
-@import "~@cultureamp/kaizen-component-library/styles/layout";
-@import "~@cultureamp/kaizen-component-library/styles/layers";
-@import "~@cultureamp/kaizen-component-library/styles/type";
+@import "~@kaizen/component-library/styles/layout";
+@import "~@kaizen/component-library/styles/layers";
+@import "~@kaizen/component-library/styles/type";
 
 .dismissButton {
   @include ca-position($end: 0, $top: -$ca-grid * 0.25);

--- a/packages/component-library/draft/Kaizen/Modal/Primitives/ModalHeader.tsx
+++ b/packages/component-library/draft/Kaizen/Modal/Primitives/ModalHeader.tsx
@@ -1,7 +1,7 @@
 import * as React from "react"
 
-import { IconButton } from "@cultureamp/kaizen-component-library"
-const close = require("@cultureamp/kaizen-component-library/icons/close.icon.svg")
+import { IconButton } from "@kaizen/component-library"
+const close = require("@kaizen/component-library/icons/close.icon.svg")
   .default
 import GenericModalSection from "./GenericModalSection"
 

--- a/packages/component-library/draft/Kaizen/Modal/Primitives/ModalHeader.tsx
+++ b/packages/component-library/draft/Kaizen/Modal/Primitives/ModalHeader.tsx
@@ -1,8 +1,7 @@
 import * as React from "react"
 
 import { IconButton } from "@kaizen/component-library"
-const close = require("@kaizen/component-library/icons/close.icon.svg")
-  .default
+const close = require("@kaizen/component-library/icons/close.icon.svg").default
 import GenericModalSection from "./GenericModalSection"
 
 const styles = require("./ModalHeader.scss")

--- a/packages/component-library/draft/Kaizen/Popover/Popover.elm
+++ b/packages/component-library/draft/Kaizen/Popover/Popover.elm
@@ -168,7 +168,7 @@ view (Config config) =
                     button [ styles.class .close, onClick closeMsg ]
                         [ Icon.view
                             Icon.presentation
-                            (svgAsset "@cultureamp/kaizen-component-library/icons/close.icon.svg")
+                            (svgAsset "@kaizen/component-library/icons/close.icon.svg")
                             |> Html.map never
                         ]
 
@@ -220,7 +220,7 @@ view (Config config) =
 
 
 styles =
-    css "@cultureamp/kaizen-component-library/draft/Kaizen/Popover/styles.scss"
+    css "@kaizen/component-library/draft/Kaizen/Popover/styles.scss"
         { container = "container"
         , root = "root"
         , defaultBox = "defaultBox"
@@ -314,25 +314,25 @@ mapVariantToIcon variant =
         Informative ->
             Icon.view
                 Icon.presentation
-                (svgAsset "@cultureamp/kaizen-component-library/icons/information.icon.svg")
+                (svgAsset "@kaizen/component-library/icons/information.icon.svg")
                 |> Html.map never
 
         Positive ->
             Icon.view
                 Icon.presentation
-                (svgAsset "@cultureamp/kaizen-component-library/icons/success.icon.svg")
+                (svgAsset "@kaizen/component-library/icons/success.icon.svg")
                 |> Html.map never
 
         Negative ->
             Icon.view
                 Icon.presentation
-                (svgAsset "@cultureamp/kaizen-component-library/icons/exclamation.icon.svg")
+                (svgAsset "@kaizen/component-library/icons/exclamation.icon.svg")
                 |> Html.map never
 
         Cautionary ->
             Icon.view
                 Icon.presentation
-                (svgAsset "@cultureamp/kaizen-component-library/icons/exclamation.icon.svg")
+                (svgAsset "@kaizen/component-library/icons/exclamation.icon.svg")
                 |> Html.map never
 
 

--- a/packages/component-library/draft/Kaizen/Popover/Popover.tsx
+++ b/packages/component-library/draft/Kaizen/Popover/Popover.tsx
@@ -1,11 +1,11 @@
-import { Icon } from "@cultureamp/kaizen-component-library"
-const closeIcon = require("@cultureamp/kaizen-component-library/icons/close.icon.svg")
+import { Icon } from "@kaizen/component-library"
+const closeIcon = require("@kaizen/component-library/icons/close.icon.svg")
   .default
-const negativeIcon = require("@cultureamp/kaizen-component-library/icons/exclamation.icon.svg")
+const negativeIcon = require("@kaizen/component-library/icons/exclamation.icon.svg")
   .default
-const informativeIcon = require("@cultureamp/kaizen-component-library/icons/information.icon.svg")
+const informativeIcon = require("@kaizen/component-library/icons/information.icon.svg")
   .default
-const positiveIcon = require("@cultureamp/kaizen-component-library/icons/success.icon.svg")
+const positiveIcon = require("@kaizen/component-library/icons/success.icon.svg")
   .default
 import classNames from "classnames"
 import * as React from "react"

--- a/packages/component-library/draft/Kaizen/Popover/styles.scss
+++ b/packages/component-library/draft/Kaizen/Popover/styles.scss
@@ -1,11 +1,11 @@
-@import "~@cultureamp/kaizen-design-tokens/sass/color";
-@import "~@cultureamp/kaizen-component-library/styles/border";
-@import "~@cultureamp/kaizen-component-library/styles/color";
-@import "~@cultureamp/kaizen-component-library/styles/layers";
-@import "~@cultureamp/kaizen-component-library/styles/layout";
-@import "~@cultureamp/kaizen-component-library/styles/responsive";
-@import "~@cultureamp/kaizen-component-library/styles/type";
-@import "~@cultureamp/kaizen-component-library/components/Button/styles";
+@import "~@kaizen/design-tokens/sass/color";
+@import "~@kaizen/component-library/styles/border";
+@import "~@kaizen/component-library/styles/color";
+@import "~@kaizen/component-library/styles/layers";
+@import "~@kaizen/component-library/styles/layout";
+@import "~@kaizen/component-library/styles/responsive";
+@import "~@kaizen/component-library/styles/type";
+@import "~@kaizen/component-library/components/Button/styles";
 
 /* The bordered part of the triangle */
 $default-size: 8px;

--- a/packages/component-library/draft/Kaizen/Radio/Primitives/styles.scss
+++ b/packages/component-library/draft/Kaizen/Radio/Primitives/styles.scss
@@ -1,7 +1,7 @@
-@import "~@cultureamp/kaizen-design-tokens/sass/color";
-@import "~@cultureamp/kaizen-component-library/styles/color";
-@import "~@cultureamp/kaizen-component-library/styles/border";
-@import "~@cultureamp/kaizen-component-library/styles/mixins/forms";
+@import "~@kaizen/design-tokens/sass/color";
+@import "~@kaizen/component-library/styles/color";
+@import "~@kaizen/component-library/styles/border";
+@import "~@kaizen/component-library/styles/mixins/forms";
 
 $radio-size: 20px;
 $icon-size: 10px;

--- a/packages/component-library/draft/Kaizen/Radio/Radio.tsx
+++ b/packages/component-library/draft/Kaizen/Radio/Radio.tsx
@@ -1,4 +1,4 @@
-import { Label } from "@cultureamp/kaizen-component-library/draft"
+import { Label } from "@kaizen/component-library/draft"
 import classnames from "classnames"
 import * as React from "react"
 import RadioInput from "./Primitives/RadioInput"

--- a/packages/component-library/draft/Kaizen/Radio/styles.scss
+++ b/packages/component-library/draft/Kaizen/Radio/styles.scss
@@ -1,7 +1,7 @@
-@import "~@cultureamp/kaizen-component-library/styles/type";
-@import "~@cultureamp/kaizen-component-library/styles/color";
+@import "~@kaizen/component-library/styles/type";
+@import "~@kaizen/component-library/styles/color";
 
-@import "~@cultureamp/kaizen-component-library/draft/Kaizen/Radio/Primitives/styles";
+@import "~@kaizen/component-library/draft/Kaizen/Radio/Primitives/styles";
 
 .container {
   position: relative;

--- a/packages/component-library/draft/Kaizen/RadioGroup/RadioGroup.tsx
+++ b/packages/component-library/draft/Kaizen/RadioGroup/RadioGroup.tsx
@@ -1,7 +1,7 @@
 import classnames from "classnames"
 import * as React from "react"
 
-import { Label } from "@cultureamp/kaizen-component-library/draft"
+import { Label } from "@kaizen/component-library/draft"
 
 const styles = require("./styles.scss")
 

--- a/packages/component-library/draft/Kaizen/RadioGroup/styles.scss
+++ b/packages/component-library/draft/Kaizen/RadioGroup/styles.scss
@@ -1,5 +1,5 @@
-@import "~@cultureamp/kaizen-component-library/styles/color";
-@import "~@cultureamp/kaizen-component-library/styles/type";
+@import "~@kaizen/component-library/styles/color";
+@import "~@kaizen/component-library/styles/type";
 
 .radioGroupLabel {
   margin-bottom: $ca-grid / 2;

--- a/packages/component-library/draft/Kaizen/Select/Select.elm
+++ b/packages/component-library/draft/Kaizen/Select/Select.elm
@@ -718,7 +718,7 @@ view (Config config) selectId =
                     [ resolveLoadingSpinner
                     , span [ styles.class .iconButton ]
                         [ Icon.view Icon.presentation
-                            (svgAsset "@cultureamp/kaizen-component-library/icons/chevron-down.icon.svg")
+                            (svgAsset "@kaizen/component-library/icons/chevron-down.icon.svg")
                             |> Html.map never
                         ]
                     ]
@@ -746,7 +746,7 @@ viewLoading : Html msg
 viewLoading =
     span [ styles.class .iconButton ]
         [ Icon.view Icon.presentation
-            (svgAsset "@cultureamp/kaizen-component-library/icons/spinner.icon.svg")
+            (svgAsset "@kaizen/component-library/icons/spinner.icon.svg")
             |> Html.map never
         ]
 
@@ -1283,7 +1283,7 @@ menuMarginTop =
 
 
 styles =
-    css "@cultureamp/kaizen-component-library/draft/Kaizen/Select/styles.elm.scss"
+    css "@kaizen/component-library/draft/Kaizen/Select/styles.elm.scss"
         { container = "container"
         , control = "control"
         , valueContainer = "valueContainer"

--- a/packages/component-library/draft/Kaizen/Select/Select.tsx
+++ b/packages/component-library/draft/Kaizen/Select/Select.tsx
@@ -5,9 +5,9 @@ import Async from "react-select/async"
 import { AsyncProps as ReactAsyncSelectProps } from "react-select/src/Async"
 import { Props as ReactSelectProps } from "react-select/src/Select"
 
-import { Icon } from "@cultureamp/kaizen-component-library"
+import { Icon } from "@kaizen/component-library"
 
-const chevronDownIcon = require("@cultureamp/kaizen-component-library/icons/chevron-down.icon.svg")
+const chevronDownIcon = require("@kaizen/component-library/icons/chevron-down.icon.svg")
   .default
 
 const styles = require("./styles.react.scss")

--- a/packages/component-library/draft/Kaizen/Select/styles.elm.scss
+++ b/packages/component-library/draft/Kaizen/Select/styles.elm.scss
@@ -1,8 +1,8 @@
-@import "~@cultureamp/kaizen-design-tokens/sass/color";
-@import "~@cultureamp/kaizen-component-library/draft/Kaizen/Form/Primitives/Input/styles.scss";
-@import "~@cultureamp/kaizen-component-library/styles/animation";
-@import "~@cultureamp/kaizen-component-library/styles/border";
-@import "~@cultureamp/kaizen-component-library/styles/type";
+@import "~@kaizen/design-tokens/sass/color";
+@import "~@kaizen/component-library/draft/Kaizen/Form/Primitives/Input/styles.scss";
+@import "~@kaizen/component-library/styles/animation";
+@import "~@kaizen/component-library/styles/border";
+@import "~@kaizen/component-library/styles/type";
 
 @mixin select-border($color: $color) {
   border-color: $color;
@@ -100,7 +100,7 @@
 
 .iconButton {
   height: 20px;
-  composes: interactiveIconWrapper from "~@cultureamp/kaizen-component-library/components/Icon/Icon.module.scss";
+  composes: interactiveIconWrapper from "~@kaizen/component-library/components/Icon/Icon.module.scss";
 }
 
 .menu {

--- a/packages/component-library/draft/Kaizen/Select/styles.react.scss
+++ b/packages/component-library/draft/Kaizen/Select/styles.react.scss
@@ -1,7 +1,7 @@
-@import "~@cultureamp/kaizen-design-tokens/sass/color";
-@import "~@cultureamp/kaizen-component-library/draft/Kaizen/Form/Primitives/Input/styles.scss";
-@import "~@cultureamp/kaizen-component-library/styles/color";
-@import "~@cultureamp/kaizen-component-library/styles/type";
+@import "~@kaizen/design-tokens/sass/color";
+@import "~@kaizen/component-library/draft/Kaizen/Form/Primitives/Input/styles.scss";
+@import "~@kaizen/component-library/styles/color";
+@import "~@kaizen/component-library/styles/type";
 
 @mixin base-font-style() {
   @include ca-type-ideal-body-bold;

--- a/packages/component-library/draft/Kaizen/SplitButton/Dropdown.tsx
+++ b/packages/component-library/draft/Kaizen/SplitButton/Dropdown.tsx
@@ -1,10 +1,10 @@
-import { Icon } from "@cultureamp/kaizen-component-library"
+import { Icon } from "@kaizen/component-library"
 import * as React from "react"
 import { SyntheticEvent } from "react"
 import DropdownMenu from "./DropdownMenu"
 import { Dir } from "./types"
 
-const chevronDown = require("@cultureamp/kaizen-component-library/icons/chevron-down.icon.svg")
+const chevronDown = require("@kaizen/component-library/icons/chevron-down.icon.svg")
   .default
 const styles = require("./styles.scss")
 

--- a/packages/component-library/draft/Kaizen/SplitButton/styles.scss
+++ b/packages/component-library/draft/Kaizen/SplitButton/styles.scss
@@ -1,8 +1,8 @@
-@import "~@cultureamp/kaizen-design-tokens/sass/color";
-@import "~@cultureamp/kaizen-component-library/styles/color";
-@import "~@cultureamp/kaizen-component-library/styles/type";
-@import "~@cultureamp/kaizen-component-library/styles/border";
-@import "~@cultureamp/kaizen-component-library/styles/layers";
+@import "~@kaizen/design-tokens/sass/color";
+@import "~@kaizen/component-library/styles/color";
+@import "~@kaizen/component-library/styles/type";
+@import "~@kaizen/component-library/styles/border";
+@import "~@kaizen/component-library/styles/layers";
 
 $base-border: 1px solid $ca-border-color;
 $focus-border-width: 2px;

--- a/packages/component-library/draft/Kaizen/Table/Table.tsx
+++ b/packages/component-library/draft/Kaizen/Table/Table.tsx
@@ -1,10 +1,10 @@
-import { Icon, Text } from "@cultureamp/kaizen-component-library"
-import { Checkbox } from "@cultureamp/kaizen-component-library/draft"
+import { Icon, Text } from "@kaizen/component-library"
+import { Checkbox } from "@kaizen/component-library/draft"
 import classNames from "classnames"
 import * as React from "react"
 import { CheckedStatus } from "../Form"
 const styles = require("./styles.scss")
-const sortDescendingIcon = require("@cultureamp/kaizen-component-library/icons/sort-descending.icon.svg")
+const sortDescendingIcon = require("@kaizen/component-library/icons/sort-descending.icon.svg")
   .default
 
 type TableContainer = React.FunctionComponent

--- a/packages/component-library/draft/Kaizen/Table/styles.scss
+++ b/packages/component-library/draft/Kaizen/Table/styles.scss
@@ -1,10 +1,10 @@
-@import "~@cultureamp/kaizen-design-tokens/sass/color";
-@import "~@cultureamp/kaizen-component-library/styles/animation";
-@import "~@cultureamp/kaizen-component-library/styles/border";
-@import "~@cultureamp/kaizen-component-library/styles/color";
-@import "~@cultureamp/kaizen-component-library/styles/type";
-@import "~@cultureamp/kaizen-component-library/styles/layout";
-@import "~@cultureamp/kaizen-component-library/components/Button/styles";
+@import "~@kaizen/design-tokens/sass/color";
+@import "~@kaizen/component-library/styles/animation";
+@import "~@kaizen/component-library/styles/border";
+@import "~@kaizen/component-library/styles/color";
+@import "~@kaizen/component-library/styles/type";
+@import "~@kaizen/component-library/styles/layout";
+@import "~@kaizen/component-library/components/Button/styles";
 
 $row-height: 60px;
 

--- a/packages/component-library/draft/Kaizen/Tabs/styles.scss
+++ b/packages/component-library/draft/Kaizen/Tabs/styles.scss
@@ -1,8 +1,8 @@
-@import "~@cultureamp/kaizen-design-tokens/sass/color";
-@import "~@cultureamp/kaizen-component-library/styles/border";
-@import "~@cultureamp/kaizen-component-library/styles/color";
-@import "~@cultureamp/kaizen-component-library/styles/layout";
-@import "~@cultureamp/kaizen-component-library/styles/type";
+@import "~@kaizen/design-tokens/sass/color";
+@import "~@kaizen/component-library/styles/border";
+@import "~@kaizen/component-library/styles/color";
+@import "~@kaizen/component-library/styles/layout";
+@import "~@kaizen/component-library/styles/type";
 
 .container {
   @include ca-margin($bottom: $ca-grid);

--- a/packages/component-library/draft/Kaizen/Tag/Tag.elm
+++ b/packages/component-library/draft/Kaizen/Tag/Tag.elm
@@ -285,7 +285,7 @@ viewPositiveValidationIcon : Configuration msg -> Html msg
 viewPositiveValidationIcon config =
     span [ styles.class .validationIcon ]
         [ Icon.view Icon.presentation
-            (svgAsset "@cultureamp/kaizen-component-library/icons/success.icon.svg")
+            (svgAsset "@kaizen/component-library/icons/success.icon.svg")
             |> Html.map never
         ]
 
@@ -294,7 +294,7 @@ viewValidationIcon : Configuration msg -> Html msg
 viewValidationIcon config =
     span [ styles.class .validationIcon ]
         [ Icon.view Icon.presentation
-            (svgAsset "@cultureamp/kaizen-component-library/icons/exclamation.icon.svg")
+            (svgAsset "@kaizen/component-library/icons/exclamation.icon.svg")
             |> Html.map never
         ]
 
@@ -327,13 +327,13 @@ viewClear config =
     in
     span ([ styles.class .dismissIcon ] ++ events)
         [ Icon.view (Icon.presentation |> Icon.inheritSize True)
-            (svgAsset "@cultureamp/kaizen-component-library/icons/clear.icon.svg")
+            (svgAsset "@kaizen/component-library/icons/clear.icon.svg")
             |> Html.map never
         ]
 
 
 styles =
-    css "@cultureamp/kaizen-component-library/draft/Kaizen/Tag/Tag.scss"
+    css "@kaizen/component-library/draft/Kaizen/Tag/Tag.scss"
         { root = "root"
         , layoutContainer = "layoutContainer"
         , default = "default"

--- a/packages/component-library/draft/Kaizen/Tag/Tag.scss
+++ b/packages/component-library/draft/Kaizen/Tag/Tag.scss
@@ -1,7 +1,7 @@
-@import "~@cultureamp/kaizen-design-tokens/sass/color";
-@import "~@cultureamp/kaizen-component-library/styles/color";
-@import "~@cultureamp/kaizen-component-library/styles/layout";
-@import "~@cultureamp/kaizen-component-library/styles/type";
+@import "~@kaizen/design-tokens/sass/color";
+@import "~@kaizen/component-library/styles/color";
+@import "~@kaizen/component-library/styles/layout";
+@import "~@kaizen/component-library/styles/type";
 
 $medium: $ca-grid * 1.25;
 $small: $ca-grid;

--- a/packages/component-library/draft/Kaizen/Tag/Tag.tsx
+++ b/packages/component-library/draft/Kaizen/Tag/Tag.tsx
@@ -1,11 +1,11 @@
-import { Icon } from "@cultureamp/kaizen-component-library"
+import { Icon } from "@kaizen/component-library"
 import classNames from "classnames"
 import * as React from "react"
-const clearIcon = require("@cultureamp/kaizen-component-library/icons/clear.icon.svg")
+const clearIcon = require("@kaizen/component-library/icons/clear.icon.svg")
   .default
-const exclamationIcon = require("@cultureamp/kaizen-component-library/icons/exclamation.icon.svg")
+const exclamationIcon = require("@kaizen/component-library/icons/exclamation.icon.svg")
   .default
-const successIcon = require("@cultureamp/kaizen-component-library/icons/success.icon.svg")
+const successIcon = require("@kaizen/component-library/icons/success.icon.svg")
   .default
 const styles = require("./Tag.scss")
 

--- a/packages/component-library/draft/Kaizen/TitleBlock/NavigationButton.elm
+++ b/packages/component-library/draft/Kaizen/TitleBlock/NavigationButton.elm
@@ -101,7 +101,7 @@ class =
 
 
 styles =
-    css "@cultureamp/kaizen-component-library/draft/Kaizen/TitleBlock/NavigationButton.scss"
+    css "@kaizen/component-library/draft/Kaizen/TitleBlock/NavigationButton.scss"
         { button = "button"
         , activeButton = "activeButton"
         , reversed = "reversed"

--- a/packages/component-library/draft/Kaizen/TitleBlock/NavigationButton.scss
+++ b/packages/component-library/draft/Kaizen/TitleBlock/NavigationButton.scss
@@ -1,9 +1,9 @@
-@import "~@cultureamp/kaizen-design-tokens/sass/color";
-@import "~@cultureamp/kaizen-component-library/styles/border";
-@import "~@cultureamp/kaizen-component-library/styles/color";
-@import "~@cultureamp/kaizen-component-library/styles/layout";
-@import "~@cultureamp/kaizen-component-library/styles/responsive";
-@import "~@cultureamp/kaizen-component-library/styles/type";
+@import "~@kaizen/design-tokens/sass/color";
+@import "~@kaizen/component-library/styles/border";
+@import "~@kaizen/component-library/styles/color";
+@import "~@kaizen/component-library/styles/layout";
+@import "~@kaizen/component-library/styles/responsive";
+@import "~@kaizen/component-library/styles/type";
 
 .button {
   @include ca-type-ideal-button;

--- a/packages/component-library/draft/Kaizen/TitleBlock/TitleBlock.elm
+++ b/packages/component-library/draft/Kaizen/TitleBlock/TitleBlock.elm
@@ -111,7 +111,7 @@ breadCrumbView { label, link } (Config config) =
         [ div [ class .circle ]
             [ Icon.view
                 Icon.presentation
-                (svgAsset "@cultureamp/kaizen-component-library/icons/arrow-backward.icon.svg")
+                (svgAsset "@kaizen/component-library/icons/arrow-backward.icon.svg")
                 |> static
             ]
         , span
@@ -237,7 +237,7 @@ class =
 
 
 styles =
-    css "@cultureamp/kaizen-component-library/draft/Kaizen/TitleBlock/TitleBlock.scss"
+    css "@kaizen/component-library/draft/Kaizen/TitleBlock/TitleBlock.scss"
         { breadcrumb = "breadcrumb"
         , circle = "circle"
         , breadcrumbText = "breadcrumbText"

--- a/packages/component-library/draft/Kaizen/TitleBlock/TitleBlock.scss
+++ b/packages/component-library/draft/Kaizen/TitleBlock/TitleBlock.scss
@@ -1,11 +1,11 @@
-@import "~@cultureamp/kaizen-design-tokens/sass/color";
-@import "~@cultureamp/kaizen-component-library/styles/border";
-@import "~@cultureamp/kaizen-component-library/styles/color";
-@import "~@cultureamp/kaizen-component-library/styles/type";
-@import "~@cultureamp/kaizen-component-library/styles/layers";
-@import "~@cultureamp/kaizen-component-library/styles/layout";
-@import "~@cultureamp/kaizen-component-library/styles/responsive";
-@import "~@cultureamp/kaizen-component-library/styles/animation";
+@import "~@kaizen/design-tokens/sass/color";
+@import "~@kaizen/component-library/styles/border";
+@import "~@kaizen/component-library/styles/color";
+@import "~@kaizen/component-library/styles/type";
+@import "~@kaizen/component-library/styles/layers";
+@import "~@kaizen/component-library/styles/layout";
+@import "~@kaizen/component-library/styles/responsive";
+@import "~@kaizen/component-library/styles/animation";
 
 $kz-color-wisteria-700-copy: #4b4d68; // temporary until we update Kaizen to Zen colour theme and get this from tokens package
 

--- a/packages/component-library/draft/Kaizen/TitleBlock/TitleBlock.tsx
+++ b/packages/component-library/draft/Kaizen/TitleBlock/TitleBlock.tsx
@@ -4,12 +4,12 @@ import { Fragment, ReactNode } from "react"
 import * as React from "react"
 import Media from "react-media"
 
-import Icon from "@cultureamp/kaizen-component-library/components/Icon/Icon"
-import { MOBILE_QUERY } from "@cultureamp/kaizen-component-library/components/NavigationBar/constants"
-import { Tag } from "@cultureamp/kaizen-component-library/draft"
-const backIcon = require("@cultureamp/kaizen-component-library/icons/arrow-backward.icon.svg")
+import Icon from "@kaizen/component-library/components/Icon/Icon"
+import { MOBILE_QUERY } from "@kaizen/component-library/components/NavigationBar/constants"
+import { Tag } from "@kaizen/component-library/draft"
+const backIcon = require("@kaizen/component-library/icons/arrow-backward.icon.svg")
   .default
-const forwardIcon = require("@cultureamp/kaizen-component-library/icons/arrow-forward.icon.svg")
+const forwardIcon = require("@kaizen/component-library/icons/arrow-forward.icon.svg")
   .default
 import { NavigationButton } from "./NavigationButtons"
 import NavigationButtons from "./NavigationButtons"

--- a/packages/component-library/draft/Kaizen/Tooltip/Tooltip.elm
+++ b/packages/component-library/draft/Kaizen/Tooltip/Tooltip.elm
@@ -98,7 +98,7 @@ baseTooltip body =
 
 
 styles =
-    css "@cultureamp/kaizen-component-library/draft/Kaizen/Tooltip/Tooltip.scss"
+    css "@kaizen/component-library/draft/Kaizen/Tooltip/Tooltip.scss"
         { root = "root"
         , default = "default"
         , tooltipWrap = "tooltipWrap"

--- a/packages/component-library/draft/Kaizen/Tooltip/Tooltip.scss
+++ b/packages/component-library/draft/Kaizen/Tooltip/Tooltip.scss
@@ -1,6 +1,6 @@
-@import "~@cultureamp/kaizen-design-tokens/sass/color";
-@import "~@cultureamp/kaizen-component-library/styles/type";
-@import "~@cultureamp/kaizen-component-library/styles/animation";
+@import "~@kaizen/design-tokens/sass/color";
+@import "~@kaizen/component-library/styles/type";
+@import "~@kaizen/component-library/styles/animation";
 
 .root {
   opacity: 0;

--- a/packages/component-library/draft/Kaizen/VerticalProgressStep/VerticalProgressIndicator/VerticalProgressIndicator.module.scss
+++ b/packages/component-library/draft/Kaizen/VerticalProgressStep/VerticalProgressIndicator/VerticalProgressIndicator.module.scss
@@ -1,7 +1,7 @@
-@import "~@cultureamp/kaizen-design-tokens/sass/color";
-@import "~@cultureamp/kaizen-component-library/styles/color";
-@import "~@cultureamp/kaizen-component-library/styles/type";
-@import "~@cultureamp/kaizen-component-library/styles/border";
+@import "~@kaizen/design-tokens/sass/color";
+@import "~@kaizen/component-library/styles/color";
+@import "~@kaizen/component-library/styles/type";
+@import "~@kaizen/component-library/styles/border";
 
 $top: $ca-grid;
 $left: $ca-grid;

--- a/packages/component-library/draft/Kaizen/VerticalProgressStep/VerticalProgressIndicator/VerticalProgressIndicator.tsx
+++ b/packages/component-library/draft/Kaizen/VerticalProgressStep/VerticalProgressIndicator/VerticalProgressIndicator.tsx
@@ -1,13 +1,13 @@
 import * as React from "react"
 
-const emptyIcon = require("@cultureamp/kaizen-component-library/icons/empty.icon.svg")
+const emptyIcon = require("@kaizen/component-library/icons/empty.icon.svg")
   .default
-const printIcon = require("@cultureamp/kaizen-component-library/icons/print.icon.svg")
+const printIcon = require("@kaizen/component-library/icons/print.icon.svg")
   .default
-const successIcon = require("@cultureamp/kaizen-component-library/icons/success.icon.svg")
+const successIcon = require("@kaizen/component-library/icons/success.icon.svg")
   .default
 
-import { Icon } from "@cultureamp/kaizen-component-library"
+import { Icon } from "@kaizen/component-library"
 
 const styles = require("./VerticalProgressIndicator.module.scss")
 

--- a/packages/component-library/draft/Kaizen/VerticalProgressStep/VerticalProgressStep.module.scss
+++ b/packages/component-library/draft/Kaizen/VerticalProgressStep/VerticalProgressStep.module.scss
@@ -1,7 +1,7 @@
-@import "~@cultureamp/kaizen-design-tokens/sass/color";
-@import "~@cultureamp/kaizen-component-library/styles/color";
-@import "~@cultureamp/kaizen-component-library/styles/type";
-@import "~@cultureamp/kaizen-component-library/components/Button/styles";
+@import "~@kaizen/design-tokens/sass/color";
+@import "~@kaizen/component-library/styles/color";
+@import "~@kaizen/component-library/styles/type";
+@import "~@kaizen/component-library/components/Button/styles";
 
 .step {
   padding: $ca-grid * 0.5;

--- a/packages/component-library/draft/Kaizen/VerticalProgressStep/VerticalProgressStep.tsx
+++ b/packages/component-library/draft/Kaizen/VerticalProgressStep/VerticalProgressStep.tsx
@@ -1,4 +1,4 @@
-import { Text } from "@cultureamp/kaizen-component-library"
+import { Text } from "@kaizen/component-library"
 import * as React from "react"
 
 const styles = require("./VerticalProgressStep.module.scss")

--- a/packages/component-library/draft/Kaizen/Well/Well.elm
+++ b/packages/component-library/draft/Kaizen/Well/Well.elm
@@ -144,7 +144,7 @@ view (Config config) children =
 
 
 styles =
-    css "@cultureamp/kaizen-component-library/draft/Kaizen/Well/styles.scss"
+    css "@kaizen/component-library/draft/Kaizen/Well/styles.scss"
         { container = "container"
         , solid = "solid"
         , dashed = "dashed"

--- a/packages/component-library/draft/Kaizen/Well/styles.scss
+++ b/packages/component-library/draft/Kaizen/Well/styles.scss
@@ -1,6 +1,6 @@
-@import "~@cultureamp/kaizen-design-tokens/sass/color";
-@import "~@cultureamp/kaizen-component-library/styles/border";
-@import "~@cultureamp/kaizen-component-library/styles/layout";
+@import "~@kaizen/design-tokens/sass/color";
+@import "~@kaizen/component-library/styles/border";
+@import "~@kaizen/component-library/styles/layout";
 
 .container {
   border-radius: $ca-border-radius;

--- a/packages/component-library/package.json
+++ b/packages/component-library/package.json
@@ -4,7 +4,8 @@
   "homepage": "https://github.com/cultureamp/kaizen-design-system/tree/master/packages/component-library",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/cultureamp/kaizen-design-system.git"
+    "url": "git+https://github.com/cultureamp/kaizen-design-system.git",
+    "directory": "packages/component-library"
   },
   "bugs": {
     "url": "https://github.com/cultureamp/kaizen-design-system/issues"

--- a/packages/component-library/package.json
+++ b/packages/component-library/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@cultureamp/kaizen-component-library",
+  "name": "@kaizen/component-library",
   "description": "Component Library for Culture Amp's Kaizen Design System",
   "homepage": "https://github.com/cultureamp/kaizen-design-system/tree/master/packages/component-library",
   "repository": {
@@ -25,7 +25,7 @@
   "private": false,
   "license": "MIT",
   "peerDependencies": {
-    "@cultureamp/kaizen-design-tokens": "0.x",
+    "@kaizen/design-tokens": "0.x",
     "focus-visible": "^4.1.5",
     "react": "^16.9.0"
   },

--- a/packages/component-library/package.json
+++ b/packages/component-library/package.json
@@ -22,7 +22,7 @@
     "!tsconfig.dist.json"
   ],
   "sideEffects": false,
-  "version": "17.9.6",
+  "version": "0.0.0",
   "private": false,
   "license": "MIT",
   "peerDependencies": {

--- a/packages/component-library/package.json
+++ b/packages/component-library/package.json
@@ -30,7 +30,7 @@
     "react": "^16.9.0"
   },
   "dependencies": {
-    "@cultureamp/kaizen-design-tokens": "^0.1.2",
+    "@kaizen/design-tokens": "^0.2.0",
     "@types/classnames": "^2.2.6",
     "@types/lodash": "^4.14.132",
     "@types/react-select": "^3.0.5",

--- a/packages/component-library/stories/Button.stories.elm
+++ b/packages/component-library/stories/Button.stories.elm
@@ -18,7 +18,7 @@ main =
         , statelessStoryOf "Destructive w/ Icon" <|
             Button.view
                 (Button.destructive
-                    |> Button.icon (svgAsset "@cultureamp/kaizen-component-library/icons/trash.icon.svg")
+                    |> Button.icon (svgAsset "@kaizen/component-library/icons/trash.icon.svg")
                     |> Button.iconPosition Button.Start
                 )
                 "Label"
@@ -31,7 +31,7 @@ main =
         , statelessStoryOf "Secondary Destructive w/ Icon" <|
             Button.view
                 (Button.secondary
-                    |> Button.icon (svgAsset "@cultureamp/kaizen-component-library/icons/trash.icon.svg")
+                    |> Button.icon (svgAsset "@kaizen/component-library/icons/trash.icon.svg")
                     |> Button.iconPosition Button.Start
                     |> Button.destructiveModifier True
                 )

--- a/packages/component-library/stories/Button.stories.tsx
+++ b/packages/component-library/stories/Button.stories.tsx
@@ -1,6 +1,6 @@
 import { loadElmStories } from "@cultureamp/elm-storybook"
-import { Button } from "@cultureamp/kaizen-component-library"
-const configureIcon = require("@cultureamp/kaizen-component-library/icons/configure.icon.svg")
+import { Button } from "@kaizen/component-library"
+const configureIcon = require("@kaizen/component-library/icons/configure.icon.svg")
   .default
 import { action } from "@storybook/addon-actions"
 import { storiesOf } from "@storybook/react"

--- a/packages/component-library/stories/CheckboxField.stories.tsx
+++ b/packages/component-library/stories/CheckboxField.stories.tsx
@@ -1,5 +1,5 @@
 import { loadElmStories } from "@cultureamp/elm-storybook"
-import { CheckboxField } from "@cultureamp/kaizen-component-library/draft"
+import { CheckboxField } from "@kaizen/component-library/draft"
 import { storiesOf } from "@storybook/react"
 import * as React from "react"
 

--- a/packages/component-library/stories/CheckboxGroup.stories.scss
+++ b/packages/component-library/stories/CheckboxGroup.stories.scss
@@ -1,4 +1,4 @@
-@import "~@cultureamp/kaizen-component-library/styles/color";
+@import "~@kaizen/component-library/styles/color";
 
 a {
   color: $ca-link-text-color;

--- a/packages/component-library/stories/CheckboxGroup.stories.tsx
+++ b/packages/component-library/stories/CheckboxGroup.stories.tsx
@@ -1,7 +1,4 @@
-import {
-  CheckboxField,
-  CheckboxGroup,
-} from "@kaizen/component-library/draft"
+import { CheckboxField, CheckboxGroup } from "@kaizen/component-library/draft"
 import { Label } from "@kaizen/component-library/draft"
 import { storiesOf } from "@storybook/react"
 import * as React from "react"

--- a/packages/component-library/stories/CheckboxGroup.stories.tsx
+++ b/packages/component-library/stories/CheckboxGroup.stories.tsx
@@ -1,8 +1,8 @@
 import {
   CheckboxField,
   CheckboxGroup,
-} from "@cultureamp/kaizen-component-library/draft"
-import { Label } from "@cultureamp/kaizen-component-library/draft"
+} from "@kaizen/component-library/draft"
+import { Label } from "@kaizen/component-library/draft"
 import { storiesOf } from "@storybook/react"
 import * as React from "react"
 const styles = require("./CheckboxGroup.stories.scss")

--- a/packages/component-library/stories/Collapsible.stories.scss
+++ b/packages/component-library/stories/Collapsible.stories.scss
@@ -1,5 +1,5 @@
-@import "~@cultureamp/kaizen-component-library/styles/layout";
-@import "~@cultureamp/kaizen-component-library/styles/border";
+@import "~@kaizen/component-library/styles/layout";
+@import "~@kaizen/component-library/styles/border";
 
 .listItem {
   @include ca-padding(

--- a/packages/component-library/stories/Collapsible.stories.tsx
+++ b/packages/component-library/stories/Collapsible.stories.tsx
@@ -1,14 +1,14 @@
-import { Icon, Text } from "@cultureamp/kaizen-component-library"
+import { Icon, Text } from "@kaizen/component-library"
 import {
   Collapsible,
   CollapsibleGroup,
-} from "@cultureamp/kaizen-component-library/draft"
+} from "@kaizen/component-library/draft"
 import { action } from "@storybook/addon-actions"
 import { storiesOf } from "@storybook/react"
 import * as React from "react"
 
 const styles = require("./Collapsible.stories.scss")
-const translationIcon = require("@cultureamp/kaizen-component-library/icons/translation.icon.svg")
+const translationIcon = require("@kaizen/component-library/icons/translation.icon.svg")
   .default
 
 const ListItem = ({ children }: { children: JSX.Element }) => (

--- a/packages/component-library/stories/Collapsible.stories.tsx
+++ b/packages/component-library/stories/Collapsible.stories.tsx
@@ -1,8 +1,5 @@
 import { Icon, Text } from "@kaizen/component-library"
-import {
-  Collapsible,
-  CollapsibleGroup,
-} from "@kaizen/component-library/draft"
+import { Collapsible, CollapsibleGroup } from "@kaizen/component-library/draft"
 import { action } from "@storybook/addon-actions"
 import { storiesOf } from "@storybook/react"
 import * as React from "react"

--- a/packages/component-library/stories/Dropdown.stories.tsx
+++ b/packages/component-library/stories/Dropdown.stories.tsx
@@ -1,8 +1,8 @@
-const caMonogramIcon = require("@cultureamp/kaizen-component-library/icons/ca-monogram.icon.svg")
+const caMonogramIcon = require("@kaizen/component-library/icons/ca-monogram.icon.svg")
   .default
-const kebabIcon = require("@cultureamp/kaizen-component-library/icons/kebab.icon.svg")
+const kebabIcon = require("@kaizen/component-library/icons/kebab.icon.svg")
   .default
-const printIcon = require("@cultureamp/kaizen-component-library/icons/print.icon.svg")
+const printIcon = require("@kaizen/component-library/icons/print.icon.svg")
   .default
 import { action } from "@storybook/addon-actions"
 import { storiesOf } from "@storybook/react"
@@ -14,7 +14,7 @@ import {
   MenuItem,
   MenuList,
   MenuSeparator,
-} from "@cultureamp/kaizen-component-library"
+} from "@kaizen/component-library"
 
 const Menu: React.FunctionComponent = () => (
   <MenuList>

--- a/packages/component-library/stories/EmptyState.stories.elm
+++ b/packages/component-library/stories/EmptyState.stories.elm
@@ -96,7 +96,7 @@ main =
                             [ div [ styles.class .buttonContainer ]
                                 [ Button.view
                                     (Button.primary
-                                        |> Button.icon (svgAsset "@cultureamp/kaizen-component-library/icons/chevron-right.icon.svg")
+                                        |> Button.icon (svgAsset "@kaizen/component-library/icons/chevron-right.icon.svg")
                                         |> Button.iconPosition Button.End
                                     )
                                     "Label"
@@ -144,7 +144,7 @@ main =
 
 
 styles =
-    css "@cultureamp/kaizen-component-library/stories/EmptyState.stories.scss"
+    css "@kaizen/component-library/stories/EmptyState.stories.scss"
         { container = "container"
         , sidebar = "sidebar"
         , content = "content"

--- a/packages/component-library/stories/EmptyState.stories.scss
+++ b/packages/component-library/stories/EmptyState.stories.scss
@@ -1,6 +1,6 @@
-@import "~@cultureamp/kaizen-component-library/styles/layout";
-@import "~@cultureamp/kaizen-component-library/styles/responsive";
-@import "~@cultureamp/kaizen-component-library/draft/Kaizen/EmptyState/responsive";
+@import "~@kaizen/component-library/styles/layout";
+@import "~@kaizen/component-library/styles/responsive";
+@import "~@kaizen/component-library/draft/Kaizen/EmptyState/responsive";
 
 .container {
   width: 100%;

--- a/packages/component-library/stories/EmptyState.stories.tsx
+++ b/packages/component-library/stories/EmptyState.stories.tsx
@@ -1,12 +1,12 @@
-const chevronLeft = require("@cultureamp/kaizen-component-library/icons/chevron-left.icon.svg")
+const chevronLeft = require("@kaizen/component-library/icons/chevron-left.icon.svg")
   .default
-const chevronRight = require("@cultureamp/kaizen-component-library/icons/chevron-right.icon.svg")
+const chevronRight = require("@kaizen/component-library/icons/chevron-right.icon.svg")
   .default
 import * as React from "react"
 
 import { loadElmStories } from "@cultureamp/elm-storybook"
-import { Button } from "@cultureamp/kaizen-component-library"
-import { EmptyState } from "@cultureamp/kaizen-component-library/draft"
+import { Button } from "@kaizen/component-library"
+import { EmptyState } from "@kaizen/component-library/draft"
 
 import { storiesOf } from "@storybook/react"
 

--- a/packages/component-library/stories/GlobalNotification.stories.tsx
+++ b/packages/component-library/stories/GlobalNotification.stories.tsx
@@ -2,7 +2,7 @@ import { loadElmStories } from "@cultureamp/elm-storybook"
 import { storiesOf } from "@storybook/react"
 import * as React from "react"
 
-import { GlobalNotification } from "@cultureamp/kaizen-component-library"
+import { GlobalNotification } from "@kaizen/component-library"
 
 storiesOf("GlobalNotification (React)", module)
   .add("Positive (Kaizen Site Demo)", () => (

--- a/packages/component-library/stories/HeroCard.stories.tsx
+++ b/packages/component-library/stories/HeroCard.stories.tsx
@@ -1,5 +1,5 @@
-import { Button } from "@cultureamp/kaizen-component-library"
-import { HeroCard } from "@cultureamp/kaizen-component-library/draft"
+import { Button } from "@kaizen/component-library"
+import { HeroCard } from "@kaizen/component-library/draft"
 import { storiesOf } from "@storybook/react"
 import * as React from "react"
 

--- a/packages/component-library/stories/Icon.stories.elm
+++ b/packages/component-library/stories/Icon.stories.elm
@@ -12,17 +12,17 @@ main =
         [ statelessStoryOf "Meaningful" <|
             Icon.view
                 (Icon.img "storybook-icon-id" "storybook-icon")
-                (svgAsset "@cultureamp/kaizen-component-library/icons/configure.icon.svg")
+                (svgAsset "@kaizen/component-library/icons/configure.icon.svg")
         , statelessStoryOf "Presentational" <|
             Icon.view
                 Icon.presentation
-                (svgAsset "@cultureamp/kaizen-component-library/icons/configure.icon.svg")
+                (svgAsset "@kaizen/component-library/icons/configure.icon.svg")
         , statelessStoryOf "Inherit Size" <|
             div [ style "width" "100vw" ]
                 [ Icon.view
                     (Icon.presentation
                         |> Icon.inheritSize True
                     )
-                    (svgAsset "@cultureamp/kaizen-component-library/icons/configure.icon.svg")
+                    (svgAsset "@kaizen/component-library/icons/configure.icon.svg")
                 ]
         ]

--- a/packages/component-library/stories/Icon.stories.tsx
+++ b/packages/component-library/stories/Icon.stories.tsx
@@ -2,8 +2,8 @@ import { loadElmStories } from "@cultureamp/elm-storybook"
 import { storiesOf } from "@storybook/react"
 import * as React from "react"
 
-import { Icon } from "@cultureamp/kaizen-component-library"
-const configureIcon = require("@cultureamp/kaizen-component-library/icons/configure.icon.svg")
+import { Icon } from "@kaizen/component-library"
+const configureIcon = require("@kaizen/component-library/icons/configure.icon.svg")
   .default
 
 storiesOf("Icon (React)", module)

--- a/packages/component-library/stories/IconButton.stories.tsx
+++ b/packages/component-library/stories/IconButton.stories.tsx
@@ -1,5 +1,5 @@
-import { IconButton } from "@cultureamp/kaizen-component-library"
-const configureIcon = require("@cultureamp/kaizen-component-library/icons/configure.icon.svg")
+import { IconButton } from "@kaizen/component-library"
+const configureIcon = require("@kaizen/component-library/icons/configure.icon.svg")
   .default
 import { action } from "@storybook/addon-actions"
 import { storiesOf } from "@storybook/react"

--- a/packages/component-library/stories/InlineNotification.stories.tsx
+++ b/packages/component-library/stories/InlineNotification.stories.tsx
@@ -2,7 +2,7 @@ import { loadElmStories } from "@cultureamp/elm-storybook"
 import { storiesOf } from "@storybook/react"
 import * as React from "react"
 
-import { InlineNotification } from "@cultureamp/kaizen-component-library"
+import { InlineNotification } from "@kaizen/component-library"
 
 storiesOf("InlineNotification (React)", module)
   .add("Dismissible, Positive (Kaizen Site Demo)", () => (

--- a/packages/component-library/stories/Layout.stories.tsx
+++ b/packages/component-library/stories/Layout.stories.tsx
@@ -10,12 +10,12 @@ import {
   NavigationBar,
   Text,
   ToastNotification,
-} from "@cultureamp/kaizen-component-library"
-const academyIcon = require("@cultureamp/kaizen-component-library/icons/academy.icon.svg")
+} from "@kaizen/component-library"
+const academyIcon = require("@kaizen/component-library/icons/academy.icon.svg")
   .default
-const caMonogramIcon = require("@cultureamp/kaizen-component-library/icons/ca-monogram.icon.svg")
+const caMonogramIcon = require("@kaizen/component-library/icons/ca-monogram.icon.svg")
   .default
-const supportIcon = require("@cultureamp/kaizen-component-library/icons/support.icon.svg")
+const supportIcon = require("@kaizen/component-library/icons/support.icon.svg")
   .default
 
 storiesOf("Layout (React)", module).add("Default", () => (

--- a/packages/component-library/stories/LoadingPlaceholder.stories.elm
+++ b/packages/component-library/stories/LoadingPlaceholder.stories.elm
@@ -261,7 +261,7 @@ class =
 
 
 styles =
-    css "@cultureamp/kaizen-component-library/stories/LoadingPlaceholder.stories.scss"
+    css "@kaizen/component-library/stories/LoadingPlaceholder.stories.scss"
         { storyContainer = "storyContainer"
         , reversedDefault = "reversedDefault"
         , reversedOcean = "reversedOcean"

--- a/packages/component-library/stories/LoadingPlaceholder.stories.scss
+++ b/packages/component-library/stories/LoadingPlaceholder.stories.scss
@@ -1,4 +1,4 @@
-@import "~@cultureamp/kaizen-design-tokens/sass/color";
+@import "~@kaizen/design-tokens/sass/color";
 
 .storyContainer {
   margin: 1rem;

--- a/packages/component-library/stories/LoadingPlaceholder.stories.tsx
+++ b/packages/component-library/stories/LoadingPlaceholder.stories.tsx
@@ -1,6 +1,6 @@
 import { loadElmStories } from "@cultureamp/elm-storybook"
-import { Text } from "@cultureamp/kaizen-component-library"
-import { LoadingPlaceholder } from "@cultureamp/kaizen-component-library/draft"
+import { Text } from "@kaizen/component-library"
+import { LoadingPlaceholder } from "@kaizen/component-library/draft"
 import { storiesOf } from "@storybook/react"
 import * as React from "react"
 

--- a/packages/component-library/stories/MenuList.stories.tsx
+++ b/packages/component-library/stories/MenuList.stories.tsx
@@ -7,8 +7,8 @@ import {
   MenuItem,
   MenuList,
   MenuSeparator,
-} from "@cultureamp/kaizen-component-library"
-const caMonogramIcon = require("@cultureamp/kaizen-component-library/icons/ca-monogram.icon.svg")
+} from "@kaizen/component-library"
+const caMonogramIcon = require("@kaizen/component-library/icons/ca-monogram.icon.svg")
   .default
 
 storiesOf("MenuList (React)", module)

--- a/packages/component-library/stories/Modal.stories.scss
+++ b/packages/component-library/stories/Modal.stories.scss
@@ -1,4 +1,4 @@
-@import "~@cultureamp/kaizen-component-library/styles/responsive";
+@import "~@kaizen/component-library/styles/responsive";
 
 .background {
   position: absolute;
@@ -9,7 +9,7 @@
 
   @include ca-media-tablet-and-up {
     background-size: 80%;
-    background-image: url(~@cultureamp/kaizen-component-library/draft/Kaizen/Modal/backgrounds/brush-informative.png);
+    background-image: url(~@kaizen/component-library/draft/Kaizen/Modal/backgrounds/brush-informative.png);
   }
 }
 
@@ -23,6 +23,6 @@
 }
 
 .genericModal {
-  composes: genericModal from "~@cultureamp/kaizen-component-library/draft/Kaizen/Modal/Primitives/GenericModal.scss";
+  composes: genericModal from "~@kaizen/component-library/draft/Kaizen/Modal/Primitives/GenericModal.scss";
   max-width: 90%;
 }

--- a/packages/component-library/stories/NavigationBar.stories.tsx
+++ b/packages/component-library/stories/NavigationBar.stories.tsx
@@ -6,12 +6,12 @@ import {
   Link,
   Menu,
   NavigationBar,
-} from "@cultureamp/kaizen-component-library"
-const academyIcon = require("@cultureamp/kaizen-component-library/icons/academy.icon.svg")
+} from "@kaizen/component-library"
+const academyIcon = require("@kaizen/component-library/icons/academy.icon.svg")
   .default
-const caMonogramIcon = require("@cultureamp/kaizen-component-library/icons/ca-monogram.icon.svg")
+const caMonogramIcon = require("@kaizen/component-library/icons/ca-monogram.icon.svg")
   .default
-const supportIcon = require("@cultureamp/kaizen-component-library/icons/support.icon.svg")
+const supportIcon = require("@kaizen/component-library/icons/support.icon.svg")
   .default
 
 storiesOf("NavigationBar (React)", module)

--- a/packages/component-library/stories/NavigationBar.stories.tsx
+++ b/packages/component-library/stories/NavigationBar.stories.tsx
@@ -1,12 +1,7 @@
 import { storiesOf } from "@storybook/react"
 import * as React from "react"
 
-import {
-  Icon,
-  Link,
-  Menu,
-  NavigationBar,
-} from "@kaizen/component-library"
+import { Icon, Link, Menu, NavigationBar } from "@kaizen/component-library"
 const academyIcon = require("@kaizen/component-library/icons/academy.icon.svg")
   .default
 const caMonogramIcon = require("@kaizen/component-library/icons/ca-monogram.icon.svg")

--- a/packages/component-library/stories/Popover.stories.tsx
+++ b/packages/component-library/stories/Popover.stories.tsx
@@ -1,5 +1,5 @@
 import { loadElmStories } from "@cultureamp/elm-storybook"
-import { Popover } from "@cultureamp/kaizen-component-library/draft"
+import { Popover } from "@kaizen/component-library/draft"
 import { storiesOf } from "@storybook/react"
 import * as React from "react"
 

--- a/packages/component-library/stories/Radio.stories.tsx
+++ b/packages/component-library/stories/Radio.stories.tsx
@@ -1,4 +1,4 @@
-import { Radio } from "@cultureamp/kaizen-component-library/draft"
+import { Radio } from "@kaizen/component-library/draft"
 import { storiesOf } from "@storybook/react"
 import * as React from "react"
 

--- a/packages/component-library/stories/RadioGroup.stories.scss
+++ b/packages/component-library/stories/RadioGroup.stories.scss
@@ -1,4 +1,4 @@
-@import "~@cultureamp/kaizen-component-library/styles/color";
+@import "~@kaizen/component-library/styles/color";
 
 a {
   color: $ca-link-text-color;

--- a/packages/component-library/stories/RadioGroup.stories.tsx
+++ b/packages/component-library/stories/RadioGroup.stories.tsx
@@ -1,5 +1,5 @@
-import { Radio, RadioGroup } from "@cultureamp/kaizen-component-library/draft"
-import { Label } from "@cultureamp/kaizen-component-library/draft"
+import { Radio, RadioGroup } from "@kaizen/component-library/draft"
+import { Label } from "@kaizen/component-library/draft"
 import { storiesOf } from "@storybook/react"
 import * as React from "react"
 const styles = require("./RadioGroup.stories.scss")

--- a/packages/component-library/stories/Select.stories.tsx
+++ b/packages/component-library/stories/Select.stories.tsx
@@ -1,5 +1,5 @@
 import { loadElmStories } from "@cultureamp/elm-storybook"
-import { AsyncSelect, Select } from "@cultureamp/kaizen-component-library/draft"
+import { AsyncSelect, Select } from "@kaizen/component-library/draft"
 import { storiesOf } from "@storybook/react"
 import * as React from "react"
 

--- a/packages/component-library/stories/SplitButton.stories.tsx
+++ b/packages/component-library/stories/SplitButton.stories.tsx
@@ -1,12 +1,12 @@
-import { MenuItem, MenuList } from "@cultureamp/kaizen-component-library"
-import { SplitButton } from "@cultureamp/kaizen-component-library/draft"
+import { MenuItem, MenuList } from "@kaizen/component-library"
+import { SplitButton } from "@kaizen/component-library/draft"
 import { action } from "@storybook/addon-actions"
 import { storiesOf } from "@storybook/react"
 import * as React from "react"
 
-const duplicateIcon = require("@cultureamp/kaizen-component-library/icons/duplicate.icon.svg")
+const duplicateIcon = require("@kaizen/component-library/icons/duplicate.icon.svg")
   .default
-const editIcon = require("@cultureamp/kaizen-component-library/icons/edit.icon.svg")
+const editIcon = require("@kaizen/component-library/icons/edit.icon.svg")
   .default
 
 storiesOf("SplitButton (React)", module)

--- a/packages/component-library/stories/Table.stories.scss
+++ b/packages/component-library/stories/Table.stories.scss
@@ -1,6 +1,6 @@
-@import "~@cultureamp/kaizen-design-tokens/sass/color";
-@import "~@cultureamp/kaizen-component-library/styles/color";
-@import "~@cultureamp/kaizen-component-library/styles/layout";
+@import "~@kaizen/design-tokens/sass/color";
+@import "~@kaizen/component-library/styles/color";
+@import "~@kaizen/component-library/styles/layout";
 
 .customExpandedHeader {
   margin-bottom: $ca-grid * 0.5;

--- a/packages/component-library/stories/Table.stories.tsx
+++ b/packages/component-library/stories/Table.stories.tsx
@@ -1,4 +1,4 @@
-import { Text } from "@cultureamp/kaizen-component-library"
+import { Text } from "@kaizen/component-library"
 import {
   CheckboxField,
   TableCard,
@@ -8,17 +8,17 @@ import {
   TableHeaderRowCell,
   TableRow,
   TableRowCell,
-} from "@cultureamp/kaizen-component-library/draft"
+} from "@kaizen/component-library/draft"
 import { storiesOf } from "@storybook/react"
 import * as React from "react"
 import { IconButton } from "../components"
 const styles = require("./Table.stories.scss")
 
-const commentIcon = require("@cultureamp/kaizen-component-library/icons/comment.icon.svg")
+const commentIcon = require("@kaizen/component-library/icons/comment.icon.svg")
   .default
-const chevronDownIcon = require("@cultureamp/kaizen-component-library/icons/chevron-down.icon.svg")
+const chevronDownIcon = require("@kaizen/component-library/icons/chevron-down.icon.svg")
   .default
-const chevronUpIcon = require("@cultureamp/kaizen-component-library/icons/chevron-up.icon.svg")
+const chevronUpIcon = require("@kaizen/component-library/icons/chevron-up.icon.svg")
   .default
 
 const Container: React.FunctionComponent = ({ children }) => (

--- a/packages/component-library/stories/Tabs.stories.tsx
+++ b/packages/component-library/stories/Tabs.stories.tsx
@@ -1,8 +1,8 @@
 import classnames from "classnames"
 import * as React from "react"
 
-import { Text } from "@cultureamp/kaizen-component-library"
-import { Tabs } from "@cultureamp/kaizen-component-library/draft"
+import { Text } from "@kaizen/component-library"
+import { Tabs } from "@kaizen/component-library/draft"
 
 import { storiesOf } from "@storybook/react"
 

--- a/packages/component-library/stories/Tag.stories.tsx
+++ b/packages/component-library/stories/Tag.stories.tsx
@@ -1,5 +1,5 @@
 import { loadElmStories } from "@cultureamp/elm-storybook"
-import { Tag } from "@cultureamp/kaizen-component-library/draft"
+import { Tag } from "@kaizen/component-library/draft"
 import { storiesOf } from "@storybook/react"
 import * as React from "react"
 

--- a/packages/component-library/stories/Text.stories.tsx
+++ b/packages/component-library/stories/Text.stories.tsx
@@ -1,5 +1,5 @@
 import { loadElmStories } from "@cultureamp/elm-storybook"
-import { Text } from "@cultureamp/kaizen-component-library"
+import { Text } from "@kaizen/component-library"
 import { storiesOf } from "@storybook/react"
 import * as React from "react"
 

--- a/packages/component-library/stories/TextField.stories.tsx
+++ b/packages/component-library/stories/TextField.stories.tsx
@@ -3,10 +3,10 @@ import { action } from "@storybook/addon-actions"
 import { storiesOf } from "@storybook/react"
 import * as React from "react"
 
-import { TextField } from "@cultureamp/kaizen-component-library/draft"
-const lockIcon = require("@cultureamp/kaizen-component-library/icons/lock.icon.svg")
+import { TextField } from "@kaizen/component-library/draft"
+const lockIcon = require("@kaizen/component-library/icons/lock.icon.svg")
   .default
-const userIcon = require("@cultureamp/kaizen-component-library/icons/user.icon.svg")
+const userIcon = require("@kaizen/component-library/icons/user.icon.svg")
   .default
 
 const ExampleContainer: React.FunctionComponent = ({ children }) => (

--- a/packages/component-library/stories/TitleBlock.stories.tsx
+++ b/packages/component-library/stories/TitleBlock.stories.tsx
@@ -1,5 +1,5 @@
-import { Button } from "@cultureamp/kaizen-component-library/components/Button"
-import { TitleBlock } from "@cultureamp/kaizen-component-library/draft"
+import { Button } from "@kaizen/component-library/components/Button"
+import { TitleBlock } from "@kaizen/component-library/draft"
 import { storiesOf } from "@storybook/react"
 import * as React from "react"
 

--- a/packages/component-library/stories/ToastNotification.stories.tsx
+++ b/packages/component-library/stories/ToastNotification.stories.tsx
@@ -2,7 +2,7 @@ import { loadElmStories } from "@cultureamp/elm-storybook"
 import { storiesOf } from "@storybook/react"
 import * as React from "react"
 
-import { ToastNotification } from "@cultureamp/kaizen-component-library"
+import { ToastNotification } from "@kaizen/component-library"
 
 storiesOf("ToastNotification (React)", module)
   .add("Positive (Kaizen Site Demo)", () => (

--- a/packages/component-library/stories/Tooltip.stories.tsx
+++ b/packages/component-library/stories/Tooltip.stories.tsx
@@ -2,8 +2,8 @@ import { loadElmStories } from "@cultureamp/elm-storybook"
 import { storiesOf } from "@storybook/react"
 import * as React from "react"
 
-import { Tag } from "@cultureamp/kaizen-component-library/draft"
-import { Tooltip } from "@cultureamp/kaizen-component-library/draft"
+import { Tag } from "@kaizen/component-library/draft"
+import { Tooltip } from "@kaizen/component-library/draft"
 
 storiesOf("Tooltip (React)", module)
   .add("Default - Below (Kaizen Site Demo)", () => (

--- a/packages/component-library/stories/VerticalProgressIndicator.stories.tsx
+++ b/packages/component-library/stories/VerticalProgressIndicator.stories.tsx
@@ -1,4 +1,4 @@
-import { VerticalProgressIndicator } from "@cultureamp/kaizen-component-library/draft/Kaizen/VerticalProgressStep/VerticalProgressIndicator"
+import { VerticalProgressIndicator } from "@kaizen/component-library/draft/Kaizen/VerticalProgressStep/VerticalProgressIndicator"
 import { storiesOf } from "@storybook/react"
 import * as React from "react"
 

--- a/packages/component-library/stories/VerticalProgressStep.stories.tsx
+++ b/packages/component-library/stories/VerticalProgressStep.stories.tsx
@@ -1,4 +1,4 @@
-import { VerticalProgressStep } from "@cultureamp/kaizen-component-library/draft"
+import { VerticalProgressStep } from "@kaizen/component-library/draft"
 import { storiesOf } from "@storybook/react"
 import * as React from "react"
 

--- a/packages/component-library/stories/Well.stories.tsx
+++ b/packages/component-library/stories/Well.stories.tsx
@@ -1,7 +1,7 @@
 import { loadElmStories } from "@cultureamp/elm-storybook"
-import { Text } from "@cultureamp/kaizen-component-library"
-import { TextField } from "@cultureamp/kaizen-component-library/draft"
-import { Well } from "@cultureamp/kaizen-component-library/draft"
+import { Text } from "@kaizen/component-library"
+import { TextField } from "@kaizen/component-library/draft"
+import { Well } from "@kaizen/component-library/draft"
 import { storiesOf } from "@storybook/react"
 import * as React from "react"
 

--- a/packages/component-library/styles/border.scss
+++ b/packages/component-library/styles/border.scss
@@ -1,4 +1,4 @@
-@import "~@cultureamp/kaizen-design-tokens/sass/color";
+@import "~@kaizen/design-tokens/sass/color";
 @import "color";
 $ca-box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
 $ca-border-color: $kz-color-wisteria-200;

--- a/packages/component-library/styles/color.scss
+++ b/packages/component-library/styles/color.scss
@@ -1,4 +1,4 @@
-@import "~@cultureamp/kaizen-design-tokens/sass/color";
+@import "~@kaizen/design-tokens/sass/color";
 $white: #fff;
 $black: #000;
 

--- a/packages/component-library/styles/type.scss
+++ b/packages/component-library/styles/type.scss
@@ -1,4 +1,4 @@
-@import "~@cultureamp/kaizen-design-tokens/sass/color";
+@import "~@kaizen/design-tokens/sass/color";
 @import "color";
 @import "layers";
 

--- a/site/package.json
+++ b/site/package.json
@@ -9,7 +9,7 @@
     "@babel/plugin-proposal-object-rest-spread": "^7.5.4",
     "@babel/preset-react": "^7.0.0",
     "@babel/preset-typescript": "^7.6.0",
-    "@cultureamp/kaizen-component-library": "*",
+    "@kaizen/component-library": "*",
     "@kaizen/design-tokens": "*",
     "@mdx-js/mdx": "^1.4.5",
     "@mdx-js/react": "^1.4.5",

--- a/site/src/components/ContentMarkdownSection.scss
+++ b/site/src/components/ContentMarkdownSection.scss
@@ -1,4 +1,4 @@
-@import "~@cultureamp/kaizen-component-library/styles/responsive";
+@import "~@kaizen/component-library/styles/responsive";
 
 .contentInner {
   margin: var(--content-top-and-bottom-margin) var(--content-side-margin);

--- a/site/src/components/ContentOnly.scss
+++ b/site/src/components/ContentOnly.scss
@@ -1,4 +1,4 @@
-@import "~@cultureamp/kaizen-component-library/styles/responsive";
+@import "~@kaizen/component-library/styles/responsive";
 
 .contentOnly {
   display: grid;

--- a/site/src/components/Footer.scss
+++ b/site/src/components/Footer.scss
@@ -1,6 +1,6 @@
 @import "~@kaizen/design-tokens/sass/color";
-@import "~@cultureamp/kaizen-component-library/styles/type";
-@import "~@cultureamp/kaizen-component-library/styles/color";
+@import "~@kaizen/component-library/styles/type";
+@import "~@kaizen/component-library/styles/color";
 
 $reverse-variant-color: $kz-color-wisteria-700;
 

--- a/site/src/components/Footer.tsx
+++ b/site/src/components/Footer.tsx
@@ -1,8 +1,8 @@
-import { Icon } from "@cultureamp/kaizen-component-library"
+import { Icon } from "@kaizen/component-library"
 import classnames from "classnames"
 import * as React from "react"
 
-const companyLogo = require("@cultureamp/kaizen-component-library/icons/ca-monogram.icon.svg")
+const companyLogo = require("@kaizen/component-library/icons/ca-monogram.icon.svg")
   .default
 
 const styles = require("./Footer.scss")

--- a/site/src/components/Layout.scss
+++ b/site/src/components/Layout.scss
@@ -1,8 +1,8 @@
-@import "~@cultureamp/kaizen-component-library/components/NavigationBar/styles";
-@import "~@cultureamp/kaizen-component-library/styles/type";
-@import "~@cultureamp/kaizen-component-library/styles/color";
-@import "~@cultureamp/kaizen-component-library/styles/responsive";
-@import "~@cultureamp/kaizen-component-library/styles/layers";
+@import "~@kaizen/component-library/components/NavigationBar/styles";
+@import "~@kaizen/component-library/styles/type";
+@import "~@kaizen/component-library/styles/color";
+@import "~@kaizen/component-library/styles/responsive";
+@import "~@kaizen/component-library/styles/layers";
 
 :root {
   --content-max-width: calc(var(--ca-grid) * 57);

--- a/site/src/components/MainNav.tsx
+++ b/site/src/components/MainNav.tsx
@@ -1,7 +1,7 @@
 import {
   Link as NavLink,
   NavigationBar,
-} from "@cultureamp/kaizen-component-library"
+} from "@kaizen/component-library"
 import { withPrefix } from "gatsby"
 import * as React from "react"
 

--- a/site/src/components/MainNav.tsx
+++ b/site/src/components/MainNav.tsx
@@ -1,7 +1,4 @@
-import {
-  Link as NavLink,
-  NavigationBar,
-} from "@kaizen/component-library"
+import { Link as NavLink, NavigationBar } from "@kaizen/component-library"
 import { withPrefix } from "gatsby"
 import * as React from "react"
 

--- a/site/src/components/PageHeader.scss
+++ b/site/src/components/PageHeader.scss
@@ -1,7 +1,7 @@
 @import "~@kaizen/design-tokens/sass/color";
-@import "~@cultureamp/kaizen-component-library/styles/type";
-@import "~@cultureamp/kaizen-component-library/styles/color";
-@import "~@cultureamp/kaizen-component-library/styles/responsive";
+@import "~@kaizen/component-library/styles/type";
+@import "~@kaizen/component-library/styles/color";
+@import "~@kaizen/component-library/styles/responsive";
 
 .pageHeader {
   display: grid;

--- a/site/src/components/SidebarAndContent.scss
+++ b/site/src/components/SidebarAndContent.scss
@@ -1,8 +1,8 @@
 @import "~@kaizen/design-tokens/sass/color";
-@import "~@cultureamp/kaizen-component-library/styles/layout";
-@import "~@cultureamp/kaizen-component-library/styles/color";
-@import "~@cultureamp/kaizen-component-library/styles/type";
-@import "~@cultureamp/kaizen-component-library/styles/responsive";
+@import "~@kaizen/component-library/styles/layout";
+@import "~@kaizen/component-library/styles/color";
+@import "~@kaizen/component-library/styles/type";
+@import "~@kaizen/component-library/styles/responsive";
 
 $sidebar-width: $ca-grid * 10;
 

--- a/site/src/components/SidebarAndContent.tsx
+++ b/site/src/components/SidebarAndContent.tsx
@@ -1,4 +1,4 @@
-import { Icon } from "@cultureamp/kaizen-component-library"
+import { Icon } from "@kaizen/component-library"
 import classnames from "classnames"
 import { Link } from "gatsby"
 import * as React from "react"

--- a/site/src/components/StorybookDemo.scss
+++ b/site/src/components/StorybookDemo.scss
@@ -1,5 +1,5 @@
-@import "~@cultureamp/kaizen-component-library/styles/color";
-@import "~@cultureamp/kaizen-component-library/styles/responsive";
+@import "~@kaizen/component-library/styles/color";
+@import "~@kaizen/component-library/styles/responsive";
 
 .container {
   display: flex;

--- a/site/src/docs-components/Card.scss
+++ b/site/src/docs-components/Card.scss
@@ -1,5 +1,5 @@
-@import "~@cultureamp/kaizen-component-library/styles/color";
-@import "~@cultureamp/kaizen-component-library/styles/type";
+@import "~@kaizen/component-library/styles/color";
+@import "~@kaizen/component-library/styles/type";
 
 .card {
   box-sizing: border-box;

--- a/site/src/docs-components/DosAndDonts.scss
+++ b/site/src/docs-components/DosAndDonts.scss
@@ -1,6 +1,6 @@
 @import "~@kaizen/design-tokens/sass/color";
-@import "~@cultureamp/kaizen-component-library/styles/color";
-@import "~@cultureamp/kaizen-component-library/styles/responsive";
+@import "~@kaizen/component-library/styles/color";
+@import "~@kaizen/component-library/styles/responsive";
 
 .container {
   display: flex;

--- a/site/src/docs-components/Link.scss
+++ b/site/src/docs-components/Link.scss
@@ -1,5 +1,5 @@
-@import "~@cultureamp/kaizen-component-library/styles/color";
-@import "~@cultureamp/kaizen-component-library/styles/type";
+@import "~@kaizen/component-library/styles/color";
+@import "~@kaizen/component-library/styles/type";
 
 .link,
 .htmlContent a[href] {

--- a/site/src/docs-components/Link.tsx
+++ b/site/src/docs-components/Link.tsx
@@ -2,7 +2,7 @@ import classnames from "classnames"
 import { Link as GatsbyLink } from "gatsby"
 import * as React from "react"
 
-const iconStyles = require("@cultureamp/kaizen-component-library/components/Icon/Icon.module.scss")
+const iconStyles = require("@kaizen/component-library/components/Icon/Icon.module.scss")
 const styles = require("./Link.scss")
 
 export const Link = ({ to, children }) => (

--- a/site/src/docs-components/WhenUse.scss
+++ b/site/src/docs-components/WhenUse.scss
@@ -1,5 +1,5 @@
 @import "~@kaizen/design-tokens/sass/color";
-@import "~@cultureamp/kaizen-component-library/styles/color";
+@import "~@kaizen/component-library/styles/color";
 
 .container {
   color: $kz-color-wisteria-800;

--- a/site/src/docs-components/WhenUse.tsx
+++ b/site/src/docs-components/WhenUse.tsx
@@ -1,11 +1,11 @@
-import { Icon } from "@cultureamp/kaizen-component-library"
+import { Icon } from "@kaizen/component-library"
 import classnames from "classnames"
 
 import * as React from "react"
 
-const success = require("@cultureamp/kaizen-component-library/icons/success-white.icon.svg")
+const success = require("@kaizen/component-library/icons/success-white.icon.svg")
   .default
-const exclamation = require("@cultureamp/kaizen-component-library/icons/exclamation-white.icon.svg")
+const exclamation = require("@kaizen/component-library/icons/exclamation-white.icon.svg")
   .default
 const styles = require("./WhenUse.scss")
 

--- a/site/src/docs-components/animation/AnimationExample.tsx
+++ b/site/src/docs-components/animation/AnimationExample.tsx
@@ -5,7 +5,7 @@ import {
   MenuList,
   MenuSeparator,
   Text,
-} from "@cultureamp/kaizen-component-library"
+} from "@kaizen/component-library"
 import classnames from "classnames"
 import * as React from "react"
 import Drop from "./Drop"

--- a/site/src/docs-components/animation/AnimationImportExample.scss
+++ b/site/src/docs-components/animation/AnimationImportExample.scss
@@ -1,1 +1,1 @@
-@import "~@cultureamp/kaizen-component-library/styles/animation";
+@import "~@kaizen/component-library/styles/animation";

--- a/site/src/docs-components/animation/AnimationPresetsExample.scss
+++ b/site/src/docs-components/animation/AnimationPresetsExample.scss
@@ -1,4 +1,4 @@
-@import "~@cultureamp/kaizen-component-library/styles/animation";
+@import "~@kaizen/component-library/styles/animation";
 
 ///////////////////////////////////////////////
 // ANIMATION PRESET CLASSES                  //

--- a/site/src/docs-components/animation/AnimationSequencesExample.scss
+++ b/site/src/docs-components/animation/AnimationSequencesExample.scss
@@ -1,4 +1,4 @@
-@import "~@cultureamp/kaizen-component-library/styles/animation";
+@import "~@kaizen/component-library/styles/animation";
 
 $duration: $ca-duration-deliberate; // 700ms
 $delay: -$ca-duration-slow; // -400ms (stagger effect)

--- a/site/src/docs-components/animation/AnimationUsageInputExample.scss
+++ b/site/src/docs-components/animation/AnimationUsageInputExample.scss
@@ -1,4 +1,4 @@
-@import "~@cultureamp/kaizen-component-library/styles/animation";
+@import "~@kaizen/component-library/styles/animation";
 
 //////////////////////////////////////////////
 // Slide Fade In Animation

--- a/site/src/docs-components/animation/AnimationUsageOutputExample.scss
+++ b/site/src/docs-components/animation/AnimationUsageOutputExample.scss
@@ -1,4 +1,4 @@
-@import "~@cultureamp/kaizen-component-library/styles/animation";
+@import "~@kaizen/component-library/styles/animation";
 
 //////////////////////////////////////////////
 // Slide Fade In Animation

--- a/site/src/docs-components/animation/Drop.scss
+++ b/site/src/docs-components/animation/Drop.scss
@@ -1,5 +1,5 @@
-@import "~@cultureamp/kaizen-component-library/styles/color";
-@import "~@cultureamp/kaizen-component-library/styles/type";
+@import "~@kaizen/component-library/styles/color";
+@import "~@kaizen/component-library/styles/type";
 
 $cardPadding: $ca-grid / 2;
 

--- a/site/src/docs-components/animation/DurationPresetsExample.jsx
+++ b/site/src/docs-components/animation/DurationPresetsExample.jsx
@@ -1,4 +1,4 @@
-import scssCode from "!raw-loader!@cultureamp/kaizen-component-library/styles/animations/_durations.scss"
+import scssCode from "!raw-loader!@kaizen/component-library/styles/animations/_durations.scss"
 import * as React from "react"
 import Code from "../Code"
 

--- a/site/src/docs-components/animation/EasingPresetsExample.jsx
+++ b/site/src/docs-components/animation/EasingPresetsExample.jsx
@@ -1,4 +1,4 @@
-import scssCode from "!raw-loader!@cultureamp/kaizen-component-library/styles/animations/_easings.scss"
+import scssCode from "!raw-loader!@kaizen/component-library/styles/animations/_easings.scss"
 import * as React from "react"
 import Code from "../Code"
 

--- a/site/src/docs-components/animation/TransitionDrop.tsx
+++ b/site/src/docs-components/animation/TransitionDrop.tsx
@@ -5,7 +5,7 @@ import {
   MenuList,
   MenuSeparator,
   Text,
-} from "@cultureamp/kaizen-component-library"
+} from "@kaizen/component-library"
 import classnames from "classnames"
 import * as React from "react"
 import Drop from "./Drop"

--- a/site/src/docs-components/animation/TransitionPresetsExample.scss
+++ b/site/src/docs-components/animation/TransitionPresetsExample.scss
@@ -1,4 +1,4 @@
-@import "~@cultureamp/kaizen-component-library/styles/animation";
+@import "~@kaizen/component-library/styles/animation";
 
 ///////////////////////////////////////////////
 // TRANSITION PRESET CLASSES                  //

--- a/site/src/docs-components/color/legacy/ColorBlockKebab.tsx
+++ b/site/src/docs-components/color/legacy/ColorBlockKebab.tsx
@@ -3,10 +3,10 @@ import {
   MenuHeader,
   MenuItem,
   MenuList,
-} from "@cultureamp/kaizen-component-library"
+} from "@kaizen/component-library"
 import * as React from "react"
 
-const duplicate = require("@cultureamp/kaizen-component-library/icons/duplicate.icon.svg")
+const duplicate = require("@kaizen/component-library/icons/duplicate.icon.svg")
 
 const styles = require("./ColorCard.scss")
 

--- a/site/src/docs-components/color/legacy/ColorCard.jsx
+++ b/site/src/docs-components/color/legacy/ColorCard.jsx
@@ -1,11 +1,11 @@
-import { Icon } from "@cultureamp/kaizen-component-library"
+import { Icon } from "@kaizen/component-library"
 import * as React from "react"
 import ColorBlock from "./ColorBlock"
 import { renderContrastHeaderIcons } from "./ContrastIcon"
 import Palette from "./Palette"
 
-const chevronDown = require("@cultureamp/kaizen-component-library/icons/chevron-down.icon.svg").default
-const chevronUp = require("@cultureamp/kaizen-component-library/icons/chevron-up.icon.svg").default
+const chevronDown = require("@kaizen/component-library/icons/chevron-down.icon.svg").default
+const chevronUp = require("@kaizen/component-library/icons/chevron-up.icon.svg").default
 const styles = require("./ColorCard.scss")
 
 class ColorCard extends React.Component {

--- a/site/src/docs-components/color/legacy/ColorCard.scss
+++ b/site/src/docs-components/color/legacy/ColorCard.scss
@@ -1,5 +1,5 @@
-@import "~@cultureamp/kaizen-component-library/styles/color";
-@import "~@cultureamp/kaizen-component-library/styles/type";
+@import "~@kaizen/component-library/styles/color";
+@import "~@kaizen/component-library/styles/type";
 
 // TODO: update references to style sheets
 
@@ -24,7 +24,7 @@
   margin: 0;
   padding: 0;
   border: none;
-  composes: interactiveIconWrapper from "@cultureamp/kaizen-component-library/components/Icon/Icon.module.scss";
+  composes: interactiveIconWrapper from "@kaizen/component-library/components/Icon/Icon.module.scss";
   color: $ca-palette-ink;
   display: flex;
   width: 100%;
@@ -99,7 +99,7 @@ $accessibilityTileWidth: 46px;
   padding-top: calc(#{$ca-grid / 2} + #{$bottomMargin / 2});
   padding-bottom: calc(#{$ca-grid / 2} - #{$bottomMargin / 2});
 
-  composes: kebabHoverArea from "@cultureamp/kaizen-component-library/components/Dropdown/Dropdown.module.scss";
+  composes: kebabHoverArea from "@kaizen/component-library/components/Dropdown/Dropdown.module.scss";
 
   display: flex;
   flex-direction: row;

--- a/site/src/docs-components/color/legacy/ColorShowcase.scss
+++ b/site/src/docs-components/color/legacy/ColorShowcase.scss
@@ -1,4 +1,4 @@
-@import "~@cultureamp/kaizen-component-library/styles/type";
+@import "~@kaizen/component-library/styles/type";
 
 @mixin setColumnSizes($numColumns, $min, $max) {
   .cardContainer {

--- a/site/src/docs-components/color/legacy/ContrastIcon.tsx
+++ b/site/src/docs-components/color/legacy/ContrastIcon.tsx
@@ -1,10 +1,10 @@
-import { Icon } from "@cultureamp/kaizen-component-library"
+import { Icon } from "@kaizen/component-library"
 import classnames from "classnames"
 import * as React from "react"
 import wcag from "wcag-contrast-verifier/lib/wcag"
 import Palette from "./Palette"
 
-const successWhite = require("@cultureamp/kaizen-component-library/icons/success.icon.svg")
+const successWhite = require("@kaizen/component-library/icons/success.icon.svg")
   .default
 
 const styles = require("./ColorCard.scss")

--- a/site/src/docs-components/icons/IconGrid.scss
+++ b/site/src/docs-components/icons/IconGrid.scss
@@ -1,7 +1,7 @@
 @import "~@kaizen/design-tokens/sass/color";
-@import "~@cultureamp/kaizen-component-library/styles/type";
-@import "~@cultureamp/kaizen-component-library/styles/border";
-@import "~@cultureamp/kaizen-component-library/styles/color";
+@import "~@kaizen/component-library/styles/type";
+@import "~@kaizen/component-library/styles/border";
+@import "~@kaizen/component-library/styles/color";
 
 .header {
   font-size: 2rem;
@@ -31,7 +31,7 @@ $tileHeight: $ca-grid * 6;
   margin: 0;
   padding: 0;
   border: none;
-  composes: interactiveIconWrapper from "@cultureamp/kaizen-component-library/components/Icon/Icon.module.scss";
+  composes: interactiveIconWrapper from "@kaizen/component-library/components/Icon/Icon.module.scss";
   cursor: pointer;
   border-radius: $ca-border-radius;
 

--- a/site/src/docs-components/icons/IconTile.tsx
+++ b/site/src/docs-components/icons/IconTile.tsx
@@ -3,8 +3,7 @@ import classnames from "classnames"
 import * as React from "react"
 
 const iconStyles = require("@kaizen/component-library/components/Icon/Icon.module.scss")
-const tick = require("@kaizen/component-library/icons/check.icon.svg")
-  .default
+const tick = require("@kaizen/component-library/icons/check.icon.svg").default
 
 const styles = require("./IconGrid.scss")
 

--- a/site/src/docs-components/icons/IconTile.tsx
+++ b/site/src/docs-components/icons/IconTile.tsx
@@ -1,14 +1,14 @@
-import { Icon } from "@cultureamp/kaizen-component-library"
+import { Icon } from "@kaizen/component-library"
 import classnames from "classnames"
 import * as React from "react"
 
-const iconStyles = require("@cultureamp/kaizen-component-library/components/Icon/Icon.module.scss")
-const tick = require("@cultureamp/kaizen-component-library/icons/check.icon.svg")
+const iconStyles = require("@kaizen/component-library/components/Icon/Icon.module.scss")
+const tick = require("@kaizen/component-library/icons/check.icon.svg")
   .default
 
 const styles = require("./IconGrid.scss")
 
-const ICONS_IMPORT_DIR = "@cultureamp/kaizen-component-library/icons/"
+const ICONS_IMPORT_DIR = "@kaizen/component-library/icons/"
 
 type IconTileProps = {
   title?: string

--- a/site/src/docs-components/icons/IconsPage.scss
+++ b/site/src/docs-components/icons/IconsPage.scss
@@ -1,4 +1,4 @@
-@import "~@cultureamp/kaizen-component-library/styles/type";
+@import "~@kaizen/component-library/styles/type";
 
 $cardPadding: $ca-grid / 2;
 

--- a/site/src/docs-components/icons/InteractionStates.tsx
+++ b/site/src/docs-components/icons/InteractionStates.tsx
@@ -1,10 +1,10 @@
-import { Icon } from "@cultureamp/kaizen-component-library"
+import { Icon } from "@kaizen/component-library"
 import classnames from "classnames"
 import * as React from "react"
 import Card from "../Card"
 
-const iconStyles = require("@cultureamp/kaizen-component-library/components/Icon/Icon.module.scss")
-const enso = require("@cultureamp/kaizen-component-library/icons/ca-monogram.icon.svg")
+const iconStyles = require("@kaizen/component-library/components/Icon/Icon.module.scss")
+const enso = require("@kaizen/component-library/icons/ca-monogram.icon.svg")
   .default
 
 const styles = require("./IconsPage.scss")

--- a/site/src/docs-components/icons/InteractionStatesDemo.scss
+++ b/site/src/docs-components/icons/InteractionStatesDemo.scss
@@ -1,4 +1,4 @@
-@import "~@cultureamp/kaizen-component-library/styles/type";
+@import "~@kaizen/component-library/styles/type";
 
 .wrapper {
   margin-top: $ca-grid * 2;

--- a/site/src/docs-components/localization/CAMarginExample.tsx
+++ b/site/src/docs-components/localization/CAMarginExample.tsx
@@ -4,7 +4,7 @@ import Code from "../Code"
 class CAMarginExample extends React.PureComponent {
   render() {
     return (
-      <Code language="scss">{`@import '~@cultureamp/kaizen-component-library/styles/layout';
+      <Code language="scss">{`@import '~@kaizen/component-library/styles/layout';
 
 .my-element {
   @include ca-margin($start: $ca-grid, $end: 0, $top: $ca-grid * 2, $bottom: $ca-grid);

--- a/site/src/docs-components/localization/CAPaddingExample.tsx
+++ b/site/src/docs-components/localization/CAPaddingExample.tsx
@@ -4,7 +4,7 @@ import Code from "../Code"
 class CAPaddingExample extends React.PureComponent {
   render() {
     return (
-      <Code language="scss">{`@import '~@cultureamp/kaizen-component-library/styles/layout';
+      <Code language="scss">{`@import '~@kaizen/component-library/styles/layout';
 
 .my-element {
   @include ca-padding($start: $ca-grid, $end: 0, $top: $ca-grid * 2, $bottom: $ca-grid);

--- a/site/src/docs-components/localization/CAPositionExample.tsx
+++ b/site/src/docs-components/localization/CAPositionExample.tsx
@@ -4,7 +4,7 @@ import Code from "../Code"
 class CAPositionExample extends React.PureComponent {
   render() {
     return (
-      <Code language="scss">{`@import '~@cultureamp/kaizen-component-library/styles/layout';
+      <Code language="scss">{`@import '~@kaizen/component-library/styles/layout';
 
 .my-element {
   @include ca-position($start: $ca-grid, $end: 0, $top: $ca-grid * 2, $bottom: $ca-grid);

--- a/site/src/docs-components/localization/CATypeAlignExample.tsx
+++ b/site/src/docs-components/localization/CATypeAlignExample.tsx
@@ -4,7 +4,7 @@ import Code from "../Code"
 class CATypeAlignExample extends React.PureComponent {
   render() {
     return (
-      <Code language="scss">{`@import '~@cultureamp/kaizen-component-library/styles/type';
+      <Code language="scss">{`@import '~@kaizen/component-library/styles/type';
 
 .my-text {
   @include ca-type-align-start;

--- a/site/src/docs-components/localization/LocalizationMixinImportExample.tsx
+++ b/site/src/docs-components/localization/LocalizationMixinImportExample.tsx
@@ -4,8 +4,8 @@ import Code from "../Code"
 class LocalizationMixinImportExample extends React.PureComponent {
   render() {
     return (
-      <Code language="scss">{`@import '~@cultureamp/kaizen-component-library/styles/type';
-@import '~@cultureamp/kaizen-component-library/styles/layout';`}</Code>
+      <Code language="scss">{`@import '~@kaizen/component-library/styles/type';
+@import '~@kaizen/component-library/styles/layout';`}</Code>
     )
   }
 }

--- a/site/src/docs-components/typography/TypographyShowcase.scss
+++ b/site/src/docs-components/typography/TypographyShowcase.scss
@@ -1,5 +1,5 @@
-@import "~@cultureamp/kaizen-component-library/styles/type";
-@import "~@cultureamp/kaizen-component-library/styles/border";
+@import "~@kaizen/component-library/styles/type";
+@import "~@kaizen/component-library/styles/border";
 
 .showcase {
   margin-top: $ca-grid * 2.5;

--- a/site/src/pages/404.tsx
+++ b/site/src/pages/404.tsx
@@ -1,4 +1,4 @@
-import { Icon } from "@cultureamp/kaizen-component-library"
+import { Icon } from "@kaizen/component-library"
 import { Link } from "gatsby"
 import * as React from "react"
 import ContentMarkdownSection from "../components/ContentMarkdownSection"
@@ -8,7 +8,7 @@ import Layout from "../components/Layout"
 import md from "../components/markdownComponents"
 import PageHeader from "../components/PageHeader"
 
-const exclamationIcon = require("@cultureamp/kaizen-component-library/icons/exclamation.icon.svg")
+const exclamationIcon = require("@kaizen/component-library/icons/exclamation.icon.svg")
   .default
 
 const FourOhFourPageHeader = (

--- a/site/src/pages/index.scss
+++ b/site/src/pages/index.scss
@@ -1,5 +1,5 @@
-@import "~@cultureamp/kaizen-component-library/styles/responsive";
-@import "~@cultureamp/kaizen-component-library/styles/animation";
+@import "~@kaizen/component-library/styles/responsive";
+@import "~@kaizen/component-library/styles/animation";
 
 .content {
   display: grid;

--- a/site/src/pages/index.tsx
+++ b/site/src/pages/index.tsx
@@ -1,4 +1,4 @@
-import { Button } from "@cultureamp/kaizen-component-library"
+import { Button } from "@kaizen/component-library"
 import { graphql, useStaticQuery, withPrefix } from "gatsby"
 import * as React from "react"
 import { Content, ContentOnly } from "../components/ContentOnly"

--- a/site/src/styles/global.scss
+++ b/site/src/styles/global.scss
@@ -1,7 +1,7 @@
 @import "~@kaizen/design-tokens/sass/color";
-@import "~@cultureamp/kaizen-component-library/styles/type";
-@import "~@cultureamp/kaizen-component-library/styles/color";
-@import "~@cultureamp/kaizen-component-library/styles/responsive";
+@import "~@kaizen/component-library/styles/type";
+@import "~@kaizen/component-library/styles/color";
+@import "~@kaizen/component-library/styles/responsive";
 
 :root {
   --ca-grid: #{$ca-grid};

--- a/site/src/styles/markdown.scss
+++ b/site/src/styles/markdown.scss
@@ -1,10 +1,10 @@
 @import "~@kaizen/design-tokens/sass/color";
-@import "~@cultureamp/kaizen-component-library/styles/layout";
-@import "~@cultureamp/kaizen-component-library/styles/type";
-@import "~@cultureamp/kaizen-component-library/styles/color";
-@import "~@cultureamp/kaizen-component-library/styles/border";
-@import "~@cultureamp/kaizen-component-library/components/NavigationBar/styles";
-@import "~@cultureamp/kaizen-component-library/components/Icon/styles";
+@import "~@kaizen/component-library/styles/layout";
+@import "~@kaizen/component-library/styles/type";
+@import "~@kaizen/component-library/styles/color";
+@import "~@kaizen/component-library/styles/border";
+@import "~@kaizen/component-library/components/NavigationBar/styles";
+@import "~@kaizen/component-library/components/Icon/styles";
 
 $link-icon-margin: 12px;
 

--- a/storybook/backgrounds.ts
+++ b/storybook/backgrounds.ts
@@ -1,4 +1,4 @@
-import * as tokens from "@cultureamp/kaizen-design-tokens/tokens/color.json"
+import * as tokens from "@kaizen/design-tokens/tokens/color.json"
 
 export const backgrounds = [
   { name: "Stone", value: tokens.kz.color.stone },

--- a/storybook/pre-build.ts
+++ b/storybook/pre-build.ts
@@ -14,9 +14,9 @@ const exitWithError = (...message: string[]) => {
 // package. This state is required for linking with murmur, but it causes
 // storybook to fail in ways that are difficult to diagnose.
 if (
-  readdirSync(
-    dirname(require.resolve("@kaizen/component-library"))
-  ).includes("index.js")
+  readdirSync(dirname(require.resolve("@kaizen/component-library"))).includes(
+    "index.js"
+  )
 ) {
   exitWithError(
     "The component-library package contains compiled javascript!",

--- a/storybook/pre-build.ts
+++ b/storybook/pre-build.ts
@@ -10,12 +10,12 @@ const exitWithError = (...message: string[]) => {
   process.exit(1)
 }
 
-// Check for compiler output in the @cultureamp/kaizen-component-library
+// Check for compiler output in the @kaizen/component-library
 // package. This state is required for linking with murmur, but it causes
 // storybook to fail in ways that are difficult to diagnose.
 if (
   readdirSync(
-    dirname(require.resolve("@cultureamp/kaizen-component-library"))
+    dirname(require.resolve("@kaizen/component-library"))
   ).includes("index.js")
 ) {
   exitWithError(

--- a/storybook/webpack.config.ts
+++ b/storybook/webpack.config.ts
@@ -140,7 +140,7 @@ const removeSvgFromTest = (rule: Rule): Rule => {
 }
 
 const excludeExternalModules = (rule: Rule): Rule => ({
-  exclude: /node_modules\/(?!(\@cultureamp)).*/,
+  exclude: /node_modules\/(?!(\@kaizen|\@cultureamp)).*/,
   ...rule,
 })
 

--- a/tslint.json
+++ b/tslint.json
@@ -7,7 +7,7 @@
     "no-implicit-dependencies": [
       true,
       "dev",
-      ["@cultureamp", "@storybook", "@testing-library", "react", "react-dom"]
+      ["@kaizen", "@storybook", "@testing-library", "react", "react-dom"]
     ],
     "ordered-imports": true
   }


### PR DESCRIPTION
Re-releases all packages under their own `@kaizen` module scope, freeing up the `@cultureamp` scope for internal use.

Uses the re-scoped `@kaizen/tokens@0.2.0`, and resets the package version to `1.0.0`.

**Note for reviewers:** The commit f804fcb was was made programmatically, so we're looking for anywhere where this package name change has ended up in an inappropriate context (where it was referencing a previous version of the package, for example).