### PR TITLE
fix: fixed modal body padding issue

### DIFF
--- a/packages/component-library/draft/Kaizen/Modal/Primitives/GenericModal.scss
+++ b/packages/component-library/draft/Kaizen/Modal/Primitives/GenericModal.scss
@@ -97,6 +97,9 @@
 
 .unscrollable {
   overflow: hidden !important;
+}
+
+.pseudoScrollbar {
   padding-right: 15px !important;
 }
 

--- a/packages/component-library/draft/Kaizen/Modal/Primitives/GenericModal.tsx
+++ b/packages/component-library/draft/Kaizen/Modal/Primitives/GenericModal.tsx
@@ -69,7 +69,7 @@ class GenericModal extends React.Component<Props> {
   restoreBodyScroll() {
     document.documentElement.classList.remove(
       styles.unscrollable,
-      styles.fakeScrollbar
+      styles.pseudoScrollbar
     )
   }
 

--- a/packages/component-library/draft/Kaizen/Modal/Primitives/GenericModal.tsx
+++ b/packages/component-library/draft/Kaizen/Modal/Primitives/GenericModal.tsx
@@ -59,11 +59,18 @@ class GenericModal extends React.Component<Props> {
   }
 
   preventBodyScroll() {
-    document.documentElement.classList.add(styles.unscrollable)
+    const hasScrollbar =
+      window.innerWidth > document.documentElement.clientWidth
+    document.documentElement.classList.add(
+      ...[styles.unscrollable, hasScrollbar && styles.pseudoScrollbar]
+    )
   }
 
   restoreBodyScroll() {
-    document.documentElement.classList.remove(styles.unscrollable)
+    document.documentElement.classList.remove(
+      styles.unscrollable,
+      styles.fakeScrollbar
+    )
   }
 
   escapeKeyHandler = (event: KeyboardEvent) => {


### PR DESCRIPTION
The problem is, when a modal is opened, we prevent body scroll behind it, this causes the scrollbar (if there is one) to disappear - the causes a 'jump' in body width.

Currently we make up for this disappearing scrollbar by creating a 15px padding on the `documentElement`. Problem with this approach is that it doesn't account for 2 scenarios:
- When the documentElement does not have enough content to scroll - hence no scrollbar
- When the browser doesn't have a scrollbar (or had a floating scrollbar, like on a mac)

In the above 2 scenarios we are currently getting the opposite effect, we add padding when there was no scrollbar, causing the 'jump' in body width in the other direction.

Some research found this article from a bootstrap contributor:
[Javascript Scrollbar Detection](https://tylercipriani.com/blog/2014/07/12/crossbrowser-javascript-scrollbar-detection/)
_Note: this article goes as far as to support IE8, as we only support IE11+ - the "The tl;dr, semi-näive version" of this is suffice for our use case._

I have applied the changes to our react generic modal:

- Cross browser detect whether there is a scrollbar present on the body - ie9 +
- Apply `padding-right: 15px;` to body only when above is true, otherwise just prevent scroll with `overflow: hidden;`

