### PR TITLE
feat: Make right/left arrows look like forward/backward

### DIFF
--- a/packages/component-library/icons/arrow-left.icon.svg
+++ b/packages/component-library/icons/arrow-left.icon.svg
@@ -4,7 +4,7 @@
     <title>arrow-left</title>
     <desc>Created with Sketch.</desc>
     <defs>
-        <polygon id="path-1" points="16 9.25 6.8725 9.25 11.065 5.0575 10 4 4 10 10 16 11.0575 14.9425 6.8725 10.75 16 10.75"></polygon>
+        <polygon id="path-1" points="17.5 9.16666667 5.69166667 9.16666667 8.67916667 6.17916667 7.5 5 2.5 10 7.5 15 8.67916667 13.8208333 5.69166667 10.8333333 17.5 10.8333333"></polygon>
     </defs>
     <g id="Symbols" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
         <g id="arrow-left">

--- a/packages/component-library/icons/arrow-right.icon.svg
+++ b/packages/component-library/icons/arrow-right.icon.svg
@@ -4,7 +4,7 @@
     <title>arrow-right</title>
     <desc>Created with Sketch.</desc>
     <defs>
-        <polygon id="path-1" points="10 4 8.9425 5.0575 13.1275 9.25 4 9.25 4 10.75 13.1275 10.75 8.9425 14.9425 10 16 16 10"></polygon>
+        <polygon id="path-1" points="12.5 5 11.3208333 6.17916667 14.3083333 9.16583333 2.5 9.16583333 2.5 10.8325 14.3083333 10.8325 11.3208333 13.8208333 12.5 15 17.5 9.99916667"></polygon>
     </defs>
     <g id="Symbols" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
         <g id="arrow-right">


### PR DESCRIPTION
_This PR will be a "breaking design change" (the look of the arrows is changing) but not a breaking change._

We currently have two pairs of left and right arrows in the platform that look different:
![image](https://user-images.githubusercontent.com/6406263/73232050-14715580-41d6-11ea-8bcc-3c1ecaa4df97.png)
![image](https://user-images.githubusercontent.com/6406263/73232059-1b986380-41d6-11ea-92e2-14321d945263.png)
Designers would like to keep the bottom pair and get rid of the top pair.

However, due to the fact that "right" and "left" are more RTL-friendly than "backward" and "forward", we want to _rename_ the bottom pair to "Arrow Right" and "Arrow Left".

**This PR preserves the filenames, but makes the top pair look like the bottom pair.**

It does not delete the now-redundant bottom pair yet, because my plan is to first remove references to the bottom pair in consuming repos, and then do another PR in `kaizen-design-system` to remove the icons themselves.