### PR TITLE
docs: update Icon and Icon Button component and fix story

### DIFF
--- a/packages/component-library/components/Icon/README.mdx
+++ b/packages/component-library/components/Icon/README.mdx
@@ -15,22 +15,31 @@ import Dont from "docs-components/Dont"
 ## To keep in mind
 
 *   See the [Icons](/guidelines/) guidelines for more information on icons, including visuals.
+*   For clickable icons that perform actions, use an [Icon Button](/components/icon-button).
 *   Meaningful or presentational:
-    *   Use **meaningful** icons with `role=img` to convey information, such as drawing attention to an item that might have a problem using a cautionary icon: 
+    *   Use **meaningful** icons with `role=img` to convey information, such as drawing attention to an item that might have a problem using a cautionary icon:
         *   Provide a short `title` and slightly more descriptive `desc` for meaningful icons so the icon is understandable by people using a screen reader.
     *   Use **presentational** icons with `role="presentation"` for icons that do not need to convey information. They might be provided for aesthetic reasons or otherwise have meaning conveyed elsewhere.
 *   To control the icon's color, set the color property on the icon's parent element. For example, `color: $kz-color-cluny-500`.
-*   For a specific subset of icons, we include a specific icon that has the preferred color baked in, such as the destructive trash icon using Coral. Otherwise, follow the [Icons: Interaction states](https://cultureamp.design/guidelines/icons/#interaction-states) guidelines.
+*   For a specific subset of icons, we include a specific icon that has the preferred color baked in, such as the destructive trash icon using Coral or the Collective Intelligence logo. Otherwise, follow the [Icons: Interaction states](https://cultureamp.design/guidelines/icons/#interaction-states) guidelines.
+
+### Icons with Tooltips or Popovers
+
+Usually, we do not support icons receiving focus. That is, a keyboard user cannot tab to an icon. This is because icons are usually presentational or supplemented with perceivable information elsewhere.
+
+Sometimes, however, we use icons without actions that link to more information, such as a [Tooltip](/components/tooltip) or [Popover](/components/popover). These are not [Icon Buttons](/components/icon-button) because they do not have an action on click. For these icons, we ensure people can tab to the Icon component to show the Tooltip or Popover on focus as well as hover. To do this, you might add `tabindex="0"` so the icon is focusable in sequential keyboard navigation, but its order is defined by the document's source order. On focus or hover of the Icon component, you might then trigger the additional information to be displayed.
+
+### Wrapper helpers
 
 We have a helper class you can compose to utilize these styles:
 
 ```
 .myButton {
-  composes: interactiveIconWrapper from 'cultureamp-style-guide/components/Icon/Icon.module.scss';
+  composes: interactiveIconWrapper from '@kaizen/component-library/components/Icon/Icon.module.scss';
 }
 
 .myReversedButton {
-  composes: reversedInteractiveIconWrapper from 'cultureamp-style-guide/components/Icon/Icon.module.scss';
+  composes: reversedInteractiveIconWrapper from '@kaizen/component-library/components/Icon/Icon.module.scss';
 }
 ```
 

--- a/packages/component-library/components/Icon/README.mdx
+++ b/packages/component-library/components/Icon/README.mdx
@@ -5,7 +5,7 @@ summaryParagraph: The Icon component displays meaningful and presentational icon
 needToKnow:
 - "This component shows a single icon that can be meaningful or presentational."
 - "To control the icon's color, set the color property on the icon's parent element."
-demoStoryId: icon--meaningful
+demoStoryId: icon-react--meaningful-kaizen-site-demo
 ---
 
 import DosAndDonts from "docs-components/DosAndDonts"

--- a/packages/component-library/stories/Icon.stories.tsx
+++ b/packages/component-library/stories/Icon.stories.tsx
@@ -8,12 +8,17 @@ const configureIcon = require("@kaizen/component-library/icons/configure.icon.sv
 
 storiesOf("Icon (React)", module)
   .add("Meaningful (Kaizen Site Demo)", () => (
-    <Icon
-      icon={configureIcon}
-      title="Warning"
-      desc="Aliens approaching!"
-      role="img"
-    />
+    // the wrapper with the fixed with is to solve a problem when this is used
+    // as a site demo: the iframe was getting a height of 0px in Firefox
+    <div style={{ width: "20px" }}>
+      <Icon
+        icon={configureIcon}
+        title="Warning"
+        desc="Aliens approaching!"
+        role="img"
+        inheritSize={true}
+      />
+    </div>
   ))
   .add("Presentational", () => (
     <Icon icon={configureIcon} role="presentation" />

--- a/site/docs/components/icon-button.mdx
+++ b/site/docs/components/icon-button.mdx
@@ -32,21 +32,26 @@ A default icon button indicates to a user that they can perform an inline action
 
 Other considerations:
 
-- Icon buttons use a button element (not a link element and no `role="button"`):
-- All buttons have an `aria-label` to describe the action to people using assistive technologies, such as screen readers:
+- Icon buttons use a button element (not a link element and no `role="button"`).
+- All icon buttons have an `aria-label` to describe the action to people using assistive technologies, such as screen readers:
     - No more than 2 to 3 words long.
     - Use verbs first; use only verbs where possible e.g. “Save”.
     - Avoid unnecessary words and articles, such as “the” or “a”.
     - Use sentence case.
 - New icons used as icon buttons need to be user tested to test comprehension—can the user identify the action indicated by the icon?
-- If there's any doubt about comprehension, a tooltip must be used on hover/focus of the icon button.
 - Icons used in icon buttons are, by default, 20px in size (minimum) and can be scaled to larger sizes if it contextually makes sense.
 - Icon buttons have a minimum touch zone of 48px.
 - RTL: flip the direction of arrow icons when the user is using a right-to-left language.
 
+### Icon buttons with Tooltips
+
+If there's any doubt about comprehension for an Icon Button with no text label, a [Tooltip](/components/tooltip) must be used on hover and focus of the Icon Button. Buttons natively receive keyboard focus so there's no need to add a `tabindex` attribute.
+
+In a Tooltip used to describe the Icon Button's action (the "tool's tip"), use 1 noun or noun phrase to label the action that will occur by activating the button.
+
 ### Breadcrumb icon button
 
-A breadcrumb icon button uses a link element instead of a button and navigates to another page.
+A breadcrumb icon button is an exceptional case that uses a link element instead of a button because it navigates to another page.
 
 ### Interaction guidelines
 
@@ -69,6 +74,7 @@ In CSS, “Default/Inactive” maps to `initial` style, “Hover/Focus” to `:h
 <Dont>
 
 - To display icons that do not have actions associated with them, use the [Icon](/components/icon) component.
+- To show a [Tooltip](/components/tooltip) or [Popover](/components/popover) on focus and hover without any button action, use an [Icon](/components/icon) component instead.
 - Avoid using more than 1 icon button in a [table](/components/table) row.
 - When there's enough space, use a [button](/components/button) instead.
 


### PR DESCRIPTION
Branch previews:

- https://dev.cultureamp.design/di/update-icon-guidelines-and-fix-story-id/components/icon
- https://dev.cultureamp.design/di/update-icon-guidelines-and-fix-story-id/components/icon-button

This PR fixes the story ID for the Icon component.

It also updates documentation around "Icon and Tooltip" and "Icon Button and Tooltip". I expect to follow up in the future with more specific guidelines around Icon Buttons for Default, Primary, Secondary, and Destructive options, Zen UI Kit assets, and someday an IconWithTooltip component.