### PR TITLE
feat: Add elm modal positive, negative variants

### DIFF
--- a/packages/component-library/draft/Kaizen/Modal/Modal.elm
+++ b/packages/component-library/draft/Kaizen/Modal/Modal.elm
@@ -66,6 +66,7 @@ type Duration
 type ConfirmationType
     = Informative
     | Positive
+    | Negative
 
 
 type alias ConfirmationConfig msg =
@@ -193,6 +194,20 @@ view (Config config) =
                         GenericModal.view GenericModal.Default
                             [ ConfirmationModal.view
                                 (ConfirmationModal.positive
+                                    |> withOnDismiss
+                                    |> withOnConfirm
+                                    |> withBodySubtext
+                                    |> ConfirmationModal.confirmLabel configs.confirmLabel
+                                    |> ConfirmationModal.dismissLabel configs.dismissLabel
+                                    |> ConfirmationModal.title configs.title
+                                )
+                            ]
+                            (genericModalConfig |> GenericModal.events genericModalEvents)
+
+                    Negative ->
+                        GenericModal.view GenericModal.Default
+                            [ ConfirmationModal.view
+                                (ConfirmationModal.negative
                                     |> withOnDismiss
                                     |> withOnConfirm
                                     |> withBodySubtext

--- a/packages/component-library/draft/Kaizen/Modal/Modal.elm
+++ b/packages/component-library/draft/Kaizen/Modal/Modal.elm
@@ -65,6 +65,7 @@ type Duration
 
 type ConfirmationType
     = Informative
+    | Positive
 
 
 type alias ConfirmationConfig msg =
@@ -178,6 +179,20 @@ view (Config config) =
                         GenericModal.view GenericModal.Default
                             [ ConfirmationModal.view
                                 (ConfirmationModal.informative
+                                    |> withOnDismiss
+                                    |> withOnConfirm
+                                    |> withBodySubtext
+                                    |> ConfirmationModal.confirmLabel configs.confirmLabel
+                                    |> ConfirmationModal.dismissLabel configs.dismissLabel
+                                    |> ConfirmationModal.title configs.title
+                                )
+                            ]
+                            (genericModalConfig |> GenericModal.events genericModalEvents)
+
+                    Positive ->
+                        GenericModal.view GenericModal.Default
+                            [ ConfirmationModal.view
+                                (ConfirmationModal.positive
                                     |> withOnDismiss
                                     |> withOnConfirm
                                     |> withBodySubtext

--- a/packages/component-library/draft/Kaizen/Modal/Presets/ConfirmationModal.elm
+++ b/packages/component-library/draft/Kaizen/Modal/Presets/ConfirmationModal.elm
@@ -5,6 +5,7 @@ module Kaizen.Modal.Presets.ConfirmationModal exposing
     , informative
     , onConfirm
     , onDismiss
+    , positive
     , title
     , view
     )
@@ -47,11 +48,17 @@ type alias Configuration msg =
 
 type Variant
     = Informative
+    | Positive
 
 
 informative : Config msg
 informative =
     Config { defaults | variant = Informative }
+
+
+positive : Config msg
+positive =
+    Config { defaults | variant = Positive }
 
 
 
@@ -103,7 +110,13 @@ view (Config config) =
 
 header : Configuration msg -> Html msg
 header config =
-    div [ styles.classList [ ( .header, True ), ( .informativeHeader, config.variant == Informative ) ] ]
+    div
+        [ styles.classList
+            [ ( .header, True )
+            , ( .informativeHeader, config.variant == Informative )
+            , ( .positiveHeader, config.variant == Positive )
+            ]
+        ]
         [ div [ styles.class .iconContainer ]
             [ svg [ class <| styles.toString .iconBackground ] [ circle [ cx "75", cy "75", r "75" ] [] ]
             , div [ styles.class .icon ]
@@ -182,6 +195,7 @@ styles =
         { elmModal = "elmModal"
         , header = "header"
         , informativeHeader = "informativeHeader"
+        , positiveHeader = "positiveHeader"
         , iconContainer = "iconContainer"
         , iconBackground = "iconBackground"
         , icon = "icon"

--- a/packages/component-library/draft/Kaizen/Modal/Presets/ConfirmationModal.elm
+++ b/packages/component-library/draft/Kaizen/Modal/Presets/ConfirmationModal.elm
@@ -3,6 +3,7 @@ module Kaizen.Modal.Presets.ConfirmationModal exposing
     , confirmLabel
     , dismissLabel
     , informative
+    , negative
     , onConfirm
     , onDismiss
     , positive
@@ -49,6 +50,7 @@ type alias Configuration msg =
 type Variant
     = Informative
     | Positive
+    | Negative
 
 
 informative : Config msg
@@ -59,6 +61,11 @@ informative =
 positive : Config msg
 positive =
     Config { defaults | variant = Positive }
+
+
+negative : Config msg
+negative =
+    Config { defaults | variant = Negative }
 
 
 
@@ -110,18 +117,28 @@ view (Config config) =
 
 header : Configuration msg -> Html msg
 header config =
+    let
+        resolveIcon =
+            case config.variant of
+                Positive ->
+                    svgAsset "@kaizen/component-library/icons/success.icon.svg"
+
+                _ ->
+                    svgAsset "@kaizen/component-library/icons/information.icon.svg"
+    in
     div
         [ styles.classList
             [ ( .header, True )
             , ( .informativeHeader, config.variant == Informative )
             , ( .positiveHeader, config.variant == Positive )
+            , ( .negativeHeader, config.variant == Negative )
             ]
         ]
         [ div [ styles.class .iconContainer ]
             [ svg [ class <| styles.toString .iconBackground ] [ circle [ cx "75", cy "75", r "75" ] [] ]
             , div [ styles.class .icon ]
                 [ Icon.view Icon.presentation
-                    (svgAsset "@kaizen/component-library/icons/exclamation.icon.svg")
+                    resolveIcon
                     |> Html.map never
                 ]
             ]
@@ -152,8 +169,15 @@ footer config =
 
                 Nothing ->
                     buttonConfig
+
+        resolveActionButtonVariant =
+            if config.variant == Negative then
+                Button.destructive
+
+            else
+                Button.primary
     in
-    [ Button.view (Button.secondary |> withOnDismiss) config.dismissLabel, Button.view (Button.primary |> withOnConfirm) config.confirmLabel ]
+    [ Button.view (Button.secondary |> withOnDismiss) config.dismissLabel, Button.view (resolveActionButtonVariant |> withOnConfirm) config.confirmLabel ]
 
 
 
@@ -195,6 +219,7 @@ styles =
         { elmModal = "elmModal"
         , header = "header"
         , informativeHeader = "informativeHeader"
+        , negativeHeader = "negativeHeader"
         , positiveHeader = "positiveHeader"
         , iconContainer = "iconContainer"
         , iconBackground = "iconBackground"

--- a/packages/component-library/stories/Modal.stories.tsx
+++ b/packages/component-library/stories/Modal.stories.tsx
@@ -570,4 +570,5 @@ loadElmStories("Modal (Elm)", module, require("./ModalStories.elm"), [
   "Generic",
   "Confirmation (Informative)",
   "Confirmation (Positive)",
+  "Confirmation (Negative)",
 ])

--- a/packages/component-library/stories/Modal.stories.tsx
+++ b/packages/component-library/stories/Modal.stories.tsx
@@ -569,4 +569,5 @@ storiesOf("Modal (React)", module)
 loadElmStories("Modal (Elm)", module, require("./ModalStories.elm"), [
   "Generic",
   "Confirmation (Informative)",
+  "Confirmation (Positive)",
 ])

--- a/packages/component-library/stories/ModalStories.elm
+++ b/packages/component-library/stories/ModalStories.elm
@@ -150,4 +150,31 @@ main =
                         Nothing ->
                             text ""
                     ]
+        , storyOf "Confirmation (Negative)" config <|
+            \m ->
+                div []
+                    [ Button.view (Button.destructive |> Button.onClick SetModalContext) "Open Modal"
+                    , case m.modalContext of
+                        Just modalState ->
+                            Modal.view <|
+                                (Modal.confirmation Modal.Negative
+                                    { title = "Negative title"
+                                    , bodySubtext =
+                                        Just
+                                            [ div [ style "text-align" "center" ]
+                                                [ Text.view (Text.p |> Text.style Text.Lede |> Text.inline True) [ text "Additional subtext to aid the user can be added here." ] ]
+                                            ]
+                                    , onDismiss = Just ModalUpdate
+                                    , onConfirm = Just ModalConfirmed
+                                    , confirmLabel = "Yea do it!"
+                                    , dismissLabel = "Nah don't do it"
+                                    }
+                                    |> Modal.modalState modalState
+                                    -- the modal backdrop uses this to close
+                                    |> Modal.onUpdate ModalUpdate
+                                )
+
+                        Nothing ->
+                            text ""
+                    ]
         ]

--- a/packages/component-library/stories/ModalStories.elm
+++ b/packages/component-library/stories/ModalStories.elm
@@ -113,7 +113,34 @@ main =
                                     , onDismiss = Just ModalUpdate
                                     , onConfirm = Just ModalConfirmed
                                     , confirmLabel = "Yea do it!"
-                                    , dismissLabel = "Nah dont do it"
+                                    , dismissLabel = "Nah don't do it"
+                                    }
+                                    |> Modal.modalState modalState
+                                    -- the modal backdrop uses this to close
+                                    |> Modal.onUpdate ModalUpdate
+                                )
+
+                        Nothing ->
+                            text ""
+                    ]
+        , storyOf "Confirmation (Positive)" config <|
+            \m ->
+                div []
+                    [ Button.view (Button.primary |> Button.onClick SetModalContext) "Open Modal"
+                    , case m.modalContext of
+                        Just modalState ->
+                            Modal.view <|
+                                (Modal.confirmation Modal.Positive
+                                    { title = "Positive title"
+                                    , bodySubtext =
+                                        Just
+                                            [ div [ style "text-align" "center" ]
+                                                [ Text.view (Text.p |> Text.style Text.Lede |> Text.inline True) [ text "Additional subtext to aid the user can be added here." ] ]
+                                            ]
+                                    , onDismiss = Just ModalUpdate
+                                    , onConfirm = Just ModalConfirmed
+                                    , confirmLabel = "Yea do it!"
+                                    , dismissLabel = "Nah don't do it"
                                     }
                                     |> Modal.modalState modalState
                                     -- the modal backdrop uses this to close


### PR DESCRIPTION
This adds the positive and negative modal variants.

## Positive
<img width="618" alt="Screen Shot 2020-01-30 at 3 01 13 pm" src="https://user-images.githubusercontent.com/25443812/73420171-85994000-4371-11ea-8d50-f34fe11f39f0.png">

## Negative
<img width="637" alt="Screen Shot 2020-01-30 at 3 01 48 pm" src="https://user-images.githubusercontent.com/25443812/73420183-8b8f2100-4371-11ea-8afd-c531420c34f1.png">
