### PR TITLE
feat: SplitButton positioning improvements

### DIFF
--- a/packages/component-library/draft/Kaizen/SplitButton/DropdownMenu.spec.tsx
+++ b/packages/component-library/draft/Kaizen/SplitButton/DropdownMenu.spec.tsx
@@ -1,6 +1,6 @@
-import { _calculateMenuTop } from "./DropdownMenu"
+import { calculateMenuTop } from "./DropdownMenu"
 
-describe("_calculateMenuTop", () => {
+describe("calculateMenuTop", () => {
   const newMenuRect = (): ClientRect => ({
     width: 170,
     height: 425,
@@ -25,7 +25,7 @@ describe("_calculateMenuTop", () => {
     "returns the css `top` value required for the dropdown menu, " +
       "when there is enough room below the SplitButtons",
     () => {
-      const result = _calculateMenuTop(newButtonsRect(32), newMenuRect(), 500)
+      const result = calculateMenuTop(newButtonsRect(32), newMenuRect(), 500)
       expect(result).toEqual(40) // ie. show the menu below the split buttons
     }
   )
@@ -34,7 +34,7 @@ describe("_calculateMenuTop", () => {
     "returns the css `top` value required for the dropdown menu, " +
       "when there is not enough room below the SplitButtons, but enough room above",
     () => {
-      const result = _calculateMenuTop(newButtonsRect(459), newMenuRect(), 500)
+      const result = calculateMenuTop(newButtonsRect(459), newMenuRect(), 500)
       expect(result).toEqual(-423) // ie. show the menu above the split buttons
     }
   )
@@ -43,8 +43,7 @@ describe("_calculateMenuTop", () => {
     "returns the css `top` value required for the dropdown menu, " +
       "when there is not enough room below or above the SplitButtons",
     () => {
-      // @ts-ignore
-      const result = _calculateMenuTop(newButtonsRect(315), newMenuRect(), 500)
+      const result = calculateMenuTop(newButtonsRect(315), newMenuRect(), 500)
       expect(result).toEqual(40) // ie. show the menu below the split buttons
     }
   )

--- a/packages/component-library/draft/Kaizen/SplitButton/DropdownMenu.spec.tsx
+++ b/packages/component-library/draft/Kaizen/SplitButton/DropdownMenu.spec.tsx
@@ -1,0 +1,51 @@
+import { _calculateMenuTop } from "./DropdownMenu"
+
+describe("_calculateMenuTop", () => {
+  const newMenuRect = (): ClientRect => ({
+    width: 170,
+    height: 425,
+    top: 70,
+    right: 170,
+    bottom: 500,
+    left: 0,
+  })
+  const newButtonsRect = (top: number): ClientRect => {
+    const height = 42
+    return {
+      width: 170,
+      height,
+      top,
+      right: 170,
+      bottom: top + height,
+      left: 0,
+    }
+  }
+
+  it(
+    "returns the css `top` value required for the dropdown menu, " +
+      "when there is enough room below the SplitButtons",
+    () => {
+      const result = _calculateMenuTop(newButtonsRect(32), newMenuRect(), 500)
+      expect(result).toEqual(40) // ie. show the menu below the split buttons
+    }
+  )
+
+  it(
+    "returns the css `top` value required for the dropdown menu, " +
+      "when there is not enough room below the SplitButtons, but enough room above",
+    () => {
+      const result = _calculateMenuTop(newButtonsRect(459), newMenuRect(), 500)
+      expect(result).toEqual(-423) // ie. show the menu above the split buttons
+    }
+  )
+
+  it(
+    "returns the css `top` value required for the dropdown menu, " +
+      "when there is not enough room below or above the SplitButtons",
+    () => {
+      // @ts-ignore
+      const result = _calculateMenuTop(newButtonsRect(315), newMenuRect(), 500)
+      expect(result).toEqual(40) // ie. show the menu below the split buttons
+    }
+  )
+})

--- a/packages/component-library/draft/Kaizen/SplitButton/DropdownMenu.tsx
+++ b/packages/component-library/draft/Kaizen/SplitButton/DropdownMenu.tsx
@@ -5,7 +5,7 @@ const styles = require("./styles.scss")
 
 type Props = {
   children: React.ReactNode
-  buttonsContainerRect: ClientRect | null // get by calling getBoundingClientRect()
+  buttonsBoundingRect: ClientRect | null // get by calling getBoundingClientRect()
   hideDropdownMenu: () => void
   dir?: Dir
 }
@@ -35,19 +35,38 @@ export default class DropdownMenu extends React.Component<Props> {
   }
 
   positionMenu() {
-    const { buttonsContainerRect } = this.props
+    const { buttonsBoundingRect } = this.props
     const menu = this._menuRef && this._menuRef.current
-    if (!buttonsContainerRect || !menu) {
+    if (!buttonsBoundingRect || !menu) {
       return
     }
     const menuRect = menu.getBoundingClientRect()
     // Used to hide the border of the buttonsContainer class
     const borderRadiusBuffer = 2
 
-    if (buttonsContainerRect.bottom + menuRect.height > window.innerHeight) {
-      menu.style.top = `${-menuRect.height + borderRadiusBuffer}px`
+    if (buttonsBoundingRect.bottom + menuRect.height <= window.innerHeight) {
+      // Show menu below the split buttons
+      menu.style.top = `${buttonsBoundingRect.height - borderRadiusBuffer}px`
     } else {
-      menu.style.top = `${buttonsContainerRect.height - borderRadiusBuffer}px`
+      if (menuRect.height <= buttonsBoundingRect.top) {
+        // Show menu above the split buttons
+        menu.style.top = `${-menuRect.height + borderRadiusBuffer}px`
+      } else {
+        // We can't completely fit the menu above or below the split buttons,
+        // so we'll position them where we can
+        let offset =
+          buttonsBoundingRect.bottom + menuRect.height - window.innerHeight
+        // Don't let the menu go above the top of the viewport
+        let top = Math.max(
+          -buttonsBoundingRect.top,
+          buttonsBoundingRect.height - offset
+        )
+        // Remove the awkward view of the menu showing half on top of the split buttons
+        if (top > 0 && top < buttonsBoundingRect.height) {
+          top = 0
+        }
+        menu.style.top = `${top}px`
+      }
     }
 
     if (this.props.dir === "rtl") {

--- a/packages/component-library/draft/Kaizen/SplitButton/DropdownMenu.tsx
+++ b/packages/component-library/draft/Kaizen/SplitButton/DropdownMenu.tsx
@@ -1,15 +1,11 @@
 import * as React from "react"
+import { RefObject } from "react"
 import { Dir } from "./types"
 const styles = require("./styles.scss")
 
 type Props = {
   children: React.ReactNode
-  position: {
-    top: number
-    bottom: number
-    left: number
-    right: number
-  } | null
+  buttonsContainerRect: ClientRect | null // get by calling getBoundingClientRect()
   hideDropdownMenu: () => void
   dir?: Dir
 }
@@ -19,7 +15,13 @@ export default class DropdownMenu extends React.Component<Props> {
   static defaultProps = {
     dir: "ltr",
   }
-  menu: HTMLDivElement | null = null
+
+  _menuRef: RefObject<HTMLDivElement> | null
+
+  constructor(props: Props) {
+    super(props)
+    this._menuRef = React.createRef()
+  }
 
   componentDidMount() {
     document.addEventListener("click", this.handleDocumentClick, false)
@@ -33,22 +35,21 @@ export default class DropdownMenu extends React.Component<Props> {
   }
 
   positionMenu() {
-    const menu = this.menu
-    if (!this.props.position || !menu) {
+    const { buttonsContainerRect } = this.props
+    const menu = this._menuRef && this._menuRef.current
+    if (!buttonsContainerRect || !menu) {
       return
     }
-    const pos = this.props.position
-    const { innerHeight } = window
-    const rect = menu.getBoundingClientRect()
+    const menuRect = menu.getBoundingClientRect()
+    // Used to hide the border of the buttonsContainer class
+    const borderRadiusBuffer = 2
 
-    if (pos.bottom > innerHeight - rect.height) {
-      const bottom = rect.height + 40
-      menu.style.bottom = `${bottom}px`
-      menu.style.top = "auto"
+    if (buttonsContainerRect.bottom + menuRect.height > window.innerHeight) {
+      menu.style.top = `${-menuRect.height + borderRadiusBuffer}px`
     } else {
-      menu.style.top = "-2px" // This is to hide the border of the buttonsContainer class
-      menu.style.bottom = "auto"
+      menu.style.top = `${buttonsContainerRect.height - borderRadiusBuffer}px`
     }
+
     if (this.props.dir === "rtl") {
       menu.style.left = "0px"
     } else {
@@ -58,9 +59,10 @@ export default class DropdownMenu extends React.Component<Props> {
 
   handleDocumentClick = (e: MouseEvent) => {
     if (
-      this.menu &&
+      this._menuRef &&
+      this._menuRef.current &&
       e.target instanceof Node &&
-      !this.menu.contains(e.target)
+      !this._menuRef.current.contains(e.target)
     ) {
       this.props.hideDropdownMenu()
     }
@@ -75,7 +77,7 @@ export default class DropdownMenu extends React.Component<Props> {
     return (
       <div
         className={styles.menuContainer}
-        ref={m => (this.menu = m)}
+        ref={this._menuRef}
         onClick={() => props.hideDropdownMenu()}
       >
         {props.children}

--- a/packages/component-library/draft/Kaizen/SplitButton/DropdownMenu.tsx
+++ b/packages/component-library/draft/Kaizen/SplitButton/DropdownMenu.tsx
@@ -52,20 +52,9 @@ export default class DropdownMenu extends React.Component<Props> {
         // Show menu above the split buttons
         menu.style.top = `${-menuRect.height + borderRadiusBuffer}px`
       } else {
-        // We can't completely fit the menu above or below the split buttons,
-        // so we'll position them where we can
-        let offset =
-          buttonsBoundingRect.bottom + menuRect.height - window.innerHeight
-        // Don't let the menu go above the top of the viewport
-        let top = Math.max(
-          -buttonsBoundingRect.top,
-          buttonsBoundingRect.height - offset
-        )
-        // Remove the awkward view of the menu showing half on top of the split buttons
-        if (top > 0 && top < buttonsBoundingRect.height) {
-          top = 0
-        }
-        menu.style.top = `${top}px`
+        // If we can't completely fit the menu above the splitbuttons, then
+        // just show the menu below, as per the normal behaviour.
+        menu.style.top = `${buttonsBoundingRect.height - borderRadiusBuffer}px`
       }
     }
 

--- a/packages/component-library/draft/Kaizen/SplitButton/DropdownMenu.tsx
+++ b/packages/component-library/draft/Kaizen/SplitButton/DropdownMenu.tsx
@@ -1,5 +1,4 @@
-import * as React from "react"
-import { RefObject } from "react"
+import React, { RefObject } from "react"
 import { Dir } from "./types"
 const styles = require("./styles.scss")
 

--- a/packages/component-library/draft/Kaizen/SplitButton/DropdownMenu.tsx
+++ b/packages/component-library/draft/Kaizen/SplitButton/DropdownMenu.tsx
@@ -10,6 +10,28 @@ type Props = {
   dir?: Dir
 }
 
+export const _calculateMenuTop = (
+  buttonsBoundingRect: ClientRect,
+  menuBoundingRect: ClientRect,
+  viewportHeight
+): number => {
+  // Used to hide the border of the buttonsContainer class
+  const borderRadiusBuffer = 2
+
+  // If there's not enough room to show the menu below the split buttons,
+  // but enough room to show it above...
+  if (
+    buttonsBoundingRect.bottom + menuBoundingRect.height > viewportHeight &&
+    menuBoundingRect.height <= buttonsBoundingRect.top
+  ) {
+    // Show menu above the split buttons
+    return -menuBoundingRect.height + borderRadiusBuffer
+  }
+
+  // Regular behaviour, show menu below the split buttons
+  return buttonsBoundingRect.height - borderRadiusBuffer
+}
+
 export default class DropdownMenu extends React.Component<Props> {
   static displayName = "DropdownMenu"
   static defaultProps = {
@@ -40,23 +62,13 @@ export default class DropdownMenu extends React.Component<Props> {
     if (!buttonsBoundingRect || !menu) {
       return
     }
-    const menuRect = menu.getBoundingClientRect()
-    // Used to hide the border of the buttonsContainer class
-    const borderRadiusBuffer = 2
+    const menuBoundingRect = menu.getBoundingClientRect()
 
-    if (buttonsBoundingRect.bottom + menuRect.height <= window.innerHeight) {
-      // Show menu below the split buttons
-      menu.style.top = `${buttonsBoundingRect.height - borderRadiusBuffer}px`
-    } else {
-      if (menuRect.height <= buttonsBoundingRect.top) {
-        // Show menu above the split buttons
-        menu.style.top = `${-menuRect.height + borderRadiusBuffer}px`
-      } else {
-        // If we can't completely fit the menu above the splitbuttons, then
-        // just show the menu below, as per the normal behaviour.
-        menu.style.top = `${buttonsBoundingRect.height - borderRadiusBuffer}px`
-      }
-    }
+    menu.style.top = `${_calculateMenuTop(
+      buttonsBoundingRect,
+      menuBoundingRect,
+      window.innerHeight
+    )}px`
   }
 
   handleDocumentClick = (e: MouseEvent) => {

--- a/packages/component-library/draft/Kaizen/SplitButton/DropdownMenu.tsx
+++ b/packages/component-library/draft/Kaizen/SplitButton/DropdownMenu.tsx
@@ -57,12 +57,6 @@ export default class DropdownMenu extends React.Component<Props> {
         menu.style.top = `${buttonsBoundingRect.height - borderRadiusBuffer}px`
       }
     }
-
-    if (this.props.dir === "rtl") {
-      menu.style.left = "0px"
-    } else {
-      menu.style.right = "0px"
-    }
   }
 
   handleDocumentClick = (e: MouseEvent) => {

--- a/packages/component-library/draft/Kaizen/SplitButton/DropdownMenu.tsx
+++ b/packages/component-library/draft/Kaizen/SplitButton/DropdownMenu.tsx
@@ -9,7 +9,7 @@ type Props = {
   dir?: Dir
 }
 
-export const _calculateMenuTop = (
+export const calculateMenuTop = (
   buttonsBoundingRect: ClientRect,
   menuBoundingRect: ClientRect,
   viewportHeight
@@ -37,11 +37,11 @@ export default class DropdownMenu extends React.Component<Props> {
     dir: "ltr",
   }
 
-  _menuRef: RefObject<HTMLDivElement> | null
+  menuRef: RefObject<HTMLDivElement> | null
 
   constructor(props: Props) {
     super(props)
-    this._menuRef = React.createRef()
+    this.menuRef = React.createRef()
   }
 
   componentDidMount() {
@@ -57,13 +57,13 @@ export default class DropdownMenu extends React.Component<Props> {
 
   positionMenu() {
     const { buttonsBoundingRect } = this.props
-    const menu = this._menuRef && this._menuRef.current
+    const menu = this.menuRef && this.menuRef.current
     if (!buttonsBoundingRect || !menu) {
       return
     }
     const menuBoundingRect = menu.getBoundingClientRect()
 
-    menu.style.top = `${_calculateMenuTop(
+    menu.style.top = `${calculateMenuTop(
       buttonsBoundingRect,
       menuBoundingRect,
       window.innerHeight
@@ -72,10 +72,10 @@ export default class DropdownMenu extends React.Component<Props> {
 
   handleDocumentClick = (e: MouseEvent) => {
     if (
-      this._menuRef &&
-      this._menuRef.current &&
+      this.menuRef &&
+      this.menuRef.current &&
       e.target instanceof Node &&
-      !this._menuRef.current.contains(e.target)
+      !this.menuRef.current.contains(e.target)
     ) {
       this.props.hideDropdownMenu()
     }
@@ -90,7 +90,7 @@ export default class DropdownMenu extends React.Component<Props> {
     return (
       <div
         className={styles.menuContainer}
-        ref={this._menuRef}
+        ref={this.menuRef}
         onClick={() => props.hideDropdownMenu()}
       >
         {props.children}

--- a/packages/component-library/draft/Kaizen/SplitButton/SplitButton.tsx
+++ b/packages/component-library/draft/Kaizen/SplitButton/SplitButton.tsx
@@ -59,7 +59,7 @@ const SplitButton: SplitButton = ({
     setIsMenuVisible(!isMenuVisible)
   }
 
-  const getButtonsContainerRect = () => {
+  const getButtonsBoundingRect = () => {
     return dropdownButtonsContainerRef.current
       ? dropdownButtonsContainerRef.current.getBoundingClientRect()
       : null
@@ -80,7 +80,6 @@ const SplitButton: SplitButton = ({
             {label}
           </a>
         ) : (
-          // @ts-ignore
           <button
             type="button"
             onClick={disabled ? undefined : (onClick as ButtonCallback)}
@@ -101,7 +100,7 @@ const SplitButton: SplitButton = ({
         <DropdownMenu
           hideDropdownMenu={toggleDropdownMenu}
           dir={dir}
-          buttonsContainerRect={getButtonsContainerRect()}
+          buttonsBoundingRect={getButtonsBoundingRect()}
         >
           {dropdownContent}
         </DropdownMenu>

--- a/packages/component-library/draft/Kaizen/SplitButton/SplitButton.tsx
+++ b/packages/component-library/draft/Kaizen/SplitButton/SplitButton.tsx
@@ -51,23 +51,26 @@ const SplitButton: SplitButton = ({
     disabled,
   }
 
-  const dropdownButtonRef = React.useRef<HTMLDivElement>(null)
+  const dropdownButtonsContainerRef = React.useRef<HTMLDivElement>(null)
 
   const [isMenuVisible, setIsMenuVisible] = React.useState<boolean>(false)
 
-  const hideDropdownMenu = () => {
+  const toggleDropdownMenu = () => {
     setIsMenuVisible(!isMenuVisible)
   }
 
-  const getPosition = () => {
-    return dropdownButtonRef.current
-      ? dropdownButtonRef.current.getBoundingClientRect()
+  const getButtonsContainerRect = () => {
+    return dropdownButtonsContainerRef.current
+      ? dropdownButtonsContainerRef.current.getBoundingClientRect()
       : null
   }
 
   return (
     <div className={styles.root} dir={dir} data-automation-id={automationId}>
-      <div className={styles.buttonsContainer} ref={dropdownButtonRef}>
+      <div
+        className={styles.buttonsContainer}
+        ref={dropdownButtonsContainerRef}
+      >
         {href ? (
           <a
             href={disabled ? undefined : href}
@@ -91,16 +94,14 @@ const SplitButton: SplitButton = ({
           dir={dir}
           variant={variant}
           dropdownAltText={dropdownAltText}
-          onOpenDropdown={() => {
-            hideDropdownMenu()
-          }}
+          onOpenDropdown={toggleDropdownMenu}
         />
       </div>
       {isMenuVisible && (
         <DropdownMenu
-          hideDropdownMenu={hideDropdownMenu}
+          hideDropdownMenu={toggleDropdownMenu}
           dir={dir}
-          position={getPosition()}
+          buttonsContainerRect={getButtonsContainerRect()}
         >
           {dropdownContent}
         </DropdownMenu>

--- a/packages/component-library/draft/Kaizen/SplitButton/SplitButton.tsx
+++ b/packages/component-library/draft/Kaizen/SplitButton/SplitButton.tsx
@@ -39,13 +39,11 @@ const SplitButton: SplitButton = ({
   // If the button has a route, it should be an `a` tag, since it is better
   // accessibility and routing. Otherwise, it should be a `button`.
   const btnProps = {
-    // tslint:disable-next-line: object-literal-key-quotes
     className: classnames({
       [styles.default]: variant === "default",
       [styles.primary]: variant === "primary",
       [styles.disabled]: disabled,
     }),
-    // tslint:disable-next-line: object-literal-key-quotes
     tabIndex: disabled ? -1 : 0,
     "data-automation-id": "split-button-button",
     disabled,

--- a/packages/component-library/draft/Kaizen/SplitButton/styles.scss
+++ b/packages/component-library/draft/Kaizen/SplitButton/styles.scss
@@ -77,6 +77,7 @@ $button-width: 124px;
 .root {
   @include ca-type-block(inline-block);
   height: 40px; // Set a fixed height to avoid expansion when dropdown is displayed
+  position: relative;
 }
 
 .buttonReset {
@@ -125,6 +126,7 @@ $button-width: 124px;
 .default,
 .primary {
   @include ca-type-ideal-body-bold;
+  top: initial; // override from ca-type-ideal-body-bold -> ca-type-ideal -> ca-type
   text-align: left;
   position: inherit;
   text-decoration: none;
@@ -250,5 +252,5 @@ $button-width: 124px;
 .menuContainer {
   z-index: $ca-z-index-dropdown;
   width: 100%;
-  position: relative;
+  position: absolute;
 }

--- a/tslint.json
+++ b/tslint.json
@@ -39,9 +39,6 @@
     "member-access": {
       "severity": "none"
     },
-    "variable-name": {
-      "options": ["allow-leading-underscore", "allow-pascal-case"]
-    },
     "object-literal-key-quotes": [true, "as-needed"]
   }
 }

--- a/tslint.json
+++ b/tslint.json
@@ -38,6 +38,10 @@
     },
     "member-access": {
       "severity": "none"
-    }
+    },
+    "variable-name": {
+      "options": ["allow-leading-underscore", "allow-pascal-case"]
+    },
+    "object-literal-key-quotes": [true, "as-needed"]
   }
 }


### PR DESCRIPTION
* Change the menu positioning from `position: relative` to `position: absolute`. I noticed when opening the dropdown menu, the content below it was getting pushed down. I am surprised that this wasn't causing issues in perform-ui, but I fixed this issue anyway, as it will likely cause unexpected behaviour in the future. @vicchirino if you could just confirm that I haven't broken any behaviour from your end.

Before:

![sb-before](https://user-images.githubusercontent.com/4495057/73601814-3004a380-45bc-11ea-9f50-ab2760568edf.gif)

After:

![sb-after](https://user-images.githubusercontent.com/4495057/73601810-2d09b300-45bc-11ea-9467-f60f20568fa4.gif)

* Fix how the dropdown menu would be positioned when we run out of room. There was some logic that would show the menu above the SplitButtons, if we didn't have enough room below. The problem was that sometimes we didn't even have room above, causing menu items to become unselectable. Example:

<img width="400" alt="Screen Shot 2020-02-02 at 10 42 23 am" src="https://user-images.githubusercontent.com/4495057/73601838-938ed100-45bc-11ea-8427-b7ade157ae7f.png">

My first iteration at fixing the issue was to have the menu overlap the buttons when necessary. eg.

![itteration1](https://user-images.githubusercontent.com/4495057/73601845-bae59e00-45bc-11ea-961d-5bebbf1cc3f4.gif)

However, I realised that this was covering the most important primary menu item (ie. the "Edit" button in that example), so that was no good. With the second iteration, now the menu still gets displayed above, but only if there's enough room. eg.

![iteration2](https://user-images.githubusercontent.com/4495057/73601855-f1bbb400-45bc-11ea-82de-1effb697ca4d.gif)

[Previous related PR](https://github.com/cultureamp/kaizen-design-system/pull/120)