### PR TITLE
feat: close elm modal with escape

### DIFF
--- a/packages/component-library/draft/Kaizen/Modal/Modal.elm
+++ b/packages/component-library/draft/Kaizen/Modal/Modal.elm
@@ -8,15 +8,18 @@ module Kaizen.Modal.Modal exposing
     , initialState
     , modalState
     , onUpdate
+    , subscriptions
     , update
     , view
     , withDispatch
     )
 
+import Browser.Events as BrowserEvents
 import CssModules exposing (css)
 import Html exposing (Html, div, text)
 import Html.Attributes exposing (style)
 import Html.Events exposing (onClick)
+import Kaizen.Events.Events as KaizenEvents
 import Kaizen.Modal.Presets.ConfirmationModal as ConfirmationModal
 import Kaizen.Modal.Primitives.GenericModal as GenericModal
 import Process
@@ -89,6 +92,15 @@ type alias Timing =
     { startedAt : Time.Posix
     , dt : Time.Posix
     }
+
+
+subscriptions : ModalState msg -> msg -> Sub msg
+subscriptions ms msg =
+    if canSubscribeToEscape ms then
+        BrowserEvents.onKeyDown (KaizenEvents.isEscape msg)
+
+    else
+        Sub.none
 
 
 view : Config msg -> Html msg
@@ -301,6 +313,16 @@ mapDuration duration =
 
         Fast ->
             300
+
+
+canSubscribeToEscape : ModalState msg -> Bool
+canSubscribeToEscape (Msg state progress) =
+    case ( state, progress ) of
+        ( Closed_ _, Stopped ) ->
+            False
+
+        _ ->
+            True
 
 
 

--- a/packages/component-library/draft/Kaizen/Modal/Modal.elm
+++ b/packages/component-library/draft/Kaizen/Modal/Modal.elm
@@ -256,7 +256,7 @@ initialState =
 
     withDispatch allows you to dispatch a (Cmd msg) on either Closed or Open from the update.
 
-    This is handy for when you want to remove the modal element from the view after the the closing animation.
+    This is handy for when you want to remove the modal element from the view after the closing animation.
 
     Use withDispatch on the modal modalState handler to always fire the Cmd msg's you want to hear back from.
 

--- a/packages/component-library/stories/ModalStories.elm
+++ b/packages/component-library/stories/ModalStories.elm
@@ -59,12 +59,22 @@ update msg state =
             update ModalUpdate state
 
 
+subscriptions : ModalState -> Sub ModalMsg
+subscriptions { modalContext } =
+    case modalContext of
+        Just modalState ->
+            Modal.subscriptions modalState ModalUpdate
+
+        Nothing ->
+            Sub.none
+
+
 main =
     let
         config =
             { update = update
             , init = ( model, Cmd.none )
-            , subscriptions = \_ -> Sub.none
+            , subscriptions = subscriptions
             }
     in
     storybook
@@ -112,8 +122,8 @@ main =
                                             ]
                                     , onDismiss = Just ModalUpdate
                                     , onConfirm = Just ModalConfirmed
-                                    , confirmLabel = "Yea do it!"
-                                    , dismissLabel = "Nah don't do it"
+                                    , confirmLabel = "Confirm"
+                                    , dismissLabel = "Cancel"
                                     }
                                     |> Modal.modalState modalState
                                     -- the modal backdrop uses this to close
@@ -139,8 +149,8 @@ main =
                                             ]
                                     , onDismiss = Just ModalUpdate
                                     , onConfirm = Just ModalConfirmed
-                                    , confirmLabel = "Yea do it!"
-                                    , dismissLabel = "Nah don't do it"
+                                    , confirmLabel = "Confirm"
+                                    , dismissLabel = "Cancel"
                                     }
                                     |> Modal.modalState modalState
                                     -- the modal backdrop uses this to close
@@ -166,8 +176,8 @@ main =
                                             ]
                                     , onDismiss = Just ModalUpdate
                                     , onConfirm = Just ModalConfirmed
-                                    , confirmLabel = "Yea do it!"
-                                    , dismissLabel = "Nah don't do it"
+                                    , confirmLabel = "Confirm"
+                                    , dismissLabel = "Cancel"
                                     }
                                     |> Modal.modalState modalState
                                     -- the modal backdrop uses this to close


### PR DESCRIPTION
The elm modal currently does not support closing by pressing the escape key.

By subscribing to onKeyDown and decoding for the escape key we can ensure the modal runs the closing animation.

Care was taken to ensure a subscription to onKeyDown is only applicable when the modal is not closed. This means that pressing escape whilst the modal is opening will disrupt the animation and close it again.