### PR TITLE
docs: Delete "e.g." section in language guidelines

### DIFF
--- a/site/docs/guidelines/language.mdx
+++ b/site/docs/guidelines/language.mdx
@@ -595,14 +595,6 @@ For dates and times, use the above considerations and combine like this: **Oct 1
 
 For dates that include days 1-9 of the month, the day takes a single digit: **Oct 7, 2017 at 4:00 p.m. (EST).**
 
-### e.g.
-
-<!-- See also [i.e.](#ie) -->
-
-e.g. can be used to introduce an example or a suggestion within a sentence. Don’t use it to present a recommendation.
-
-If you want to use e.g. at the beginning of a sentence, don’t. Instead, write “For example” or “One example is.”
-
 ### Ellipses (…)
 
 Ellipses have two purposes. They’re used:


### PR DESCRIPTION
Fixes: #266  