### PR TITLE
feat: Elm modal focus first focusable element

### DIFF
--- a/packages/component-library/draft/Kaizen/Modal/Modal.elm
+++ b/packages/component-library/draft/Kaizen/Modal/Modal.elm
@@ -5,9 +5,12 @@ module Kaizen.Modal.Modal exposing
     , ModalState
     , Status(..)
     , confirmation
+    , defaultFocusableId
+    , firstFocusableId
     , forceOpen
     , generic
     , initialState
+    , lastFocusableId
     , modalState
     , onUpdate
     , subscriptions
@@ -16,6 +19,7 @@ module Kaizen.Modal.Modal exposing
     , view
     )
 
+import Browser.Dom as BrowserDom
 import Browser.Events as BrowserEvents
 import CssModules exposing (css)
 import Html exposing (Html, div, text)
@@ -23,6 +27,7 @@ import Html.Attributes exposing (style)
 import Html.Events exposing (onClick)
 import Kaizen.Events.Events as KaizenEvents
 import Kaizen.Modal.Presets.ConfirmationModal as ConfirmationModal
+import Kaizen.Modal.Primitives.Constants as Constants
 import Kaizen.Modal.Primitives.GenericModal as GenericModal
 import Process
 import Task
@@ -49,6 +54,10 @@ type Status
 
 type ModalMsg
     = Update
+    | FirstFocusableElementFocused (Result BrowserDom.Error ())
+    | LastFocusableElementFocused (Result BrowserDom.Error ())
+    | DefaultFocusableElementFocused (Result BrowserDom.Error ())
+    | InitiateDefaultFocusableElementFocus Time.Posix
 
 
 type alias Configuration msg =
@@ -58,11 +67,15 @@ type alias Configuration msg =
     }
 
 
-type State
-    = Opening_ ModalData
-    | Open_ ModalData
-    | Closing_ ModalData
-    | Closed_ ModalData
+type alias State =
+    ( State_, ModalData )
+
+
+type State_
+    = Opening_
+    | Open_
+    | Closing_
+    | Closed_
 
 
 type Duration
@@ -78,6 +91,18 @@ type ConfirmationType
     | Negative
 
 
+type FirstFocusableId
+    = FirstFocusableId String
+
+
+type LastFocusableId
+    = LastFocusableId String
+
+
+type DefaultFocusableId
+    = DefaultFocusableId String
+
+
 type alias ConfirmationConfig msg =
     { title : String
     , bodySubtext : Maybe (List (Html msg))
@@ -90,6 +115,10 @@ type alias ConfirmationConfig msg =
 
 type alias ModalData =
     { duration : Duration
+    , firstFocusableId : FirstFocusableId
+    , lastFocusableId : LastFocusableId
+    , defaultFocusableControlId : DefaultFocusableId
+    , forceDefaultFocusableElementFocus : Bool
     }
 
 
@@ -101,11 +130,25 @@ type alias Timing =
 
 subscriptions : ModalState msg -> Sub ModalMsg
 subscriptions ms =
-    if canSubscribeToEscape ms then
-        BrowserEvents.onKeyDown (KaizenEvents.isEscape Update)
+    let
+        (ModalState ( _, mData ) _) =
+            ms
 
-    else
-        Sub.none
+        subscribeToEscape =
+            if isOpenStopped ms then
+                BrowserEvents.onKeyDown (KaizenEvents.isEscape Update)
+
+            else
+                Sub.none
+
+        focusDefaultFocusableElement =
+            if mData.forceDefaultFocusableElementFocus && isOpenStopped ms then
+                BrowserEvents.onAnimationFrame InitiateDefaultFocusableElementFocus
+
+            else
+                Sub.none
+    in
+    Sub.batch [ subscribeToEscape, focusDefaultFocusableElement ]
 
 
 view : Config msg -> Html msg
@@ -117,11 +160,8 @@ view (Config config) =
         genericModalConfig =
             GenericModal.default
 
-        mState =
+        ( mState, modalData ) =
             getState config.state
-
-        modalData =
-            getData mState
 
         genericModalEvents =
             List.filterMap identity
@@ -130,21 +170,21 @@ view (Config config) =
 
         resolveAnimationStyles =
             case mState of
-                Opening_ _ ->
+                Opening_ ->
                     [ ( .animatingElmEnter, True ) ]
 
-                Open_ _ ->
+                Open_ ->
                     [ ( .animatingElmEnter, True ) ]
 
-                Closing_ _ ->
+                Closing_ ->
                     [ ( .animatingElmExit, True ) ]
 
-                Closed_ _ ->
+                Closed_ ->
                     [ ( .animatingElmExit, True ) ]
 
         resolveVisibilityStyles =
             case config.state of
-                ModalState (Closed_ _) Stopped ->
+                ModalState ( Closed_, _ ) Stopped ->
                     [ ( .hide, True ) ]
 
                 _ ->
@@ -196,6 +236,10 @@ view (Config config) =
 
                             Nothing ->
                                 confirmationConfig
+
+                    withFocusableIds confirmationConfig =
+                        ConfirmationModal.headerDismissId (firstFocusableIdToString modalData.firstFocusableId) confirmationConfig
+                            |> ConfirmationModal.confirmId (lastFocusableIdToString modalData.lastFocusableId)
                 in
                 case confirmationType of
                     Informative ->
@@ -205,6 +249,7 @@ view (Config config) =
                                     |> withOnDismiss
                                     |> withOnConfirm
                                     |> withBodySubtext
+                                    |> withFocusableIds
                                     |> ConfirmationModal.confirmLabel configs.confirmLabel
                                     |> ConfirmationModal.dismissLabel configs.dismissLabel
                                     |> ConfirmationModal.title configs.title
@@ -219,6 +264,7 @@ view (Config config) =
                                     |> withOnDismiss
                                     |> withOnConfirm
                                     |> withBodySubtext
+                                    |> withFocusableIds
                                     |> ConfirmationModal.confirmLabel configs.confirmLabel
                                     |> ConfirmationModal.dismissLabel configs.dismissLabel
                                     |> ConfirmationModal.title configs.title
@@ -233,6 +279,7 @@ view (Config config) =
                                     |> withOnDismiss
                                     |> withOnConfirm
                                     |> withBodySubtext
+                                    |> withFocusableIds
                                     |> ConfirmationModal.confirmLabel configs.confirmLabel
                                     |> ConfirmationModal.dismissLabel configs.dismissLabel
                                     |> ConfirmationModal.title configs.title
@@ -263,17 +310,15 @@ defaults =
 initialState : ModalState msg
 initialState =
     ModalState
-        (Closed_
-            { duration = Fast
-            }
+        ( Closed_
+        , { duration = Fast
+          , firstFocusableId = firstFocusableId Constants.firstFocusableId
+          , lastFocusableId = lastFocusableId Constants.lastFocusableId
+          , defaultFocusableControlId = defaultFocusableId Constants.defaultFocusableControlId
+          , forceDefaultFocusableElementFocus = False
+          }
         )
         Stopped
-
-
-defaultModalData : ModalData
-defaultModalData =
-    { duration = Fast
-    }
 
 
 styles =
@@ -287,7 +332,7 @@ styles =
 
 
 
--- HELPERS
+-- INTERNAL HELPERS
 
 
 mapDuration : Duration -> Float
@@ -306,47 +351,76 @@ mapDuration duration =
             300
 
 
-canSubscribeToEscape : ModalState msg -> Bool
-canSubscribeToEscape (ModalState state progress) =
+isOpenStopped : ModalState msg -> Bool
+isOpenStopped (ModalState state progress) =
     case ( state, progress ) of
-        ( Closed_ _, Stopped ) ->
-            False
+        ( ( Open_, _ ), Stopped ) ->
+            True
 
         _ ->
-            True
+            False
+
+
+firstFocusableIdToString : FirstFocusableId -> String
+firstFocusableIdToString (FirstFocusableId id_) =
+    id_
+
+
+lastFocusableIdToString : LastFocusableId -> String
+lastFocusableIdToString (LastFocusableId id_) =
+    id_
+
+
+defaultFocusableIdToString : DefaultFocusableId -> String
+defaultFocusableIdToString (DefaultFocusableId id_) =
+    id_
+
+
+setForceDefaultFocusableElementFocus : Bool -> ModalState msg -> ModalState msg
+setForceDefaultFocusableElementFocus force (ModalState ( mState, mData ) progress) =
+    ModalState ( mState, { mData | forceDefaultFocusableElementFocus = force } ) progress
+
+
+
+-- HELPERS
 
 
 {-| For when you want to start the modal off open without being triggered open.
 
     This is not recommended as modals should be triggered by an intentional user action
 
+    Forcing the modal open will bypass the internal Cmd msgs so the forced open property
+    will be set to True. This ensures the subscriptions trigger the modal to focus on
+    the first focusable element in this situation.
+
 -}
 forceOpen : ModalState msg -> ModalState msg
-forceOpen ms =
-    case ms of
-        ModalState (Open_ s) Animating ->
-            ModalState (Open_ s) Stopped
+forceOpen (ModalState ( _, mData ) _) =
+    ModalState ( Open_, { mData | forceDefaultFocusableElementFocus = True } ) Stopped
 
-        ModalState (Opening_ s) Animating ->
-            ModalState (Open_ s) Stopped
 
-        ModalState (Closed_ s) Animating ->
-            ModalState (Open_ s) Stopped
+{-| Set the first focusable element id. Modal updates will attempt to focus on this element
+When the modal is in an open state.
 
-        ModalState (Closing_ s) Animating ->
-            ModalState (Open_ s) Stopped
+By default Modal will use Kaizen.Modal.Primitives.Constants.firstFocusableId which consumers
+can use as id attributes to their custom views in a Generic variant.
 
-        ModalState (Opening_ s) Stopped ->
-            ModalState (Open_ s) Stopped
+This function can also be used to create more uniqueness to the default id used internally.
 
-        ModalState (Closed_ s) Stopped ->
-            ModalState (Open_ s) Stopped
+-}
+firstFocusableId : String -> FirstFocusableId
+firstFocusableId id =
+    FirstFocusableId id
 
-        ModalState (Closing_ s) Stopped ->
-            ModalState (Open_ s) Stopped
 
-        _ ->
-            ms
+lastFocusableId : String -> LastFocusableId
+lastFocusableId id =
+    LastFocusableId id
+
+
+defaultFocusableId : String -> DefaultFocusableId
+defaultFocusableId id =
+    DefaultFocusableId id
 
 
 
@@ -365,15 +439,16 @@ generic v size =
 
 confirmation : ConfirmationType -> ConfirmationConfig msg -> Config msg
 confirmation confirmationType confirmationConfig =
-    Config { defaults | variant = Confirmation confirmationType confirmationConfig }
+    Config
+        { defaults
+            | variant = Confirmation confirmationType confirmationConfig
+        }
 
 
 
 -- MODIFIERS
 
 
-{-| Handler should call Modal.update to handle all animating states.
--}
 onUpdate : (ModalMsg -> msg) -> Config msg -> Config msg
 onUpdate msg (Config config) =
     Config { config | onUpdate = Just msg }
@@ -392,36 +467,36 @@ modalState msg (Config config) =
 E.g. If the modal is closed trigger will begin the open animation for the modal.
 -}
 trigger : ModalState msg -> ( ModalState msg, Cmd ModalMsg, Maybe Status )
-trigger (ModalState state progress) =
+trigger (ModalState ( state, mData ) progress) =
     case progress of
         Animating ->
-            updateRunning state
+            updateRunning ( state, mData )
 
         -- To know what to do next we specify what state the modal was in when stopped
         Stopped ->
             case state of
                 -- Impossible state as updates never set Stopped on an Opening state
-                Opening_ _ ->
-                    ( ModalState (Closed_ defaultModalData) Stopped
+                Opening_ ->
+                    ( initialState
                     , Task.perform identity (Task.succeed Update)
                     , Nothing
                     )
 
-                Open_ s ->
-                    ( ModalState (Closing_ s) <| Animating
+                Open_ ->
+                    ( ModalState ( Closing_, mData ) <| Animating
                     , Task.perform identity (Task.succeed Update)
                     , Nothing
                     )
 
                 -- Impossible state as updates never set Stopped on a Closing state
-                Closing_ _ ->
-                    ( ModalState (Closed_ defaultModalData) Stopped
+                Closing_ ->
+                    ( initialState
                     , Cmd.none
                     , Nothing
                     )
 
-                Closed_ s ->
-                    ( ModalState (Opening_ s) <| Animating
+                Closed_ ->
+                    ( ModalState ( Opening_, mData ) <| Animating
                     , Task.perform identity (Task.succeed Update)
                     , Nothing
                     )
@@ -429,34 +504,73 @@ trigger (ModalState state progress) =
 
 update : ModalState msg -> ModalMsg -> ( ModalState msg, Cmd ModalMsg, Maybe Status )
 update ms modalMsg =
+    let
+        (ModalState ( _, mData ) _) =
+            ms
+    in
     case modalMsg of
         Update ->
             trigger ms
 
+        FirstFocusableElementFocused focusResult ->
+            case focusResult of
+                Ok () ->
+                    ( ms, Cmd.none, Nothing )
+
+                Err _ ->
+                    ( ms, Cmd.none, Nothing )
+
+        LastFocusableElementFocused focusResult ->
+            case focusResult of
+                Ok () ->
+                    ( ms, Cmd.none, Nothing )
+
+                Err _ ->
+                    ( ms, Cmd.none, Nothing )
+
+        DefaultFocusableElementFocused focusResult ->
+            case focusResult of
+                Ok () ->
+                    ( ms, Cmd.none, Nothing )
+
+                -- Fallback to the last focusable element if the default focusable element is not found
+                -- This will work for when the last and default focusable element ids are the same e.g. Confirmation variants
+                Err _ ->
+                    ( ms
+                    , Task.attempt LastFocusableElementFocused (BrowserDom.focus <| lastFocusableIdToString mData.lastFocusableId)
+                    , Nothing
+                    )
+
+        InitiateDefaultFocusableElementFocus _ ->
+            ( ms |> setForceDefaultFocusableElementFocus False
+            , Task.attempt DefaultFocusableElementFocused (BrowserDom.focus <| defaultFocusableIdToString mData.defaultFocusableControlId)
+            , Nothing
+            )
+
 
 updateRunning : State -> ( ModalState msg, Cmd ModalMsg, Maybe Status )
-updateRunning state =
+updateRunning ( state, mData ) =
     case state of
-        Opening_ d ->
-            ( ModalState (Open_ d) Animating
+        Opening_ ->
+            ( ModalState ( Open_, mData ) Animating
             , Task.perform identity (Task.succeed Update)
             , Nothing
             )
 
-        Open_ d ->
-            ( ModalState (Open_ d) Stopped
-            , Cmd.none
+        Open_ ->
+            ( ModalState ( Open_, mData ) Stopped
+            , Task.attempt FirstFocusableElementFocused (BrowserDom.focus <| firstFocusableIdToString mData.firstFocusableId)
             , Just Open
             )
 
-        Closing_ d ->
-            ( ModalState (Closed_ d) Animating
-            , Task.perform (\_ -> Update) (Process.sleep <| mapDuration d.duration)
+        Closing_ ->
+            ( ModalState ( Closed_, mData ) Animating
+            , Task.perform (\_ -> Update) (Process.sleep <| mapDuration mData.duration)
             , Nothing
             )
 
-        Closed_ d ->
-            ( ModalState (Closed_ d) Stopped
+        Closed_ ->
+            ( ModalState ( Closed_, mData ) Stopped
             , Cmd.none
             , Just Closed
             )
@@ -465,19 +579,3 @@ updateRunning state =
 getState : ModalState msg -> State
 getState (ModalState state _) =
     state
-
-
-getData : State -> ModalData
-getData state =
-    case state of
-        Opening_ s ->
-            s
-
-        Open_ s ->
-            s
-
-        Closing_ s ->
-            s
-
-        Closed_ s ->
-            s

--- a/packages/component-library/draft/Kaizen/Modal/Presets/ConfirmationModal.elm
+++ b/packages/component-library/draft/Kaizen/Modal/Presets/ConfirmationModal.elm
@@ -1,7 +1,9 @@
 module Kaizen.Modal.Presets.ConfirmationModal exposing
     ( bodySubtext
+    , confirmId
     , confirmLabel
     , dismissLabel
+    , headerDismissId
     , informative
     , negative
     , onConfirm
@@ -16,6 +18,7 @@ import CssModules exposing (css)
 import Html exposing (Html, div, text)
 import Icon.Icon as Icon
 import Icon.SvgAsset exposing (svgAsset)
+import Kaizen.Modal.Primitives.Constants as Constants
 import Kaizen.Modal.Primitives.ModalBody as ModalBody
 import Kaizen.Modal.Primitives.ModalFooter as ModalFooter
 import Kaizen.Modal.Primitives.ModalHeader as ModalHeader
@@ -40,6 +43,8 @@ type alias Configuration msg =
     , bodySubtext : Maybe (List (Html msg))
     , dismissLabel : String
     , confirmLabel : String
+    , headerDismissId : Maybe String
+    , confirmId : Maybe String
     }
 
 
@@ -81,6 +86,8 @@ defaults =
     , bodySubtext = Nothing
     , dismissLabel = "Cancel"
     , confirmLabel = "Confirm"
+    , headerDismissId = Nothing
+    , confirmId = Just Constants.lastFocusableId
     }
 
 
@@ -95,6 +102,14 @@ view (Config config) =
                 Nothing ->
                     headerConfig
 
+        withHeaderDismissId headerConfig =
+            case config.headerDismissId of
+                Just id_ ->
+                    ModalHeader.dismissId id_ headerConfig
+
+                Nothing ->
+                    headerConfig
+
         withBody =
             case config.bodySubtext of
                 Just bodyContent ->
@@ -104,7 +119,11 @@ view (Config config) =
                     text ""
     in
     div [ styles.class .elmModal ]
-        [ ModalHeader.view (ModalHeader.layout [ header config ] |> withHeaderOnDismiss)
+        [ ModalHeader.view
+            (ModalHeader.layout [ header config ]
+                |> withHeaderOnDismiss
+                |> withHeaderDismissId
+            )
         , withBody
         , ModalFooter.view <|
             (ModalFooter.layout (footer config)
@@ -176,8 +195,27 @@ footer config =
 
             else
                 Button.primary
+
+        withConfirmId buttonConfig =
+            case config.confirmId of
+                Just id ->
+                    Button.id id buttonConfig
+
+                Nothing ->
+                    buttonConfig
     in
-    [ Button.view (Button.secondary |> withOnDismiss) config.dismissLabel, Button.view (resolveActionButtonVariant |> withOnConfirm) config.confirmLabel ]
+    [ Button.view
+        (Button.secondary
+            |> withOnDismiss
+        )
+        config.dismissLabel
+    , Button.view
+        (resolveActionButtonVariant
+            |> withOnConfirm
+            |> withConfirmId
+        )
+        config.confirmLabel
+    ]
 
 
 
@@ -212,6 +250,16 @@ confirmLabel confirmString (Config config) =
 dismissLabel : String -> Config msg -> Config msg
 dismissLabel dismissString (Config config) =
     Config { config | dismissLabel = dismissString }
+
+
+headerDismissId : String -> Config msg -> Config msg
+headerDismissId id_ (Config config) =
+    Config { config | headerDismissId = Just id_ }
+
+
+confirmId : String -> Config msg -> Config msg
+confirmId id_ (Config config) =
+    Config { config | confirmId = Just id_ }
 
 
 styles =

--- a/packages/component-library/draft/Kaizen/Modal/Primitives/Constants.elm
+++ b/packages/component-library/draft/Kaizen/Modal/Primitives/Constants.elm
@@ -1,7 +1,7 @@
 module Kaizen.Modal.Primitives.Constants exposing
     ( ariaDescribedBy
     , ariaLabelledBy
-    , defaultFocusableControlId
+    , defaultFocusableId
     , firstFocusableId
     , lastFocusableId
     )
@@ -19,14 +19,14 @@ ariaLabelledBy =
 
 firstFocusableId : String
 firstFocusableId =
-    "modal-header-dismiss-id-focusable"
+    "modal-first-focusable"
 
 
 lastFocusableId : String
 lastFocusableId =
-    "modal-footer-action-id-focusable"
+    "modal-last-focusable"
 
 
-defaultFocusableControlId : String
-defaultFocusableControlId =
+defaultFocusableId : String
+defaultFocusableId =
     "modal-default-control-focusable"

--- a/packages/component-library/draft/Kaizen/Modal/Primitives/Constants.elm
+++ b/packages/component-library/draft/Kaizen/Modal/Primitives/Constants.elm
@@ -1,4 +1,10 @@
-module Kaizen.Modal.Primitives.Constants exposing (ariaDescribedBy, ariaLabelledBy)
+module Kaizen.Modal.Primitives.Constants exposing
+    ( ariaDescribedBy
+    , ariaLabelledBy
+    , defaultFocusableControlId
+    , firstFocusableId
+    , lastFocusableId
+    )
 
 
 ariaDescribedBy : String
@@ -9,3 +15,18 @@ ariaDescribedBy =
 ariaLabelledBy : String
 ariaLabelledBy =
     "modal-labelledBy"
+
+
+firstFocusableId : String
+firstFocusableId =
+    "modal-header-dismiss-id-focusable"
+
+
+lastFocusableId : String
+lastFocusableId =
+    "modal-footer-action-id-focusable"
+
+
+defaultFocusableControlId : String
+defaultFocusableControlId =
+    "modal-default-control-focusable"

--- a/packages/component-library/draft/Kaizen/Modal/Primitives/GenericModal.scss
+++ b/packages/component-library/draft/Kaizen/Modal/Primitives/GenericModal.scss
@@ -101,12 +101,6 @@
   }
 }
 
-.elmEntered {
-  .scrollLayer {
-    overflow-y: auto;
-  }
-}
-
 .unscrollable {
   overflow: hidden !important;
 }

--- a/packages/component-library/draft/Kaizen/Modal/Primitives/GenericModal.scss
+++ b/packages/component-library/draft/Kaizen/Modal/Primitives/GenericModal.scss
@@ -95,6 +95,18 @@
   }
 }
 
+.elmUnscrollable {
+  .scrollLayer {
+    overflow-y: hidden;
+  }
+}
+
+.elmEntered {
+  .scrollLayer {
+    overflow-y: auto;
+  }
+}
+
 .unscrollable {
   overflow: hidden !important;
 }

--- a/packages/component-library/draft/Kaizen/Modal/Primitives/ModalHeader.elm
+++ b/packages/component-library/draft/Kaizen/Modal/Primitives/ModalHeader.elm
@@ -1,5 +1,6 @@
 module Kaizen.Modal.Primitives.ModalHeader exposing
-    ( fixed
+    ( dismissId
+    , fixed
     , layout
     , onDismiss
     , view
@@ -20,6 +21,7 @@ type alias Configuration msg =
     { variant : Variant msg
     , fixed : Bool
     , onDismiss : Maybe msg
+    , dismissId : Maybe String
     }
 
 
@@ -28,6 +30,7 @@ defaults =
     { variant = Layout [ text "" ]
     , fixed = False
     , onDismiss = Nothing
+    , dismissId = Nothing
     }
 
 
@@ -53,6 +56,14 @@ view (Config config) =
 layoutBox : List (Html msg) -> Configuration msg -> List (Html msg)
 layoutBox content config =
     let
+        withDismissId buttonConfig =
+            case config.dismissId of
+                Just id_ ->
+                    Button.id id_ buttonConfig
+
+                Nothing ->
+                    buttonConfig
+
         resolveDismissButton =
             case config.onDismiss of
                 Just onDismissMsg ->
@@ -61,6 +72,7 @@ layoutBox content config =
                             (Button.iconButton
                                 (svgAsset "@kaizen/component-library/icons/close.icon.svg")
                                 |> Button.reversed True
+                                |> withDismissId
                             )
                             "Dismiss"
                         ]
@@ -114,6 +126,11 @@ as it may clash with the provided close button
 onDismiss : msg -> Config msg -> Config msg
 onDismiss msg (Config config) =
     Config { config | onDismiss = Just msg }
+
+
+dismissId : String -> Config msg -> Config msg
+dismissId id_ (Config config) =
+    Config { config | dismissId = Just id_ }
 
 
 styles =

--- a/packages/component-library/stories/ModalStories.elm
+++ b/packages/component-library/stories/ModalStories.elm
@@ -17,7 +17,7 @@ type ModalMsg
 
 
 
---    | SetModalContext
+-- SetModalContext
 
 
 model : ModalState
@@ -120,6 +120,7 @@ main =
                                     ]
                                     ( 800, 640 )
                                     |> Modal.modalState modalState
+                                    -- IMPORTANT: the modal uses this for internal messages
                                     |> Modal.onUpdate ModalUpdate
                                 )
 
@@ -145,7 +146,7 @@ main =
                                     , dismissLabel = "Cancel"
                                     }
                                     |> Modal.modalState modalState
-                                    -- the modal uses this for internal messages
+                                    -- IMPORTANT: the modal uses this for internal messages
                                     |> Modal.onUpdate ModalUpdate
                                 )
 
@@ -171,7 +172,7 @@ main =
                                     , dismissLabel = "Cancel"
                                     }
                                     |> Modal.modalState modalState
-                                    -- the modal uses this for internal messages
+                                    -- IMPORTANT: the modal uses this for internal messages
                                     |> Modal.onUpdate ModalUpdate
                                 )
 
@@ -197,7 +198,7 @@ main =
                                     , dismissLabel = "Cancel"
                                     }
                                     |> Modal.modalState modalState
-                                    -- the modal uses this for internal messages
+                                    -- IMPORTANT: the modal uses this for internal messages
                                     |> Modal.onUpdate ModalUpdate
                                 )
 


### PR DESCRIPTION
# Background
The elm modal currently doesn't place browser focus on to a default focusable element within the modal view. This is problematic as the focus is likely left under the modal somewhere which is not ideal for accessibility or general modal ease of use.
issue: https://github.com/cultureamp/kaizen-design-system/issues/172

# Changes
This PR Follows https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/dialog_role advice that the modal focus should be placed on to a default focusable control such as the Confirm button.

When the elm modal is forced open without a user action (storybook examples) subscriptions trigger the update of the modal so that all the Cmds run and the default focus is set.

# Things to Consider
Whilst we might usually want the Confirm/Action button to be focused on open the PR has allowed for a consumer to indicate the default element to focus on when the modal has opened in the situation custom views are being used.

Different preset variants may also require flexibility with default focus such as the Input Edit modal variant which requires focus to be placed on a form field on open.

# Future Improvements
Triggering the modal via subscriptions has actually turned into a pretty neat pattern and I would argue the modal should be made to work exclusively via subscriptions. This would tremendously clean up the update/trigger code and be very little work to fix current implementations.

Implement a focus lock feature.

