### PR TITLE
refactor: Rebuild as major change

### DIFF
--- a/packages/design-tokens/tokens/color.ts
+++ b/packages/design-tokens/tokens/color.ts
@@ -13,6 +13,11 @@ export interface Color {
   }
 }
 
+/**
+ * A helper to access deeply nested tokens
+ * @param name The color name
+ * @param variant A variant typically between 100-900
+ */
 export const get: <N extends ColorNames>(
   name: N,
   variant: keyof ColorTokens[N]


### PR DESCRIPTION
BREAKING CHANGE:
* Sass and Less tokens will now strictly follow the kebab case convention.
* Sass and Less variables are all lower-case

Context: 
I accidentally removed the `BREAKING CHANGE` from the commit footer when I merged the previous commit. This means it was released as a patch (the default) instead of a major release. Instead of rolling back and removing the published package from NPM this is a bit of a dummy commit with some better comments that I will use as the major release. 