### PR TITLE
feat: Add type styles for data

### DIFF
--- a/packages/design-tokens/tokens/typography.json
+++ b/packages/design-tokens/tokens/typography.json
@@ -1,6 +1,27 @@
 {
   "kz": {
     "typography": {
+      "dataLarge": {
+        "fontFamily": "\"Greycliff CF\"",
+        "fontWeight": "700",
+        "fontSize": "5.25rem",
+        "lineHeight": "5.25rem",
+        "letterSpacing": "normal"
+      },
+      "dataMedium": {
+        "fontFamily": "\"Greycliff CF\"",
+        "fontWeight": "700",
+        "fontSize": "3rem",
+        "lineHeight": "5rem",
+        "letterSpacing": "normal"
+      },
+      "dataSmall": {
+        "fontFamily": "\"Greycliff CF\"",
+        "fontWeight": "700",
+        "fontSize": "1.5rem",
+        "lineHeight": "1.5rem",
+        "letterSpacing": "normal"
+      },
       "display0": {
         "fontFamily": "\"Greycliff CF\"",
         "fontWeight": "700",

--- a/packages/design-tokens/tokens/typography.json
+++ b/packages/design-tokens/tokens/typography.json
@@ -8,6 +8,13 @@
         "lineHeight": "5.25rem",
         "letterSpacing": "normal"
       },
+      "dataLargeUnits": {
+        "fontFamily": "\"Greycliff CF\"",
+        "fontWeight": "700",
+        "fontSize": "2.625rem",
+        "lineHeight": "5.25rem",
+        "letterSpacing": "normal"
+      },
       "dataMedium": {
         "fontFamily": "\"Greycliff CF\"",
         "fontWeight": "700",
@@ -15,10 +22,24 @@
         "lineHeight": "5rem",
         "letterSpacing": "normal"
       },
+      "dataMediumUnits": {
+        "fontFamily": "\"Greycliff CF\"",
+        "fontWeight": "700",
+        "fontSize": "1.5rem",
+        "lineHeight": "5rem",
+        "letterSpacing": "normal"
+      },
       "dataSmall": {
         "fontFamily": "\"Greycliff CF\"",
         "fontWeight": "700",
         "fontSize": "1.5rem",
+        "lineHeight": "1.5rem",
+        "letterSpacing": "normal"
+      },
+      "dataSmallUnits": {
+        "fontFamily": "\"Greycliff CF\"",
+        "fontWeight": "700",
+        "fontSize": "1.125rem",
         "lineHeight": "1.5rem",
         "letterSpacing": "normal"
       },


### PR DESCRIPTION
# Typography tokens for data

This adds tokens to represent our data-related type styles, as shown below:

![image](https://user-images.githubusercontent.com/6406263/74631118-4875e000-51b0-11ea-8993-5123485f9573.png)

## The tricky part

The units like `$%` are not a consistent proportion to their numerical text.
- For the `large` and `medium` styles, the units' font size is 50% of the numerical text font size.
- For the `small` style, the units' font size is 75% of the numerical text font size.

Two potential ways of solving this:

1. Create 3 extra full type styles just for the units, like `dataLargeUnits` to sit alongside `dataLarge`. A bit gross, but simple and easy.

```
      "dataLarge": {
        "fontFamily": "\"Greycliff CF\"",
        "fontWeight": "700",
        "fontSize": "5.25rem",
        "lineHeight": "5.25rem",
        "letterSpacing": "normal"
      },
      "dataMedium": {
        "fontFamily": "\"Greycliff CF\"",
        "fontWeight": "700",
        "fontSize": "3rem",
        "lineHeight": "5rem",
        "letterSpacing": "normal"
      },
      "dataSmall": {
        "fontFamily": "\"Greycliff CF\"",
        "fontWeight": "700",
        "fontSize": "1.5rem",
        "lineHeight": "1.5rem",
        "letterSpacing": "normal"
      },
      "dataLargeUnits": {
        "fontFamily": "\"Greycliff CF\"",
        "fontWeight": "700",
        "fontSize": "2.625rem",
        "lineHeight": "5.25rem",
        "letterSpacing": "normal"
      },
      "dataMediumUnits": {
        "fontFamily": "\"Greycliff CF\"",
        "fontWeight": "700",
        "fontSize": "1.5rem",
        "lineHeight": "5rem",
        "letterSpacing": "normal"
      },
      "dataSmallUnits": {
        "fontFamily": "\"Greycliff CF\"",
        "fontWeight": "700",
        "fontSize": "1.125rem",
        "lineHeight": "1.5rem",
        "letterSpacing": "normal"
      }, ...
```

2. Create an extra property like `unitsSizeRatio: "0.5"` that goes after the other ones like `letterSpacing`. This would break the consistency of the object shape and would need an optional type to be added to the TS types:

```
      "dataLarge": {
        "fontFamily": "\"Greycliff CF\"",
        "fontWeight": "700",
        "fontSize": "5.25rem",
        "lineHeight": "5.25rem",
        "letterSpacing": "normal",
        "unitsSizeRatio": "0.5"
      },
      "dataMedium": {
        "fontFamily": "\"Greycliff CF\"",
        "fontWeight": "700",
        "fontSize": "3rem",
        "lineHeight": "5rem",
        "letterSpacing": "normal",
        "unitsSizeRatio": "0.5"
      },
      "dataSmall": {
        "fontFamily": "\"Greycliff CF\"",
        "fontWeight": "700",
        "fontSize": "1.5rem",
        "lineHeight": "1.5rem",
        "letterSpacing": "normal",
        "unitsSizeRatio": "0.75"
      },
```
```
export interface Typography {
  kz: {
    typography: {
      [key: string]: {
        fontFamily: string
        fontWeight: string
        fontSize: string
        lineHeight: string
        letterSpacing: string
        unitsSizeRatio?: string
      }
    }
  }
}
```