### PR TITLE
refactor: Make elm modal completely dependant on subscriptions

### DIFF
--- a/packages/component-library/stories/ModalStories.elm
+++ b/packages/component-library/stories/ModalStories.elm
@@ -22,7 +22,7 @@ type ModalMsg
 
 model : ModalState
 model =
-    { modalContext = Just (Modal.forceOpen Modal.initialState) }
+    { modalContext = Just (Modal.trigger Modal.initialState) }
 
 
 type alias ModalState =
@@ -58,10 +58,10 @@ update msg state =
             case state.modalContext of
                 Just ms ->
                     let
-                        ( modalState, modalCmd, _ ) =
+                        modalState =
                             Modal.trigger ms
                     in
-                    ( { state | modalContext = Just modalState }, Cmd.map ModalUpdate modalCmd )
+                    ( { state | modalContext = Just modalState }, Cmd.none )
 
                 Nothing ->
                     ( state, Cmd.none )
@@ -71,10 +71,10 @@ update msg state =
             case state.modalContext of
                 Just ms ->
                     let
-                        ( modalState, modalCmd, _ ) =
+                        modalState =
                             Modal.trigger ms
                     in
-                    ( { state | modalContext = Just modalState }, Cmd.map ModalUpdate modalCmd )
+                    ( { state | modalContext = Just modalState }, Cmd.none )
 
                 Nothing ->
                     ( state, Cmd.none )


### PR DESCRIPTION
Instead of returning Cmd ModalMsgs when triggering the modal it makes
more sense to simply ask the modal to run. This is a simple field in the
modal data that will be picked up by subscriptions.

This will then trigger the modal update in which case the modal can do
all the normal things it was doing previously. This moves all the modal
running logic to just one flow.

# Breaking Changes
Old trigger
```
triggerModal : (ModalState msg, Cmd (ModalMsg), ModalStatus)
triggerModal =
    trigger modalState
```
New trigger
```
triggerModal: ModalState msg
triggerModal =
    trigger modalState
```