### PR TITLE
feat: Add ability to set a tab index on a Checkbox and CheckboxField

### DIFF
--- a/packages/component-library/draft/Kaizen/Form/CheckboxField/CheckboxField.tsx
+++ b/packages/component-library/draft/Kaizen/Form/CheckboxField/CheckboxField.tsx
@@ -13,6 +13,7 @@ export type CheckboxFieldProps = {
   onCheck?: (event: React.ChangeEvent<HTMLInputElement>) => any
   disabled?: boolean
   noBottomMargin?: boolean
+  tabIndex?: number
 }
 
 type CheckboxField = React.FunctionComponent<CheckboxFieldProps>
@@ -26,6 +27,7 @@ const CheckboxField: CheckboxField = ({
   onCheck,
   disabled = false,
   noBottomMargin = false,
+  tabIndex,
 }) => (
   <div
     data-automation-id={automationId}
@@ -50,6 +52,7 @@ const CheckboxField: CheckboxField = ({
         checkedStatus={checkedStatus}
         name={name}
         onCheck={onCheck}
+        tabIndex={tabIndex}
       />
     </Label>
   </div>

--- a/packages/component-library/draft/Kaizen/Form/Primitives/Checkbox/Checkbox.tsx
+++ b/packages/component-library/draft/Kaizen/Form/Primitives/Checkbox/Checkbox.tsx
@@ -17,6 +17,7 @@ export type CheckboxProps = {
   onCheck?: (event: React.ChangeEvent<HTMLInputElement>) => any
   disabled?: boolean
   name?: string
+  tabIndex?: number
 }
 
 type Input = React.FunctionComponent<CheckboxProps>
@@ -48,12 +49,14 @@ const Input: Input = ({
   checkedStatus = "off" as CheckedStatus,
   onCheck,
   disabled = false,
+  tabIndex,
 }) => (
   <div className={styles.container}>
     <input
       type="checkbox"
       id={id}
       name={name}
+      tabIndex={tabIndex}
       data-automation-id={automationId}
       // This si only used as a handle for unit testing
       data-indeterminate={checkedStatus === "mixed"}


### PR DESCRIPTION
This PR adds the ability to set a tab index on a Checkbox and CheckboxField.

The motivation behind it was that I wanted to have a checkbox that was purely presentational, so to do that I needed to set the `tabIndex` of the checkbox as -1.