### PR TITLE
fix: remove elm18 module reference

### DIFF
--- a/packages/component-library/components/Button/Button.elm
+++ b/packages/component-library/components/Button/Button.elm
@@ -29,7 +29,6 @@ module Button.Button exposing
     )
 
 import CssModules exposing (css)
-import Elm18Compatible.Html.Events exposing (defaultOptions, onWithOptions)
 import Html exposing (Html, a, button, span, text)
 import Html.Attributes
 import Html.Attributes.Aria
@@ -170,12 +169,18 @@ onClickAttribs config =
 
                         Nothing ->
                             True
+
+                decoder =
+                    Json.map
+                        (\m ->
+                            { message = m
+                            , stopPropagation = False
+                            , preventDefault = preventDefault
+                            }
+                        )
+                        (Json.succeed msg)
             in
-            [ onWithOptions
-                "click"
-                { defaultOptions | preventDefault = preventDefault }
-                (Json.succeed msg)
-            ]
+            [ HtmlEvents.custom "click" decoder ]
 
         Nothing ->
             []


### PR DESCRIPTION
We are using elm 19 exclusively so this PR removes uses of Elm18 compatible modules for the Button component.