### PR TITLE
feat: apply focus lock on modal

### DIFF
--- a/packages/component-library/draft/Kaizen/Events/Events.elm
+++ b/packages/component-library/draft/Kaizen/Events/Events.elm
@@ -6,7 +6,9 @@ module Kaizen.Events.Events exposing
     , isEnter
     , isEnterAndValueChange
     , isEscape
+    , isShift
     , isSpace
+    , isTab
     , isUpArrow
     , mapAt
     , onBlurAt
@@ -193,6 +195,16 @@ isDownArrow msg =
 isUpArrow : msg -> Decode.Decoder msg
 isUpArrow msg =
     keyCode |> Decode.andThen (isCode UpArrow msg)
+
+
+isShift : msg -> Decode.Decoder msg
+isShift msg =
+    keyCode |> Decode.andThen (isCode Shift msg)
+
+
+isTab : msg -> Decode.Decoder msg
+isTab msg =
+    keyCode |> Decode.andThen (isCode Tab msg)
 
 
 isEnterAndValueChange : String -> (String -> msg) -> msg -> ( Keyboard.KeyCode, String ) -> Decode.Decoder msg

--- a/packages/component-library/draft/Kaizen/Modal/Presets/ConfirmationModal.elm
+++ b/packages/component-library/draft/Kaizen/Modal/Presets/ConfirmationModal.elm
@@ -7,7 +7,9 @@ module Kaizen.Modal.Presets.ConfirmationModal exposing
     , informative
     , negative
     , onConfirm
+    , onConfirmFocus
     , onDismiss
+    , onHeaderDismissFocus
     , positive
     , title
     , view
@@ -44,6 +46,8 @@ type alias Configuration msg =
     , dismissLabel : String
     , confirmLabel : String
     , headerDismissId : Maybe String
+    , onHeaderDismissFocus : Maybe msg
+    , onConfirmFocus : Maybe msg
     , confirmId : Maybe String
     }
 
@@ -87,6 +91,8 @@ defaults =
     , dismissLabel = "Cancel"
     , confirmLabel = "Confirm"
     , headerDismissId = Nothing
+    , onHeaderDismissFocus = Nothing
+    , onConfirmFocus = Nothing
     , confirmId = Just Constants.lastFocusableId
     }
 
@@ -110,6 +116,14 @@ view (Config config) =
                 Nothing ->
                     headerConfig
 
+        withHeaderOnDismissFocus headerConfig =
+            case config.onHeaderDismissFocus of
+                Just dismissFocus ->
+                    ModalHeader.onDismissFocus dismissFocus headerConfig
+
+                Nothing ->
+                    headerConfig
+
         withBody =
             case config.bodySubtext of
                 Just bodyContent ->
@@ -122,6 +136,7 @@ view (Config config) =
         [ ModalHeader.view
             (ModalHeader.layout [ header config ]
                 |> withHeaderOnDismiss
+                |> withHeaderOnDismissFocus
                 |> withHeaderDismissId
             )
         , withBody
@@ -203,6 +218,14 @@ footer config =
 
                 Nothing ->
                     buttonConfig
+
+        withOnConfirmFocus buttonConfig =
+            case config.onConfirmFocus of
+                Just onConfirmMsg ->
+                    Button.onFocus onConfirmMsg buttonConfig
+
+                Nothing ->
+                    buttonConfig
     in
     [ Button.view
         (Button.secondary
@@ -213,6 +236,7 @@ footer config =
         (resolveActionButtonVariant
             |> withOnConfirm
             |> withConfirmId
+            |> withOnConfirmFocus
         )
         config.confirmLabel
     ]
@@ -255,6 +279,16 @@ dismissLabel dismissString (Config config) =
 headerDismissId : String -> Config msg -> Config msg
 headerDismissId id_ (Config config) =
     Config { config | headerDismissId = Just id_ }
+
+
+onHeaderDismissFocus : msg -> Config msg -> Config msg
+onHeaderDismissFocus msg (Config config) =
+    Config { config | onHeaderDismissFocus = Just msg }
+
+
+onConfirmFocus : msg -> Config msg -> Config msg
+onConfirmFocus msg (Config config) =
+    Config { config | onConfirmFocus = Just msg }
 
 
 confirmId : String -> Config msg -> Config msg

--- a/packages/component-library/draft/Kaizen/Modal/Presets/ConfirmationModal.elm
+++ b/packages/component-library/draft/Kaizen/Modal/Presets/ConfirmationModal.elm
@@ -2,14 +2,18 @@ module Kaizen.Modal.Presets.ConfirmationModal exposing
     ( bodySubtext
     , confirmId
     , confirmLabel
+    , confirmPreventKeydownOn
     , dismissLabel
     , headerDismissId
     , informative
     , negative
     , onConfirm
+    , onConfirmBlur
     , onConfirmFocus
     , onDismiss
+    , onHeaderDismissBlur
     , onHeaderDismissFocus
+    , onPreventHeaderDismissKeydown
     , positive
     , title
     , view
@@ -20,6 +24,7 @@ import CssModules exposing (css)
 import Html exposing (Html, div, text)
 import Icon.Icon as Icon
 import Icon.SvgAsset exposing (svgAsset)
+import Json.Decode as Decode
 import Kaizen.Modal.Primitives.Constants as Constants
 import Kaizen.Modal.Primitives.ModalBody as ModalBody
 import Kaizen.Modal.Primitives.ModalFooter as ModalFooter
@@ -47,7 +52,11 @@ type alias Configuration msg =
     , confirmLabel : String
     , headerDismissId : Maybe String
     , onHeaderDismissFocus : Maybe msg
+    , onHeaderDismissBlur : Maybe msg
+    , onPreventHeaderDismissKeydown : List (Decode.Decoder msg)
+    , confirmPreventKeydownOn : List (Decode.Decoder msg)
     , onConfirmFocus : Maybe msg
+    , onConfirmBlur : Maybe msg
     , confirmId : Maybe String
     }
 
@@ -92,7 +101,11 @@ defaults =
     , confirmLabel = "Confirm"
     , headerDismissId = Nothing
     , onHeaderDismissFocus = Nothing
+    , onHeaderDismissBlur = Nothing
+    , onPreventHeaderDismissKeydown = []
+    , confirmPreventKeydownOn = []
     , onConfirmFocus = Nothing
+    , onConfirmBlur = Nothing
     , confirmId = Just Constants.lastFocusableId
     }
 
@@ -116,13 +129,28 @@ view (Config config) =
                 Nothing ->
                     headerConfig
 
-        withHeaderOnDismissFocus headerConfig =
+        withHeaderDismissFocus headerConfig =
             case config.onHeaderDismissFocus of
                 Just dismissFocus ->
                     ModalHeader.onDismissFocus dismissFocus headerConfig
 
                 Nothing ->
                     headerConfig
+
+        withHeaderDismissBlur headerConfig =
+            case config.onHeaderDismissBlur of
+                Just dismissBlur ->
+                    ModalHeader.onDismissBlur dismissBlur headerConfig
+
+                Nothing ->
+                    headerConfig
+
+        withPreventHeaderDismissKeydown headerConfig =
+            if List.isEmpty config.onPreventHeaderDismissKeydown then
+                headerConfig
+
+            else
+                ModalHeader.preventDismissKeydown config.onPreventHeaderDismissKeydown headerConfig
 
         withBody =
             case config.bodySubtext of
@@ -136,8 +164,10 @@ view (Config config) =
         [ ModalHeader.view
             (ModalHeader.layout [ header config ]
                 |> withHeaderOnDismiss
-                |> withHeaderOnDismissFocus
+                |> withHeaderDismissFocus
+                |> withHeaderDismissBlur
                 |> withHeaderDismissId
+                |> withPreventHeaderDismissKeydown
             )
         , withBody
         , ModalFooter.view <|
@@ -176,7 +206,7 @@ header config =
                     |> Html.map never
                 ]
             ]
-        , Text.view (Text.h1 |> Text.inline True) [ text config.title ]
+        , Text.view (Text.h1 |> Text.inline True |> Text.id Constants.ariaLabelledBy) [ text config.title ]
         ]
 
 
@@ -219,13 +249,28 @@ footer config =
                 Nothing ->
                     buttonConfig
 
-        withOnConfirmFocus buttonConfig =
+        withConfirmFocus buttonConfig =
             case config.onConfirmFocus of
                 Just onConfirmMsg ->
                     Button.onFocus onConfirmMsg buttonConfig
 
                 Nothing ->
                     buttonConfig
+
+        withConfirmBlur buttonConfig =
+            case config.onConfirmBlur of
+                Just onConfirmBlurMsg ->
+                    Button.onBlur onConfirmBlurMsg buttonConfig
+
+                Nothing ->
+                    buttonConfig
+
+        withConfirmPreventKeydown buttonConfig =
+            if List.isEmpty config.confirmPreventKeydownOn then
+                buttonConfig
+
+            else
+                Button.preventKeydownOn config.confirmPreventKeydownOn buttonConfig
     in
     [ Button.view
         (Button.secondary
@@ -236,7 +281,9 @@ footer config =
         (resolveActionButtonVariant
             |> withOnConfirm
             |> withConfirmId
-            |> withOnConfirmFocus
+            |> withConfirmFocus
+            |> withConfirmBlur
+            |> withConfirmPreventKeydown
         )
         config.confirmLabel
     ]
@@ -286,9 +333,29 @@ onHeaderDismissFocus msg (Config config) =
     Config { config | onHeaderDismissFocus = Just msg }
 
 
+onHeaderDismissBlur : msg -> Config msg -> Config msg
+onHeaderDismissBlur msg (Config config) =
+    Config { config | onHeaderDismissBlur = Just msg }
+
+
 onConfirmFocus : msg -> Config msg -> Config msg
 onConfirmFocus msg (Config config) =
     Config { config | onConfirmFocus = Just msg }
+
+
+onPreventHeaderDismissKeydown : List (Decode.Decoder msg) -> Config msg -> Config msg
+onPreventHeaderDismissKeydown keydownDecoders (Config config) =
+    Config { config | onPreventHeaderDismissKeydown = keydownDecoders }
+
+
+confirmPreventKeydownOn : List (Decode.Decoder msg) -> Config msg -> Config msg
+confirmPreventKeydownOn keydownDecoders (Config config) =
+    Config { config | confirmPreventKeydownOn = keydownDecoders }
+
+
+onConfirmBlur : msg -> Config msg -> Config msg
+onConfirmBlur msg (Config config) =
+    Config { config | onConfirmBlur = Just msg }
 
 
 confirmId : String -> Config msg -> Config msg

--- a/packages/component-library/draft/Kaizen/Modal/Primitives/ModalBody.elm
+++ b/packages/component-library/draft/Kaizen/Modal/Primitives/ModalBody.elm
@@ -9,6 +9,8 @@ module Kaizen.Modal.Primitives.ModalBody exposing
 
 import CssModules exposing (css)
 import Html exposing (Html, section, text)
+import Html.Attributes as HtmlAttributes
+import Kaizen.Modal.Primitives.Constants as Constants
 
 
 type Config msg
@@ -45,6 +47,7 @@ modalBody content config =
             , ( .scrollable, config.scrollable )
             , ( .fillSpace, config.fillSpace )
             ]
+        , HtmlAttributes.id Constants.ariaDescribedBy
         ]
         content
 

--- a/packages/component-library/draft/Kaizen/Modal/Primitives/ModalHeader.elm
+++ b/packages/component-library/draft/Kaizen/Modal/Primitives/ModalHeader.elm
@@ -3,7 +3,9 @@ module Kaizen.Modal.Primitives.ModalHeader exposing
     , fixed
     , layout
     , onDismiss
+    , onDismissBlur
     , onDismissFocus
+    , preventDismissKeydown
     , view
     )
 
@@ -12,6 +14,7 @@ import CssModules exposing (css)
 import Html exposing (Html, div, text)
 import Html.Events exposing (onClick)
 import Icon.SvgAsset exposing (svgAsset)
+import Json.Decode as Decode
 
 
 type Config msg
@@ -24,6 +27,8 @@ type alias Configuration msg =
     , onDismiss : Maybe msg
     , dismissId : Maybe String
     , onDismissFocus : Maybe msg
+    , onDismissBlur : Maybe msg
+    , preventDismissKeydown : List (Decode.Decoder msg)
     }
 
 
@@ -34,6 +39,8 @@ defaults =
     , onDismiss = Nothing
     , dismissId = Nothing
     , onDismissFocus = Nothing
+    , onDismissBlur = Nothing
+    , preventDismissKeydown = []
     }
 
 
@@ -75,6 +82,21 @@ layoutBox content config =
                 Nothing ->
                     buttonConfig
 
+        withBlur buttonConfig =
+            case config.onDismissBlur of
+                Just msg ->
+                    Button.onBlur msg buttonConfig
+
+                Nothing ->
+                    buttonConfig
+
+        withPreventKeydown buttonConfig =
+            if List.isEmpty config.preventDismissKeydown then
+                buttonConfig
+
+            else
+                Button.preventKeydownOn config.preventDismissKeydown buttonConfig
+
         resolveDismissButton =
             case config.onDismiss of
                 Just onDismissMsg ->
@@ -85,6 +107,8 @@ layoutBox content config =
                                 |> Button.reversed True
                                 |> withDismissId
                                 |> withFocus
+                                |> withBlur
+                                |> withPreventKeydown
                             )
                             "Dismiss"
                         ]
@@ -145,9 +169,19 @@ onDismissFocus msg (Config config) =
     Config { config | onDismissFocus = Just msg }
 
 
+onDismissBlur : msg -> Config msg -> Config msg
+onDismissBlur msg (Config config) =
+    Config { config | onDismissBlur = Just msg }
+
+
 dismissId : String -> Config msg -> Config msg
 dismissId id_ (Config config) =
     Config { config | dismissId = Just id_ }
+
+
+preventDismissKeydown : List (Decode.Decoder msg) -> Config msg -> Config msg
+preventDismissKeydown keydownDecoders (Config config) =
+    Config { config | preventDismissKeydown = keydownDecoders }
 
 
 styles =

--- a/packages/component-library/draft/Kaizen/Modal/Primitives/ModalHeader.elm
+++ b/packages/component-library/draft/Kaizen/Modal/Primitives/ModalHeader.elm
@@ -3,6 +3,7 @@ module Kaizen.Modal.Primitives.ModalHeader exposing
     , fixed
     , layout
     , onDismiss
+    , onDismissFocus
     , view
     )
 
@@ -22,6 +23,7 @@ type alias Configuration msg =
     , fixed : Bool
     , onDismiss : Maybe msg
     , dismissId : Maybe String
+    , onDismissFocus : Maybe msg
     }
 
 
@@ -31,6 +33,7 @@ defaults =
     , fixed = False
     , onDismiss = Nothing
     , dismissId = Nothing
+    , onDismissFocus = Nothing
     }
 
 
@@ -64,6 +67,14 @@ layoutBox content config =
                 Nothing ->
                     buttonConfig
 
+        withFocus buttonConfig =
+            case config.onDismissFocus of
+                Just msg ->
+                    Button.onFocus msg buttonConfig
+
+                Nothing ->
+                    buttonConfig
+
         resolveDismissButton =
             case config.onDismiss of
                 Just onDismissMsg ->
@@ -73,6 +84,7 @@ layoutBox content config =
                                 (svgAsset "@kaizen/component-library/icons/close.icon.svg")
                                 |> Button.reversed True
                                 |> withDismissId
+                                |> withFocus
                             )
                             "Dismiss"
                         ]
@@ -126,6 +138,11 @@ as it may clash with the provided close button
 onDismiss : msg -> Config msg -> Config msg
 onDismiss msg (Config config) =
     Config { config | onDismiss = Just msg }
+
+
+onDismissFocus : msg -> Config msg -> Config msg
+onDismissFocus msg (Config config) =
+    Config { config | onDismissFocus = Just msg }
 
 
 dismissId : String -> Config msg -> Config msg

--- a/packages/component-library/draft/Kaizen/UserInteractions/KeyCodes.elm
+++ b/packages/component-library/draft/Kaizen/UserInteractions/KeyCodes.elm
@@ -1,4 +1,13 @@
-module Kaizen.UserInteractions.KeyCodes exposing (backspace, downArrow, enter, escape, space, tab, upArrow)
+module Kaizen.UserInteractions.KeyCodes exposing
+    ( backspace
+    , downArrow
+    , enter
+    , escape
+    , shift
+    , space
+    , tab
+    , upArrow
+    )
 
 import Elm18Compatible.Keyboard as Keyboard18
 
@@ -36,3 +45,8 @@ downArrow =
 space : Keyboard18.KeyCode
 space =
     32
+
+
+shift : Keyboard18.KeyCode
+shift =
+    16

--- a/packages/component-library/draft/Kaizen/UserInteractions/Keyboard.elm
+++ b/packages/component-library/draft/Kaizen/UserInteractions/Keyboard.elm
@@ -11,6 +11,8 @@ type Key
     | Enter
     | Backspace
     | Space
+    | Shift
+    | Tab
     | Other
 
 
@@ -33,6 +35,12 @@ decoder keyCode =
 
     else if keyCode == KeyCodes.space then
         Space
+
+    else if keyCode == KeyCodes.shift then
+        Shift
+
+    else if keyCode == KeyCodes.tab then
+        Tab
 
     else
         Other

--- a/packages/component-library/stories/Modal.stories.tsx
+++ b/packages/component-library/stories/Modal.stories.tsx
@@ -628,4 +628,5 @@ loadElmStories("Modal (Elm)", module, require("./ModalStories.elm"), [
   "Confirmation (Informative)",
   "Confirmation (Positive)",
   "Confirmation (Negative)",
+  "Confirmation (User action)",
 ])

--- a/packages/component-library/stories/ModalStories.elm
+++ b/packages/component-library/stories/ModalStories.elm
@@ -1,5 +1,6 @@
 module Main exposing (main)
 
+import Button.Button as Button
 import ElmStorybook exposing (storyOf, storybook)
 import Html exposing (div, text)
 import Html.Attributes exposing (style)
@@ -14,19 +15,23 @@ type ModalMsg
     = ModalUpdate Modal.ModalMsg
     | ModalConfirmed
     | ModalDismissed
+    | SetModalContext
 
 
 
--- SetModalContext
-
-
-model : ModalState
-model =
-    { modalContext = Just (Modal.trigger Modal.initialState) }
+-- MODEL
 
 
 type alias ModalState =
     { modalContext : Maybe (Modal.ModalState ModalMsg)
+    , idealWayToSetUpModal : Bool
+    }
+
+
+model : ModalState
+model =
+    { modalContext = Just (Modal.trigger Modal.initialState)
+    , idealWayToSetUpModal = False
     }
 
 
@@ -78,6 +83,15 @@ update msg state =
 
                 Nothing ->
                     ( state, Cmd.none )
+
+        -- Typically modals dont start off open when you load a page. Setting the modal context is the ideal way
+        -- to render the modal into view.
+        SetModalContext ->
+            let
+                modalState =
+                    Modal.trigger Modal.initialState
+            in
+            ( { state | idealWayToSetUpModal = True, modalContext = Just modalState }, Cmd.none )
 
 
 subscriptions : ModalState -> Sub ModalMsg
@@ -204,5 +218,36 @@ main =
 
                         Nothing ->
                             text ""
+                    ]
+        , storyOf "Confirmation (User action)" config <|
+            \m ->
+                div []
+                    [ Button.view (Button.default |> Button.onClick SetModalContext) "Open Modal"
+                    , if m.idealWayToSetUpModal then
+                        case m.modalContext of
+                            Just modalState ->
+                                Modal.view <|
+                                    (Modal.confirmation Modal.Negative
+                                        { title = "Negative title"
+                                        , bodySubtext =
+                                            Just
+                                                [ div [ style "text-align" "center" ]
+                                                    [ Text.view (Text.p |> Text.style Text.Lede |> Text.inline True) [ text "Additional subtext to aid the user can be added here." ] ]
+                                                ]
+                                        , onDismiss = Just ModalDismissed
+                                        , onConfirm = Just ModalConfirmed
+                                        , confirmLabel = "Confirm"
+                                        , dismissLabel = "Cancel"
+                                        }
+                                        |> Modal.modalState modalState
+                                        -- IMPORTANT: the modal uses this for internal messages
+                                        |> Modal.onUpdate ModalUpdate
+                                    )
+
+                            Nothing ->
+                                text ""
+
+                      else
+                        text ""
                     ]
         ]


### PR DESCRIPTION
# Background 
Elm modal was previously not handling focus. This meant when the modal opened the focus was left somewhere on the main page and not with the content within the modal.

Also, if focus did happen to be within the modal content, a user could essentially tab focus their way out of the open modal.

# Proposed Solution
In order to properly manage focus we create a focus-lock. Essentially this traps focus within the confines of the first and last focusable elements of the modal content.

If focus for example is on the last focusable element and the user "tabs", we reset focus onto the first focusable element. The same applies for focus on the first focusable element i.e. shift tabbing would set focus to the last focusable element.

# Improvements
Currently focus lock works for Confirmation variants only. This is because they are preset modal views that have a defined first and last focusable element. 

The Generic variant of the modal receives a custom view from the consumer so we cannot know the first and last focusable elements. An API will need to be developed to let consumers mark which elements of their custom views are the first and last focusable elements. This can then utilise the focus-lock implementation.

Focus is currently not being returned to the original trigger.