### PR TITLE
feat: Add Zen headings and hero data styles to Text component

### DIFF
--- a/packages/component-library/components/Text/Text.elm
+++ b/packages/component-library/components/Text/Text.elm
@@ -111,6 +111,18 @@ className tag typeStyle shouldInheritBaseline shouldInline =
 
                 Button ->
                     .button
+
+                ZenDisplay0 ->
+                    .zenDisplay0
+
+                ZenHeading1 ->
+                    .zenHeading1
+
+                ZenHeading2 ->
+                    .zenHeading2
+
+                ZenHeading3 ->
+                    .zenHeading3
     in
     styles.classList
         [ ( styleClass, True )
@@ -138,6 +150,10 @@ styles =
         , button = "button"
         , inheritBaseline = "inheritBaseline"
         , inline = "inline"
+        , zenDisplay0 = "zen-display-0"
+        , zenHeading1 = "zen-heading-1"
+        , zenHeading2 = "zen-heading-2"
+        , zenHeading3 = "zen-heading-3"
         }
 
 
@@ -178,6 +194,10 @@ type TypeStyle
     | Label
     | ControlAction
     | Button
+    | ZenDisplay0
+    | ZenHeading1
+    | ZenHeading2
+    | ZenHeading3
 
 
 defaultConfig : ConfigValue msg

--- a/packages/component-library/components/Text/Text.elm
+++ b/packages/component-library/components/Text/Text.elm
@@ -123,6 +123,24 @@ className tag typeStyle shouldInheritBaseline shouldInline =
 
                 ZenHeading3 ->
                     .zenHeading3
+
+                ZenDataLarge ->
+                    .zenDataLarge
+
+                ZenDataLargeUnits ->
+                    .zenDataLargeUnits
+
+                ZenDataMedium ->
+                    .zenDataMedium
+
+                ZenDataMediumUnits ->
+                    .zenDataMediumUnits
+
+                ZenDataSmall ->
+                    .zenDataSmall
+
+                ZenDataSmallUnits ->
+                    .zenDataSmallUnits
     in
     styles.classList
         [ ( styleClass, True )
@@ -154,6 +172,12 @@ styles =
         , zenHeading1 = "zen-heading-1"
         , zenHeading2 = "zen-heading-2"
         , zenHeading3 = "zen-heading-3"
+        , zenDataLarge = "zen-data-large"
+        , zenDataLargeUnits = "zen-data-large-units"
+        , zenDataMedium = "zen-data-medium"
+        , zenDataMediumUnits = "zen-data-medium-units"
+        , zenDataSmall = "zen-data-small"
+        , zenDataSmallUnits = "zen-data-small-units"
         }
 
 
@@ -198,6 +222,12 @@ type TypeStyle
     | ZenHeading1
     | ZenHeading2
     | ZenHeading3
+    | ZenDataLarge
+    | ZenDataLargeUnits
+    | ZenDataMedium
+    | ZenDataMediumUnits
+    | ZenDataSmall
+    | ZenDataSmallUnits
 
 
 defaultConfig : ConfigValue msg

--- a/packages/component-library/components/Text/Text.module.scss
+++ b/packages/component-library/components/Text/Text.module.scss
@@ -136,3 +136,39 @@ p.default-style {
   margin-bottom: $ca-grid;
   margin-top: 0;
 }
+
+.zen-data-large {
+  @include kz-typography-data-large;
+  margin-bottom: $ca-grid;
+  margin-top: 0;
+}
+
+.zen-data-large-units {
+  @include kz-typography-data-large-units;
+  margin-bottom: $ca-grid;
+  margin-top: 0;
+}
+
+.zen-data-medium {
+  @include kz-typography-data-medium;
+  margin-bottom: $ca-grid;
+  margin-top: 0;
+}
+
+.zen-data-medium-units {
+  @include kz-typography-data-medium-units;
+  margin-bottom: $ca-grid;
+  margin-top: 0;
+}
+
+.zen-data-small {
+  @include kz-typography-data-small;
+  margin-bottom: $ca-grid;
+  margin-top: 0;
+}
+
+.zen-data-small-units {
+  @include kz-typography-data-small-units;
+  margin-bottom: $ca-grid;
+  margin-top: 0;
+}

--- a/packages/component-library/components/Text/Text.module.scss
+++ b/packages/component-library/components/Text/Text.module.scss
@@ -1,4 +1,5 @@
 @import "../../styles/type";
+@import "@kaizen/deprecated-component-library-helpers/styles/type";
 
 .page-title,
 h1.default-style {
@@ -110,4 +111,28 @@ p.default-style {
 }
 .controlAction {
   composes: control-action;
+}
+
+.zen-display-0 {
+  @include kz-typography-display-0;
+  margin-bottom: $ca-grid;
+  margin-top: 0;
+}
+
+.zen-heading-1 {
+  @include kz-typography-heading-1;
+  margin-bottom: $ca-grid;
+  margin-top: 0;
+}
+
+.zen-heading-2 {
+  @include kz-typography-heading-2;
+  margin-bottom: $ca-grid;
+  margin-top: 0;
+}
+
+.zen-heading-3 {
+  @include kz-typography-heading-3;
+  margin-bottom: $ca-grid;
+  margin-top: 0;
 }

--- a/packages/component-library/components/Text/Text.tsx
+++ b/packages/component-library/components/Text/Text.tsx
@@ -25,6 +25,12 @@ type TextProps = {
     | "zen-heading-1"
     | "zen-heading-2"
     | "zen-heading-3"
+    | "zen-data-large"
+    | "zen-data-large-units"
+    | "zen-data-medium"
+    | "zen-data-medium-units"
+    | "zen-data-small"
+    | "zen-data-small-units"
   inheritBaseline?: boolean
   inline?: boolean
 }

--- a/packages/component-library/components/Text/Text.tsx
+++ b/packages/component-library/components/Text/Text.tsx
@@ -21,6 +21,10 @@ type TextProps = {
     | "label"
     | "control-action"
     | "button"
+    | "zen-display-0"
+    | "zen-heading-1"
+    | "zen-heading-2"
+    | "zen-heading-3"
   inheritBaseline?: boolean
   inline?: boolean
 }

--- a/packages/component-library/stories/Text.stories.tsx
+++ b/packages/component-library/stories/Text.stories.tsx
@@ -206,6 +206,42 @@ export const ZenHeading3 = () => (
   </Text>
 )
 
+export const ZenDataLarge = () => (
+  <Text style="zen-data-large" tag="span">
+    42
+  </Text>
+)
+
+export const ZenDataLargeUnits = () => (
+  <Text style="zen-data-large-units" tag="span">
+    %
+  </Text>
+)
+
+export const ZenDataMedium = () => (
+  <Text style="zen-data-medium" tag="span">
+    42
+  </Text>
+)
+
+export const ZenDataMediumUnits = () => (
+  <Text style="zen-data-medium-units" tag="span">
+    %
+  </Text>
+)
+
+export const ZenDataSmall = () => (
+  <Text style="zen-data-small" tag="span">
+    42
+  </Text>
+)
+
+export const ZenDataSmallUnits = () => (
+  <Text style="zen-data-small-units" tag="span">
+    %
+  </Text>
+)
+
 loadElmStories("Text (Elm)", module, require("./TextStories.elm"), [
   "h1",
   "h2",

--- a/packages/component-library/stories/Text.stories.tsx
+++ b/packages/component-library/stories/Text.stories.tsx
@@ -66,6 +66,7 @@ H6.story = {
   name: "H6",
 }
 
+
 export const Paragraph = () => (
   <Text tag="p">
     Dr. Brené Brown, author of Daring Greatly, is a research professor from the
@@ -179,6 +180,30 @@ ControlAction.story = {
 export const Button = () => (
   <Text tag="div" style="button">
     Div with "Button" styles
+  </Text>
+)
+
+export const ZenDisplay0 = () => (
+  <Text style="zen-display-0" tag="p">
+    This is a Zen Display 0, which uses Heading styles
+  </Text>
+)
+
+export const ZenHeading1 = () => (
+  <Text style="zen-heading-1" tag="h1">
+    This is a Zend Heading 1, which uses Heading styles
+  </Text>
+)
+
+export const ZenHeading2 = () => (
+  <Text style="zen-heading-2" tag="h2">
+    This is a Zen Heading 2, which uses Heading styles
+  </Text>
+)
+
+export const ZenHeading3 = () => (
+  <Text style="zen-heading-3" tag="h3">
+    This is a Zen Heading 3, which uses Heading styles
   </Text>
 )
 

--- a/packages/component-library/stories/Text.stories.tsx
+++ b/packages/component-library/stories/Text.stories.tsx
@@ -246,4 +246,8 @@ loadElmStories("Text (Elm)", module, require("./TextStories.elm"), [
   "h1",
   "h2",
   "h3",
+  "zen-display-0",
+  "zen-heading-1",
+  "zen-heading-3",
+  "zen-heading-3",
 ])

--- a/packages/component-library/stories/Text.stories.tsx
+++ b/packages/component-library/stories/Text.stories.tsx
@@ -250,4 +250,10 @@ loadElmStories("Text (Elm)", module, require("./TextStories.elm"), [
   "zen-heading-1",
   "zen-heading-3",
   "zen-heading-3",
+  "zen-data-large",
+  "zen-data-large-units",
+  "zen-data-medium",
+  "zen-data-medium-units",
+  "zen-data-small",
+  "zen-data-small-units",
 ])

--- a/packages/component-library/stories/Text.stories.tsx
+++ b/packages/component-library/stories/Text.stories.tsx
@@ -66,7 +66,6 @@ H6.story = {
   name: "H6",
 }
 
-
 export const Paragraph = () => (
   <Text tag="p">
     Dr. Brené Brown, author of Daring Greatly, is a research professor from the
@@ -191,7 +190,7 @@ export const ZenDisplay0 = () => (
 
 export const ZenHeading1 = () => (
   <Text style="zen-heading-1" tag="h1">
-    This is a Zend Heading 1, which uses Heading styles
+    This is a Zen Heading 1, which uses Heading styles
   </Text>
 )
 

--- a/packages/component-library/stories/TextStories.elm
+++ b/packages/component-library/stories/TextStories.elm
@@ -2,7 +2,7 @@ module Main exposing (main)
 
 import ElmStorybook exposing (statelessStoryOf, storybook)
 import Html exposing (text)
-import Text.Text as Text exposing (h1, view)
+import Text.Text as Text exposing (TypeStyle(..), h1, view)
 
 
 main =
@@ -19,4 +19,20 @@ main =
             Text.view
                 Text.h3
                 [ Html.text "This is a h3" ]
+        , statelessStoryOf "zen-display-0" <|
+            Text.view
+                (Text.p |> Text.style ZenDisplay0)
+                [ Html.text "This is a Zen Display 0" ]
+        , statelessStoryOf "zen-heading-1" <|
+            Text.view
+                (Text.h1 |> Text.style ZenHeading1)
+                [ Html.text "This is a Zen Heading 1" ]
+        , statelessStoryOf "zen-heading-2" <|
+            Text.view
+                (Text.h2 |> Text.style ZenHeading2)
+                [ Html.text "This is a Zen Heading 2" ]
+        , statelessStoryOf "zen-heading-3" <|
+            Text.view
+                (Text.h3 |> Text.style ZenHeading3)
+                [ Html.text "This is a Zen Heading 3" ]
         ]

--- a/packages/component-library/stories/TextStories.elm
+++ b/packages/component-library/stories/TextStories.elm
@@ -35,4 +35,28 @@ main =
             Text.view
                 (Text.h3 |> Text.style ZenHeading3)
                 [ Html.text "This is a Zen Heading 3" ]
+        , statelessStoryOf "zen-data-large" <|
+            Text.view
+                (Text.span |> Text.style ZenDataLarge)
+                [ Html.text "This is a Zen Data Large" ]
+        , statelessStoryOf "zen-data-large-units" <|
+            Text.view
+                (Text.span |> Text.style ZenDataLargeUnits)
+                [ Html.text "This is a Zen Data Large Units" ]
+        , statelessStoryOf "zen-data-medium" <|
+            Text.view
+                (Text.span |> Text.style ZenDataMedium)
+                [ Html.text "This is a Zen Data Medium" ]
+        , statelessStoryOf "zen-data-medium-units" <|
+            Text.view
+                (Text.span |> Text.style ZenDataMediumUnits)
+                [ Html.text "This is a Zen Data Medium Units" ]
+        , statelessStoryOf "zen-data-small" <|
+            Text.view
+                (Text.span |> Text.style ZenDataSmall)
+                [ Html.text "This is a Zen Data Small" ]
+        , statelessStoryOf "zen-data-small-units" <|
+            Text.view
+                (Text.span |> Text.style ZenDataSmallUnits)
+                [ Html.text "This is a Zen Data Small Units" ]
         ]

--- a/storybook/preview.ts
+++ b/storybook/preview.ts
@@ -14,6 +14,8 @@ require("focus-visible")
 // See: https://github.com/necolas/normalize.css/
 require("normalize.css")
 
+require("@kaizen/component-library/styles/fonts.scss")
+
 addDecorator(withA11y)
 
 addParameters({


### PR DESCRIPTION
This adds optional Zen headings and hero data styles to the React and Elm Text components

https://dev.cultureamp.design/dst/text-component-zen-headings/storybook/