### PR TITLE
fix: add @kaizen/deprecated-component-library-helpers depency to packages/component-library

### DIFF
--- a/packages/component-library/package.json
+++ b/packages/component-library/package.json
@@ -31,6 +31,7 @@
     "react": "^16.9.0"
   },
   "dependencies": {
+    "@kaizen/deprecated-component-library-helpers": "1.3.0",
     "@types/classnames": "^2.2.6",
     "@types/lodash": "^4.14.132",
     "@types/react-select": "^3.0.5",


### PR DESCRIPTION
add `@kaizen/deprecated-component-library-helpers` dependency to `packages/component-library`

Not having this causes builds to break when the package is consumed.