### PR TITLE
feat: Uplift Title Block heading to Greycliff

### DIFF
--- a/packages/component-library/draft/Kaizen/TitleBlock/NavigationButton.scss
+++ b/packages/component-library/draft/Kaizen/TitleBlock/NavigationButton.scss
@@ -1,7 +1,7 @@
 @import "~@kaizen/design-tokens/sass/color";
 @import "~@kaizen/deprecated-component-library-helpers/styles/type";
+@import "~@kaizen/deprecated-component-library-helpers/styles/color";
 @import "~@kaizen/component-library/styles/border";
-@import "~@kaizen/component-library/styles/color";
 @import "~@kaizen/component-library/styles/layout";
 @import "~@kaizen/component-library/styles/responsive";
 

--- a/packages/component-library/draft/Kaizen/TitleBlock/NavigationButton.scss
+++ b/packages/component-library/draft/Kaizen/TitleBlock/NavigationButton.scss
@@ -1,9 +1,9 @@
 @import "~@kaizen/design-tokens/sass/color";
+@import "~@kaizen/deprecated-component-library-helpers/styles/type";
 @import "~@kaizen/component-library/styles/border";
 @import "~@kaizen/component-library/styles/color";
 @import "~@kaizen/component-library/styles/layout";
 @import "~@kaizen/component-library/styles/responsive";
-@import "~@kaizen/component-library/styles/type";
 
 .button {
   @include ca-type-ideal-button;

--- a/packages/component-library/draft/Kaizen/TitleBlock/NavigationButton.scss
+++ b/packages/component-library/draft/Kaizen/TitleBlock/NavigationButton.scss
@@ -27,12 +27,12 @@
 
   @include ca-media-tablet-and-up {
     color: $kz-color-wisteria-800;
-    padding-top: 17px;
+    padding-top: 1.0625rem;
   }
 
   @include ca-media-mobile {
     margin: 0;
-    padding-bottom: 5px;
+    padding-bottom: 0.3125rem;
   }
 }
 

--- a/packages/component-library/draft/Kaizen/TitleBlock/NavigationButton.scss
+++ b/packages/component-library/draft/Kaizen/TitleBlock/NavigationButton.scss
@@ -27,6 +27,7 @@
 
   @include ca-media-tablet-and-up {
     color: $kz-color-wisteria-800;
+    padding-top: 17px;
   }
 
   @include ca-media-mobile {

--- a/packages/component-library/draft/Kaizen/TitleBlock/TitleBlock.scss
+++ b/packages/component-library/draft/Kaizen/TitleBlock/TitleBlock.scss
@@ -1,7 +1,7 @@
 @import "~@kaizen/design-tokens/sass/color";
 @import "~@kaizen/deprecated-component-library-helpers/styles/type";
+@import "~@kaizen/deprecated-component-library-helpers/styles/color";
 @import "~@kaizen/component-library/styles/border";
-@import "~@kaizen/component-library/styles/color";
 @import "~@kaizen/component-library/styles/layers";
 @import "~@kaizen/component-library/styles/layout";
 @import "~@kaizen/component-library/styles/responsive";

--- a/packages/component-library/draft/Kaizen/TitleBlock/TitleBlock.scss
+++ b/packages/component-library/draft/Kaizen/TitleBlock/TitleBlock.scss
@@ -1,7 +1,7 @@
 @import "~@kaizen/design-tokens/sass/color";
+@import "~@kaizen/deprecated-component-library-helpers/styles/type";
 @import "~@kaizen/component-library/styles/border";
 @import "~@kaizen/component-library/styles/color";
-@import "~@kaizen/component-library/styles/type";
 @import "~@kaizen/component-library/styles/layers";
 @import "~@kaizen/component-library/styles/layout";
 @import "~@kaizen/component-library/styles/responsive";
@@ -157,17 +157,17 @@ $kz-color-wisteria-700-copy: #4b4d68; // temporary until we update Kaizen to Zen
 }
 
 .title {
-  @include ca-type-ideal-page-title;
+  @include kz-typography-heading-1;
   display: inline-block;
   top: auto;
 
   @include ca-media-tablet {
-    @include ca-type-ideal-title;
+    @include kz-typography-heading-2;
     @include ca-inherit-baseline;
   }
 
   @include ca-media-mobile {
-    @include ca-type-ideal-display;
+    @include kz-typography-heading-3;
     @include ca-inherit-baseline;
   }
 }

--- a/packages/component-library/draft/Kaizen/TitleBlock/TitleBlock.scss
+++ b/packages/component-library/draft/Kaizen/TitleBlock/TitleBlock.scss
@@ -182,6 +182,7 @@ $kz-color-wisteria-700-copy: #4b4d68; // temporary until we update Kaizen to Zen
   display: inline-block;
   top: auto;
   @include ca-margin($start: $ca-grid);
+  transform: translateY(-1px);
 
   @include ca-media-mobile {
     display: none;


### PR DESCRIPTION
## Changes

This PR uplifts the heading of the Title Block from Ideal Sans to Greycliff.

It uses styles Heading 1, 2 and 3 for the desktop, tablet and mobile viewport widths respectively:

![2020-02-24 15 09 10](https://user-images.githubusercontent.com/6406263/75128332-b0c84280-5717-11ea-99d5-ed1233ce596f.gif)

## Context

The Title Block is currently only used in Murmur, so it can be safely uplifted without causing issues in other repos. It is being uplifted as part of the work Design Systems Team is doing as part of our rollout of the typography uplift in Murmur.