### PR TITLE
feat: Add prevent default on keydown to Button

### DIFF
--- a/packages/component-library/components/Button/Button.elm
+++ b/packages/component-library/components/Button/Button.elm
@@ -35,7 +35,7 @@ import Html.Attributes.Aria
 import Html.Events as HtmlEvents
 import Icon.Icon as Icon
 import Icon.SvgAsset exposing (SvgAsset)
-import Json.Decode as Json
+import Json.Decode as Decode
 import Maybe
 
 
@@ -171,14 +171,14 @@ onClickAttribs config =
                             True
 
                 decoder =
-                    Json.map
+                    Decode.map
                         (\m ->
                             { message = m
                             , stopPropagation = False
                             , preventDefault = preventDefault
                             }
                         )
-                        (Json.succeed msg)
+                        (Decode.succeed msg)
             in
             [ HtmlEvents.custom "click" decoder ]
 

--- a/packages/component-library/components/Button/Button.elm
+++ b/packages/component-library/components/Button/Button.elm
@@ -21,6 +21,7 @@ module Button.Button exposing
     , onBlur
     , onClick
     , onFocus
+    , preventKeydownOn
     , primary
     , reverseColor
     , reversed
@@ -110,6 +111,7 @@ view (Config config) label =
                 ++ onClickAttribs config
                 ++ onFocusAttribs config
                 ++ onBlurAttribs config
+                ++ preventKeydownAttribs config
                 ++ automationIdAttr
                 ++ titleAttr
                 ++ buttonTypeAttribs config
@@ -150,6 +152,15 @@ onBlurAttribs config =
 
         Nothing ->
             []
+
+
+preventKeydownAttribs : ConfigValue msg -> List (Html.Attribute msg)
+preventKeydownAttribs config =
+    if List.isEmpty config.preventKeydownOn then
+        []
+
+    else
+        [ HtmlEvents.preventDefaultOn "keydown" <| Decode.map (\msg -> ( msg, True )) (Decode.oneOf config.preventKeydownOn) ]
 
 
 onClickAttribs : ConfigValue msg -> List (Html.Attribute msg)
@@ -290,6 +301,7 @@ type alias ConfigValue msg =
     , onClick : Maybe msg
     , onFocus : Maybe msg
     , onBlur : Maybe msg
+    , preventKeydownOn : List (Decode.Decoder msg)
     , href : Maybe String
     , newTabAndIUnderstandTheAccessibilityImplications : Bool
     , id : Maybe String
@@ -339,6 +351,7 @@ defaults =
     , onClick = Nothing
     , onFocus = Nothing
     , onBlur = Nothing
+    , preventKeydownOn = []
     , href = Nothing
     , newTabAndIUnderstandTheAccessibilityImplications = False
     , id = Nothing
@@ -426,6 +439,11 @@ onFocus value (Config config) =
 onBlur : msg -> Config msg -> Config msg
 onBlur value (Config config) =
     Config { config | onBlur = Just value }
+
+
+preventKeydownOn : List (Decode.Decoder msg) -> Config msg -> Config msg
+preventKeydownOn decoders (Config config) =
+    Config { config | preventKeydownOn = decoders }
 
 
 href : String -> Config msg -> Config msg


### PR DESCRIPTION
This adds the ability to prevent default behaviour on keydown when
interacting with the button.

The modifier function takes a list of decoders provided by the consumer.
The successful decoders will prevent default behaviour.

## Example
Say we want to prevent default behaviour when the user presses 'tab' on the button.

```
Button.view (Button.default |> Button.preventKeydownOn [isTabDecoder]) "Button"
```

## Why is this being added now?
The elm Modal component handles focus lock which is important for overall modal accessibility. It internally uses the Button component and needs to be able to prevent the default behaviour of the Tab key in specific situations 

e.g. When the user is focused on the first focusable element and shift/tabs. We prevent the native tab which will place the focus somewhere outside the modal and instead focus the last focusable element thus creating the "lock".