### PR TITLE
feat: Uplift Empty State with Greycliff headings

### DIFF
--- a/packages/component-library/draft/Kaizen/EmptyState/EmptyState.tsx
+++ b/packages/component-library/draft/Kaizen/EmptyState/EmptyState.tsx
@@ -34,6 +34,7 @@ export type EmptyStateProps = {
   straightCorners?: boolean
   illustrationType?: IllustrationType
   layoutContext?: LayoutContextType
+  useZenStyles?: boolean
   children?: React.ReactNode
 }
 
@@ -48,6 +49,7 @@ const EmptyState: EmptyState = ({
   bodyText,
   children,
   straightCorners,
+  useZenStyles,
 }) => (
   <div
     className={classnames([
@@ -64,7 +66,9 @@ const EmptyState: EmptyState = ({
         className={styles.illustration}
       />
     </div>
-    <div className={styles.textSide}>
+    <div
+      className={classnames([styles.textSide, { [styles.zen]: useZenStyles }])}
+    >
       <div className={styles.textSideInner}>
         <div className={styles.heading}>{headingText}</div>
         <div className={styles.description}>{bodyText}</div>

--- a/packages/component-library/draft/Kaizen/EmptyState/styles.scss
+++ b/packages/component-library/draft/Kaizen/EmptyState/styles.scss
@@ -1,7 +1,8 @@
 @import "~@kaizen/design-tokens/sass/color";
-@import "~@kaizen/component-library/styles/color";
 @import "~@kaizen/component-library/styles/border";
 @import "~@kaizen/component-library/styles/type";
+@import "~@kaizen/deprecated-component-library-helpers/styles/color";
+@import "~@kaizen/deprecated-component-library-helpers/styles/type";
 @import "./responsive";
 
 .container {
@@ -139,6 +140,27 @@
     }
   }
 }
+
+// ===================================================
+// This works with the temporary useZenStyles prop and
+// will enable Zen headings. This block can be removed
+// once these typography styles are the default.
+.zen .heading {
+  @include kz-typography-heading-3;
+
+  .sidebarAndContent & {
+    @include large-sidebar-and-content {
+      @include kz-typography-heading-2;
+    }
+  }
+
+  .contentOnly & {
+    @include large-content-only {
+      @include kz-typography-heading-2;
+    }
+  }
+}
+// ===================================================
 
 .description {
   @include ca-type-ideal-lede;

--- a/packages/component-library/draft/Kaizen/EmptyState/styles.scss
+++ b/packages/component-library/draft/Kaizen/EmptyState/styles.scss
@@ -1,6 +1,5 @@
 @import "~@kaizen/design-tokens/sass/color";
 @import "~@kaizen/component-library/styles/border";
-@import "~@kaizen/component-library/styles/type";
 @import "~@kaizen/deprecated-component-library-helpers/styles/color";
 @import "~@kaizen/deprecated-component-library-helpers/styles/type";
 @import "./responsive";

--- a/packages/component-library/stories/EmptyState.stories.tsx
+++ b/packages/component-library/stories/EmptyState.stories.tsx
@@ -37,6 +37,7 @@ export const DefaultKaizenSiteDemo = () => (
       headingText="Empty state title"
       bodyText="If providing further actions, include a link to an action or use a
           Default or Primary action."
+      useZenStyles
     />
   </SidebarAndContentLayout>
 )
@@ -52,6 +53,7 @@ export const LayoutSidebarContent = () => (
       bodyText="If providing further actions, include a link to an action or use a
           Default or Primary action."
       layoutContext="sidebarAndContent"
+      useZenStyles
     />
   </SidebarAndContentLayout>
 )
@@ -67,6 +69,7 @@ export const LayoutContentOnly = () => (
       bodyText="If providing further actions, include a link to an action or use a
           Default or Primary action."
       layoutContext="contentOnly"
+      useZenStyles
     />
   </ContentOnlyLayout>
 )
@@ -82,6 +85,7 @@ export const Positive = () => (
       bodyText="If providing further actions, include a link to an action or use a
           Default or Primary action."
       illustrationType="positive"
+      useZenStyles
     >
       <div className={styles.buttonContainer}>
         <Button
@@ -102,11 +106,33 @@ export const Informative = () => (
       bodyText="If providing further actions, include a link to an action or use a
           Default or Primary action."
       illustrationType="informative"
+      useZenStyles
     />
   </SidebarAndContentLayout>
 )
 
 export const Action = () => (
+  <SidebarAndContentLayout>
+    <EmptyState
+      headingText="Action empty state"
+      bodyText="If providing further actions, include a link to an action or use a
+          Default or Primary action."
+      illustrationType="action"
+      useZenStyles
+    >
+      <div className={styles.buttonContainer}>
+        <Button
+          label="Label"
+          icon={chevronRight}
+          iconPosition="end"
+          fullWidth
+        />
+      </div>
+    </EmptyState>
+  </SidebarAndContentLayout>
+)
+
+export const ActionButNotZen = () => (
   <SidebarAndContentLayout>
     <EmptyState
       headingText="Action empty state"
@@ -126,6 +152,10 @@ export const Action = () => (
   </SidebarAndContentLayout>
 )
 
+ActionButNotZen.story = {
+  name: "Action (pre-Zen legacy styles)",
+}
+
 export const ActionButton = () => (
   <SidebarAndContentLayout>
     <EmptyState
@@ -137,6 +167,7 @@ export const ActionButton = () => (
         </p>
       }
       illustrationType="action"
+      useZenStyles
     >
       <div className={styles.buttonContainer}>
         <Button
@@ -162,6 +193,7 @@ export const Neutral = () => (
       bodyText="If providing further actions, include a link to an action or use a
           Default or Primary action."
       illustrationType="neutral"
+      useZenStyles
     />
   </SidebarAndContentLayout>
 )
@@ -173,6 +205,7 @@ export const Negative = () => (
       bodyText="If providing further actions, include a link to an action or use a
           Default or Primary action."
       illustrationType="negative"
+      useZenStyles
     >
       <div className={styles.buttonContainer}>
         <Button
@@ -194,6 +227,7 @@ export const RtlAction = () => (
         bodyText="If providing further actions, include a link to an action or use a
           Default or Primary action."
         illustrationType="action"
+        useZenStyles
       >
         <div className={styles.buttonContainer}>
           <Button
@@ -220,6 +254,7 @@ export const StraightCorners = () => (
           Default or Primary action."
       illustrationType="action"
       straightCorners
+      useZenStyles
     >
       <div className={styles.buttonContainer}>
         <Button label="Label" icon={chevronLeft} iconPosition="end" fullWidth />


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/6406263/75134029-1c6ad980-5731-11ea-9855-c882068cddc1.png)

## Changes
- adds optional Zen headings (using the Greycliff font), controlled by a boolean `useZenStyles` prop that is false by default
- updates all Storybook stories to use this prop by default
- adds an extra Storybook story to demonstrate the legacy version without the prop

## Context
Design Systems Team is uplifting Murmur now, and Perform soon. Murmur uses the Empty State component consistently, but Perform uses a forked version of it _except in one particular case where it uses the Kaizen Empty State_.

Because of this, we want to uplift the Empty State as part of our Murmur work without making the single Empty State instance in Perform look strange. This prop means we can ship the Murmur uplift by using the prop without affecting the instance of it in Perform.

The Perform Empty State can then be uplifted as part of the Perform rollout.