### PR TITLE
fix: Use correct import path for hosted-assets sass file in fonts

### DIFF
--- a/packages/component-library/styles/fonts.scss
+++ b/packages/component-library/styles/fonts.scss
@@ -1,4 +1,4 @@
-@import "~@kaizen/hosted-assets";
+@import "~@kaizen/hosted-assets/index";
 
 // =============== GREYCLIFF ===============
 


### PR DESCRIPTION
### Problem
Webpack will resolve to the JavaScript index file and tries to parse it as Sass, for some reason (at least in BFR)
![Screen Shot 2020-02-25 at 3 25 56 pm](https://user-images.githubusercontent.com/7019081/75215252-33b6cf00-57e4-11ea-951c-51dd82b7988a.png)

### Solution
Update the import path to directly reference the name of the file