### PR TITLE
fix: Bump design-tokens peer dependency

### DIFF
--- a/packages/component-library/package.json
+++ b/packages/component-library/package.json
@@ -26,7 +26,7 @@
   "private": false,
   "license": "MIT",
   "peerDependencies": {
-    "@kaizen/design-tokens": "0.x",
+    "@kaizen/design-tokens": "^1.2.0",
     "focus-visible": "^4.1.5",
     "react": "^16.9.0"
   },


### PR DESCRIPTION
![Screen Shot 2020-02-26 at 1 34 37 pm](https://user-images.githubusercontent.com/7019081/75306333-db8fd380-589c-11ea-9b4a-94ee3ab15fb0.png)

### Problem
The `Text.module.scss` file is importing a file that doesn't exist in the version of `design-tokens` that's listed as the peer dependency.

### Solution
Bump to the correct version