### PR TITLE
fix: Added @kaizen/hosted-assets as a dependency of component library

### DIFF
--- a/packages/component-library/package.json
+++ b/packages/component-library/package.json
@@ -32,6 +32,7 @@
   },
   "dependencies": {
     "@kaizen/deprecated-component-library-helpers": "1.3.0",
+    "@kaizen/hosted-assets": "^1.0.1",
     "@types/classnames": "^2.2.6",
     "@types/lodash": "^4.14.132",
     "@types/react-select": "^3.0.5",


### PR DESCRIPTION
fix: Added @kaizen/hosted-assets as a dependency of @kaizen/component-library, as it is used in font-face.scss


see here: https://github.com/cultureamp/kaizen-design-system/blob/master/packages/component-library/styles/type.scss#L1

