### PR TITLE
feat: return focus on modal close

### DIFF
--- a/packages/component-library/stories/ModalStories.elm
+++ b/packages/component-library/stories/ModalStories.elm
@@ -89,7 +89,11 @@ update msg state =
         SetModalContext ->
             let
                 modalState =
-                    Modal.trigger Modal.initialState
+                    Modal.trigger
+                        (Modal.initialState
+                            -- focus on the element with this id when the modal closes
+                            |> Modal.focusElementWhenClosed (Modal.returnFocusableId "modal-invoker-element")
+                        )
             in
             ( { state | idealWayToSetUpModal = True, modalContext = Just modalState }, Cmd.none )
 
@@ -222,7 +226,12 @@ main =
         , storyOf "Confirmation (User action)" config <|
             \m ->
                 div []
-                    [ Button.view (Button.default |> Button.onClick SetModalContext) "Open Modal"
+                    [ Button.view
+                        (Button.default
+                            |> Button.onClick SetModalContext
+                            |> Button.id "modal-invoker-element"
+                        )
+                        "Open Modal"
                     , if m.idealWayToSetUpModal then
                         case m.modalContext of
                             Just modalState ->


### PR DESCRIPTION
This feature addresses issue #307 

The modal should return focus to some logical element after it closes. This PR allows the consumer to set the ID of an element which the modal update will try set focus on when it completes its closing animation.