### PR TITLE
fix: add missing @kaizen/design-tokens dependency to deprecated-component-library-helpers

### DIFF
--- a/packages/deprecated-component-library-helpers/package.json
+++ b/packages/deprecated-component-library-helpers/package.json
@@ -14,5 +14,8 @@
   ],
   "sideEffects": false,
   "private": false,
-  "license": "MIT"
+  "license": "MIT",
+  "dependencies": {
+    "@kaizen/design-tokens": "^1.2.0"
+  }
 }


### PR DESCRIPTION
I don't know that this is currently specifically causing any issues, but it's a timebomb waiting to happen.

This would break any consuming project that doesn't have `@kaizen/design-tokens` somewhere in the `node_modules` hierarchy.