### PR TITLE
feat: use zen css styling for Elm Empty State by default

### DIFF
--- a/packages/component-library/draft/Kaizen/EmptyState/EmptyState.elm
+++ b/packages/component-library/draft/Kaizen/EmptyState/EmptyState.elm
@@ -198,6 +198,7 @@ view (Config config) =
                     [ ( .container, True )
                     , ( .sidebarAndContent, config.layoutContext == SidebarAndContent )
                     , ( .contentOnly, config.layoutContext == ContentOnly )
+                    , ( .zen, True )
                     ]
                ]
         )
@@ -222,6 +223,7 @@ styles =
         , textSide = "textSide"
         , illustration = "illustration"
         , textSideInner = "textSideInner"
+        , zen = "zen"
         , heading = "heading"
         , description = "description"
         , sidebarAndContent = "sidebarAndContent"


### PR DESCRIPTION
Before:

<img width="1109" alt="image" src="https://user-images.githubusercontent.com/702885/75738015-42a60000-5d55-11ea-9dc4-be6ada510ffd.png">



After:

<img width="1109" alt="image" src="https://user-images.githubusercontent.com/702885/75738055-60736500-5d55-11ea-8ef1-f7a24ac3fdd4.png">
