### PR TITLE
feat: Paragraph component for React

### DIFF
--- a/packages/component-library/components/Paragraph/Paragraph.module.scss
+++ b/packages/component-library/components/Paragraph/Paragraph.module.scss
@@ -1,0 +1,41 @@
+@import "~@kaizen/design-tokens/sass/typography";
+@import "~@kaizen/design-tokens/sass/color";
+@import "~@kaizen/component-library/styles/fonts";
+@import "~@kaizen/deprecated-component-library-helpers/styles/type";
+
+.paragraph {
+  color: $kz-color-wisteria-800;
+  margin: 0;
+}
+
+.intro-lede {
+  font-family: $kz-typography-paragraph-intro-lede-font-family;
+  font-weight: $kz-typography-paragraph-intro-lede-font-weight;
+  font-size: $kz-typography-paragraph-intro-lede-font-size;
+  line-height: $kz-typography-paragraph-intro-lede-line-height;
+  letter-spacing: $kz-typography-paragraph-intro-lede-letter-spacing;
+}
+
+.body {
+  font-family: $kz-typography-paragraph-body-font-family;
+  font-weight: $kz-typography-paragraph-body-font-weight;
+  font-size: $kz-typography-paragraph-body-font-size;
+  line-height: $kz-typography-paragraph-body-line-height;
+  letter-spacing: $kz-typography-paragraph-body-letter-spacing;
+}
+
+.small {
+  font-family: $kz-typography-paragraph-small-font-family;
+  font-weight: $kz-typography-paragraph-small-font-weight;
+  font-size: $kz-typography-paragraph-small-font-size;
+  line-height: $kz-typography-paragraph-small-line-height;
+  letter-spacing: $kz-typography-paragraph-small-letter-spacing;
+}
+
+.extra-small {
+  font-family: $kz-typography-paragraph-extra-small-font-family;
+  font-weight: $kz-typography-paragraph-extra-small-font-weight;
+  font-size: $kz-typography-paragraph-extra-small-font-size;
+  line-height: $kz-typography-paragraph-extra-small-line-height;
+  letter-spacing: $kz-typography-paragraph-extra-small-letter-spacing;
+}

--- a/packages/component-library/components/Paragraph/Paragraph.spec.tsx
+++ b/packages/component-library/components/Paragraph/Paragraph.spec.tsx
@@ -1,0 +1,94 @@
+import { cleanup, render } from "@testing-library/react"
+import * as React from "react"
+import { AllowedTags, Paragraph, ParagraphVariants } from "./index"
+
+afterEach(cleanup)
+
+describe("<Paragraph />", () => {
+  describe("renders the correct classes", () => {
+    const testCases: ParagraphVariants[] = [
+      "intro-lede",
+      "body",
+      "small",
+      "extra-small",
+    ]
+
+    testCases.forEach(variant => {
+      it(`renders the correct element for <Paragraph variant={${variant}} />`, () => {
+        const paragraphMock = render(
+          <Paragraph variant={variant} tag="div">
+            Example
+          </Paragraph>
+        )
+        const paragraphClasslist = paragraphMock.getByText("Example").classList
+        expect(paragraphClasslist).toContain("paragraph")
+        expect(paragraphClasslist).toContain(variant)
+      })
+    })
+  })
+
+  describe("changes rendered HTML element when passed tag", () => {
+    const testCases: ParagraphVariants[] = [
+      "intro-lede",
+      "body",
+      "small",
+      "extra-small",
+    ]
+
+    testCases.forEach(variant => {
+      it(`renders the correct element for <Paragraph variant={${variant}} />`, () => {
+        const paragraphMock = render(
+          <Paragraph variant={variant} tag="div">
+            Example
+          </Paragraph>
+        )
+        expect(paragraphMock.getByText("Example").tagName).toBe("DIV")
+      })
+    })
+  })
+
+  it("passes through data attributes", () => {
+    const { container } = render(
+      <Paragraph variant="intro-lede" data-automation-id="test-id">
+        Example
+      </Paragraph>
+    )
+    expect(
+      container.querySelector('[data-automation-id="test-id"]')
+    ).not.toBeNull()
+  })
+
+  describe("defaults to the correct HTML element", () => {
+    type TestObject = { variant: ParagraphVariants; el: AllowedTags }
+    const testCases: TestObject[] = [
+      { variant: "intro-lede", el: "p" },
+      { variant: "body", el: "p" },
+      { variant: "small", el: "p" },
+      { variant: "extra-small", el: "p" },
+    ]
+
+    testCases.forEach(({ variant, el }) => {
+      it(`renders the correct element for <Paragraph variant={${variant}} />`, () => {
+        const paragraphMock = render(
+          <Paragraph variant={variant}>Example</Paragraph>
+        )
+        expect(paragraphMock.getByText("Example").tagName.toLowerCase()).toBe(
+          el
+        )
+        expect(paragraphMock.baseElement).toMatchSnapshot()
+      })
+    })
+  })
+
+  it("allows consumers to provide a className", () => {
+    const { getByText } = render(
+      <Paragraph
+        variant="body"
+        classNameAndIHaveSpokenToDST="example-classname"
+      >
+        Example
+      </Paragraph>
+    )
+    expect(getByText("Example").classList).toContain("example-classname")
+  })
+})

--- a/packages/component-library/components/Paragraph/Paragraph.tsx
+++ b/packages/component-library/components/Paragraph/Paragraph.tsx
@@ -1,0 +1,46 @@
+import classNames from "classnames"
+import { createElement } from "react"
+
+const styles = require("./Paragraph.module.scss")
+
+export type ParagraphVariants = "intro-lede" | "body" | "small" | "extra-small"
+
+export type AllowedTags =
+  | "pre"
+  | "p"
+  | "a"
+  | "div"
+  | "span"
+  | "h1"
+  | "h2"
+  | "h3"
+  | "h4"
+  | "h5"
+  | "h6"
+
+export interface ParagraphProps {
+  classNameAndIHaveSpokenToDST?: string
+  children: React.ReactNode
+  tag?: AllowedTags
+  variant: ParagraphVariants
+}
+
+export const Paragraph = ({
+  classNameAndIHaveSpokenToDST,
+  children,
+  tag,
+  variant,
+  ...otherProps
+}: ParagraphProps) => {
+  const classes: string[] = [
+    styles.paragraph,
+    styles[variant],
+    classNameAndIHaveSpokenToDST,
+  ]
+
+  return createElement(
+    tag === undefined ? "p" : tag,
+    { ...otherProps, className: classNames(classes) },
+    children
+  )
+}

--- a/packages/component-library/components/Paragraph/__snapshots__/Paragraph.spec.tsx.snap
+++ b/packages/component-library/components/Paragraph/__snapshots__/Paragraph.spec.tsx.snap
@@ -1,0 +1,49 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<Paragraph /> defaults to the correct HTML element renders the correct element for <Paragraph variant={body} /> 1`] = `
+<body>
+  <div>
+    <p
+      class="paragraph body"
+    >
+      Example
+    </p>
+  </div>
+</body>
+`;
+
+exports[`<Paragraph /> defaults to the correct HTML element renders the correct element for <Paragraph variant={extra-small} /> 1`] = `
+<body>
+  <div>
+    <p
+      class="paragraph extra-small"
+    >
+      Example
+    </p>
+  </div>
+</body>
+`;
+
+exports[`<Paragraph /> defaults to the correct HTML element renders the correct element for <Paragraph variant={intro-lede} /> 1`] = `
+<body>
+  <div>
+    <p
+      class="paragraph intro-lede"
+    >
+      Example
+    </p>
+  </div>
+</body>
+`;
+
+exports[`<Paragraph /> defaults to the correct HTML element renders the correct element for <Paragraph variant={small} /> 1`] = `
+<body>
+  <div>
+    <p
+      class="paragraph small"
+    >
+      Example
+    </p>
+  </div>
+</body>
+`;

--- a/packages/component-library/components/Paragraph/index.tsx
+++ b/packages/component-library/components/Paragraph/index.tsx
@@ -1,0 +1,1 @@
+export * from "./Paragraph"

--- a/packages/component-library/stories/Paragraph.stories.tsx
+++ b/packages/component-library/stories/Paragraph.stories.tsx
@@ -4,17 +4,19 @@ import { Paragraph } from "../components/Paragraph"
 export default { title: "typography/Paragraph" }
 
 export const IntroLede = () => (
-  <Paragraph variant="intro-lede">Intro Lede</Paragraph>
+  <Paragraph variant="intro-lede">Paragraph Intro Lede</Paragraph>
 )
 
 export const Body = () => (
   <Paragraph data-automation-id="test" variant="body">
-    Body
+    Paragraph Body
   </Paragraph>
 )
 
-export const Small = () => <Paragraph variant="small">Small</Paragraph>
+export const Small = () => (
+  <Paragraph variant="small">Paragraph Small</Paragraph>
+)
 
 export const ExtraSmall = () => (
-  <Paragraph variant="extra-small">Extra Small</Paragraph>
+  <Paragraph variant="extra-small">Paragraph Extra Small</Paragraph>
 )

--- a/packages/component-library/stories/Paragraph.stories.tsx
+++ b/packages/component-library/stories/Paragraph.stories.tsx
@@ -1,0 +1,20 @@
+import * as React from "react"
+import { Paragraph } from "../components/Paragraph"
+
+export default { title: "typography/Paragraph" }
+
+export const IntroLede = () => (
+  <Paragraph variant="intro-lede">Intro Lede</Paragraph>
+)
+
+export const Body = () => (
+  <Paragraph data-automation-id="test" variant="body">
+    Body
+  </Paragraph>
+)
+
+export const Small = () => <Paragraph variant="small">Small</Paragraph>
+
+export const ExtraSmall = () => (
+  <Paragraph variant="extra-small">Extra Small</Paragraph>
+)


### PR DESCRIPTION
Paragraph only has one required prop, which is variant. The options are identical to the Zen UI Kit in Figma: `intro-lede`, `body`, `small`, `extra-small`. 

Usage is similar to the Heading component: 
```
<Paragraph variant="body">
   Some text, or nest other <Link>Components</Link>.
</Paragraph>
```

`data-*`, `tag` and `classNameAndIHaveSpokenToDST` are all optional props. 