### PR TITLE
fix: Fix Title Block color bug

### DIFF
--- a/packages/component-library/draft/Kaizen/TitleBlock/TitleBlock.scss
+++ b/packages/component-library/draft/Kaizen/TitleBlock/TitleBlock.scss
@@ -7,8 +7,6 @@
 @import "~@kaizen/component-library/styles/responsive";
 @import "~@kaizen/component-library/styles/animation";
 
-$kz-color-wisteria-700-copy: #4b4d68; // temporary until we update Kaizen to Zen colour theme and get this from tokens package
-
 .titleBlockContainer {
   color: $kz-color-wisteria-800;
   width: 100%;
@@ -517,12 +515,12 @@ $kz-color-wisteria-700-copy: #4b4d68; // temporary until we update Kaizen to Zen
 .stickyColorWisteria {
   @include ca-media-tablet-and-up {
     .titleBlock {
-      background-color: $kz-color-wisteria-700-copy;
+      background-color: $kz-color-wisteria-700;
     }
   }
   @include ca-media-mobile {
     .navContainer {
-      background-color: $kz-color-wisteria-700-copy;
+      background-color: $kz-color-wisteria-700;
     }
   }
 }

--- a/packages/component-library/draft/Kaizen/TitleBlock/TitleBlock.scss
+++ b/packages/component-library/draft/Kaizen/TitleBlock/TitleBlock.scss
@@ -10,13 +10,13 @@
 $kz-color-wisteria-700-copy: #4b4d68; // temporary until we update Kaizen to Zen colour theme and get this from tokens package
 
 .titleBlockContainer {
+  color: $kz-color-wisteria-800;
   width: 100%;
 }
 
 .titleBlock {
   background-color: #fff;
   border-bottom: 1px solid $ca-border-color;
-  color: $kz-color-wisteria-800;
   width: inherit;
 
   @media print {


### PR DESCRIPTION
## Bug

There was a recent update to the Title Block that added an explicit color rule, so that the Title Block would stop inheriting its default text color from its container.

Unfortunately the color rule was put on the wrong class, so that the `.reversed` class that overrides the color with `#fff` was not overriding it properly, leading to the following bug (see barely visible Wisteria text):

![image](https://user-images.githubusercontent.com/6406263/76375133-2cbdbe00-6399-11ea-852a-dd5ea2523e95.png)

This PR moves it to the correct class.
