### PR TITLE
feat: Paragraph component for Elm

### DIFF
--- a/packages/component-library/components/Paragraph/Paragraph.elm
+++ b/packages/component-library/components/Paragraph/Paragraph.elm
@@ -1,0 +1,225 @@
+module Paragraph.Paragraph exposing
+    ( Config
+    , DataAttribute
+    , TypeVariant(..)
+    , a
+    , addDataAttribute
+    , classNameAndIHaveSpokenToDST
+    , div
+    , h1
+    , h2
+    , h3
+    , h4
+    , h5
+    , h6
+    , id
+    , p
+    , pre
+    , span
+    , tag
+    , variant
+    , view
+    )
+
+import CssModules exposing (css)
+import Debug exposing (log)
+import Html exposing (text)
+import Html.Attributes
+import List
+
+
+type Config msg
+    = Config (ConfigValue msg)
+
+
+type alias Element msg =
+    List (Html.Attribute msg) -> List (Html.Html msg) -> Html.Html msg
+
+
+type alias DataAttribute =
+    { name : String
+    , value : String
+    }
+
+
+type alias ConfigValue msg =
+    { tag : Maybe (Element msg)
+    , variant : TypeVariant
+    , id : Maybe String
+    , dataAttribute : List DataAttribute
+    , classNameAndIHaveSpokenToDST : Maybe String
+    }
+
+
+defaultConfig : ConfigValue msg
+defaultConfig =
+    { tag = Nothing
+    , variant = Body
+    , id = Nothing
+    , dataAttribute = []
+    , classNameAndIHaveSpokenToDST = Nothing
+    }
+
+
+toUntypedDataAttribute : DataAttribute -> Html.Attribute msg
+toUntypedDataAttribute typedAttribute =
+    case typedAttribute of
+        { name, value } ->
+            Html.Attributes.attribute ("data-" ++ name) value
+
+
+
+-- VIEW
+
+
+view : Config msg -> List (Html.Html msg) -> Html.Html msg
+view (Config config) children =
+    let
+        resolveId =
+            case config.id of
+                Just id_ ->
+                    [ Html.Attributes.id id_ ]
+
+                Nothing ->
+                    []
+
+        resolveAttributes =
+            List.map toUntypedDataAttribute config.dataAttribute
+
+        resolveTag =
+            case config.tag of
+                Just tag_ ->
+                    tag_
+
+                Nothing ->
+                    Html.p
+
+        resolveCustomClass =
+            config.classNameAndIHaveSpokenToDST |> Maybe.withDefault ""
+    in
+    resolveTag
+        ([ className config.variant ] ++ [ Html.Attributes.class resolveCustomClass ] ++ resolveId ++ resolveAttributes)
+        children
+
+
+className : TypeVariant -> Html.Attribute msg
+className typeVariant =
+    let
+        styleClass =
+            case typeVariant of
+                IntroLede ->
+                    .introLede
+
+                Body ->
+                    .body
+
+                Small ->
+                    .small
+
+                ExtraSmall ->
+                    .extraSmall
+    in
+    styles.classList
+        [ ( styleClass, True )
+        , ( .paragraph, True )
+        ]
+
+
+styles =
+    css "@kaizen/component-library/components/Paragraph/Paragraph.module.scss"
+        { paragraph = "paragraph"
+        , introLede = "intro-lede"
+        , body = "body"
+        , small = "small"
+        , extraSmall = "extra-small"
+        }
+
+
+type TypeVariant
+    = IntroLede
+    | Body
+    | Small
+    | ExtraSmall
+
+
+
+-- MODIFIERS
+
+
+pre : Config msg
+pre =
+    Config { defaultConfig | tag = Just Html.pre }
+
+
+p : Config msg
+p =
+    Config { defaultConfig | tag = Just Html.p }
+
+
+a : Config msg
+a =
+    Config { defaultConfig | tag = Just Html.a }
+
+
+div : Config msg
+div =
+    Config { defaultConfig | tag = Just Html.div }
+
+
+span : Config msg
+span =
+    Config { defaultConfig | tag = Just Html.span }
+
+
+h1 : Config msg
+h1 =
+    Config { defaultConfig | tag = Just Html.h1 }
+
+
+h2 : Config msg
+h2 =
+    Config { defaultConfig | tag = Just Html.h2 }
+
+
+h3 : Config msg
+h3 =
+    Config { defaultConfig | tag = Just Html.h3 }
+
+
+h4 : Config msg
+h4 =
+    Config { defaultConfig | tag = Just Html.h4 }
+
+
+h5 : Config msg
+h5 =
+    Config { defaultConfig | tag = Just Html.h5 }
+
+
+h6 : Config msg
+h6 =
+    Config { defaultConfig | tag = Just Html.h6 }
+
+
+variant : TypeVariant -> Config msg -> Config msg
+variant value (Config config) =
+    Config { config | variant = value }
+
+
+id : String -> Config msg -> Config msg
+id id_ (Config config) =
+    Config { config | id = Just id_ }
+
+
+classNameAndIHaveSpokenToDST : String -> Config msg -> Config msg
+classNameAndIHaveSpokenToDST value (Config config) =
+    Config { config | classNameAndIHaveSpokenToDST = Just value }
+
+
+addDataAttribute : DataAttribute -> Config msg -> Config msg
+addDataAttribute attribute_ (Config config) =
+    Config { config | dataAttribute = config.dataAttribute ++ [ attribute_ ] }
+
+
+tag tag_ (Config config) =
+    Config { config | id = Just tag_ }

--- a/packages/component-library/components/Paragraph/Paragraph.module.scss
+++ b/packages/component-library/components/Paragraph/Paragraph.module.scss
@@ -1,0 +1,41 @@
+@import "~@kaizen/design-tokens/sass/typography";
+@import "~@kaizen/design-tokens/sass/color";
+@import "~@kaizen/component-library/styles/fonts";
+@import "~@kaizen/deprecated-component-library-helpers/styles/type";
+
+.paragraph {
+  color: $kz-color-wisteria-800;
+  margin: 0;
+}
+
+.intro-lede {
+  font-family: $kz-typography-paragraph-intro-lede-font-family;
+  font-weight: $kz-typography-paragraph-intro-lede-font-weight;
+  font-size: $kz-typography-paragraph-intro-lede-font-size;
+  line-height: $kz-typography-paragraph-intro-lede-line-height;
+  letter-spacing: $kz-typography-paragraph-intro-lede-letter-spacing;
+}
+
+.body {
+  font-family: $kz-typography-paragraph-body-font-family;
+  font-weight: $kz-typography-paragraph-body-font-weight;
+  font-size: $kz-typography-paragraph-body-font-size;
+  line-height: $kz-typography-paragraph-body-line-height;
+  letter-spacing: $kz-typography-paragraph-body-letter-spacing;
+}
+
+.small {
+  font-family: $kz-typography-paragraph-small-font-family;
+  font-weight: $kz-typography-paragraph-small-font-weight;
+  font-size: $kz-typography-paragraph-small-font-size;
+  line-height: $kz-typography-paragraph-small-line-height;
+  letter-spacing: $kz-typography-paragraph-small-letter-spacing;
+}
+
+.extra-small {
+  font-family: $kz-typography-paragraph-extra-small-font-family;
+  font-weight: $kz-typography-paragraph-extra-small-font-weight;
+  font-size: $kz-typography-paragraph-extra-small-font-size;
+  line-height: $kz-typography-paragraph-extra-small-line-height;
+  letter-spacing: $kz-typography-paragraph-extra-small-letter-spacing;
+}

--- a/packages/component-library/stories/Paragraph.stories.elm
+++ b/packages/component-library/stories/Paragraph.stories.elm
@@ -1,0 +1,27 @@
+module Main exposing (main)
+
+import CssModules exposing (css)
+import ElmStorybook exposing (statelessStoryOf, storybook)
+import Html exposing (text)
+import Paragraph.Paragraph as Paragraph exposing (TypeVariant(..), view)
+
+
+main =
+    storybook
+        [ statelessStoryOf "IntroLede" <|
+            Paragraph.view
+                (Paragraph.p |> Paragraph.variant IntroLede)
+                [ Html.text "IntroLede Paragraph" ]
+        , statelessStoryOf "Body" <|
+            Paragraph.view
+                (Paragraph.p |> Paragraph.variant Body)
+                [ Html.text "Body Paragraph" ]
+        , statelessStoryOf "Small" <|
+            Paragraph.view
+                (Paragraph.p |> Paragraph.variant Small)
+                [ Html.text "Small Paragraph" ]
+        , statelessStoryOf "ExtraSmall" <|
+            Paragraph.view
+                (Paragraph.p |> Paragraph.variant ExtraSmall)
+                [ Html.text "ExtraSmall Paragraph" ]
+        ]

--- a/packages/component-library/stories/Paragraph.stories.elm
+++ b/packages/component-library/stories/Paragraph.stories.elm
@@ -11,17 +11,17 @@ main =
         [ statelessStoryOf "IntroLede" <|
             Paragraph.view
                 (Paragraph.p |> Paragraph.variant IntroLede)
-                [ Html.text "IntroLede Paragraph" ]
+                [ Html.text "Paragraph Intro Lede " ]
         , statelessStoryOf "Body" <|
             Paragraph.view
                 (Paragraph.p |> Paragraph.variant Body)
-                [ Html.text "Body Paragraph" ]
+                [ Html.text "Paragraph Body" ]
         , statelessStoryOf "Small" <|
             Paragraph.view
                 (Paragraph.p |> Paragraph.variant Small)
-                [ Html.text "Small Paragraph" ]
+                [ Html.text "Paragraph Small" ]
         , statelessStoryOf "ExtraSmall" <|
             Paragraph.view
                 (Paragraph.p |> Paragraph.variant ExtraSmall)
-                [ Html.text "ExtraSmall Paragraph" ]
+                [ Html.text "Paragraph Extra Small" ]
         ]

--- a/packages/component-library/stories/Paragraph.stories.tsx
+++ b/packages/component-library/stories/Paragraph.stories.tsx
@@ -1,0 +1,8 @@
+import { loadElmStories } from "@cultureamp/elm-storybook"
+
+loadElmStories("Paragraph (Elm)", module, require("./Paragraph.stories.elm"), [
+  "IntroLede",
+  "Body",
+  "Small",
+  "ExtraSmall",
+])


### PR DESCRIPTION
Usage is very similar to the Heading component for Elm. Variant is the only required property, and there's also support for tags, classNames (AndIHaveSpokenToDST), ids, and data attributes.

```
Paragraph.view
                (Paragraph.p |> Paragraph.variant IntroLede)
                [ Html.text "IntroLede Paragraph" ]
```