### PR TITLE
fix: make Heading component support Gatsby's webpack conf

### DIFF
--- a/packages/component-library/components/Heading/Heading.module.scss
+++ b/packages/component-library/components/Heading/Heading.module.scss
@@ -3,12 +3,16 @@
 @import "~@kaizen/component-library/styles/fonts";
 @import "~@kaizen/deprecated-component-library-helpers/styles/type";
 
+// NOTE: we are intentionally not using dashes like the variant names, because Gatsby's webpack
+// config automatically camelCases classnames. So we need to use camelcase so that the behaviour is
+// the same outside of Gatsby
+
 .heading {
   color: $kz-color-wisteria-800;
   margin: 0;
 }
 
-.display-0 {
+.display0 {
   font-family: $kz-typography-display-0-font-family;
   font-weight: $kz-typography-display-0-font-weight;
   font-size: $kz-typography-display-0-font-size;
@@ -16,7 +20,7 @@
   letter-spacing: $kz-typography-display-0-letter-spacing;
 }
 
-.heading-1 {
+.heading1 {
   font-family: $kz-typography-heading-1-font-family;
   font-weight: $kz-typography-heading-1-font-weight;
   font-size: $kz-typography-heading-1-font-size;
@@ -24,7 +28,7 @@
   letter-spacing: $kz-typography-heading-1-letter-spacing;
 }
 
-.heading-2 {
+.heading2 {
   font-family: $kz-typography-heading-2-font-family;
   font-weight: $kz-typography-heading-2-font-weight;
   font-size: $kz-typography-heading-2-font-size;
@@ -32,7 +36,7 @@
   letter-spacing: $kz-typography-heading-2-letter-spacing;
 }
 
-.heading-3 {
+.heading3 {
   font-family: $kz-typography-heading-3-font-family;
   font-weight: $kz-typography-heading-3-font-weight;
   font-size: $kz-typography-heading-3-font-size;
@@ -40,7 +44,7 @@
   letter-spacing: $kz-typography-heading-3-letter-spacing;
 }
 
-.heading-4 {
+.heading4 {
   font-family: $kz-typography-heading-4-font-family;
   font-weight: $kz-typography-heading-4-font-weight;
   font-size: $kz-typography-heading-4-font-size;
@@ -48,7 +52,7 @@
   letter-spacing: $kz-typography-heading-4-letter-spacing;
 }
 
-.heading-5 {
+.heading5 {
   font-family: $kz-typography-heading-5-font-family;
   font-weight: $kz-typography-heading-5-font-weight;
   font-size: $kz-typography-heading-5-font-size;
@@ -56,7 +60,7 @@
   letter-spacing: $kz-typography-heading-5-letter-spacing;
 }
 
-.heading-6 {
+.heading6 {
   font-family: $kz-typography-heading-6-font-family;
   font-weight: $kz-typography-heading-6-font-weight;
   font-size: $kz-typography-heading-6-font-size;

--- a/packages/component-library/components/Heading/Heading.tsx
+++ b/packages/component-library/components/Heading/Heading.tsx
@@ -1,3 +1,4 @@
+import camelCase from "camelcase"
 import classNames from "classnames"
 import { createElement } from "react"
 
@@ -44,7 +45,7 @@ export const Heading = ({
 
   const classes: string[] = [
     styles.heading,
-    styles[variant],
+    styles[camelCase(variant)], // the variant name needs to be camelCased to match the CSS Modules class name
     classNameAndIHaveSpokenToDST,
   ]
 

--- a/packages/component-library/package.json
+++ b/packages/component-library/package.json
@@ -37,6 +37,7 @@
     "@types/lodash": "^4.14.132",
     "@types/react-select": "^3.0.5",
     "@types/uuid": "^3.4.4",
+    "camelcase": "^5.3.1",
     "classnames": "^2.2.6",
     "lodash": "^4.17.11",
     "motion-ui": "^2.0.3",


### PR DESCRIPTION
**WAIT**

There might be a better approach in customising Gatsby's webpack conf, so let's hold off on this.