### PR TITLE
build: Don't transform kebab-cased classnames in gatsby

### DIFF
--- a/site/gatsby-config.js
+++ b/site/gatsby-config.js
@@ -83,6 +83,7 @@ module.exports = {
         precision: 9,
         sassRuleModulesTest: /^(?!(.*normalize\.css$)).+\.s?css$/,
         cssLoaderOptions: {
+          camelCase: false,
           modules: true,
         },
       },


### PR DESCRIPTION
This change addresses an issue in the gatsby build for kaizen site, where kebab-cased classnames for the new `Heading` component were being dropped from the CSS modules classnames.

Example build: https://dev.cultureamp.design/louis/fix-gatsby-kebab-demo/