### PR TITLE
feat: Add max-width to Paragraph styles

### DIFF
--- a/packages/component-library/components/Paragraph/Paragraph.module.scss
+++ b/packages/component-library/components/Paragraph/Paragraph.module.scss
@@ -14,6 +14,7 @@
   font-size: $kz-typography-paragraph-intro-lede-font-size;
   line-height: $kz-typography-paragraph-intro-lede-line-height;
   letter-spacing: $kz-typography-paragraph-intro-lede-letter-spacing;
+  max-width: 60.9375rem; // 975px
 }
 
 .body {
@@ -22,6 +23,7 @@
   font-size: $kz-typography-paragraph-body-font-size;
   line-height: $kz-typography-paragraph-body-line-height;
   letter-spacing: $kz-typography-paragraph-body-letter-spacing;
+  max-width: 48.75rem; // 780px
 }
 
 .small {
@@ -30,6 +32,7 @@
   font-size: $kz-typography-paragraph-small-font-size;
   line-height: $kz-typography-paragraph-small-line-height;
   letter-spacing: $kz-typography-paragraph-small-letter-spacing;
+  max-width: 42.5rem; // 680px
 }
 
 .extra-small {
@@ -38,4 +41,5 @@
   font-size: $kz-typography-paragraph-extra-small-font-size;
   line-height: $kz-typography-paragraph-extra-small-line-height;
   letter-spacing: $kz-typography-paragraph-extra-small-letter-spacing;
+  max-width: 37.5rem; // 600px
 }


### PR DESCRIPTION
## Changes

Add a `max-width` rule to each paragraph style, according to its design.

These max-width values were taken from the Typography page of the Zen UI Kit in Figma:

![image](https://user-images.githubusercontent.com/6406263/76815083-bb768300-6850-11ea-9c2c-2ec21c1ded73.png)
