### PR TITLE
fix: Remove text margin in the button

### DIFF
--- a/packages/component-library/components/Button/styles.scss
+++ b/packages/component-library/components/Button/styles.scss
@@ -345,8 +345,6 @@ $caButton-verticalPaddingForm: calc(
   line-height: 1;
 
   &:only-child {
-    margin: 0 $ca-grid / 2;
-
     %caButtonSecondary & {
       margin: 0;
     }


### PR DESCRIPTION
If a button has a icon inside, the text only has the right/left margin
![image](https://user-images.githubusercontent.com/4084952/77018315-2d75d600-69d1-11ea-9d54-ec39505d407e.png)
![image](https://user-images.githubusercontent.com/4084952/77018319-31a1f380-69d1-11ea-97f8-6f2a650f68c2.png)

If a button has no icon inside, the text has the both right left margin which makes the button bigger
![image](https://user-images.githubusercontent.com/4084952/77018325-35ce1100-69d1-11ea-95d5-e7bc7059e5da.png)
![image](https://user-images.githubusercontent.com/4084952/77018332-3a92c500-69d1-11ea-8837-553e9f8029a2.png)
