### PR TITLE
fix: Add padding in dropdown

### DIFF
--- a/packages/component-library/components/Dropdown/Dropdown.module.scss
+++ b/packages/component-library/components/Dropdown/Dropdown.module.scss
@@ -4,9 +4,13 @@
 @import "../../styles/type";
 
 $width: 248px;
+$caButton-border-width: 1px;
+$caButton-verticalPadding: calc(#{$ca-grid / 2} - #{$caButton-border-width});
 
 .dropdown {
   position: relative;
+  padding: $caButton-verticalPadding
+    calc(#{$ca-grid * 1} - #{$caButton-border-width});
 }
 
 .buttonReset {

--- a/site/docs/components/icon-button.mdx
+++ b/site/docs/components/icon-button.mdx
@@ -6,6 +6,8 @@ summaryParagraph: |
 tags: ['Breadcrumb button', 'Button', 'Icon']
 needToKnow:
   - Default icon buttons perform actions using action icons without labels.
+  - Use a Primary icon button when it's the most important action to take.
+  - Use a Destructive icon button when the action will result in data loss, cannot be undone, or otherwise have significant consequences.
   - Breadcrumb icon buttons use link elements to navigate and must show a destination as text on hover/focus.
 demoStoryId: iconbutton-react--default-kaizen-site-demo
 ---
@@ -56,13 +58,7 @@ A breadcrumb icon button is an exceptional case that uses a link element instead
 
 ### Interaction guidelines
 
-| Icon color | Disabled    | Default/Inactive | Hover/Focus | Active/Pressed |
-| ---------- | ----------- | ---------------- | ----------- | -------------- |
-| Ink        | 30% opacity | 50% opacity      | 70% opacity | 100% opacity   |
-| White      | 30% opacity | 50% opacity      | 70% opacity | 100% opacity   |
-| Ocean      | 30% opacity | 50% opacity      | 70% opacity | 100% opacity   |
-
-In CSS, “Default/Inactive” maps to `initial` style, “Hover/Focus” to `:hover` and `:focus`, and “Active/Pressed” to `:active`.
+Disabled Icon Buttons use 30% opacity on the component itself (not, for example, the inner icon).
 
 ## When to use and when not to use
 


### PR DESCRIPTION
There is a padding around all buttons:
![image](https://user-images.githubusercontent.com/4084952/77019068-c0177480-69d3-11ea-8e87-bda6c29213fa.png)
But there is no padding around the dropdown:
![image](https://user-images.githubusercontent.com/4084952/77019081-cad20980-69d3-11ea-809b-e6965371003d.png)
So when we have button+dropdown, it looks like the edit icon is in the middle:
![image](https://user-images.githubusercontent.com/4084952/77019087-d3c2db00-69d3-11ea-8bb8-a3e42aac7a2f.png)
What's the new expected behaviour?
Add the same padding around the dropdown.
![image](https://user-images.githubusercontent.com/4084952/77019107-e0dfca00-69d3-11ea-8578-332125d3ca49.png)
![image](https://user-images.githubusercontent.com/4084952/77019118-e4735100-69d3-11ea-9c76-48915f3a4823.png)


