### PR TITLE
fix: revert "Remove text margin in the button"

### DIFF
--- a/packages/component-library/components/Button/styles.scss
+++ b/packages/component-library/components/Button/styles.scss
@@ -345,6 +345,8 @@ $caButton-verticalPaddingForm: calc(
   line-height: 1;
 
   &:only-child {
+    margin: 0 $ca-grid / 2;
+
     %caButtonSecondary & {
       margin: 0;
     }


### PR DESCRIPTION
Reverts cultureamp/kaizen-design-system#338
I was too eager to approve this PR. I think this PR and https://github.com/cultureamp/kaizen-design-system/pull/339 need to be QA'ed and released at the same time to avoid breakages, as they are related to one another, so I want to hold off on releasing this until we have a better plan for QA.