### PR TITLE
fix: unrevert "Remove text margin in the button""

### DIFF
--- a/packages/component-library/components/Button/styles.scss
+++ b/packages/component-library/components/Button/styles.scss
@@ -345,8 +345,6 @@ $caButton-verticalPaddingForm: calc(
   line-height: 1;
 
   &:only-child {
-    margin: 0 $ca-grid / 2;
-
     %caButtonSecondary & {
       margin: 0;
     }


### PR DESCRIPTION
Reverts cultureamp/kaizen-design-system#340, which was a revert of https://github.com/cultureamp/kaizen-design-system/pull/338.

Please see https://github.com/cultureamp/kaizen-design-system/pull/338 for a description of changes that this PR will introduce.

The original PR was reverted because we didn't have a QA plan in place and there was a danger that the Kaizen change would be released to Murmur before it was QA'ed. We have a QA plan now: this PR and https://github.com/cultureamp/kaizen-design-system/pull/339 will be released and QA'ed at the same time as they are related.