### PR TITLE
feat: Add color to Heading

### DIFF
--- a/packages/component-library/components/Heading/Heading.elm
+++ b/packages/component-library/components/Heading/Heading.elm
@@ -1,9 +1,11 @@
 module Heading.Heading exposing
-    ( Config
+    ( AllowedColor(..)
+    , Config
     , DataAttribute
     , TypeVariant(..)
     , addDataAttribute
     , classNameAndIHaveSpokenToDST
+    , color
     , div
     , h1
     , h2
@@ -44,6 +46,7 @@ type alias DataAttribute =
 type alias ConfigValue msg =
     { tag : Maybe (Element msg)
     , variant : TypeVariant
+    , color : AllowedColor
     , id : Maybe String
     , dataAttribute : List DataAttribute
     , classNameAndIHaveSpokenToDST : Maybe String
@@ -54,6 +57,7 @@ defaultConfig : ConfigValue msg
 defaultConfig =
     { tag = Nothing
     , variant = Display0
+    , color = Dark
     , id = Nothing
     , dataAttribute = []
     , classNameAndIHaveSpokenToDST = Nothing
@@ -122,14 +126,43 @@ view (Config config) children =
             config.classNameAndIHaveSpokenToDST |> Maybe.withDefault ""
     in
     resolveTag
-        ([ className config.variant ] ++ [ Html.Attributes.class resolveCustomClass ] ++ resolveId ++ resolveAttributes)
+        ([ styles.class .heading, variantClass config.variant, sizeClass config.variant, colorClass config.color ] ++ [ Html.Attributes.class resolveCustomClass ] ++ resolveId ++ resolveAttributes)
         children
 
 
-className : TypeVariant -> Html.Attribute msg
-className typeVariant =
+sizeClass : TypeVariant -> Html.Attribute msg
+sizeClass typeVariant =
     let
-        styleClass =
+        sizeClassname =
+            case typeVariant of
+                Display0 ->
+                    .large
+
+                Heading1 ->
+                    .large
+
+                Heading2 ->
+                    .large
+
+                Heading3 ->
+                    .small
+
+                Heading4 ->
+                    .small
+
+                Heading5 ->
+                    .small
+
+                Heading6 ->
+                    .small
+    in
+    styles.class sizeClassname
+
+
+variantClass : TypeVariant -> Html.Attribute msg
+variantClass typeVariant =
+    let
+        variantClassname =
             case typeVariant of
                 Display0 ->
                     .display0
@@ -152,10 +185,7 @@ className typeVariant =
                 Heading6 ->
                     .heading6
     in
-    styles.classList
-        [ ( styleClass, True )
-        , ( .heading, True )
-        ]
+    styles.class variantClassname
 
 
 styles =
@@ -168,6 +198,14 @@ styles =
         , heading4 = "heading-4"
         , heading5 = "heading-5"
         , heading6 = "heading-6"
+        , dark = "dark"
+        , darkReducedOpacity = "dark-reduced-opacity"
+        , white = "white"
+        , whiteReducedOpacity = "white-reduced-opacity"
+        , positive = "positive"
+        , negative = "negative"
+        , small = "small"
+        , large = "large"
         }
 
 
@@ -179,6 +217,41 @@ type TypeVariant
     | Heading4
     | Heading5
     | Heading6
+
+
+type AllowedColor
+    = Dark
+    | DarkReducedOpacity
+    | White
+    | WhiteReducedOpacity
+    | Positive
+    | Negative
+
+
+colorClass : AllowedColor -> Html.Attribute msg
+colorClass allowedColor =
+    let
+        colorClassname =
+            case allowedColor of
+                Dark ->
+                    .dark
+
+                DarkReducedOpacity ->
+                    .darkReducedOpacity
+
+                White ->
+                    .white
+
+                WhiteReducedOpacity ->
+                    .whiteReducedOpacity
+
+                Positive ->
+                    .positive
+
+                Negative ->
+                    .negative
+    in
+    styles.class colorClassname
 
 
 
@@ -238,6 +311,11 @@ h6 =
 variant : TypeVariant -> Config msg -> Config msg
 variant value (Config config) =
     Config { config | variant = value }
+
+
+color : AllowedColor -> Config msg -> Config msg
+color value (Config config) =
+    Config { config | color = value }
 
 
 id : String -> Config msg -> Config msg

--- a/packages/component-library/components/Heading/Heading.elm
+++ b/packages/component-library/components/Heading/Heading.elm
@@ -2,7 +2,6 @@ module Heading.Heading exposing
     ( Config
     , DataAttribute
     , TypeVariant(..)
-    , a
     , addDataAttribute
     , classNameAndIHaveSpokenToDST
     , div
@@ -194,11 +193,6 @@ pre =
 p : Config msg
 p =
     Config { defaultConfig | tag = Just Html.p }
-
-
-a : Config msg
-a =
-    Config { defaultConfig | tag = Just Html.a }
 
 
 div : Config msg

--- a/packages/component-library/components/Heading/Heading.module.scss
+++ b/packages/component-library/components/Heading/Heading.module.scss
@@ -63,3 +63,42 @@
   line-height: $kz-typography-heading-6-line-height;
   letter-spacing: $kz-typography-heading-6-letter-spacing;
 }
+
+.dark {
+  color: $kz-color-wisteria-800;
+  opacity: 1;
+}
+
+.dark-translucent {
+  color: $kz-color-wisteria-800;
+  opacity: 0.7;
+}
+
+.light {
+  color: $kz-color-white;
+  opacity: 1;
+}
+
+.light-translucent {
+  color: $kz-color-white;
+  opacity: 0.8;
+}
+
+.positive {
+  &.small {
+    color: $kz-color-seedling-600;
+  }
+  &.large {
+    color: $kz-color-seedling-500;
+  }
+}
+
+.negative {
+  &.small {
+    color: $kz-color-coral-600;
+  }
+
+  &.large {
+    color: $kz-color-coral-500;
+  }
+}

--- a/packages/component-library/components/Heading/Heading.module.scss
+++ b/packages/component-library/components/Heading/Heading.module.scss
@@ -69,17 +69,17 @@
   opacity: 1;
 }
 
-.dark-translucent {
+.dark-reduced-opacity {
   color: $kz-color-wisteria-800;
   opacity: 0.7;
 }
 
-.light {
+.white {
   color: $kz-color-white;
   opacity: 1;
 }
 
-.light-translucent {
+.white-reduced-opacity {
   color: $kz-color-white;
   opacity: 0.8;
 }

--- a/packages/component-library/components/Heading/Heading.module.scss
+++ b/packages/component-library/components/Heading/Heading.module.scss
@@ -4,7 +4,6 @@
 @import "~@kaizen/deprecated-component-library-helpers/styles/type";
 
 .heading {
-  color: $kz-color-wisteria-800;
   margin: 0;
 }
 

--- a/packages/component-library/components/Heading/Heading.spec.tsx
+++ b/packages/component-library/components/Heading/Heading.spec.tsx
@@ -10,6 +10,28 @@ describe("<Heading />", () => {
     const headingClasslist = headingMock.getByText("Example").classList
     expect(headingClasslist).toContain("heading")
     expect(headingClasslist).toContain("display-0")
+    expect(headingClasslist).toContain("large")
+  })
+
+  it("adds a .small class instead of .large if a Heading 3 is used", () => {
+    const headingMock = render(
+      <Heading variant="heading-3" tag="div">
+        Example
+      </Heading>
+    )
+    expect(headingMock.getByText("Example").classList).toContain("small")
+    expect(headingMock.getByText("Example").classList).not.toContain("large")
+  })
+
+  it("adds a .dark-reduced-opacity class if the color prop is set to that", () => {
+    const headingMock = render(
+      <Heading variant="heading-3" color="dark-reduced-opacity">
+        Example
+      </Heading>
+    )
+    expect(headingMock.getByText("Example").classList).toContain(
+      "dark-reduced-opacity"
+    )
   })
 
   it("changes rendered HTML element when passed tag", () => {

--- a/packages/component-library/components/Heading/Heading.tsx
+++ b/packages/component-library/components/Heading/Heading.tsx
@@ -15,7 +15,6 @@ export type HeadingVariants =
 export type AllowedTags =
   | "pre"
   | "p"
-  | "a"
   | "div"
   | "span"
   | "h1"

--- a/packages/component-library/components/Heading/Heading.tsx
+++ b/packages/component-library/components/Heading/Heading.tsx
@@ -50,7 +50,7 @@ export interface HeadingProps {
    * Allowed heading variants
    */
   variant: HeadingVariants
-  textColor?: AllowedColors
+  color?: AllowedColors
 }
 
 export const Heading = ({
@@ -58,7 +58,7 @@ export const Heading = ({
   children,
   tag,
   variant,
-  textColor = "dark",
+  color = "dark",
   ...otherProps
 }: HeadingProps) => {
   const inferredTag =
@@ -68,7 +68,7 @@ export const Heading = ({
     styles.heading,
     styles[variant],
     classNameAndIHaveSpokenToDST,
-    styles[textColor],
+    styles[color],
     VARIANTS_24PX_OR_GREATER.includes(variant) ? styles.large : styles.small,
   ]
 

--- a/packages/component-library/components/Heading/Heading.tsx
+++ b/packages/component-library/components/Heading/Heading.tsx
@@ -3,6 +3,8 @@ import { createElement } from "react"
 
 const styles = require("./Heading.module.scss")
 
+const VARIANTS_24PX_OR_GREATER = ["display-0", "heading-1", "heading-2"]
+
 export type HeadingVariants =
   | "display-0"
   | "heading-1"
@@ -24,6 +26,14 @@ export type AllowedTags =
   | "h5"
   | "h6"
 
+export type AllowedColors =
+  | "dark"
+  | "dark-translucent"
+  | "light"
+  | "light-translucent"
+  | "positive"
+  | "negative"
+
 export interface HeadingProps {
   /**
    * Not recommended. A short-circuit for overriding styles in a pinch
@@ -40,6 +50,7 @@ export interface HeadingProps {
    * Allowed heading variants
    */
   variant: HeadingVariants
+  color?: AllowedColors
 }
 
 export const Heading = ({
@@ -47,6 +58,7 @@ export const Heading = ({
   children,
   tag,
   variant,
+  color = "dark",
   ...otherProps
 }: HeadingProps) => {
   const inferredTag =
@@ -56,6 +68,8 @@ export const Heading = ({
     styles.heading,
     styles[variant],
     classNameAndIHaveSpokenToDST,
+    styles[color],
+    VARIANTS_24PX_OR_GREATER.includes(variant) ? styles.large : styles.small,
   ]
 
   return createElement(

--- a/packages/component-library/components/Heading/Heading.tsx
+++ b/packages/component-library/components/Heading/Heading.tsx
@@ -28,9 +28,9 @@ export type AllowedTags =
 
 export type AllowedColors =
   | "dark"
-  | "dark-translucent"
-  | "light"
-  | "light-translucent"
+  | "dark-reduced-opacity"
+  | "white"
+  | "white-reduced-opacity"
   | "positive"
   | "negative"
 
@@ -50,7 +50,7 @@ export interface HeadingProps {
    * Allowed heading variants
    */
   variant: HeadingVariants
-  color?: AllowedColors
+  textColor?: AllowedColors
 }
 
 export const Heading = ({
@@ -58,7 +58,7 @@ export const Heading = ({
   children,
   tag,
   variant,
-  color = "dark",
+  textColor = "dark",
   ...otherProps
 }: HeadingProps) => {
   const inferredTag =
@@ -68,7 +68,7 @@ export const Heading = ({
     styles.heading,
     styles[variant],
     classNameAndIHaveSpokenToDST,
-    styles[color],
+    styles[textColor],
     VARIANTS_24PX_OR_GREATER.includes(variant) ? styles.large : styles.small,
   ]
 

--- a/packages/component-library/components/Heading/__snapshots__/Heading.spec.tsx.snap
+++ b/packages/component-library/components/Heading/__snapshots__/Heading.spec.tsx.snap
@@ -4,7 +4,7 @@ exports[`<Heading /> defaults to the correct HTML element renders the correct el
 <body>
   <div>
     <h1
-      class="heading display-0"
+      class="heading display-0 dark large"
     >
       Example
     </h1>
@@ -16,7 +16,7 @@ exports[`<Heading /> defaults to the correct HTML element renders the correct el
 <body>
   <div>
     <h1
-      class="heading heading-1"
+      class="heading heading-1 dark large"
     >
       Example
     </h1>
@@ -28,7 +28,7 @@ exports[`<Heading /> defaults to the correct HTML element renders the correct el
 <body>
   <div>
     <h2
-      class="heading heading-2"
+      class="heading heading-2 dark large"
     >
       Example
     </h2>
@@ -40,7 +40,7 @@ exports[`<Heading /> defaults to the correct HTML element renders the correct el
 <body>
   <div>
     <h3
-      class="heading heading-3"
+      class="heading heading-3 dark small"
     >
       Example
     </h3>
@@ -52,7 +52,7 @@ exports[`<Heading /> defaults to the correct HTML element renders the correct el
 <body>
   <div>
     <h4
-      class="heading heading-4"
+      class="heading heading-4 dark small"
     >
       Example
     </h4>
@@ -64,7 +64,7 @@ exports[`<Heading /> defaults to the correct HTML element renders the correct el
 <body>
   <div>
     <h5
-      class="heading heading-5"
+      class="heading heading-5 dark small"
     >
       Example
     </h5>
@@ -76,7 +76,7 @@ exports[`<Heading /> defaults to the correct HTML element renders the correct el
 <body>
   <div>
     <h6
-      class="heading heading-6"
+      class="heading heading-6 dark small"
     >
       Example
     </h6>

--- a/packages/component-library/components/Paragraph/Paragraph.elm
+++ b/packages/component-library/components/Paragraph/Paragraph.elm
@@ -2,7 +2,6 @@ module Paragraph.Paragraph exposing
     ( Config
     , DataAttribute
     , TypeVariant(..)
-    , a
     , addDataAttribute
     , classNameAndIHaveSpokenToDST
     , div
@@ -154,11 +153,6 @@ pre =
 p : Config msg
 p =
     Config { defaultConfig | tag = Just Html.p }
-
-
-a : Config msg
-a =
-    Config { defaultConfig | tag = Just Html.a }
 
 
 div : Config msg

--- a/packages/component-library/components/Paragraph/Paragraph.tsx
+++ b/packages/component-library/components/Paragraph/Paragraph.tsx
@@ -8,7 +8,6 @@ export type ParagraphVariants = "intro-lede" | "body" | "small" | "extra-small"
 export type AllowedTags =
   | "pre"
   | "p"
-  | "a"
   | "div"
   | "span"
   | "h1"

--- a/packages/component-library/stories/Heading.stories.elm
+++ b/packages/component-library/stories/Heading.stories.elm
@@ -2,7 +2,7 @@ module Main exposing (main)
 
 import CssModules exposing (css)
 import ElmStorybook exposing (statelessStoryOf, storybook)
-import Heading.Heading as Heading exposing (TypeVariant(..), view)
+import Heading.Heading as Heading exposing (AllowedColor(..), TypeVariant(..), view)
 import Html exposing (text)
 
 
@@ -50,6 +50,10 @@ main =
                     |> Heading.classNameAndIHaveSpokenToDST (styles.toString .blinking)
                 )
                 [ Html.text "Heading with custom class" ]
+        , statelessStoryOf "HeadingWithPositiveColor" <|
+            Heading.view
+                (Heading.h1 |> Heading.variant Heading1 |> Heading.color Positive)
+                [ Html.text "Heading with Positive color" ]
         ]
 
 

--- a/packages/component-library/stories/Heading.stories.tsx
+++ b/packages/component-library/stories/Heading.stories.tsx
@@ -24,50 +24,50 @@ export const Heading5 = () => <Heading variant="heading-5">Heading 5</Heading>
 
 export const Heading6 = () => <Heading variant="heading-6">Heading 6</Heading>
 
-const Heading1DarkTranslucent = () => (
-  <Heading variant="heading-1" color="dark-translucent">
-    Heading 1 (dark, translucent)
+const Heading1DarkReducedOpacity = () => (
+  <Heading variant="heading-1" textColor="dark-reduced-opacity">
+    Heading 1 (dark, reduced opacity)
   </Heading>
 )
 
-const Heading1Light = () => (
-  <Heading variant="heading-1" color="light">
-    Heading 1 (light)
+const Heading1White = () => (
+  <Heading variant="heading-1" textColor="white">
+    Heading 1 (white)
   </Heading>
 )
 
-const Heading1LightTranslucent = () => (
-  <Heading variant="heading-1" color="light-translucent">
-    Heading 1 (light, translucent)
+const Heading1WhiteReducedOpacity = () => (
+  <Heading variant="heading-1" textColor="white-reduced-opacity">
+    Heading 1 (white, reduced opacity)
   </Heading>
 )
 
 export const Heading1Positive = () => (
-  <Heading variant="heading-1" color="positive">
+  <Heading variant="heading-1" textColor="positive">
     Heading 1 (positive)
   </Heading>
 )
 
 export const Heading1Negative = () => (
-  <Heading variant="heading-1" color="negative">
+  <Heading variant="heading-1" textColor="negative">
     Heading 1 (negative)
   </Heading>
 )
 
 export const Heading3Positive = () => (
-  <Heading variant="heading-3" color="positive">
+  <Heading variant="heading-3" textColor="positive">
     Heading 3 (positive)
   </Heading>
 )
 
 export const Heading3Negative = () => (
-  <Heading variant="heading-3" color="negative">
+  <Heading variant="heading-3" textColor="negative">
     Heading 3 (negative)
   </Heading>
 )
 
-Heading1Light.story = {
-  name: "Heading 1 Light",
+Heading1White.story = {
+  name: "Heading 1 White",
   parameters: {
     backgrounds: [
       {
@@ -79,8 +79,8 @@ Heading1Light.story = {
   },
 }
 
-Heading1LightTranslucent.story = {
-  name: "Heading 1 Light Translucent",
+Heading1WhiteReducedOpacity.story = {
+  name: "Heading 1 White Reduced Opacity",
   parameters: {
     backgrounds: [
       {
@@ -92,7 +92,11 @@ Heading1LightTranslucent.story = {
   },
 }
 
-export { Heading1Light, Heading1LightTranslucent, Heading1DarkTranslucent }
+export {
+  Heading1White,
+  Heading1WhiteReducedOpacity,
+  Heading1DarkReducedOpacity,
+}
 
 loadElmStories("Heading (Elm)", module, require("./Heading.stories.elm"), [
   "Display0",

--- a/packages/component-library/stories/Heading.stories.tsx
+++ b/packages/component-library/stories/Heading.stories.tsx
@@ -25,43 +25,43 @@ export const Heading5 = () => <Heading variant="heading-5">Heading 5</Heading>
 export const Heading6 = () => <Heading variant="heading-6">Heading 6</Heading>
 
 const Heading1DarkReducedOpacity = () => (
-  <Heading variant="heading-1" textColor="dark-reduced-opacity">
+  <Heading variant="heading-1" color="dark-reduced-opacity">
     Heading 1 (dark, reduced opacity)
   </Heading>
 )
 
 const Heading1White = () => (
-  <Heading variant="heading-1" textColor="white">
+  <Heading variant="heading-1" color="white">
     Heading 1 (white)
   </Heading>
 )
 
 const Heading1WhiteReducedOpacity = () => (
-  <Heading variant="heading-1" textColor="white-reduced-opacity">
+  <Heading variant="heading-1" color="white-reduced-opacity">
     Heading 1 (white, reduced opacity)
   </Heading>
 )
 
 export const Heading1Positive = () => (
-  <Heading variant="heading-1" textColor="positive">
+  <Heading variant="heading-1" color="positive">
     Heading 1 (positive)
   </Heading>
 )
 
 export const Heading1Negative = () => (
-  <Heading variant="heading-1" textColor="negative">
+  <Heading variant="heading-1" color="negative">
     Heading 1 (negative)
   </Heading>
 )
 
 export const Heading3Positive = () => (
-  <Heading variant="heading-3" textColor="positive">
+  <Heading variant="heading-3" color="positive">
     Heading 3 (positive)
   </Heading>
 )
 
 export const Heading3Negative = () => (
-  <Heading variant="heading-3" textColor="negative">
+  <Heading variant="heading-3" color="negative">
     Heading 3 (negative)
   </Heading>
 )

--- a/packages/component-library/stories/Heading.stories.tsx
+++ b/packages/component-library/stories/Heading.stories.tsx
@@ -108,4 +108,5 @@ loadElmStories("Heading (Elm)", module, require("./Heading.stories.elm"), [
   "Heading6",
   "HeadingWithDataAttr",
   "HeadingWithCustomClass",
+  "HeadingWithPositiveColor",
 ])

--- a/packages/component-library/stories/Heading.stories.tsx
+++ b/packages/component-library/stories/Heading.stories.tsx
@@ -1,4 +1,5 @@
 import { loadElmStories } from "@cultureamp/elm-storybook"
+import * as colorTokens from "@kaizen/design-tokens/tokens/color.json"
 import * as React from "react"
 import { Box } from "../components/Box"
 import { Heading } from "../components/Heading"
@@ -22,6 +23,76 @@ export const Heading4 = () => <Heading variant="heading-4">Heading 4</Heading>
 export const Heading5 = () => <Heading variant="heading-5">Heading 5</Heading>
 
 export const Heading6 = () => <Heading variant="heading-6">Heading 6</Heading>
+
+const Heading1DarkTranslucent = () => (
+  <Heading variant="heading-1" color="dark-translucent">
+    Heading 1 (dark, translucent)
+  </Heading>
+)
+
+const Heading1Light = () => (
+  <Heading variant="heading-1" color="light">
+    Heading 1 (light)
+  </Heading>
+)
+
+const Heading1LightTranslucent = () => (
+  <Heading variant="heading-1" color="light-translucent">
+    Heading 1 (light, translucent)
+  </Heading>
+)
+
+export const Heading1Positive = () => (
+  <Heading variant="heading-1" color="positive">
+    Heading 1 (positive)
+  </Heading>
+)
+
+export const Heading1Negative = () => (
+  <Heading variant="heading-1" color="negative">
+    Heading 1 (negative)
+  </Heading>
+)
+
+export const Heading3Positive = () => (
+  <Heading variant="heading-3" color="positive">
+    Heading 3 (positive)
+  </Heading>
+)
+
+export const Heading3Negative = () => (
+  <Heading variant="heading-3" color="negative">
+    Heading 3 (negative)
+  </Heading>
+)
+
+Heading1Light.story = {
+  name: "Heading 1 Light",
+  parameters: {
+    backgrounds: [
+      {
+        name: "Wisteria 700",
+        value: colorTokens.kz.color.wisteria["700"],
+        default: true,
+      },
+    ],
+  },
+}
+
+Heading1LightTranslucent.story = {
+  name: "Heading 1 Light Translucent",
+  parameters: {
+    backgrounds: [
+      {
+        name: "Wisteria 700",
+        value: colorTokens.kz.color.wisteria["700"],
+        default: true,
+      },
+    ],
+  },
+}
+
+export { Heading1Light, Heading1LightTranslucent, Heading1DarkTranslucent }
 
 loadElmStories("Heading (Elm)", module, require("./Heading.stories.elm"), [
   "Display0",


### PR DESCRIPTION
## Changes

- added the `color` prop to both the React and Elm components
- make sure both components are correctly applying `.small` and `.large` classes, which affect the color output if the `color` prop is set to `positive` or `negative` (if the `variant` is a Heading 2 or larger, it should get `.large` and it will be a different colour to Heading 3 or smaller, which gets `.small`).
- updated both React and Elm stories
- updated the React spec
- removed the `a` tag as an available option for both the React and Elm components (see below)

### Note on removing `a` as an available tag

This was following up on a discussion that DST had where we agreed that anchor tags do not belong here. Links tends to wrap things completely, or wrap a piece of text inside a larger bit of text. That means that you would be more likely to **pass in a link as a child of the Heading component** or **wrap the entire Heading component inside a link** (which means you could also include other things in the link, like an icon next to the Heading) rather than make the Heading component itself manifest as an anchor tag. We may also create a `<Link>` component in the future, and if so it'd be good to restrict anchor tags to that component rather than have some in there and some in Heading or Paragraph that end up drifting from `<Link>`.
