### PR TITLE
feat: add disabled confirmButton feature to elm modal

### DIFF
--- a/packages/component-library/draft/Kaizen/Modal/Modal.elm
+++ b/packages/component-library/draft/Kaizen/Modal/Modal.elm
@@ -139,6 +139,7 @@ type alias ConfirmationConfig msg =
     , onConfirm : Maybe msg
     , confirmLabel : String
     , dismissLabel : String
+    , onConfirmDisabled : Bool
     }
 
 
@@ -297,6 +298,13 @@ viewContent (Config config) =
                             Nothing ->
                                 confirmationConfig
 
+                    withOnConfirmDisabled confirmationConfig =
+                        if configs.onConfirmDisabled then
+                            ConfirmationModal.onConfirmDisabled True confirmationConfig
+
+                        else
+                            ConfirmationModal.onConfirmDisabled False confirmationConfig
+
                     withBodySubtext confirmationConfig =
                         case configs.bodySubtext of
                             Just subtext ->
@@ -340,6 +348,7 @@ viewContent (Config config) =
                     commonConfirmationConfig confirmationConfig =
                         withOnDismiss confirmationConfig
                             |> withOnConfirm
+                            |> withOnConfirmDisabled
                             |> withBodySubtext
                             |> withFocusableIds
                             |> withFocusLockAttribs

--- a/packages/component-library/draft/Kaizen/Modal/Presets/ConfirmationModal.elm
+++ b/packages/component-library/draft/Kaizen/Modal/Presets/ConfirmationModal.elm
@@ -10,6 +10,7 @@ module Kaizen.Modal.Presets.ConfirmationModal exposing
     , negative
     , onConfirm
     , onConfirmBlur
+    , onConfirmDisabled
     , onConfirmFocus
     , onDismiss
     , onHeaderDismissBlur
@@ -59,6 +60,7 @@ type alias Configuration msg =
     , onConfirmFocus : Maybe msg
     , onConfirmBlur : Maybe msg
     , confirmId : Maybe String
+    , onConfirmDisabled : Bool
     }
 
 
@@ -114,6 +116,7 @@ defaults =
     , onConfirmFocus = Nothing
     , onConfirmBlur = Nothing
     , confirmId = Just Constants.lastFocusableId
+    , onConfirmDisabled = False
     }
 
 
@@ -242,6 +245,13 @@ footer config =
                 Nothing ->
                     buttonConfig
 
+        withOnConfirmDisabled buttonConfig =
+            if config.onConfirmDisabled then
+                Button.disabled True buttonConfig
+
+            else
+                Button.disabled False buttonConfig
+
         resolveActionButtonVariant =
             if config.variant == Negative then
                 Button.destructive
@@ -288,6 +298,7 @@ footer config =
     , Button.view
         (resolveActionButtonVariant
             |> withOnConfirm
+            |> withOnConfirmDisabled
             |> withConfirmId
             |> withConfirmFocus
             |> withConfirmBlur
@@ -309,6 +320,11 @@ onDismiss msg (Config config) =
 onConfirm : msg -> Config msg -> Config msg
 onConfirm msg (Config config) =
     Config { config | onConfirm = Just msg }
+
+
+onConfirmDisabled : Bool -> Config msg -> Config msg
+onConfirmDisabled isDisabled (Config config) =
+    Config { config | onConfirmDisabled = isDisabled }
 
 
 title : String -> Config msg -> Config msg

--- a/packages/component-library/stories/Modal.stories.tsx
+++ b/packages/component-library/stories/Modal.stories.tsx
@@ -629,6 +629,7 @@ loadElmStories("Modal (Elm)", module, require("./ModalStories.elm"), [
   "Confirmation (informative), shown by default",
   "Confirmation (positive), shown by default",
   "Confirmation (negative), shown by default",
+  "Confirmation (negative), with disabled confirm button",
   "Confirmation, user initiated",
   "InputEdit (positive), user initiated",
   "InputEdit (negative), user initiated",

--- a/packages/component-library/stories/ModalStories.elm
+++ b/packages/component-library/stories/ModalStories.elm
@@ -181,6 +181,7 @@ main =
                                     , onConfirm = Just ModalConfirmed
                                     , confirmLabel = "Confirm"
                                     , dismissLabel = "Cancel"
+                                    , onConfirmDisabled = False
                                     }
                                     |> Modal.modalState modalState
                                     -- IMPORTANT: the modal uses this for internal messages
@@ -235,6 +236,7 @@ main =
                                     , onConfirm = Just ModalConfirmed
                                     , confirmLabel = "Confirm"
                                     , dismissLabel = "Cancel"
+                                    , onConfirmDisabled = False
                                     }
                                     |> Modal.modalState modalState
                                     -- IMPORTANT: the modal uses this for internal messages
@@ -261,6 +263,7 @@ main =
                                     , onConfirm = Just ModalConfirmed
                                     , confirmLabel = "Confirm"
                                     , dismissLabel = "Cancel"
+                                    , onConfirmDisabled = False
                                     }
                                     |> Modal.modalState modalState
                                     -- IMPORTANT: the modal uses this for internal messages
@@ -287,6 +290,34 @@ main =
                                     , onConfirm = Just ModalConfirmed
                                     , confirmLabel = "Confirm"
                                     , dismissLabel = "Cancel"
+                                    , onConfirmDisabled = False
+                                    }
+                                    |> Modal.modalState modalState
+                                    -- IMPORTANT: the modal uses this for internal messages
+                                    |> Modal.onUpdate ModalUpdate
+                                )
+
+                        _ ->
+                            text ""
+                    ]
+        , storyOf "Confirmation (negative), with disabled confirm button" config <|
+            \m ->
+                div []
+                    [ case m.modalContext of
+                        Default modalState ->
+                            Modal.view <|
+                                (Modal.confirmation Modal.Negative
+                                    { title = "Negative title"
+                                    , bodySubtext =
+                                        Just
+                                            [ div [ style "text-align" "center" ]
+                                                [ Text.view (Text.p |> Text.style Text.Lede |> Text.inline True) [ text "Additional subtext to aid the user can be added here." ] ]
+                                            ]
+                                    , onDismiss = Just ModalDismissed
+                                    , onConfirm = Nothing
+                                    , confirmLabel = "Confirm"
+                                    , dismissLabel = "Cancel"
+                                    , onConfirmDisabled = True
                                     }
                                     |> Modal.modalState modalState
                                     -- IMPORTANT: the modal uses this for internal messages
@@ -315,6 +346,7 @@ main =
                                         , onConfirm = Just ModalConfirmed
                                         , confirmLabel = "Confirm"
                                         , dismissLabel = "Cancel"
+                                        , onConfirmDisabled = False
                                         }
                                         |> Modal.modalState modalState
                                         -- IMPORTANT: the modal uses this for internal messages


### PR DESCRIPTION
BREAKING CHANGE: everywhere the modal is used will need to now have the 'onConfirmDisabled' in the config

Context:

- I'm looking to create something like an ApplyChanges confirmation modal in Elm - where the user has to input a number that matches for example the number of ignored users, before going ahead with their employee data import and applying the changes. 
- If the user hasn't entered any numbers or entered a number that doesn't match, the confirm button should be disabled.

Example screenshot of current react modal I'm trying to have in Elm.
![image](https://user-images.githubusercontent.com/39490942/77491764-ca81b480-6e92-11ea-9fd7-2f5fad55683b.png)
