### PR TITLE
fix: update minimist transitive dependency to fix vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,5 +112,7 @@
     "@storybook/node-logger": "^5.3.9",
     "jscodeshift": "^0.7.0"
   },
-  "resolutions": { "**/**/minimist": "^1.2.3" }
+  "resolutions": {
+    "**/**/minimist": "^1.2.3"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "jest": "^24.9.0",
     "jest-circus": "^24.9.0",
     "jest-static-stubs": "^0.0.1",
-    "lerna": "^3.16.4",
+    "lerna": "3.20.2",
     "node-sass": "^4.12.0",
     "normalize.css": "^8.0.1",
     "postcss-flexbugs-fixes": "^4.1.0",
@@ -111,5 +111,6 @@
     "@storybook/csf": "^0.0.1",
     "@storybook/node-logger": "^5.3.9",
     "jscodeshift": "^0.7.0"
-  }
+  },
+  "resolutions": { "**/**/minimist": "^1.2.3" }
 }

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "jest": "^24.9.0",
     "jest-circus": "^24.9.0",
     "jest-static-stubs": "^0.0.1",
-    "lerna": "3.20.2",
+    "lerna": "^3.20.2",
     "node-sass": "^4.12.0",
     "normalize.css": "^8.0.1",
     "postcss-flexbugs-fixes": "^4.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11737,7 +11737,7 @@ left-pad@^1.3.0:
   resolved "https://registry.yarnpkg.com/left-pad/-/left-pad-1.3.0.tgz#5b8a3a7765dfe001261dde915589e782f8c94d1e"
   integrity sha512-XI5MPzVNApjAyhQzphX8BkmKsKUxD4LdyK24iZeQGinBN9yTQT3bFlCBy/aVx2HrNcqQGsdot8ghrjyrvMCoEA==
 
-lerna@^3.16.4:
+lerna@3.20.2:
   version "3.20.2"
   resolved "https://registry.yarnpkg.com/lerna/-/lerna-3.20.2.tgz#abf84e73055fe84ee21b46e64baf37b496c24864"
   integrity sha512-bjdL7hPLpU3Y8CBnw/1ys3ynQMUjiK6l9iDWnEGwFtDy48Xh5JboR9ZJwmKGCz9A/sarVVIGwf1tlRNKUG9etA==
@@ -12729,15 +12729,10 @@ minimist-options@^3.0.1:
     arrify "^1.0.1"
     is-plain-obj "^1.1.0"
 
-minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0, minimist@^1.2.5:
+minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0, minimist@^1.2.3, minimist@^1.2.5, minimist@~0.0.1:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
   integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
-
-minimist@~0.0.1:
-  version "0.0.10"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.10.tgz#de3f98543dbf96082be48ad1a0c7cda836301dcf"
-  integrity sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=
 
 minipass-collect@^1.0.2:
   version "1.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -11737,7 +11737,7 @@ left-pad@^1.3.0:
   resolved "https://registry.yarnpkg.com/left-pad/-/left-pad-1.3.0.tgz#5b8a3a7765dfe001261dde915589e782f8c94d1e"
   integrity sha512-XI5MPzVNApjAyhQzphX8BkmKsKUxD4LdyK24iZeQGinBN9yTQT3bFlCBy/aVx2HrNcqQGsdot8ghrjyrvMCoEA==
 
-lerna@3.20.2:
+lerna@^3.20.2:
   version "3.20.2"
   resolved "https://registry.yarnpkg.com/lerna/-/lerna-3.20.2.tgz#abf84e73055fe84ee21b46e64baf37b496c24864"
   integrity sha512-bjdL7hPLpU3Y8CBnw/1ys3ynQMUjiK6l9iDWnEGwFtDy48Xh5JboR9ZJwmKGCz9A/sarVVIGwf1tlRNKUG9etA==


### PR DESCRIPTION
`minimist` was a transitive dependency of `lerna`. Upgrading `lerna` to the latest version did not fix the vulernatbility (it appears that `lerna` has not upgraded it yet), so I used the `resolutions` feature of yarn/npm to upgrade the transitive dependency.

I left in the lerna upgrade, because why not.