### PR TITLE
fix: Focus lock fix when confirm button disabled

### DIFF
--- a/packages/component-library/draft/Kaizen/Modal/Modal.elm
+++ b/packages/component-library/draft/Kaizen/Modal/Modal.elm
@@ -132,7 +132,7 @@ type ModalStep
     | Running
 
 
-type alias ConfirmationConfig msg =
+type alias ConfirmationContract msg =
     { title : String
     , bodySubtext : Maybe (List (Html msg))
     , onDismiss : Maybe msg
@@ -221,7 +221,7 @@ view c =
 
 
 viewContent : Config msg -> Html msg
-viewContent (Config config) =
+viewContent (Config modalConfig) =
     let
         updateModal onUpdateMsg =
             onClick (onUpdateMsg Update)
@@ -230,11 +230,11 @@ viewContent (Config config) =
             GenericModal.default
 
         ( mState, modalData ) =
-            getState config.state
+            getState modalConfig.state
 
         genericModalEvents =
             List.filterMap identity
-                [ Maybe.map updateModal config.onUpdate
+                [ Maybe.map updateModal modalConfig.onUpdate
                 ]
 
         resolveAnimationStyles =
@@ -249,7 +249,7 @@ viewContent (Config config) =
                     []
 
         resolveVisibilityStyles =
-            case config.state of
+            case modalConfig.state of
                 ModalState ( Opening_, _ ) ->
                     [ ( .elmUnscrollable, True ) ]
 
@@ -269,21 +269,21 @@ viewContent (Config config) =
                 ++ [ style "animation-duration" <| (mapDuration modalData.duration |> String.fromFloat |> (\duration -> duration ++ "ms")) ]
             )
             []
-        , case config.variant of
+        , case modalConfig.variant of
             Generic content size ->
                 GenericModal.view (GenericModal.Custom size)
                     content
                     (genericModalConfig |> GenericModal.events genericModalEvents)
 
-            Confirmation confirmationType configs ->
+            Confirmation confirmationType contract ->
                 let
                     withOnDismiss confirmationConfig =
-                        case configs.onDismiss of
+                        case contract.onDismiss of
                             Just dismissMsg ->
                                 ConfirmationModal.onDismiss dismissMsg confirmationConfig
 
                             Nothing ->
-                                case config.onUpdate of
+                                case modalConfig.onUpdate of
                                     Just updateMsg ->
                                         ConfirmationModal.onDismiss (updateMsg Update) confirmationConfig
 
@@ -291,7 +291,7 @@ viewContent (Config config) =
                                         confirmationConfig
 
                     withOnConfirm confirmationConfig =
-                        case configs.onConfirm of
+                        case contract.onConfirm of
                             Just confirmMsg ->
                                 ConfirmationModal.onConfirm confirmMsg confirmationConfig
 
@@ -299,48 +299,36 @@ viewContent (Config config) =
                                 confirmationConfig
 
                     withOnConfirmDisabled confirmationConfig =
-                        if configs.onConfirmDisabled then
+                        if contract.onConfirmDisabled then
                             ConfirmationModal.onConfirmDisabled True confirmationConfig
 
                         else
                             ConfirmationModal.onConfirmDisabled False confirmationConfig
 
                     withBodySubtext confirmationConfig =
-                        case configs.bodySubtext of
+                        case contract.bodySubtext of
                             Just subtext ->
                                 ConfirmationModal.bodySubtext subtext confirmationConfig
 
                             Nothing ->
                                 confirmationConfig
 
-                    withFocusableIds confirmationConfig =
-                        ConfirmationModal.headerDismissId (firstFocusableIdToString modalData.firstFocusableId) confirmationConfig
-                            |> ConfirmationModal.confirmId (lastFocusableIdToString modalData.lastFocusableId)
-
                     withFocusLockAttribs confirmationConfig =
-                        case config.onUpdate of
+                        case modalConfig.onUpdate of
                             Just updateMsg ->
                                 let
-                                    withHeaderDismissPreventKeydownOn conConfig =
-                                        if isShiftKeydown config.state && firstFocusableFocused config.state then
-                                            ConfirmationModal.onPreventHeaderDismissKeydown [ KaizenEvents.isTab (updateMsg FirstFocusableShiftTabbed) ] conConfig
-
-                                        else
-                                            conConfig
-
-                                    withConfirmPreventKeydownOn conConfig =
-                                        if not <| isShiftKeydown config.state && lastFocusableFocused config.state then
-                                            ConfirmationModal.confirmPreventKeydownOn [ KaizenEvents.isTab (updateMsg LastFocusableTabbed) ] conConfig
+                                    withFirstFocusablePreventKeydownOn conConfig =
+                                        if isShiftKeydown modalConfig.state && firstFocusableFocused modalConfig.state then
+                                            ConfirmationModal.onHeaderDismissPreventKeydown [ KaizenEvents.isTab (updateMsg FirstFocusableShiftTabbed) ] conConfig
 
                                         else
                                             conConfig
                                 in
                                 ConfirmationModal.onHeaderDismissFocus (updateMsg FirstFocusableElementFocused) confirmationConfig
-                                    |> ConfirmationModal.onConfirmFocus (updateMsg LastFocusableElementFocused)
-                                    |> ConfirmationModal.onConfirmBlur (updateMsg ClearFocusedFocusable)
+                                    |> ConfirmationModal.headerDismissId (firstFocusableIdToString modalData.firstFocusableId)
                                     |> ConfirmationModal.onHeaderDismissBlur (updateMsg ClearFocusedFocusable)
-                                    |> withHeaderDismissPreventKeydownOn
-                                    |> withConfirmPreventKeydownOn
+                                    |> withFirstFocusablePreventKeydownOn
+                                    |> confirmationLastFocusableConfig modalConfig.state contract updateMsg
 
                             Nothing ->
                                 confirmationConfig
@@ -350,11 +338,10 @@ viewContent (Config config) =
                             |> withOnConfirm
                             |> withOnConfirmDisabled
                             |> withBodySubtext
-                            |> withFocusableIds
                             |> withFocusLockAttribs
-                            |> ConfirmationModal.confirmLabel configs.confirmLabel
-                            |> ConfirmationModal.dismissLabel configs.dismissLabel
-                            |> ConfirmationModal.title configs.title
+                            |> ConfirmationModal.confirmLabel contract.confirmLabel
+                            |> ConfirmationModal.dismissLabel contract.dismissLabel
+                            |> ConfirmationModal.title contract.title
                 in
                 case confirmationType of
                     Informative ->
@@ -401,7 +388,7 @@ viewContent (Config config) =
                                 InputEditModal.onDismiss dismissMsg inputEditConfig
 
                             Nothing ->
-                                case config.onUpdate of
+                                case modalConfig.onUpdate of
                                     Just updateMsg ->
                                         InputEditModal.onDismiss (updateMsg Update) inputEditConfig
 
@@ -421,18 +408,18 @@ viewContent (Config config) =
                             |> InputEditModal.confirmId (lastFocusableIdToString modalData.lastFocusableId)
 
                     withFocusLockAttribs inputEditConfig =
-                        case config.onUpdate of
+                        case modalConfig.onUpdate of
                             Just updateMsg ->
                                 let
                                     withHeaderDismissPreventKeydownOn inputEConfig =
-                                        if isShiftKeydown config.state && firstFocusableFocused config.state then
+                                        if isShiftKeydown modalConfig.state && firstFocusableFocused modalConfig.state then
                                             InputEditModal.onPreventHeaderDismissKeydown [ KaizenEvents.isTab (updateMsg FirstFocusableShiftTabbed) ] inputEConfig
 
                                         else
                                             inputEConfig
 
                                     withConfirmPreventKeydownOn inputEConfig =
-                                        if not <| isShiftKeydown config.state && lastFocusableFocused config.state then
+                                        if not <| isShiftKeydown modalConfig.state && lastFocusableFocused modalConfig.state then
                                             InputEditModal.confirmPreventKeydownOn [ KaizenEvents.isTab (updateMsg LastFocusableTabbed) ] inputEConfig
 
                                         else
@@ -538,6 +525,43 @@ styles =
 
 
 -- INTERNAL HELPERS
+
+
+{-| This handles setting up the last focusable element attributes.
+For example if the confirm button which is typically set as the last focusable element
+is disabled, then the logic promotes the footer dismiss button as the last focusable element
+-}
+confirmationLastFocusableConfig : ModalState msg -> ConfirmationContract msg -> (ModalMsg -> msg) -> ConfirmationModal.Config msg -> ConfirmationModal.Config msg
+confirmationLastFocusableConfig ((ModalState ( _, modalData )) as ms) contract updateMsg config =
+    let
+        shouldPreventKeydown =
+            not <| isShiftKeydown ms && lastFocusableFocused ms
+
+        withFooterPreventKeydown conConfig =
+            if shouldPreventKeydown then
+                ConfirmationModal.onFooterDismissPreventKeydownOn [ KaizenEvents.isTab (updateMsg LastFocusableTabbed) ] conConfig
+
+            else
+                conConfig
+
+        withConfirmPreventKeydown conConfig =
+            if shouldPreventKeydown then
+                ConfirmationModal.onConfirmPreventKeydownOn [ KaizenEvents.isTab (updateMsg LastFocusableTabbed) ] conConfig
+
+            else
+                conConfig
+    in
+    if contract.onConfirmDisabled then
+        ConfirmationModal.onFooterDismissFocus (updateMsg LastFocusableElementFocused) config
+            |> ConfirmationModal.onFooterDismissBlur (updateMsg ClearFocusedFocusable)
+            |> ConfirmationModal.footerDismissId (lastFocusableIdToString modalData.lastFocusableId)
+            |> withFooterPreventKeydown
+
+    else
+        ConfirmationModal.onConfirmFocus (updateMsg LastFocusableElementFocused) config
+            |> ConfirmationModal.onConfirmBlur (updateMsg ClearFocusedFocusable)
+            |> ConfirmationModal.confirmId (lastFocusableIdToString modalData.lastFocusableId)
+            |> withConfirmPreventKeydown
 
 
 mapDuration : Duration -> Float
@@ -674,7 +698,7 @@ defaultFocusableId id =
 
 type Variant msg
     = Generic (List (Html msg)) ( Float, Float )
-    | Confirmation ConfirmationType (ConfirmationConfig msg)
+    | Confirmation ConfirmationType (ConfirmationContract msg)
     | InputEdit InputEditType (InputEditConfig msg)
 
 
@@ -683,7 +707,7 @@ generic v size =
     Config { defaults | variant = Generic v size }
 
 
-confirmation : ConfirmationType -> ConfirmationConfig msg -> Config msg
+confirmation : ConfirmationType -> ConfirmationContract msg -> Config msg
 confirmation confirmationType confirmationConfig =
     Config
         { defaults
@@ -766,8 +790,12 @@ update ms modalMsg =
                 Ok () ->
                     ( ms, Cmd.none, Nothing )
 
+                -- Fallback to the FirstFocusableElement
                 Err _ ->
-                    ( ms, Cmd.none, Nothing )
+                    ( ms
+                    , Task.attempt FocusFirstFocusableElement (BrowserDom.focus <| firstFocusableIdToString mData.firstFocusableId)
+                    , Nothing
+                    )
 
         DefaultFocusableElementFocused focusResult ->
             case focusResult of

--- a/packages/component-library/draft/Kaizen/Modal/Presets/ConfirmationModal.elm
+++ b/packages/component-library/draft/Kaizen/Modal/Presets/ConfirmationModal.elm
@@ -1,10 +1,11 @@
 module Kaizen.Modal.Presets.ConfirmationModal exposing
-    ( bodySubtext
+    ( Config
+    , bodySubtext
     , cautionary
     , confirmId
     , confirmLabel
-    , confirmPreventKeydownOn
     , dismissLabel
+    , footerDismissId
     , headerDismissId
     , informative
     , negative
@@ -12,10 +13,14 @@ module Kaizen.Modal.Presets.ConfirmationModal exposing
     , onConfirmBlur
     , onConfirmDisabled
     , onConfirmFocus
+    , onConfirmPreventKeydownOn
     , onDismiss
+    , onFooterDismissBlur
+    , onFooterDismissFocus
+    , onFooterDismissPreventKeydownOn
     , onHeaderDismissBlur
     , onHeaderDismissFocus
-    , onPreventHeaderDismissKeydown
+    , onHeaderDismissPreventKeydown
     , positive
     , title
     , view
@@ -55,8 +60,12 @@ type alias Configuration msg =
     , headerDismissId : Maybe String
     , onHeaderDismissFocus : Maybe msg
     , onHeaderDismissBlur : Maybe msg
-    , onPreventHeaderDismissKeydown : List (Decode.Decoder msg)
-    , confirmPreventKeydownOn : List (Decode.Decoder msg)
+    , onHeaderDismissPreventKeydownOn : List (Decode.Decoder msg)
+    , onFooterDismissFocus : Maybe msg
+    , onFooterDismissBlur : Maybe msg
+    , footerDismissId : Maybe String
+    , onConfirmPreventKeydownOn : List (Decode.Decoder msg)
+    , onFooterDismissPreventKeydownOn : List (Decode.Decoder msg)
     , onConfirmFocus : Maybe msg
     , onConfirmBlur : Maybe msg
     , confirmId : Maybe String
@@ -111,8 +120,12 @@ defaults =
     , headerDismissId = Nothing
     , onHeaderDismissFocus = Nothing
     , onHeaderDismissBlur = Nothing
-    , onPreventHeaderDismissKeydown = []
-    , confirmPreventKeydownOn = []
+    , onFooterDismissFocus = Nothing
+    , onFooterDismissBlur = Nothing
+    , footerDismissId = Nothing
+    , onHeaderDismissPreventKeydownOn = []
+    , onConfirmPreventKeydownOn = []
+    , onFooterDismissPreventKeydownOn = []
     , onConfirmFocus = Nothing
     , onConfirmBlur = Nothing
     , confirmId = Just Constants.lastFocusableId
@@ -156,11 +169,11 @@ view (Config config) =
                     headerConfig
 
         withPreventHeaderDismissKeydown headerConfig =
-            if List.isEmpty config.onPreventHeaderDismissKeydown then
+            if List.isEmpty config.onHeaderDismissPreventKeydownOn then
                 headerConfig
 
             else
-                ModalHeader.preventDismissKeydown config.onPreventHeaderDismissKeydown headerConfig
+                ModalHeader.preventDismissKeydown config.onHeaderDismissPreventKeydownOn headerConfig
 
         withBody =
             case config.bodySubtext of
@@ -229,21 +242,48 @@ body content =
 footer : Configuration msg -> List (Html msg)
 footer config =
     let
-        withOnDismiss buttonConfig =
-            case config.onDismiss of
-                Just dismissMsg ->
-                    Button.onClick dismissMsg buttonConfig
+        withOnClick configSelector buttonConfig =
+            case configSelector config of
+                Just onClickMsg ->
+                    Button.onClick onClickMsg buttonConfig
 
                 Nothing ->
                     buttonConfig
 
-        withOnConfirm buttonConfig =
-            case config.onConfirm of
-                Just confirmMsg ->
-                    Button.onClick confirmMsg buttonConfig
+        withId configSelector disabled buttonConfig =
+            case configSelector config of
+                Just id ->
+                    if disabled then
+                        buttonConfig
+
+                    else
+                        Button.id id buttonConfig
 
                 Nothing ->
                     buttonConfig
+
+        withFocus configSelector buttonConfig =
+            case configSelector config of
+                Just onFocusMsg ->
+                    Button.onFocus onFocusMsg buttonConfig
+
+                Nothing ->
+                    buttonConfig
+
+        withBlur configSelector buttonConfig =
+            case configSelector config of
+                Just blurMsg ->
+                    Button.onBlur blurMsg buttonConfig
+
+                Nothing ->
+                    buttonConfig
+
+        withPreventKeydown configSelector buttonConfig =
+            if List.isEmpty (configSelector config) then
+                buttonConfig
+
+            else
+                Button.preventKeydownOn (configSelector config) buttonConfig
 
         withOnConfirmDisabled buttonConfig =
             if config.onConfirmDisabled then
@@ -258,51 +298,24 @@ footer config =
 
             else
                 Button.primary
-
-        withConfirmId buttonConfig =
-            case config.confirmId of
-                Just id ->
-                    Button.id id buttonConfig
-
-                Nothing ->
-                    buttonConfig
-
-        withConfirmFocus buttonConfig =
-            case config.onConfirmFocus of
-                Just onConfirmMsg ->
-                    Button.onFocus onConfirmMsg buttonConfig
-
-                Nothing ->
-                    buttonConfig
-
-        withConfirmBlur buttonConfig =
-            case config.onConfirmBlur of
-                Just onConfirmBlurMsg ->
-                    Button.onBlur onConfirmBlurMsg buttonConfig
-
-                Nothing ->
-                    buttonConfig
-
-        withConfirmPreventKeydown buttonConfig =
-            if List.isEmpty config.confirmPreventKeydownOn then
-                buttonConfig
-
-            else
-                Button.preventKeydownOn config.confirmPreventKeydownOn buttonConfig
     in
     [ Button.view
         (Button.secondary
-            |> withOnDismiss
+            |> withOnClick .onDismiss
+            |> withId .footerDismissId False
+            |> withFocus .onFooterDismissFocus
+            |> withBlur .onFooterDismissBlur
+            |> withPreventKeydown .onFooterDismissPreventKeydownOn
         )
         config.dismissLabel
     , Button.view
         (resolveActionButtonVariant
-            |> withOnConfirm
+            |> withOnClick .onConfirm
             |> withOnConfirmDisabled
-            |> withConfirmId
-            |> withConfirmFocus
-            |> withConfirmBlur
-            |> withConfirmPreventKeydown
+            |> withId .confirmId config.onConfirmDisabled
+            |> withFocus .onConfirmFocus
+            |> withBlur .onConfirmBlur
+            |> withPreventKeydown .onConfirmPreventKeydownOn
         )
         config.confirmLabel
     ]
@@ -352,6 +365,11 @@ headerDismissId id_ (Config config) =
     Config { config | headerDismissId = Just id_ }
 
 
+footerDismissId : String -> Config msg -> Config msg
+footerDismissId id_ (Config config) =
+    Config { config | footerDismissId = Just id_ }
+
+
 onHeaderDismissFocus : msg -> Config msg -> Config msg
 onHeaderDismissFocus msg (Config config) =
     Config { config | onHeaderDismissFocus = Just msg }
@@ -367,19 +385,34 @@ onConfirmFocus msg (Config config) =
     Config { config | onConfirmFocus = Just msg }
 
 
-onPreventHeaderDismissKeydown : List (Decode.Decoder msg) -> Config msg -> Config msg
-onPreventHeaderDismissKeydown keydownDecoders (Config config) =
-    Config { config | onPreventHeaderDismissKeydown = keydownDecoders }
+onHeaderDismissPreventKeydown : List (Decode.Decoder msg) -> Config msg -> Config msg
+onHeaderDismissPreventKeydown keydownDecoders (Config config) =
+    Config { config | onHeaderDismissPreventKeydownOn = keydownDecoders }
 
 
-confirmPreventKeydownOn : List (Decode.Decoder msg) -> Config msg -> Config msg
-confirmPreventKeydownOn keydownDecoders (Config config) =
-    Config { config | confirmPreventKeydownOn = keydownDecoders }
+onConfirmPreventKeydownOn : List (Decode.Decoder msg) -> Config msg -> Config msg
+onConfirmPreventKeydownOn keydownDecoders (Config config) =
+    Config { config | onConfirmPreventKeydownOn = keydownDecoders }
+
+
+onFooterDismissPreventKeydownOn : List (Decode.Decoder msg) -> Config msg -> Config msg
+onFooterDismissPreventKeydownOn keydownDecoders (Config config) =
+    Config { config | onFooterDismissPreventKeydownOn = keydownDecoders }
 
 
 onConfirmBlur : msg -> Config msg -> Config msg
 onConfirmBlur msg (Config config) =
     Config { config | onConfirmBlur = Just msg }
+
+
+onFooterDismissFocus : msg -> Config msg -> Config msg
+onFooterDismissFocus msg (Config config) =
+    Config { config | onFooterDismissFocus = Just msg }
+
+
+onFooterDismissBlur : msg -> Config msg -> Config msg
+onFooterDismissBlur msg (Config config) =
+    Config { config | onFooterDismissBlur = Just msg }
 
 
 confirmId : String -> Config msg -> Config msg


### PR DESCRIPTION
The feature to be able to disable the confirm button broke the focus-lock implementation to Confirmation variant modals.

In the case the confirm button is disabled the footer dismiss button will be promoted to the last focusable element. Setting the focusable attributes on that the dismiss button doesn't disrupt the focus-lock implementation.