### PR TITLE
feat: Add color support to Paragraph component

### DIFF
--- a/packages/component-library/components/Paragraph/Paragraph.elm
+++ b/packages/component-library/components/Paragraph/Paragraph.elm
@@ -1,9 +1,11 @@
 module Paragraph.Paragraph exposing
-    ( Config
+    ( AllowedColor(..)
+    , Config
     , DataAttribute
     , TypeVariant(..)
     , addDataAttribute
     , classNameAndIHaveSpokenToDST
+    , color
     , div
     , h1
     , h2
@@ -44,6 +46,7 @@ type alias DataAttribute =
 type alias ConfigValue msg =
     { tag : Maybe (Element msg)
     , variant : TypeVariant
+    , color : AllowedColor
     , id : Maybe String
     , dataAttribute : List DataAttribute
     , classNameAndIHaveSpokenToDST : Maybe String
@@ -54,6 +57,7 @@ defaultConfig : ConfigValue msg
 defaultConfig =
     { tag = Nothing
     , variant = Body
+    , color = Dark
     , id = Nothing
     , dataAttribute = []
     , classNameAndIHaveSpokenToDST = Nothing
@@ -97,14 +101,14 @@ view (Config config) children =
             config.classNameAndIHaveSpokenToDST |> Maybe.withDefault ""
     in
     resolveTag
-        ([ className config.variant ] ++ [ Html.Attributes.class resolveCustomClass ] ++ resolveId ++ resolveAttributes)
+        ([ styles.class .paragraph, variantClass config.variant, colorClass config.color ] ++ [ Html.Attributes.class resolveCustomClass ] ++ resolveId ++ resolveAttributes)
         children
 
 
-className : TypeVariant -> Html.Attribute msg
-className typeVariant =
+variantClass : TypeVariant -> Html.Attribute msg
+variantClass typeVariant =
     let
-        styleClass =
+        variantClassname =
             case typeVariant of
                 IntroLede ->
                     .introLede
@@ -118,10 +122,33 @@ className typeVariant =
                 ExtraSmall ->
                     .extraSmall
     in
-    styles.classList
-        [ ( styleClass, True )
-        , ( .paragraph, True )
-        ]
+    styles.class variantClassname
+
+
+colorClass : AllowedColor -> Html.Attribute msg
+colorClass allowedColor =
+    let
+        colorClassname =
+            case allowedColor of
+                Dark ->
+                    .dark
+
+                DarkReducedOpacity ->
+                    .darkReducedOpacity
+
+                White ->
+                    .white
+
+                WhiteReducedOpacity ->
+                    .whiteReducedOpacity
+
+                Positive ->
+                    .positive
+
+                Negative ->
+                    .negative
+    in
+    styles.class colorClassname
 
 
 styles =
@@ -131,6 +158,12 @@ styles =
         , body = "body"
         , small = "small"
         , extraSmall = "extra-small"
+        , dark = "dark"
+        , darkReducedOpacity = "dark-reduced-opacity"
+        , white = "white"
+        , whiteReducedOpacity = "white-reduced-opacity"
+        , positive = "positive"
+        , negative = "negative"
         }
 
 
@@ -139,6 +172,15 @@ type TypeVariant
     | Body
     | Small
     | ExtraSmall
+
+
+type AllowedColor
+    = Dark
+    | DarkReducedOpacity
+    | White
+    | WhiteReducedOpacity
+    | Positive
+    | Negative
 
 
 
@@ -198,6 +240,11 @@ h6 =
 variant : TypeVariant -> Config msg -> Config msg
 variant value (Config config) =
     Config { config | variant = value }
+
+
+color : AllowedColor -> Config msg -> Config msg
+color value (Config config) =
+    Config { config | color = value }
 
 
 id : String -> Config msg -> Config msg

--- a/packages/component-library/components/Paragraph/Paragraph.module.scss
+++ b/packages/component-library/components/Paragraph/Paragraph.module.scss
@@ -4,7 +4,6 @@
 @import "~@kaizen/deprecated-component-library-helpers/styles/type";
 
 .paragraph {
-  color: $kz-color-wisteria-800;
   margin: 0;
 }
 
@@ -38,4 +37,32 @@
   font-size: $kz-typography-paragraph-extra-small-font-size;
   line-height: $kz-typography-paragraph-extra-small-line-height;
   letter-spacing: $kz-typography-paragraph-extra-small-letter-spacing;
+}
+
+.dark {
+  color: $kz-color-wisteria-800;
+  opacity: 1;
+}
+
+.dark-reduced-opacity {
+  color: $kz-color-wisteria-800;
+  opacity: 0.7;
+}
+
+.white {
+  color: $kz-color-white;
+  opacity: 1;
+}
+
+.white-reduced-opacity {
+  color: $kz-color-white;
+  opacity: 0.8;
+}
+
+.positive {
+  color: $kz-color-seedling-600;
+}
+
+.negative {
+  color: $kz-color-coral-600;
 }

--- a/packages/component-library/components/Paragraph/Paragraph.spec.tsx
+++ b/packages/component-library/components/Paragraph/Paragraph.spec.tsx
@@ -1,11 +1,16 @@
 import { cleanup, render } from "@testing-library/react"
 import * as React from "react"
-import { AllowedTags, Paragraph, ParagraphVariants } from "./index"
+import {
+  AllowedColors,
+  AllowedTags,
+  Paragraph,
+  ParagraphVariants,
+} from "./index"
 
 afterEach(cleanup)
 
 describe("<Paragraph />", () => {
-  describe("renders the correct classes", () => {
+  describe("renders the correct variant classes", () => {
     const testCases: ParagraphVariants[] = [
       "intro-lede",
       "body",
@@ -43,6 +48,30 @@ describe("<Paragraph />", () => {
           </Paragraph>
         )
         expect(paragraphMock.getByText("Example").tagName).toBe("DIV")
+      })
+    })
+  })
+
+  describe("renders the correct color classes", () => {
+    const testCases: AllowedColors[] = [
+      "dark",
+      "dark-reduced-opacity",
+      "white",
+      "white-reduced-opacity",
+      "positive",
+      "negative",
+    ]
+
+    testCases.forEach(color => {
+      it(`renders the correct class for <Paragraph color={${color}} />`, () => {
+        const paragraphMock = render(
+          <Paragraph variant="body" color={color} tag="div">
+            Example
+          </Paragraph>
+        )
+        const paragraphClasslist = paragraphMock.getByText("Example").classList
+        expect(paragraphClasslist).toContain("paragraph")
+        expect(paragraphClasslist).toContain(color)
       })
     })
   })

--- a/packages/component-library/components/Paragraph/Paragraph.tsx
+++ b/packages/component-library/components/Paragraph/Paragraph.tsx
@@ -17,6 +17,14 @@ export type AllowedTags =
   | "h5"
   | "h6"
 
+export type AllowedColors =
+  | "dark"
+  | "dark-reduced-opacity"
+  | "white"
+  | "white-reduced-opacity"
+  | "positive"
+  | "negative"
+
 export interface ParagraphProps {
   /**
    * Not recommended. A short-circuit for overriding styles in a pinch
@@ -33,6 +41,7 @@ export interface ParagraphProps {
    * Allowed paragraph variants
    */
   variant: ParagraphVariants
+  color?: AllowedColors
 }
 
 export const Paragraph = ({
@@ -40,11 +49,13 @@ export const Paragraph = ({
   children,
   tag,
   variant,
+  color = "dark",
   ...otherProps
 }: ParagraphProps) => {
   const classes: string[] = [
     styles.paragraph,
     styles[variant],
+    styles[color],
     classNameAndIHaveSpokenToDST,
   ]
 

--- a/packages/component-library/components/Paragraph/__snapshots__/Paragraph.spec.tsx.snap
+++ b/packages/component-library/components/Paragraph/__snapshots__/Paragraph.spec.tsx.snap
@@ -4,7 +4,7 @@ exports[`<Paragraph /> defaults to the correct HTML element renders the correct 
 <body>
   <div>
     <p
-      class="paragraph body"
+      class="paragraph body dark"
     >
       Example
     </p>
@@ -16,7 +16,7 @@ exports[`<Paragraph /> defaults to the correct HTML element renders the correct 
 <body>
   <div>
     <p
-      class="paragraph extra-small"
+      class="paragraph extra-small dark"
     >
       Example
     </p>
@@ -28,7 +28,7 @@ exports[`<Paragraph /> defaults to the correct HTML element renders the correct 
 <body>
   <div>
     <p
-      class="paragraph intro-lede"
+      class="paragraph intro-lede dark"
     >
       Example
     </p>
@@ -40,7 +40,7 @@ exports[`<Paragraph /> defaults to the correct HTML element renders the correct 
 <body>
   <div>
     <p
-      class="paragraph small"
+      class="paragraph small dark"
     >
       Example
     </p>

--- a/packages/component-library/stories/Paragraph.stories.elm
+++ b/packages/component-library/stories/Paragraph.stories.elm
@@ -3,7 +3,7 @@ module Main exposing (main)
 import CssModules exposing (css)
 import ElmStorybook exposing (statelessStoryOf, storybook)
 import Html exposing (text)
-import Paragraph.Paragraph as Paragraph exposing (TypeVariant(..), view)
+import Paragraph.Paragraph as Paragraph exposing (AllowedColor(..), TypeVariant(..), view)
 
 
 main =
@@ -11,10 +11,22 @@ main =
         [ statelessStoryOf "IntroLede" <|
             Paragraph.view
                 (Paragraph.p |> Paragraph.variant IntroLede)
-                [ Html.text "Paragraph Intro Lede " ]
+                [ Html.text "Paragraph Intro Lede" ]
         , statelessStoryOf "Body" <|
             Paragraph.view
                 (Paragraph.p |> Paragraph.variant Body)
+                [ Html.text "Paragraph Body" ]
+        , statelessStoryOf "Body Dark Reduced Opacity" <|
+            Paragraph.view
+                (Paragraph.p |> Paragraph.variant Body |> Paragraph.color DarkReducedOpacity)
+                [ Html.text "Paragraph Body" ]
+        , statelessStoryOf "Body Positive" <|
+            Paragraph.view
+                (Paragraph.p |> Paragraph.variant Body |> Paragraph.color Positive)
+                [ Html.text "Paragraph Body" ]
+        , statelessStoryOf "Body Negative" <|
+            Paragraph.view
+                (Paragraph.p |> Paragraph.variant Body |> Paragraph.color Negative)
                 [ Html.text "Paragraph Body" ]
         , statelessStoryOf "Small" <|
             Paragraph.view

--- a/packages/component-library/stories/Paragraph.stories.tsx
+++ b/packages/component-library/stories/Paragraph.stories.tsx
@@ -1,4 +1,5 @@
 import { loadElmStories } from "@cultureamp/elm-storybook"
+import * as colorTokens from "@kaizen/design-tokens/tokens/color.json"
 import * as React from "react"
 import { Paragraph } from "../components/Paragraph"
 
@@ -14,6 +15,47 @@ export const Body = () => (
   </Paragraph>
 )
 
+export const BodyDarkReducedOpacity = () => (
+  <Paragraph
+    data-automation-id="test"
+    variant="body"
+    color="dark-reduced-opacity"
+  >
+    Paragraph Body
+  </Paragraph>
+)
+
+export const BodyWhite = () => (
+  <Paragraph variant="body" color="white">
+    Paragraph Body
+  </Paragraph>
+)
+
+BodyWhite.story = {
+  name: "Body White",
+  parameters: {
+    backgrounds: [
+      {
+        name: "Wisteria 700",
+        value: colorTokens.kz.color.wisteria["700"],
+        default: true,
+      },
+    ],
+  },
+}
+
+export const BodyPositive = () => (
+  <Paragraph variant="body" color="positive">
+    Paragraph Body
+  </Paragraph>
+)
+
+export const BodyNegative = () => (
+  <Paragraph variant="body" color="negative">
+    Paragraph Body
+  </Paragraph>
+)
+
 export const Small = () => (
   <Paragraph variant="small">Paragraph Small</Paragraph>
 )
@@ -25,6 +67,9 @@ export const ExtraSmall = () => (
 loadElmStories("Paragraph (Elm)", module, require("./Paragraph.stories.elm"), [
   "IntroLede",
   "Body",
+  "Body Dark Reduced Opacity",
+  "Body Positive",
+  "Body Negative",
   "Small",
   "ExtraSmall",
 ])


### PR DESCRIPTION
## Changes

This follows the recently-shipped PR that adds color support to the Heading component (https://github.com/cultureamp/kaizen-design-system/pull/343).

It uses the same `AllowedColors` types as the Heading, but removes the distinction of positive and negative colors being over 24px or under, since all paragraph type styles are under 24px.

Updated:

- React component
- React unit tests
- React snapshot tests
- React stories
- Elm component
- Elm stories

![image](https://user-images.githubusercontent.com/6406263/78219325-052ac300-750b-11ea-8a0d-b9062a73ccb3.png)
