### PR TITLE
fix: Adjust active link color for content colorscheme

### DIFF
--- a/packages/component-library/components/NavigationBar/NavigationBar.module.scss
+++ b/packages/component-library/components/NavigationBar/NavigationBar.module.scss
@@ -24,6 +24,10 @@
         color: $kz-color-wisteria-800;
         font-weight: 500;
       }
+
+      .active a {
+        color: $kz-color-cluny-500;
+      }
     }
   }
 }
@@ -87,12 +91,4 @@
 
 .kaizen .active {
   background-color: $kz-color-wisteria-700;
-}
-
-.content .active {
-  background-color: $kz-color-cluny-200;
-
-  a {
-    color: $kz-color-cluny-500;
-  }
 }


### PR DESCRIPTION
<img width="230" alt="Screen Shot 2020-04-03 at 1 41 37 pm" src="https://user-images.githubusercontent.com/7019081/78318652-07475d00-75b1-11ea-8399-dd52c18896fe.png">
