### PR TITLE
chore: Bump elm-storybook

### DIFF
--- a/packages/component-library/package.json
+++ b/packages/component-library/package.json
@@ -48,7 +48,7 @@
     "uuid": "^3.3.2"
   },
   "devDependencies": {
-    "@cultureamp/elm-storybook": "cultureamp/elm-storybook#0.1.0",
+    "@cultureamp/elm-storybook": "cultureamp/elm-storybook#0.2.0",
     "rimraf": "^2.6.3"
   },
   "scripts": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -999,6 +999,12 @@
   dependencies:
     react-elm-components "^1.1.0"
 
+"@cultureamp/elm-storybook@cultureamp/elm-storybook#0.2.0":
+  version "0.2.0"
+  resolved "https://codeload.github.com/cultureamp/elm-storybook/tar.gz/e73b617a069e8ecdd40056fedb361a55b886321b"
+  dependencies:
+    react-elm-components "^1.1.0"
+
 "@egoist/vue-to-react@^1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@egoist/vue-to-react/-/vue-to-react-1.1.0.tgz#83c884b8608e8ee62e76c03e91ce9c26063a91ad"


### PR DESCRIPTION
This allows elm programs in storybook to leverage ports and execute
javascript.

Creating elm views that rely on ports brings up questions around how
this dependency is communicated to consumers.

Ongoing discussions are being had with the design systems team around
documentation.

The use of ports as it stands should ideally be used as a performance
enhancer to a problem not able to be solved with Elm alone.