### PR TITLE
fix: Point to correct tsconfig file

### DIFF
--- a/draft-packages/well/tsconfig.dist.json
+++ b/draft-packages/well/tsconfig.dist.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../../tsconfig.json",
+  "extends": "../../tsconfig.json",
   "compilerOptions": {
     "allowJs": false,
     "declaration": true,


### PR DESCRIPTION
This broke master :/ 

The build was trying to find a config file that does not exist: 
https://buildkite.com/culture-amp/kaizen-design-system/builds/1966#3ea6bceb-f21e-46cb-942a-4924d3a03483