### PR TITLE
feat: Tweak the vertical centering of the Tab component

### DIFF
--- a/packages/component-library/draft/Kaizen/Tabs/styles.scss
+++ b/packages/component-library/draft/Kaizen/Tabs/styles.scss
@@ -11,12 +11,18 @@
 }
 
 .tab {
+  $underline-height: 4px;
+
   @include ca-padding($top: $ca-grid * 0.5, $bottom: $ca-grid * 0.75);
   @include ca-type-ideal-button;
   @include ca-inherit-baseline;
   text-decoration: none;
   color: $kz-color-wisteria-800;
-  border-bottom: 4px solid transparent;
+  // This border will become visible when the .activeTab class is applied
+  border-bottom: $underline-height solid transparent;
+  // This invisible border is to compensate for the bottom border,
+  // as to make sure the content is vertically centered
+  border-top: $underline-height solid transparent;
   cursor: pointer;
 
   &:hover {


### PR DESCRIPTION
* Tweak the vertical centering of the `Tab` component. When I added these tabs to the preform site, they were added to a sticky header, which made them positioned flush up against the top of the viewport, and therefore they looked a bit misaligned.

The fix I implemented was to add an invisible top border, as to compensate for the bottom one.

Before:
<img width="462" alt="Screen Shot 2020-04-20 at 3 12 06 pm" src="https://user-images.githubusercontent.com/4495057/79716277-92e31c80-8319-11ea-9a55-f01c1c26a884.png">

After:
<img width="494" alt="Screen Shot 2020-04-20 at 3 11 28 pm" src="https://user-images.githubusercontent.com/4495057/79716282-99719400-8319-11ea-95b6-e91b4befc344.png">
