### PR TITLE
docs: Custom illustrations in confirmation modals

### DIFF
--- a/packages/component-library/draft/Kaizen/Modal/README.mdx
+++ b/packages/component-library/draft/Kaizen/Modal/README.mdx
@@ -63,6 +63,8 @@ The confirmation modal confirms the end result of an action such as Negative or 
 - Header: States what the intent of Modal is. A verb and a noun (e.g. Upload an image, Notify users, Restart imports etc.)
 - Footer: Primary/Destructive action label reflect the action they are performing (relative to the header).
 
+We don't use custom spot illustrations in confirmation modals. Instead, use the standard spot illustrations.
+
 ### Input/edit modal
 
 Input/edit modals allow people to change data or settings without leaving the page. They support the ability to edit up to 3 fields. Any more becomes crowded and a new page or Isolation modal is preferred.


### PR DESCRIPTION
Adding to modal documentation about not using custom spot illustrations on confirmation variants of the modal component.