### PR TITLE
feat: allow menu items to return click event

### DIFF
--- a/packages/component-library/components/NavigationBar/components/Menu.tsx
+++ b/packages/component-library/components/NavigationBar/components/Menu.tsx
@@ -152,10 +152,17 @@ export default class Menu extends React.Component<MenuProps, State> {
     )
   }
 
-  renderOffCanvasMenuItem = (item: MenuItem) => (
-    <Link key={item.url} text={item.label} href={item.url} />
-  )
-
+  renderOffCanvasMenuItem = (item: MenuItem) => {
+    const { onLinkClick } = this.props
+    return (
+      <Link
+        key={item.url}
+        text={item.label}
+        href={item.url}
+        onClick={onLinkClick}
+      />
+    )
+  }
   renderOffCanvasMenuGroup = (menuGroup: MenuGroup) => {
     const { title, items } = menuGroup
 
@@ -168,6 +175,7 @@ export default class Menu extends React.Component<MenuProps, State> {
   }
 
   renderMenuItem = (item: MenuItem) => {
+    const { onLinkClick } = this.props
     const { label, url, method, active = false } = item
 
     if (method && method !== "get") {
@@ -196,6 +204,7 @@ export default class Menu extends React.Component<MenuProps, State> {
           [styles.menuItemActive]: active,
         })}
         tabIndex={0}
+        onClick={onLinkClick}
       >
         {label}
       </a>

--- a/packages/component-library/components/NavigationBar/types.ts
+++ b/packages/component-library/components/NavigationBar/types.ts
@@ -8,6 +8,8 @@ export type Navigation = {
 
 export type NavigationItem = ReactElement<LinkProps> | ReactElement<MenuProps>
 
+export type LinkClick = (event: React.MouseEvent<HTMLAnchorElement>) => void
+
 export type LinkProps = {
   icon?: React.SVGAttributes<SVGSymbolElement>
   text?: string
@@ -15,7 +17,7 @@ export type LinkProps = {
   href: string
   active?: boolean
   id?: string
-  onClick?: (event: React.MouseEvent<HTMLAnchorElement>) => void
+  onClick?: LinkClick
   target?: "_self" | "_blank"
   hasMenu?: boolean
   badge?: {
@@ -33,6 +35,7 @@ export type MenuProps = {
   heading: string
   mobileEnabled?: boolean
   section?: string
+  onLinkClick?: LinkClick
 }
 
 export type MenuItem = {


### PR DESCRIPTION
- needed to implement correct routing in performance-ui