### PR TITLE
fix: revert "update caButtonContainer display type to avoid IE11 issue"

### DIFF
--- a/packages/component-library/components/Button/styles.scss
+++ b/packages/component-library/components/Button/styles.scss
@@ -27,7 +27,7 @@ $caButton-verticalPaddingForm: calc(
 }
 
 %caButtonContainer {
-  @include ca-type-block(inline-flex);
+  @include ca-type-block(inline-block);
 }
 
 %caButton {


### PR DESCRIPTION
Reverts cultureamp/kaizen-design-system#401

This appears to be causing issues with IconButton alignment, so this is being reverted.

The bug in IE11 is much less impactful than the bug that's this PR was affecting IconButton. Let's revisit the IE11 issue after this has been reverted.