### PR TITLE
docs: update docs for content/canvas dividers

### DIFF
--- a/site/docs/components/divider.mdx
+++ b/site/docs/components/divider.mdx
@@ -25,7 +25,10 @@ import WhenNotToUse from "docs-components/WhenNotToUse"
 
 ## To keep in mind
 
-Dividers separate content into clear groups. This helps people navigate the information hierarchy. 
+Dividers separate content into clear groups. This helps people navigate the information hierarchy.
+
+- **Content dividers** are used to separate content within a card, table, or any white content area.
+- **Canvas dividers** are used on the canvas (not cards) to separate large blocks of content. For example, a canvas divider is used to define the area under the [Title Block](/components/title-block) to create a single hierarchical plain at the top of the page.
 
 * We use full-bleed dividers in lists/menus and middle dividers to group or separate content.
 * They inherit the background color they sit on, hence the need for an opacity (alpha).


### PR DESCRIPTION
This PR adds:

- **Content dividers** are used to separate content within a card, table, or any white content area.
- **Canvas dividers** are used on the canvas (not cards) to separate large blocks of content. For example, a canvas divider is used to define the area under the [Title Block](/components/title-block) to create a single hierarchical plain at the top of the page.