### PR TITLE
ci: make chromatic build optional

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -46,16 +46,6 @@ steps:
     <<: *defaults
     agent_query_rules: ["queue=build-unrestricted-large"]
 
-  - name: ":rainbow: Build (chromatic)"
-    command: ".buildkite/scripts/run-chromatic-build.sh"
-    <<: *defaults
-    agent_query_rules: ["queue=build-unrestricted-large"]
-    plugins:
-      - cultureamp/aws-assume-role#v0.1.0:
-          role: "${KAIZEN_ROLE_ARN}"
-      - docker-compose#v3.0.3:
-          run: release
-
   - wait: ~
     continue_on_failure: true
 
@@ -69,3 +59,19 @@ steps:
           role: "${KAIZEN_ROLE_ARN}"
       - docker-compose#v3.0.3:
           run: publish
+
+  - block: ":rainbow: Build (chromatic)"
+    fields:
+      - text: "Build Chromatic"
+        key: "build-chromatic"
+
+
+  - name: ":rainbow: Build (chromatic)"
+    command: ".buildkite/scripts/run-chromatic-build.sh"
+    <<: *defaults
+    agent_query_rules: ["queue=build-unrestricted-large"]
+    plugins:
+      - cultureamp/aws-assume-role#v0.1.0:
+          role: "${KAIZEN_ROLE_ARN}"
+      - docker-compose#v3.0.3:
+          run: release

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -64,6 +64,7 @@ steps:
     fields:
       - text: "Build Chromatic"
         key: "build-chromatic"
+        prompt: "check in Chromatic?"
 
 
   - name: ":rainbow: Build (chromatic)"

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -61,11 +61,7 @@ steps:
           run: publish
 
   - block: ":rainbow: Build (chromatic)"
-    fields:
-      - text: "Build Chromatic"
-        key: "build-chromatic"
-        prompt: "check in Chromatic?"
-
+    prompt: "Check in Chromatic?"
 
   - name: ":rainbow: Build (chromatic)"
     command: ".buildkite/scripts/run-chromatic-build.sh"


### PR DESCRIPTION
We are very quickly burning through our open source plan snapshot limit. We are already on 18000 / 35000, and that's after 2 days. This is not going to work if we do a chromatic build on every commit. So, this makes it optional - you would generally only do it on the final commit of a PR. This was a very quick PR, and there might be a better sequence (such as not having to wait for the dev site build), but it works .

**I'm really concerned about burning our credits and having to wait a month.** That would be a real bummer, as there are lots of useful things we can do with this over the next month. This is out of scope for our current work, but I think this quick fix is much better than the current config which will burn all our credits within the next day or two.

It looks like this if you don't unlock the Chromatic step, but the build goes green (is mergable)


![image](https://user-images.githubusercontent.com/702885/80680949-0e578180-8b03-11ea-8e35-4fbd6f016013.png)


This is what is looks like after you unblock at the step:

![image](https://user-images.githubusercontent.com/702885/80680991-1fa08e00-8b03-11ea-962a-0a23004aaa53.png)
