### PR TITLE
feat: Copy layout styles to deprecated-helpers pkg

### DIFF
--- a/packages/deprecated-component-library-helpers/styles/layout.scss
+++ b/packages/deprecated-component-library-helpers/styles/layout.scss
@@ -1,0 +1,55 @@
+@import "type";
+
+$ca-layout-max-width: 1416px;
+$ca-layout-side-padding: 24px;
+$ca-layout-content-width: 1080px;
+$ca-layout-title-block-height: 5 * $ca-grid;
+$ca-layout-title-block-tablet-height: 3.5 * $ca-grid;
+$ca-layout-title-block-mobile-height: 2.5 * $ca-grid;
+$ca-layout-sidebar-width: 10 * $ca-grid;
+
+@mixin ca-margin($start: 0, $end: 0, $top: null, $bottom: null) {
+  margin-top: $top;
+  margin-bottom: $bottom;
+  margin-right: $end;
+  margin-left: $start;
+
+  &[dir="rtl"],
+  [dir="rtl"] & {
+    margin-right: $start;
+    margin-left: $end;
+  }
+}
+
+@mixin ca-padding($start: 0, $end: 0, $top: null, $bottom: null) {
+  padding-top: $top;
+  padding-bottom: $bottom;
+  padding-right: $end;
+  padding-left: $start;
+
+  &[dir="rtl"],
+  [dir="rtl"] & {
+    padding-right: $start;
+    padding-left: $end;
+  }
+}
+
+@mixin ca-position($start: null, $end: null, $top: null, $bottom: null) {
+  @if ($start == null and $end != null) {
+    $start: auto;
+  }
+  @if ($end == null and $start != null) {
+    $end: auto;
+  }
+
+  top: $top;
+  bottom: $bottom;
+  right: $end;
+  left: $start;
+
+  &[dir="rtl"],
+  [dir="rtl"] & {
+    right: $start;
+    left: $end;
+  }
+}


### PR DESCRIPTION
## Changes

Copy the `layout.scss` to `deprecated-component-library-helpers`.

This is
- because we eventually want to do this anyway, and
- so that the new Button draft component can get all its style imports from either `design-tokens` or `deprecated-component-library-helpers` without having a `component-library` import in there as well.

I.e. after this change, the draft component Button styles can look like this:
![image](https://user-images.githubusercontent.com/6406263/81045027-b81a8200-8ef8-11ea-86e4-701615b51ea1.png)
