### PR TITLE
feat: pass arbitrary children to input edit model instead of text fields

### DIFF
--- a/draft-packages/modal/KaizenDraft/Modal/Modal.elm
+++ b/draft-packages/modal/KaizenDraft/Modal/Modal.elm
@@ -30,7 +30,6 @@ import Html.Attributes exposing (style)
 import Html.Events exposing (onClick)
 import Html.Lazy exposing (lazy)
 import KaizenDraft.Events.Events as KaizenEvents
-import KaizenDraft.Form.TextField.TextField as TextField
 import KaizenDraft.Modal.Presets.ConfirmationModal as ConfirmationModal
 import KaizenDraft.Modal.Presets.InputEditModal as InputEditModal
 import KaizenDraft.Modal.Primitives.Constants as Constants
@@ -145,8 +144,7 @@ type alias ConfirmationContract msg =
 
 type alias InputEditConfig msg =
     { title : String
-    , instructiveText : Maybe String
-    , textFieldConfigs : List (TextField.Config msg)
+    , children : List (Html msg)
     , onDismiss : Maybe msg
     , onConfirm : Maybe msg
     , confirmLabel : String
@@ -435,14 +433,6 @@ viewContent (Config modalConfig) =
                             Nothing ->
                                 inputEditConfig
 
-                    withInstructiveText inputEditConfig =
-                        case configs.instructiveText of
-                            Just instructiveText ->
-                                InputEditModal.instructiveText instructiveText inputEditConfig
-
-                            Nothing ->
-                                inputEditConfig
-
                     commonInputEditConfig inputEditConfig =
                         withOnDismiss inputEditConfig
                             |> withOnConfirm
@@ -451,7 +441,7 @@ viewContent (Config modalConfig) =
                             |> InputEditModal.confirmLabel configs.confirmLabel
                             |> InputEditModal.dismissLabel configs.dismissLabel
                             |> InputEditModal.title configs.title
-                            |> InputEditModal.textFieldConfigs configs.textFieldConfigs
+                            |> InputEditModal.children configs.children
                 in
                 case inputEditType of
                     InputPositive ->
@@ -459,7 +449,6 @@ viewContent (Config modalConfig) =
                             [ InputEditModal.view
                                 (InputEditModal.positive
                                     |> commonInputEditConfig
-                                    |> withInstructiveText
                                 )
                             ]
                             (genericModalConfig |> GenericModal.events genericModalEvents)
@@ -469,7 +458,6 @@ viewContent (Config modalConfig) =
                             [ InputEditModal.view
                                 (InputEditModal.negative
                                     |> commonInputEditConfig
-                                    |> withInstructiveText
                                 )
                             ]
                             (genericModalConfig |> GenericModal.events genericModalEvents)

--- a/draft-packages/modal/KaizenDraft/Modal/Presets/InputEditModal.elm
+++ b/draft-packages/modal/KaizenDraft/Modal/Presets/InputEditModal.elm
@@ -1,10 +1,10 @@
 module KaizenDraft.Modal.Presets.InputEditModal exposing
-    ( confirmId
+    ( children
+    , confirmId
     , confirmLabel
     , confirmPreventKeydownOn
     , dismissLabel
     , headerDismissId
-    , instructiveText
     , negative
     , onConfirm
     , onConfirmBlur
@@ -14,18 +14,15 @@ module KaizenDraft.Modal.Presets.InputEditModal exposing
     , onHeaderDismissFocus
     , onPreventHeaderDismissKeydown
     , positive
-    , textFieldConfigs
     , title
     , view
     )
 
 import Button.Button as Button
 import CssModules exposing (css)
-import Html exposing (Html, div, form, span, text)
+import Html exposing (Html, div, text)
 import Json.Decode as Decode
-import KaizenDraft.Form.TextField.TextField as TextField
 import KaizenDraft.Modal.Primitives.Configuration as ModalConfiguration exposing (configurationDefaults)
-import KaizenDraft.Modal.Primitives.ModalAccessibleDescription as ModalAccessibleDescription
 import KaizenDraft.Modal.Primitives.ModalAccessibleLabel as ModalAccessibleLabel
 import KaizenDraft.Modal.Primitives.ModalBody as ModalBody
 import KaizenDraft.Modal.Primitives.ModalFooter as ModalFooter
@@ -44,8 +41,7 @@ type alias Configuration msg =
 type alias InputEditConfiguration msg base =
     { base
         | variant : Variant
-        , instructiveText : Maybe String
-        , textFieldConfigs : List (TextField.Config msg)
+        , children : List (Html msg)
     }
 
 
@@ -57,8 +53,7 @@ type Variant
 defaults : Configuration msg
 defaults =
     { variant = Positive
-    , instructiveText = Nothing
-    , textFieldConfigs = []
+    , children = []
     , onDismiss = configurationDefaults.onDismiss
     , onConfirm = configurationDefaults.onConfirm
     , title = configurationDefaults.title
@@ -138,7 +133,7 @@ view (Config config) =
                 |> ModalHeader.dismissReverse False
             )
         , ModalBody.view <|
-            (ModalBody.layout [ body config ]
+            (ModalBody.layout config.children
                 |> ModalBody.background ModalBody.Stone
             )
         , ModalFooter.view <|
@@ -162,31 +157,6 @@ header config =
                 [ text config.title ]
             ]
         ]
-
-
-body : Configuration msg -> Html msg
-body config =
-    let
-        withInstructiveText =
-            case config.instructiveText of
-                Just instText ->
-                    ModalAccessibleDescription.view
-                        [ Text.view Text.p [ text instText ]
-                        ]
-
-                Nothing ->
-                    text ""
-
-        textField textConfig =
-            TextField.view textConfig
-
-        withTextFields =
-            List.map textField config.textFieldConfigs
-    in
-    div []
-        ([ span [ styles.class .instructiveText ] [ withInstructiveText ] ]
-            ++ [ form [] withTextFields ]
-        )
 
 
 footer : Configuration msg -> List (Html msg)
@@ -282,11 +252,6 @@ title titleString (Config config) =
     Config { config | title = titleString }
 
 
-instructiveText : String -> Config msg -> Config msg
-instructiveText instText (Config config) =
-    Config { config | instructiveText = Just instText }
-
-
 headerDismissId : String -> Config msg -> Config msg
 headerDismissId id_ (Config config) =
     Config { config | headerDismissId = Just id_ }
@@ -337,15 +302,14 @@ onConfirmBlur msg (Config config) =
     Config { config | onConfirmBlur = Just msg }
 
 
-textFieldConfigs : List (TextField.Config msg) -> Config msg -> Config msg
-textFieldConfigs configs (Config config) =
-    Config { config | textFieldConfigs = configs }
+children : List (Html msg) -> Config msg -> Config msg
+children value (Config config) =
+    Config { config | children = value }
 
 
 styles =
     css "@kaizen/component-library/draft/Kaizen/Modal/Presets/InputEditModal.scss"
         { header = "header"
-        , instructiveText = "instructiveText"
         }
 
 

--- a/draft-packages/modal/KaizenDraft/Modal/Presets/InputEditModal.scss
+++ b/draft-packages/modal/KaizenDraft/Modal/Presets/InputEditModal.scss
@@ -21,7 +21,3 @@
   padding: $ca-grid $ca-grid $ca-grid * 1.5;
   border-bottom: 1px solid $ca-border-color;
 }
-
-.instructiveText {
-  text-align: center;
-}

--- a/draft-packages/stories/ModalStories.elm
+++ b/draft-packages/stories/ModalStories.elm
@@ -7,11 +7,12 @@ import Html.Attributes exposing (style)
 import Icon.Icon as Icon
 import Icon.SvgAsset exposing (svgAsset)
 import Kaizen.Form.TextField.TextField as TextField
-import Kaizen.Modal.Modal as Modal
-import Kaizen.Modal.Primitives.Constants as ModalConstants
-import Kaizen.Modal.Primitives.ModalBody as ModalBody
-import Kaizen.Modal.Primitives.ModalFooter as ModalFooter
-import Kaizen.Modal.Primitives.ModalHeader as ModalHeader
+import KaizenDraft.Modal.Modal as Modal
+import KaizenDraft.Modal.Primitives.Constants as ModalConstants
+import KaizenDraft.Modal.Primitives.ModalAccessibleDescription as ModalAccessibleDescription
+import KaizenDraft.Modal.Primitives.ModalBody as ModalBody
+import KaizenDraft.Modal.Primitives.ModalFooter as ModalFooter
+import KaizenDraft.Modal.Primitives.ModalHeader as ModalHeader
 import Text.Text as Text
 
 
@@ -375,6 +376,14 @@ main =
                             |> TextField.inputValue "123456789"
                             |> TextField.icon [ Html.map never <| Icon.view Icon.presentation (svgAsset "@kaizen/component-library/icons/lock.icon.svg") ]
                         ]
+
+                    instructionText =
+                        ModalAccessibleDescription.view
+                            [ Text.view Text.p [ text "Instructive text to drive user selection goes here." ]
+                            ]
+
+                    textFields =
+                        List.map TextField.view textFieldConfigs
                 in
                 div []
                     [ Button.view (Button.default |> Button.onClick SetInputEditModalContext) "Open Modal"
@@ -383,9 +392,7 @@ main =
                             Modal.view <|
                                 (Modal.inputEdit Modal.InputPositive
                                     { title = "Input-edit modal title"
-                                    , textFieldConfigs = textFieldConfigs
-                                    , instructiveText =
-                                        Just "Instructive text to drive user selection goes here."
+                                    , children = instructionText :: textFields
                                     , onDismiss = Just ModalDismissed
                                     , onConfirm = Just ModalConfirmed
                                     , confirmLabel = "Submit"
@@ -415,17 +422,23 @@ main =
                             |> TextField.inputValue "123456789"
                             |> TextField.icon [ Html.map never <| Icon.view Icon.presentation (svgAsset "@kaizen/component-library/icons/lock.icon.svg") ]
                         ]
+
+                    instructionText =
+                        ModalAccessibleDescription.view
+                            [ Text.view Text.p [ text "Instructive text to drive user selection goes here." ]
+                            ]
+
+                    textFields =
+                        List.map TextField.view textFieldConfigs
                 in
                 div []
                     [ Button.view (Button.default |> Button.onClick SetInputEditModalContext) "Open Modal"
                     , case m.modalContext of
                         InputEditModal modalState ->
-                            Modal.view <|
+                            Modal.view
                                 (Modal.inputEdit Modal.InputNegative
                                     { title = "Input-edit modal title"
-                                    , textFieldConfigs = textFieldConfigs
-                                    , instructiveText =
-                                        Just "Instructive text to drive user selection goes here."
+                                    , children = instructionText :: textFields
                                     , onDismiss = Just ModalDismissed
                                     , onConfirm = Just ModalConfirmed
                                     , confirmLabel = "Submit"


### PR DESCRIPTION
We extend the input edit modal to be able to receive generic children as opposed to be scoped only to the input text fields as before.

The driver decision for this was when we wanted a modal containing a dropdown. We realised that the current implementation would accept only text fields and instructional text. There was no flexibility.

We combed the code looking for usages. Seems like only the story board was actually using it.