### PR TITLE
feat: Create description prop for TextAreaField

### DIFF
--- a/draft-packages/stories/TextAreaField.stories.tsx
+++ b/draft-packages/stories/TextAreaField.stories.tsx
@@ -161,3 +161,21 @@ export const DefaultInline = () => (
 DefaultInline.story = {
   name: "Default, Inline",
 }
+
+export const DefaultErrorAndDesc = () => (
+  <ExampleContainer>
+    <TextAreaField
+      id="reply"
+      labelText="Your Reply"
+      placeholder="Write your reply..."
+      onChange={action("user input")}
+      status="error"
+      validationMessage="Enter a reply"
+      description="Your reply will only be seen by you"
+    />
+  </ExampleContainer>
+)
+
+DefaultErrorAndDesc.story = {
+  name: "Default, Error & Description",
+}

--- a/draft-packages/stories/TextAreaField.stories.tsx
+++ b/draft-packages/stories/TextAreaField.stories.tsx
@@ -145,3 +145,19 @@ export const DefaultWithDesc = () => (
 DefaultWithDesc.story = {
   name: "Default, With description",
 }
+
+export const DefaultInline = () => (
+  <ExampleContainer>
+    <TextAreaField
+      id="reply"
+      labelText="Your Reply"
+      placeholder="Write your reply..."
+      onChange={action("user input")}
+      inline={true}
+    />
+  </ExampleContainer>
+)
+
+DefaultInline.story = {
+  name: "Default, Inline",
+}

--- a/draft-packages/stories/TextAreaField.stories.tsx
+++ b/draft-packages/stories/TextAreaField.stories.tsx
@@ -129,3 +129,19 @@ export const DefaultControlled = () => (
 DefaultControlled.story = {
   name: "Default, Controlled",
 }
+
+export const DefaultWithDesc = () => (
+  <ExampleContainer>
+    <TextAreaField
+      id="reply"
+      labelText="Your Reply"
+      placeholder="Write your reply..."
+      onChange={action("user input")}
+      description="Your reply will only be seen by you"
+    />
+  </ExampleContainer>
+)
+
+DefaultWithDesc.story = {
+  name: "Default, With description",
+}

--- a/draft-packages/stories/TextAreaField.stories.tsx
+++ b/draft-packages/stories/TextAreaField.stories.tsx
@@ -87,7 +87,7 @@ export const DefaultError = () => (
       placeholder="Write your reply..."
       onChange={action("user input")}
       status="error"
-      validationMessage="Enter a reply."
+      validationMessage="Enter a reply"
     />
   </ExampleContainer>
 )
@@ -137,7 +137,7 @@ export const DefaultWithDesc = () => (
       labelText="Your Reply"
       placeholder="Write your reply..."
       onChange={action("user input")}
-      description="Your reply will only be seen by you."
+      description="Your reply will only be seen by you"
     />
   </ExampleContainer>
 )
@@ -170,8 +170,8 @@ export const DefaultErrorAndDesc = () => (
       placeholder="Write your reply..."
       onChange={action("user input")}
       status="error"
-      validationMessage="Enter a reply."
-      description="Your reply will only be seen by you."
+      validationMessage="Enter a reply"
+      description="Your reply will only be seen by you"
     />
   </ExampleContainer>
 )

--- a/draft-packages/stories/TextAreaField.stories.tsx
+++ b/draft-packages/stories/TextAreaField.stories.tsx
@@ -87,7 +87,7 @@ export const DefaultError = () => (
       placeholder="Write your reply..."
       onChange={action("user input")}
       status="error"
-      validationMessage="Enter a reply"
+      validationMessage="Enter a reply."
     />
   </ExampleContainer>
 )
@@ -137,7 +137,7 @@ export const DefaultWithDesc = () => (
       labelText="Your Reply"
       placeholder="Write your reply..."
       onChange={action("user input")}
-      description="Your reply will only be seen by you"
+      description="Your reply will only be seen by you."
     />
   </ExampleContainer>
 )
@@ -170,8 +170,8 @@ export const DefaultErrorAndDesc = () => (
       placeholder="Write your reply..."
       onChange={action("user input")}
       status="error"
-      validationMessage="Enter a reply"
-      description="Your reply will only be seen by you"
+      validationMessage="Enter a reply."
+      description="Your reply will only be seen by you."
     />
   </ExampleContainer>
 )

--- a/draft-packages/stories/TextField.stories.tsx
+++ b/draft-packages/stories/TextField.stories.tsx
@@ -31,7 +31,7 @@ export const DefaultKaizenSiteDemo = () => (
       }
       placeholder="Please enter your email"
       onChange={action("user input")}
-      description="Valid email addresses must have an @ and a suffix."
+      description="Valid email addresses must have an @ and a suffix"
     />
   </ExampleContainer>
 )
@@ -50,7 +50,7 @@ export const DefaultInline = () => (
       placeholder="Please enter your email"
       onChange={action("user input")}
       inline={true}
-      description="Valid email addresses must have an @ and a suffix."
+      description="Valid email addresses must have an @ and a suffix"
     />
   </ExampleContainer>
 )
@@ -179,7 +179,7 @@ export const DefaultError = () => (
       placeholder="Please enter your email"
       onChange={action("user input")}
       status="error"
-      validationMessage="Your email address looks like it’s from 1996."
+      validationMessage="Your email address looks like it’s from 1996"
     />
   </ExampleContainer>
 )
@@ -245,7 +245,7 @@ export const DefaultMultipleFieldsError = () => (
       placeholder="Please enter your email"
       onChange={action("user input")}
       icon={userIcon}
-      validationMessage="Please enter a valid email address."
+      validationMessage="Please enter a valid email address"
     />
     <TextField
       id="password"
@@ -256,7 +256,7 @@ export const DefaultMultipleFieldsError = () => (
       placeholder="Please enter your password"
       onChange={action("user input")}
       icon={lockIcon}
-      validationMessage="The password entered does not correctly match the provided email address."
+      validationMessage="The password entered does not correctly match the provided email address"
     />
   </ExampleContainer>
 )
@@ -406,7 +406,7 @@ export const ReversedError = () => (
       onChange={action("user input")}
       reversed={true}
       status="error"
-      validationMessage="Your email address looks like it’s from 1996."
+      validationMessage="Your email address looks like it’s from 1996"
     />
   </ExampleContainer>
 )
@@ -427,7 +427,7 @@ export const ReversedErrorIcon = () => (
       icon={userIcon}
       reversed={true}
       status="error"
-      validationMessage="Your email address looks like it’s from 1996."
+      validationMessage="Your email address looks like it’s from 1996"
     />
   </ExampleContainer>
 )
@@ -476,7 +476,7 @@ export const ReversedMultipleFieldsWError = () => (
       placeholder="Please enter your email"
       onChange={action("user input")}
       icon={userIcon}
-      validationMessage="Please enter a valid email address."
+      validationMessage="Please enter a valid email address"
       reversed={true}
     />
     <TextField
@@ -488,7 +488,7 @@ export const ReversedMultipleFieldsWError = () => (
       placeholder="Please enter your password"
       onChange={action("user input")}
       icon={lockIcon}
-      validationMessage="The password entered does not correctly match the provided email addrress."
+      validationMessage="The password entered does not correctly match the provided email addrress"
       reversed={true}
     />
   </ExampleContainer>
@@ -516,7 +516,7 @@ export const DefaultFocusBlurEvents = () => (
       onFocus={action("onFocus fired")}
       onBlur={action("onBlur fired")}
       onChange={action("user input")}
-      description="Valid email addresses must have an @ and a suffix."
+      description="Valid email addresses must have an @ and a suffix"
     />
   </ExampleContainer>
 )

--- a/packages/component-library/draft/Kaizen/Form/TextAreaField/TextAreaField.tsx
+++ b/packages/component-library/draft/Kaizen/Form/TextAreaField/TextAreaField.tsx
@@ -17,6 +17,7 @@ type Props = {
   defaultValue?: string
   validationMessage?: string
   status?: InputStatus
+  description?: string
   onChange?: (event: React.ChangeEvent<HTMLTextAreaElement>) => any
   onBlur?: (event: React.FocusEvent<HTMLTextAreaElement>) => any
   onFocus?: (event: React.FocusEvent<HTMLTextAreaElement>) => any
@@ -30,6 +31,7 @@ const TextAreaField: React.FunctionComponent<Props> = props => {
     defaultValue,
     validationMessage,
     status,
+    description,
     placeholder,
     onChange,
     onBlur,
@@ -63,6 +65,13 @@ const TextAreaField: React.FunctionComponent<Props> = props => {
           automationId={`${id}-field-validation-message`}
           message={validationMessage}
           status={status}
+        />
+      )}
+      {description && (
+        <FieldMessage
+          id={`${id}-field-message`}
+          automationId={`${id}-field-description`}
+          message={description}
         />
       )}
     </FieldGroup>

--- a/packages/component-library/draft/Kaizen/Form/TextAreaField/TextAreaField.tsx
+++ b/packages/component-library/draft/Kaizen/Form/TextAreaField/TextAreaField.tsx
@@ -14,6 +14,7 @@ type Props = {
   placeholder?: string
   name?: string
   value?: string
+  inline?: boolean
   defaultValue?: string
   validationMessage?: string
   status?: InputStatus
@@ -32,6 +33,7 @@ const TextAreaField: React.FunctionComponent<Props> = props => {
     validationMessage,
     status,
     description,
+    inline,
     placeholder,
     onChange,
     onBlur,
@@ -40,7 +42,11 @@ const TextAreaField: React.FunctionComponent<Props> = props => {
   } = props
 
   return (
-    <FieldGroup id={`${id}-field-group`} automationId={`${id}-field-group`}>
+    <FieldGroup
+      id={`${id}-field-group`}
+      inline={inline}
+      automationId={`${id}-field-group`}
+    >
       <Label
         id={`${id}-field-label`}
         automationId={`${id}-field-label`}


### PR DESCRIPTION
Adds a couple of props to `TextAreaField`, with the same functionality as the equivalent props on `TextField`:

Description:
![image](https://user-images.githubusercontent.com/1811583/81255454-005cb000-9071-11ea-8031-97c36c061a04.png)

Inline (removes the bottom margin):
![image](https://user-images.githubusercontent.com/1811583/81255664-998bc680-9071-11ea-8bb1-ea5ee75a2662.png)


