### PR TITLE
fix: bugfix for navigation route change

### DIFF
--- a/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/NavigationBar.tsx
+++ b/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/NavigationBar.tsx
@@ -64,8 +64,8 @@ export default class NavigationBar extends React.Component<Props, State> {
       <LinkClickContext.Provider
         value={{
           handleNavigationChange: event => {
-            const navigationHref = event.currentTarget.href
-            if (!!navigationHref && navigationHref !== "#") {
+            const navigationHash = event.currentTarget.hash
+            if (!!navigationHash && navigationHash !== "#") {
               this.setState({
                 mobileKey: this.state.mobileKey + 1,
               })

--- a/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/NavigationBar.tsx
+++ b/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/NavigationBar.tsx
@@ -64,10 +64,13 @@ export default class NavigationBar extends React.Component<Props, State> {
       <LinkClickContext.Provider
         value={{
           handleNavigationChange: event => {
-            this.setState({
-              mobileKey: this.state.mobileKey + 1,
-            })
-            onNavigationChange(event)
+            const navigationHref = event.currentTarget.href
+            if (!!navigationHref && navigationHref !== "#") {
+              this.setState({
+                mobileKey: this.state.mobileKey + 1,
+              })
+              onNavigationChange(event)
+            }
           },
         }}
       >

--- a/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/components/Menu.tsx
+++ b/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/components/Menu.tsx
@@ -1,4 +1,5 @@
 import * as React from "react"
+import uuid from "uuid/v4"
 
 import { Icon, IconButton } from "@kaizen/component-library"
 import { OffCanvasContext, ZenOffCanvas } from "@kaizen/draft-zen-off-canvas"
@@ -57,6 +58,7 @@ export default class Menu extends React.Component<MenuProps, State> {
               <OffCanvasContext.Consumer>
                 {({ toggleVisibleMenu }) => (
                   <Link
+                    key={uuid()}
                     text={heading}
                     href="#"
                     onClick={() => toggleVisibleMenu(heading)}
@@ -121,9 +123,22 @@ export default class Menu extends React.Component<MenuProps, State> {
     const links: Array<NavigationItem | undefined> = items.map(
       (item, index) => {
         if ("url" in item) {
-          return <Link key={item.url} text={item.label} href={item.url} />
+          return (
+            <Link
+              key={`${item.url}-${uuid()}`}
+              text={item.label}
+              href={item.url}
+            />
+          )
         } else if ("title" in item) {
-          return <MenuGroup first={index === 0} {...item} offCanvas />
+          return (
+            <MenuGroup
+              key={`${item.title}-${uuid()}`}
+              first={index === 0}
+              {...item}
+              offCanvas
+            />
+          )
         }
       }
     )

--- a/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/components/MenuGroup.tsx
+++ b/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/components/MenuGroup.tsx
@@ -14,7 +14,7 @@ const MenuGroup = ({
   offCanvas,
 }: MenuGroupProps) => {
   const renderOffCanvasMenuItem = (item: MenuItemProps) => (
-    <Link key={item.url} text={item.label} href={item.url} />
+    <Link key={`${item.url}-${uuid()}`} text={item.label} href={item.url} />
   )
 
   const renderOffCanvasMenuGroup = () => {

--- a/draft-packages/zen-off-canvas/KaizenDraft/ZenOffCanvas/ZenOffCanvas.tsx
+++ b/draft-packages/zen-off-canvas/KaizenDraft/ZenOffCanvas/ZenOffCanvas.tsx
@@ -73,7 +73,11 @@ export class ZenOffCanvas extends React.Component<Props> {
               <nav className={styles.links}>
                 {links &&
                   Object.keys(links).map(section => (
-                    <Menu section={section} link={links[section]} />
+                    <Menu
+                      key={section}
+                      section={section}
+                      link={links[section]}
+                    />
                   ))}
               </nav>
             </div>


### PR DESCRIPTION
When a user in the mobile nav clicks into a sub-menu, the navigation closes thinking there has been a route change. This has been fixed by checking if a trigger before triggering the nav change event.

Also added missing keys in list renders.