### PR TITLE
feat: Extend TableHeader API for bg colors + revert box shadow

### DIFF
--- a/draft-packages/stories/Table.stories.tsx
+++ b/draft-packages/stories/Table.stories.tsx
@@ -131,6 +131,29 @@ DefaultKaizenSiteDemo.story = {
   name: "Default (Kaizen Site Demo)",
 }
 
+export const HeaderWithWhiteBackground = () => (
+  <Container>
+    <TableContainer>
+      <TableHeader backgroundColor="white">
+        <ExampleTableHeaderRow checkable />
+      </TableHeader>
+      <TableCard>
+        <ExampleTableRow expandable={false} />
+      </TableCard>
+      <TableCard>
+        <ExampleTableRow expandable={false} />
+      </TableCard>
+      <TableCard>
+        <ExampleTableRow expandable={false} />
+      </TableCard>
+    </TableContainer>
+  </Container>
+)
+
+HeaderWithWhiteBackground.story = {
+  name: "Header with white background",
+}
+
 export const Multiline = () => (
   <Container>
     <TableContainer>

--- a/draft-packages/table/KaizenDraft/Table/Table.spec.tsx
+++ b/draft-packages/table/KaizenDraft/Table/Table.spec.tsx
@@ -1,6 +1,7 @@
 import { cleanup, render } from "@testing-library/react"
 import * as React from "react"
 import {
+  AllowedTableHeaderBackgroundColors,
   TableCard,
   TableContainer,
   TableHeader,
@@ -67,6 +68,27 @@ const Wrapper: React.FunctionComponent = () => (
 )
 
 describe("Table", () => {
+  describe("Table props", () => {
+    const testCases: AllowedTableHeaderBackgroundColors[] = ["ash", "white"]
+
+    testCases.forEach(variant => {
+      it(`renders the correct element for <TableHeader backgroundColor={${variant}} />`, () => {
+        const paragraphMock = render(
+          <TableHeader
+            backgroundColor={variant}
+            data-testid={TestId.tableHeader}
+          >
+            Example
+          </TableHeader>
+        )
+        const paragraphClasslist = paragraphMock.getByTestId(TestId.tableHeader)
+          .classList
+        expect(paragraphClasslist).toContain("header")
+        expect(paragraphClasslist).toContain(variant)
+      })
+    })
+  })
+
   describe("Custom HTML props", () => {
     for (const [key, value] of Object.entries(TestId)) {
       it(`${key} accepts custom data-* attributes`, () => {

--- a/draft-packages/table/KaizenDraft/Table/Table.tsx
+++ b/draft-packages/table/KaizenDraft/Table/Table.tsx
@@ -13,9 +13,21 @@ export const TableContainer: TableContainer = ({ children, ...otherProps }) => (
   </div>
 )
 
-type TableHeader = React.FunctionComponent
-export const TableHeader: TableHeader = ({ children, ...otherProps }) => (
-  <div className={styles.header} role="rowgroup" {...otherProps}>
+export type AllowedTableHeaderBackgroundColors = "ash" | "white"
+
+type TableHeader = React.FunctionComponent<{
+  backgroundColor?: AllowedTableHeaderBackgroundColors
+}>
+export const TableHeader: TableHeader = ({
+  children,
+  backgroundColor = "ash",
+  ...otherProps
+}) => (
+  <div
+    className={classNames(styles.header, styles[backgroundColor])}
+    role="rowgroup"
+    {...otherProps}
+  >
     {children}
   </div>
 )

--- a/draft-packages/table/KaizenDraft/Table/index.ts
+++ b/draft-packages/table/KaizenDraft/Table/index.ts
@@ -1,4 +1,5 @@
 export {
+  AllowedTableHeaderBackgroundColors,
   TableCard,
   TableContainer,
   TableHeader,

--- a/draft-packages/table/KaizenDraft/Table/styles.scss
+++ b/draft-packages/table/KaizenDraft/Table/styles.scss
@@ -157,7 +157,6 @@ $row-height: 60px;
   padding: 0 $ca-grid * 0.8;
   display: flex;
   align-items: center;
-  box-shadow: none;
   // These css properties are required for when the cells are anchor elements
   composes: anchorReset;
 }

--- a/draft-packages/table/KaizenDraft/Table/styles.scss
+++ b/draft-packages/table/KaizenDraft/Table/styles.scss
@@ -28,14 +28,14 @@ $row-height: 60px;
 
 .header {
   border: solid 1px $ca-border-color;
-}
 
-.ash {
-  background-color: $kz-color-ash;
-}
+  &.ash {
+    background-color: $kz-color-ash;
+  }
 
-.white {
-  background-color: $kz-color-white;
+  &.white {
+    background-color: $kz-color-white;
+  }
 }
 
 .headerRow {

--- a/draft-packages/table/KaizenDraft/Table/styles.scss
+++ b/draft-packages/table/KaizenDraft/Table/styles.scss
@@ -27,8 +27,15 @@ $row-height: 60px;
 }
 
 .header {
-  background-color: $kz-color-ash;
   border: solid 1px $ca-border-color;
+}
+
+.ash {
+  background-color: $kz-color-ash;
+}
+
+.white {
+  background-color: $kz-color-white;
 }
 
 .headerRow {
@@ -74,7 +81,9 @@ $row-height: 60px;
   @include button-reset;
   background: $kz-color-white;
   border: solid 1px $ca-border-color;
-  box-shadow: $kz-shadow-small-box-shadow;
+  // Reverting back from $kz-shadow-small-box-shadow as an interim.
+  // @see https://cultureamp.slack.com/archives/CETLTFG9G/p1588658249280300?thread_ts=1588587636.273700&cid=CETLTFG9G
+  box-shadow: $ca-box-shadow;
   transition: box-shadow $ca-duration-rapid, border-color $ca-duration-rapid,
     margin $ca-duration-rapid, padding $ca-duration-rapid,
     width $ca-duration-rapid;
@@ -148,6 +157,7 @@ $row-height: 60px;
   padding: 0 $ca-grid * 0.8;
   display: flex;
   align-items: center;
+  box-shadow: none;
   // These css properties are required for when the cells are anchor elements
   composes: anchorReset;
 }


### PR DESCRIPTION
## Objective
1. Enable the `TableHeader` to accept an optional prop to override the background color.
2. Revert the box shadow on the `TableCard` back to previous post-feedback.

### Context
Slack convos based on tickets:
- https://cultureamp.slack.com/archives/CETLTFG9G/p1588587636273700
- https://cultureamp.slack.com/archives/CETLTFG9G/p1588295755236700?thread_ts=1588295755.236700
- https://cultureamp.slack.com/archives/CHZQVHRK5/p1588295527203600
- https://cultureamp.slack.com/archives/CHZQVHRK5/p1588119044429700?thread_ts=1588118180.426800
- https://cultureamp.slack.com/archives/CHZQVHRK5/p1588553720324800?thread_ts=1588553720.324800
- https://cultureamp.slack.com/archives/CHZQVHRK5/p1588761923140000?thread_ts=1588760979.139100

JIRA tickets:
- https://cultureamp.atlassian.net/browse/FOW-1140
- https://cultureamp.atlassian.net/browse/FOW-1112

Figma designs:
- https://www.figma.com/file/cA1dCqQewJO5hMaIdKs4FS/Manager-task-widget?node-id=1098%3A226

### Causes
- The box shadow from token `$kz-shadow-small-box-shadow` bleeds through from the `TableCard` to child components. See the Slack thread for details, but this is an interim fix.

### Changes
1. Reverted the shadow in styles.
2. Extended the `TableHeader` API to take an optional `backgroundColor` that defaults the the current implementation of `ash` but enables overrides to accepted colors (only `white` for now).
3. Added a basic story with the prop override based on the Kaizen demo.
4. Added testing based on convention of checking valid classnames for the API.

### Notes

It looks as though any child button will maintain its darker grey colour if the header cell is selectable. Changes won't cause any breaking issues for current implementations, but could be weird down the track aesthetically if others opt for a white BG header and have selectable headers.

![Screen Shot 2020-05-08 at 7 55 59 am](https://user-images.githubusercontent.com/4946487/81349722-eae49600-9103-11ea-916c-d72e93381032.png)

<img width="503" alt="Screen Shot 2020-05-08 at 7 55 23 am" src="https://user-images.githubusercontent.com/4946487/81349733-efa94a00-9103-11ea-9321-ab575c280b54.png">


### Verification
1. Check the box shadow equates to the older box-shadow token.
2. Check that the default `TableHeader` has an ash background.
3. Check that the `TableHeader` can take a strongly typed `backgroundColor` prop that allows for `ash` or `white` and that `white` overrides the header.

### Checklist
* [x] I have updated the test suite
* [x] I have tested the change on Storybook
* [ ] I have tested the change locally
* [ ] I have done the cross-browser testing [supported browsers](https://academy.cultureamp.com/hc/en-us/articles/204539569-Supported-browsers-for-Participants)
* [x] I am basing off the correct branch
* [x] I have updated any relevant documentation or left useful comments in the code.
* [ ] I have reviewed the [security considerations](https://cultureamp.atlassian.net/wiki/spaces/AU/pages/923893881/Key+Security+Concepts) and highlighted them as appropriate. 