### PR TITLE
feat: Ensure focus-lock for modals when using iOS VoiceOver [CAP-54]

### DIFF
--- a/draft-packages/modal/KaizenDraft/Modal/Primitives/GenericModal.tsx
+++ b/draft-packages/modal/KaizenDraft/Modal/Primitives/GenericModal.tsx
@@ -42,11 +42,15 @@ class GenericModal extends React.Component<Props> {
     this.preventBodyScroll()
     this.ensureAccessiblityIsMet()
     this.scrollModalToTop()
+    if (this.modalLayer) {
+      this.removeAriaHider = createAriaHider(this.modalLayer)
+    }
   }
 
   onClose() {
     this.removeEventHandlers()
     this.restoreBodyScroll()
+    this.removeAriaHider()
   }
 
   addEventHandlers() {
@@ -58,6 +62,9 @@ class GenericModal extends React.Component<Props> {
     this.props.onEscapeKeyup &&
       document.removeEventListener("keyup", this.escapeKeyHandler)
   }
+
+  // tslint:disable-next-line: no-empty
+  removeAriaHider(): void {}
 
   preventBodyScroll() {
     const hasScrollbar =

--- a/draft-packages/modal/KaizenDraft/Modal/Primitives/GenericModal.tsx
+++ b/draft-packages/modal/KaizenDraft/Modal/Primitives/GenericModal.tsx
@@ -160,8 +160,6 @@ class GenericModal extends React.Component<Props> {
 /**
  * Get an element's owner document. Useful when components are used in iframes
  * or other environments like dev tools.
- *
- * @param element
  */
 function getOwnerDocument<T extends HTMLElement = HTMLElement>(
   element: T | null
@@ -173,6 +171,9 @@ function getOwnerDocument<T extends HTMLElement = HTMLElement>(
     : null
 }
 
+/**
+ * Check if the DOM exists and is usable
+ */
 function canUseDOM(): boolean {
   return (
     typeof window !== "undefined" &&
@@ -184,7 +185,15 @@ function canUseDOM(): boolean {
 // tslint:disable-next-line: no-empty
 function noop(): void {}
 
-function createAriaHider(dialogNode: HTMLElement) {
+/**
+ * Hide elements in the DOM from screenreaders that are outside the parent tree
+ * of the reference node. We do this by setting `aria-hidden` attribute to true
+ * for any elements top-level DOM nodes.
+ *
+ * Returns a function that restores the _original_ values of the affected nodes,
+ * so any pre-aria-hidden values will continue to stay hidden.
+ */
+function createAriaHider(dialogNode: HTMLElement): () => void {
   const originalValues: any[] = []
   const rootNodes: HTMLElement[] = []
   const ownerDocument = getOwnerDocument(dialogNode) || document

--- a/draft-packages/stories/Modal.stories.tsx
+++ b/draft-packages/stories/Modal.stories.tsx
@@ -623,3 +623,50 @@ export const TestScrollingModalAndScrollingContent = () => (
 TestScrollingModalAndScrollingContent.story = {
   name: "Test - scrolling modal and scrolling content",
 }
+
+export const NestedModal = () => (
+  <ModalStateContainer isInitiallyOpen={false}>
+    {({ open, close, isOpen }) => (
+      <div>
+        <Button label="Open modal" onClick={open} />
+        <ModalStateContainer isInitiallyOpen={false}>
+          {internal => (
+            <>
+              <ConfirmationModal
+                isOpen={isOpen}
+                type="positive"
+                title="Positive title"
+                onConfirm={internal.open}
+                onDismiss={close}
+                confirmLabel={"Go deeper"}
+              >
+                <div style={{ textAlign: "center" }}>
+                  <Text tag="p" style="lede" inline>
+                    Additional subtext to aid the user can be added here.
+                  </Text>
+                </div>
+              </ConfirmationModal>
+              <ConfirmationModal
+                isOpen={internal.isOpen}
+                type="negative"
+                title="Inception"
+                onConfirm={internal.close}
+                onDismiss={internal.close}
+              >
+                <div style={{ textAlign: "center" }}>
+                  <Text tag="p" style="lede" inline>
+                    Whoa, this is, like, deep.
+                  </Text>
+                </div>
+              </ConfirmationModal>
+            </>
+          )}
+        </ModalStateContainer>
+      </div>
+    )}
+  </ModalStateContainer>
+)
+
+NestedModal.story = {
+  name: "Nested confirmation modal",
+}


### PR DESCRIPTION
The current `<GenericModal>` implementation has an issue with iOS VoiceOver where the focus lock implementation allows focus to escape if someone uses the swipe left/right gestures to move focus.

This PR fixes that issue by adding `aria-hidden="true"` attributes to every direct descendant of the `<body>` that _isn’t_ a parent of the passed reference modal node, and then undo-ing that change once the modal is closed.

The implementation is cribbed directly from the [reach-ui implementation solving the same issue](https://github.com/reach/reach-ui/blob/de0655b2de8698f5e7add2e4507dee5062750b36/packages/dialog/src/index.tsx#L320-L362).

You should be able to confirm the existing behaviour/new on these pages with VoiceOver on:

* [Broken focus lock in Modal](https://cultureamp.design/storybook-static/iframe.html?id=modal-react--confirmation-positive-kaizen-site-demo)
* [Fixed focus lock in Modal](https://dev.cultureamp.design/fix-focus-lock-ios/storybook-static/iframe.html?id=modal-react--confirmation-positive-kaizen-site-demo)

Swiping left once the modal is open in the broken one should move the focus back to the "Open modal" button eventually.

Questions:

~- [x] Are there any likely issues this will cause within apps?~
~- [x] Is there a sensible place for the utils here to live? I’ve dumped them into the component for now until you let me know :)~