### PR TITLE
experiment: Component coordination with global state

### DIFF
--- a/packages/component-library/components/NavigationBar/components/Menu.tsx
+++ b/packages/component-library/components/NavigationBar/components/Menu.tsx
@@ -12,6 +12,7 @@ const chevronDownIcon = require("@kaizen/component-library/icons/chevron-down.ic
 import classNames from "classnames"
 import * as React from "react"
 import Media from "react-media"
+import store from "../../../state"
 import { MOBILE_QUERY } from "../constants"
 import { MenuGroup, MenuItem, MenuProps } from "../types"
 import Link from "./Link"
@@ -96,6 +97,7 @@ export default class Menu extends React.Component<MenuProps, State> {
   ) => {
     const open = !this.state.open
     this.setState({ open })
+    store.actions.setNavigationBarMenuOpen(open)
   }
 
   renderMenu() {

--- a/packages/component-library/components/Notification/ToastNotification.tsx
+++ b/packages/component-library/components/Notification/ToastNotification.tsx
@@ -1,4 +1,6 @@
 import * as React from "react"
+import store from "../../state"
+import useGlobalUIState from "../../state/useGlobalUIState"
 import GenericNotification, {
   NotificationType,
 } from "./components/GenericNotification"
@@ -15,14 +17,26 @@ type Props = {
 }
 
 const ToastNotification = ({ hideCloseIcon, ...otherProps }: Props) => {
+  const [state] = useGlobalUIState()
   const persistent = otherProps.autohide && hideCloseIcon
+  const opacity = state.navigationBar.menuOpen ? 0 : 1
 
   return (
-    <GenericNotification
-      style="toast"
-      persistent={persistent}
-      {...otherProps}
-    />
+    <div
+      style={{
+        position: "fixed",
+        right: 6,
+        top: 70,
+        opacity,
+        transition: "opacity 200ms",
+      }}
+    >
+      <GenericNotification
+        style="toast"
+        persistent={persistent}
+        {...otherProps}
+      />
+    </div>
   )
 }
 

--- a/packages/component-library/state/index.ts
+++ b/packages/component-library/state/index.ts
@@ -1,0 +1,26 @@
+import createSimpleStore, {
+  Actions,
+  SimpleStore,
+  State,
+} from "../util/simpleStore"
+
+const initialState: State = {
+  navigationBar: {
+    menuOpen: false,
+  },
+}
+
+const actions: Actions = {
+  setNavigationBarMenuOpen: menuOpen => state => ({
+    navigationBar: {
+      ...state.navigationBar,
+      menuOpen,
+    },
+  }),
+}
+
+function createGlobalUIStore(): SimpleStore {
+  return createSimpleStore(initialState, actions)
+}
+
+export default createGlobalUIStore()

--- a/packages/component-library/state/useGlobalUIState.ts
+++ b/packages/component-library/state/useGlobalUIState.ts
@@ -1,0 +1,14 @@
+import React, { useEffect, useState } from "react"
+import store from "./"
+
+export default function useGlobalUIState(slicer = state => state) {
+  const [slice, setSlice] = useState(slicer(store.getState()))
+
+  useEffect(() => {
+    store.subscribe(() => {
+      setSlice(store.getState())
+    })
+  }, [store, slicer, setSlice])
+
+  return [slice]
+}

--- a/packages/component-library/stories/NavigationBar.stories.tsx
+++ b/packages/component-library/stories/NavigationBar.stories.tsx
@@ -1,6 +1,12 @@
 import * as React from "react"
 
-import { Icon, Link, Menu, NavigationBar } from "@kaizen/component-library"
+import {
+  Icon,
+  Link,
+  Menu,
+  NavigationBar,
+  ToastNotification,
+} from "@kaizen/component-library"
 
 const academyIcon = require("@kaizen/component-library/icons/academy.icon.svg")
   .default
@@ -374,6 +380,20 @@ export const MenuGroup = () => (
       ],
     }}
   </NavigationBar>
+)
+
+export const WithToast = () => (
+  <>
+    <Default />
+    <ToastNotification
+      type="informative"
+      title="Informative"
+      automationId="notification1"
+    >
+      New user data is currently being processed. We'll let you know when the
+      process is completed. <a href="/">Manage users</a>
+    </ToastNotification>
+  </>
 )
 
 export const Empty = () => <NavigationBar />

--- a/packages/component-library/util/simpleStore.ts
+++ b/packages/component-library/util/simpleStore.ts
@@ -1,0 +1,122 @@
+/**
+ * Create store
+ *
+ *   const initialState = { counter: 0 }
+ *   const actions = {
+ *     set: value => ({counter: value}).
+ *     increment: (value = 1) => (state) => ({counter: state.counter + value})
+ *   }
+ *   const store = createStore(initialState, actions);
+ *
+ *   store.subscribe(() => {
+ *     doSomethingWithUpdatedState(store.getState());
+ *   });
+ *
+ * @param {Object} state Initial state object
+ * @param {Object} actions Actions to modify state
+ */
+
+export type State = {
+  [key: string]: any
+}
+
+export type Actions = {
+  // tslint:disable-next-line: ban-types
+  [key: string]: Function
+}
+
+export type SimpleStore = {
+  actions: Actions
+  destroy: () => void
+  getState: () => State
+  // tslint:disable-next-line: ban-types
+  subscribe: Function
+}
+
+export default function createSimpleStore(
+  state: State = {},
+  actions: Actions = {}
+): SimpleStore {
+  // Add a default set action to make it easy to set state
+  if (!actions.set) {
+    actions.set = (partialState: State) => partialState
+  }
+
+  let globalState = { ...state }
+  let subscriptions: Array<() => void> = []
+  let wiredActions: Actions = wireStateToActions(actions)
+
+  /**
+   * Subscribe a function to changes
+   * @param {Function} subscription
+   */
+  function subscribe(subscription: () => void): () => void {
+    subscriptions.push(subscription) // Mutation!
+
+    return function unsubscribe(): void {
+      const index = subscriptions.indexOf(subscription)
+      subscriptions.splice(index, 1) // Mutation!
+    }
+  }
+
+  /**
+   * Wire the state to the passed actions object
+   *
+   * @param {Object} actions
+   */
+  function wireStateToActions(actionsToWire: Actions): Actions {
+    // tslint:disable-next-line: forin
+    for (const key in actionsToWire) {
+      const wire = (wiredKey, action) => {
+        // Mutate actions object
+        actionsToWire[wiredKey] = data => {
+          let result = action(data)
+          // If an action returns a function, call that function with two
+          // arguments: current state, and actions object. This allows us
+          // to access both state and other actions.
+          if (typeof result === "function") {
+            result = result(globalState, actionsToWire)
+          }
+          if (result) {
+            globalState = { ...globalState, ...result }
+            dispatch()
+          }
+          return result
+        }
+      }
+      wire(key, actionsToWire[key])
+    }
+    return actionsToWire
+  }
+
+  /**
+   * Dispatch each subscription
+   */
+  function dispatch() {
+    subscriptions.forEach(subscription => {
+      subscription()
+    })
+  }
+
+  /**
+   * Return the current global state
+   */
+  function getState() {
+    return globalState
+  }
+
+  /**
+   * Destroy everything
+   */
+  function destroy() {
+    subscriptions = []
+    wiredActions = {}
+  }
+
+  return {
+    actions: wiredActions,
+    destroy,
+    getState,
+    subscribe,
+  }
+}


### PR DESCRIPTION
I mused with @mbylstra in a convo the other day that I thought it would be interesting for the design system to do some "orchestration" of components under its purview.

This is a very quick experiment intended to start a discussion around that idea. What I’ve done is:

* Create a singleton "store" within the component library that contains some state and actions for affecting that state.
* Put a value into that state object for noting whether the navigation bar has a menu that’s open or not.
* Use that value to hide the `ToastNotification` that overlaps the menu when its open.

You can see the behaviour here: https://dev.cultureamp.design/orchestration-experiment/storybook-static/iframe.html?id=navigationbar-react--with-toast&viewMode=story

My thought is that something like could mean apps consuming the design system don’t have to worry about certain aspects of coordinating components: they’re handled OOTB. Which in turn hopefully mean less work implementing, and less fragmentation of implementation. The design system could also expose the store _to_ consuming apps, which would allow consuming apps to do their own coordination with the values it contains.

There’s a large rabbit-hole we could fall into with this sort of thing, and I haven’t deeply explored the pain points, but I think there’s value in _some_ variation of it.

Would be interested to hear thoughts!