### PR TITLE
chore: Export ValueType from react-select in Select

### DIFF
--- a/draft-packages/select/KaizenDraft/Select/Select.tsx
+++ b/draft-packages/select/KaizenDraft/Select/Select.tsx
@@ -12,6 +12,8 @@ const chevronDownIcon = require("@kaizen/component-library/icons/chevron-down.ic
 
 const styles = require("./styles.react.scss")
 
+export { ValueType } from "react-select"
+
 export const Select = (props: ReactSelectProps) => {
   return (
     <ReactSelect


### PR DESCRIPTION
`react-select` has this frustrating type on their `onChange` prop. This hasn't been any issue for us so far because in Flow you don't have to specify the type for this param, but in TypeScript we have to. So we'll need this `ValueType` type.

https://github.com/JedWatson/react-select/issues/2902