### PR TITLE
fix: Add ValueType export to old component-library location as well

### DIFF
--- a/packages/component-library/draft/Kaizen/Select/Select.tsx
+++ b/packages/component-library/draft/Kaizen/Select/Select.tsx
@@ -12,6 +12,8 @@ const chevronDownIcon = require("@kaizen/component-library/icons/chevron-down.ic
 
 const styles = require("./styles.react.scss")
 
+export { ValueType } from "react-select"
+
 export const Select = (props: ReactSelectProps) => {
   return (
     <ReactSelect


### PR DESCRIPTION
I forgot to update both versions of `Select` in https://github.com/cultureamp/kaizen-design-system/pull/494