### PR TITLE
fix: Make Navigation Bar consume core components

### DIFF
--- a/packages/component-library/draft/Kaizen/Table/Table.tsx
+++ b/packages/component-library/draft/Kaizen/Table/Table.tsx
@@ -1,7 +1,7 @@
 import { Icon, Text } from "@kaizen/component-library"
-import { Checkbox, CheckedStatus } from "@kaizen/draft-form"
 import classNames from "classnames"
 import * as React from "react"
+import { Checkbox, CheckedStatus } from "../Form" // relative imports are not ideal, but drafts are being deleted soon
 const styles = require("./styles.scss")
 const sortDescendingIcon = require("@kaizen/component-library/icons/sort-descending.icon.svg")
   .default

--- a/packages/component-library/draft/Kaizen/ZenNavigationBar/NavigationBar.tsx
+++ b/packages/component-library/draft/Kaizen/ZenNavigationBar/NavigationBar.tsx
@@ -1,9 +1,9 @@
 import * as React from "react"
 
-import { ZenControlledOffCanvas } from "@kaizen/draft-zen-off-canvas"
 import classNames from "classnames"
 import Media from "react-media"
 import uuid from "uuid/v4"
+import { ZenControlledOffCanvas } from "../ZenOffCanvas"
 import Badge from "./components/Badge"
 import Link from "./components/Link"
 import Menu from "./components/Menu"

--- a/packages/component-library/draft/Kaizen/ZenNavigationBar/components/Menu.tsx
+++ b/packages/component-library/draft/Kaizen/ZenNavigationBar/components/Menu.tsx
@@ -2,7 +2,7 @@ import * as React from "react"
 import uuid from "uuid/v4"
 
 import { Icon, IconButton } from "@kaizen/component-library"
-import { OffCanvasContext, ZenOffCanvas } from "@kaizen/draft-zen-off-canvas"
+import { OffCanvasContext, ZenOffCanvas } from "../../ZenOffCanvas" // relative imports are not ideal
 
 import classNames from "classnames"
 import Media from "react-media"

--- a/packages/component-library/draft/Kaizen/ZenOffCanvas/ZenOffCanvas.tsx
+++ b/packages/component-library/draft/Kaizen/ZenOffCanvas/ZenOffCanvas.tsx
@@ -1,7 +1,7 @@
 import * as React from "react"
 
-import { ColorScheme } from "@kaizen/draft-zen-navigation-bar/KaizenDraft/ZenNavigationBar/NavigationBar"
 import classNames from "classnames"
+import { ColorScheme } from "../ZenNavigationBar/NavigationBar"
 import Header from "./components/Header"
 import Menu from "./components/Menu"
 

--- a/packages/component-library/draft/Kaizen/ZenOffCanvas/components/Header.module.scss
+++ b/packages/component-library/draft/Kaizen/ZenOffCanvas/components/Header.module.scss
@@ -3,7 +3,7 @@
 @import "~@kaizen/component-library/styles/layout";
 @import "~@kaizen/component-library/styles/color";
 @import "~@kaizen/component-library/styles/responsive";
-@import "~@kaizen/draft-zen-navigation-bar/KaizenDraft/ZenNavigationBar/_styles";
+@import "~@kaizen/component-library/draft/Kaizen/ZenNavigationBar/_styles";
 
 .root {
   @include ca-padding($end: $ca-grid / 2);

--- a/packages/component-library/draft/Kaizen/ZenOffCanvas/components/Header.tsx
+++ b/packages/component-library/draft/Kaizen/ZenOffCanvas/components/Header.tsx
@@ -1,7 +1,7 @@
 import * as React from "react"
 
-import { ColorScheme } from "@kaizen/draft-zen-navigation-bar/KaizenDraft/ZenNavigationBar/NavigationBar"
 import classNames from "classnames"
+import { ColorScheme } from "../../ZenNavigationBar/NavigationBar"
 const closeIcon = require("@kaizen/component-library/icons/close.icon.svg")
   .default
 import IconButton from "@kaizen/component-library/components/Button/IconButton"


### PR DESCRIPTION
Some components in (now deprecated) drafts were incorrectly linking to the new draft packages. 

This was changed when we last did a large sweep of Kaizen to change any draft imports. 