### PR TITLE
fix: Export ValueType from Select index.ts

### DIFF
--- a/draft-packages/select/KaizenDraft/Select/index.ts
+++ b/draft-packages/select/KaizenDraft/Select/index.ts
@@ -1,1 +1,1 @@
-export { Select, AsyncSelect } from "./Select"
+export { Select, AsyncSelect, ValueType } from "./Select"

--- a/packages/component-library/draft/Kaizen/Select/index.ts
+++ b/packages/component-library/draft/Kaizen/Select/index.ts
@@ -1,1 +1,1 @@
-export { Select, AsyncSelect } from "./Select"
+export { Select, AsyncSelect, ValueType } from "./Select"


### PR DESCRIPTION
I missed this part in https://github.com/cultureamp/kaizen-design-system/pull/494 and https://github.com/cultureamp/kaizen-design-system/pull/495