### PR TITLE
fix: Conditionally dispatch port for Multi Select variant

### DIFF
--- a/draft-packages/select/KaizenDraft/Select/Select.elm
+++ b/draft-packages/select/KaizenDraft/Select/Select.elm
@@ -430,7 +430,7 @@ update msg (State state_) =
                 ( updatedState, updatedCmds ) =
                     case state_.initialMousedown of
                         ContainerMousedown ->
-                            ( { state_ | inputValue = Nothing }, Cmd.none )
+                            ( { state_ | inputValue = Nothing }, ports )
 
                         MultiItemMousedown _ ->
                             ( state_, Cmd.none )
@@ -441,7 +441,7 @@ update msg (State state_) =
                                 , controlFocused = False
                                 , inputValue = Nothing
                               }
-                            , cmdWithClosedMenu
+                            , Cmd.batch [ cmdWithClosedMenu, ports ]
                             )
 
                 ports =
@@ -458,7 +458,7 @@ update msg (State state_) =
             in
             ( Internal
             , State updatedState
-            , Cmd.batch [ updatedCmds, ports ]
+            , updatedCmds
             )
 
         MenuItemClickFocus i ->


### PR DESCRIPTION
When using a Multi Select variant and having some text populated in the
input, deleting a tag whilst focused should not resize the input.

This follows the react select functionality.

![select](https://user-images.githubusercontent.com/25443812/82325648-b5e91500-9a1a-11ea-9324-86619f24d829.gif)

This bug was only present when using the `usePorts` is `True` config modifier.