### PR TITLE
fix: unpin unintentionally pinned @kaizen/design-token peer dependencies

### DIFF
--- a/draft-packages/checkbox-group/package.json
+++ b/draft-packages/checkbox-group/package.json
@@ -41,7 +41,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "1.2.0",
+    "@kaizen/design-tokens": "^1.2.0",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/collapsible/package.json
+++ b/draft-packages/collapsible/package.json
@@ -41,7 +41,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "1.2.0",
+    "@kaizen/design-tokens": "^1.2.0",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/dropdown-menu/package.json
+++ b/draft-packages/dropdown-menu/package.json
@@ -40,7 +40,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "1.2.0",
+    "@kaizen/design-tokens": "^1.2.0",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/dropdown/package.json
+++ b/draft-packages/dropdown/package.json
@@ -40,7 +40,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "1.2.0",
+    "@kaizen/design-tokens": "^1.2.0",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/empty-state/package.json
+++ b/draft-packages/empty-state/package.json
@@ -40,7 +40,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "1.2.0",
+    "@kaizen/design-tokens": "^1.2.0",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/events/package.json
+++ b/draft-packages/events/package.json
@@ -40,7 +40,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "1.2.0",
+    "@kaizen/design-tokens": "^1.2.0",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/form/package.json
+++ b/draft-packages/form/package.json
@@ -40,7 +40,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "1.2.0",
+    "@kaizen/design-tokens": "^1.2.0",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/guidance-block/package.json
+++ b/draft-packages/guidance-block/package.json
@@ -40,7 +40,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "1.2.0",
+    "@kaizen/design-tokens": "^1.2.0",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/hero-card/package.json
+++ b/draft-packages/hero-card/package.json
@@ -41,7 +41,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "1.2.0",
+    "@kaizen/design-tokens": "^1.2.0",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/hero-panel/package.json
+++ b/draft-packages/hero-panel/package.json
@@ -40,7 +40,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "1.2.0",
+    "@kaizen/design-tokens": "^1.2.0",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/loading-placeholder/package.json
+++ b/draft-packages/loading-placeholder/package.json
@@ -40,7 +40,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "1.2.0",
+    "@kaizen/design-tokens": "^1.2.0",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/menu-list/package.json
+++ b/draft-packages/menu-list/package.json
@@ -40,7 +40,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "1.2.0",
+    "@kaizen/design-tokens": "^1.2.0",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/modal/package.json
+++ b/draft-packages/modal/package.json
@@ -43,7 +43,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "1.2.0",
+    "@kaizen/design-tokens": "^1.2.0",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/popover/package.json
+++ b/draft-packages/popover/package.json
@@ -40,7 +40,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "1.2.0",
+    "@kaizen/design-tokens": "^1.2.0",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/radio-group/package.json
+++ b/draft-packages/radio-group/package.json
@@ -40,7 +40,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "1.2.0",
+    "@kaizen/design-tokens": "^1.2.0",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/radio/package.json
+++ b/draft-packages/radio/package.json
@@ -40,7 +40,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "1.2.0",
+    "@kaizen/design-tokens": "^1.2.0",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/select/package.json
+++ b/draft-packages/select/package.json
@@ -42,7 +42,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "1.2.0",
+    "@kaizen/design-tokens": "^1.2.0",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/split-button/package.json
+++ b/draft-packages/split-button/package.json
@@ -40,7 +40,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "1.2.0",
+    "@kaizen/design-tokens": "^1.2.0",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/table/package.json
+++ b/draft-packages/table/package.json
@@ -41,7 +41,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "1.2.0",
+    "@kaizen/design-tokens": "^1.2.0",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/tabs/package.json
+++ b/draft-packages/tabs/package.json
@@ -40,7 +40,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "1.2.0",
+    "@kaizen/design-tokens": "^1.2.0",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/tag/package.json
+++ b/draft-packages/tag/package.json
@@ -40,7 +40,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "1.2.0",
+    "@kaizen/design-tokens": "^1.2.0",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/title-block/package.json
+++ b/draft-packages/title-block/package.json
@@ -43,7 +43,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "1.2.0",
+    "@kaizen/design-tokens": "^1.2.0",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/tooltip/package.json
+++ b/draft-packages/tooltip/package.json
@@ -40,7 +40,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "1.2.0",
+    "@kaizen/design-tokens": "^1.2.0",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/user-interactions/package.json
+++ b/draft-packages/user-interactions/package.json
@@ -40,7 +40,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "1.2.0",
+    "@kaizen/design-tokens": "^1.2.0",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/vertical-progress-step/package.json
+++ b/draft-packages/vertical-progress-step/package.json
@@ -40,7 +40,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "1.2.0",
+    "@kaizen/design-tokens": "^1.2.0",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/well/package.json
+++ b/draft-packages/well/package.json
@@ -40,7 +40,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "1.2.0",
+    "@kaizen/design-tokens": "^1.2.0",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/zen-navigation-bar/package.json
+++ b/draft-packages/zen-navigation-bar/package.json
@@ -44,7 +44,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "1.2.0",
+    "@kaizen/design-tokens": "^1.2.0",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/zen-off-canvas/package.json
+++ b/draft-packages/zen-off-canvas/package.json
@@ -42,7 +42,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "1.2.0",
+    "@kaizen/design-tokens": "^1.2.0",
     "react": "^16.9.0"
   }
 }


### PR DESCRIPTION
They should not be pinned to a specific patch version. This causes a lot of peer dependency warnings in other packages.