### PR TITLE
fix: Menulist styles linking to incorrect location

### DIFF
--- a/draft-packages/menu-list/KaizenDraft/MenuList/MenuList.elm
+++ b/draft-packages/menu-list/KaizenDraft/MenuList/MenuList.elm
@@ -34,7 +34,7 @@ item { onClickMsg, label } =
 
 menuListCss : CssModules.Helpers { menuList : String, menuItem : String } msg
 menuListCss =
-    css "@kaizen/draft-menulist/KaizenDraft/MenuList/MenuList.scss"
+    css "@kaizen/draft-menu-list/KaizenDraft/MenuList/MenuList.scss"
         { menuList = "menuList"
         , menuItem = "menuItem"
         }


### PR DESCRIPTION
## About
* The Elm styles in Menu List were broken in the last big find and replace