### PR TITLE
feat: navigation bar spacing alterations

### DIFF
--- a/draft-packages/stories/ZenNavigationBar.stories.tsx
+++ b/draft-packages/stories/ZenNavigationBar.stories.tsx
@@ -309,9 +309,6 @@ export const WithFooterAndHeaderComponents = () => (
         <Link text="Home" href="/" active />,
         <Link text="Surveys" href="/" />,
         <Link text="Performance" href="/" />,
-        <Link text="Performance" href="/" />,
-        <Link text="Performance" href="/" />,
-        <Link text="Performance" href="/" />,
       ],
       secondary: [
         <Menu
@@ -355,11 +352,6 @@ export const WithFooterAndHeaderComponents = () => (
         />,
       ],
       final: [
-        <Link
-          icon={supportIcon}
-          text="Support"
-          href="http://academy.cultureamp.com/"
-        />,
         <Link
           icon={supportIcon}
           text="Support"

--- a/draft-packages/stories/ZenNavigationBar.stories.tsx
+++ b/draft-packages/stories/ZenNavigationBar.stories.tsx
@@ -355,6 +355,7 @@ export const WithFooterAndHeaderComponents = () => (
         <Link
           icon={supportIcon}
           text="Support"
+          active
           href="http://academy.cultureamp.com/"
         />,
         <Link

--- a/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/NavigationBar.module.scss
+++ b/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/NavigationBar.module.scss
@@ -90,6 +90,4 @@
 .headerSlot {
   @include ca-margin($start: $ca-navigation-bar__spacer);
   height: 100%;
-  display: flex;
-  align-items: center;
 }

--- a/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/NavigationBar.module.scss
+++ b/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/NavigationBar.module.scss
@@ -90,4 +90,5 @@
 .headerSlot {
   @include ca-margin($start: $ca-navigation-bar__spacer);
   height: 100%;
+  display: flex;
 }

--- a/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/NavigationBar.module.scss
+++ b/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/NavigationBar.module.scss
@@ -11,7 +11,7 @@
 }
 
 .links {
-  @include navbar-responsive-spacing($end: true, $start: true, $margin: true);
+  @include ca-margin($end: $ca-grid);
   display: inline-flex;
   flex: 1 0 0;
   height: 100%;
@@ -29,11 +29,8 @@
 
     &.secondary {
       @include ca-margin($start: 0);
-      @include navbar-responsive-spacing(
-        $start: true,
-        $padding: true,
-        $large: false
-      );
+      @include ca-padding($start: 0);
+      @include navbar-uncollapsed-spacing($start: true, $padding: true);
       position: relative;
       &:before {
         position: absolute;
@@ -66,21 +63,17 @@
   }
 
   @include navbar-tablet-up {
-    @include ca-margin($start: $ca-grid / 2);
+    @include ca-margin($start: $ca-grid);
   }
 }
 
 .child {
   &:not(:last-child) {
-    @include navbar-responsive-spacing($end: true, $margin: true);
+    @include navbar-uncollapsed-spacing($end: true, $margin: true);
   }
 
   &:last-child {
-    @include navbar-responsive-spacing(
-      $end: true,
-      $margin: true,
-      $large: false
-    );
+    @include navbar-uncollapsed-spacing($end: true, $margin: true);
   }
 
   .final & {
@@ -95,7 +88,7 @@
 }
 
 .headerSlot {
-  @include navbar-responsive-spacing($start: true, $margin: true);
+  @include ca-margin($start: $ca-navigation-bar__spacer);
   height: 100%;
   display: flex;
   align-items: center;

--- a/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/_styles.scss
+++ b/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/_styles.scss
@@ -92,6 +92,7 @@ $navbar-breakpoint-condensed-large-up: 1150px;
   height: 100%;
   justify-content: center;
   min-width: 2 * $ca-grid;
+  position: relative;
   text-decoration: none;
   transition: background-color $ca-duration-rapid $ca-ease-in-out;
 
@@ -162,11 +163,6 @@ $navbar-breakpoint-condensed-large-up: 1150px;
     }
   }
 
-  @include font-heading-4;
-  @include ca-inherit-baseline;
-
-  position: relative;
-
   .linkIcon {
     display: inline-flex;
     opacity: 0.5;
@@ -186,19 +182,24 @@ $navbar-breakpoint-condensed-large-up: 1150px;
   }
 
   .linkText {
+    @include font-heading-4;
+    @include ca-inherit-baseline;
     box-sizing: border-box;
     position: relative;
     display: flex;
     align-items: center;
     justify-content: center;
     height: 48px;
+    @include navbar-mobile-only {
+      font-weight: $kz-typography-paragraph-body-font-weight;
+    }
   }
 
   &.small {
     @include navbar-tablet-up {
-      @include font-heading-5;
-      @include ca-inherit-baseline;
       .linkText {
+        @include font-heading-5;
+        @include ca-inherit-baseline;
         display: none;
       }
     }
@@ -226,20 +227,12 @@ $navbar-breakpoint-condensed-large-up: 1150px;
       &:focus {
         .hoverArea {
           background-color: rgba($kz-color-white, 0.1);
-
-          .linkIcon {
-            opacity: 0.7;
-          }
         }
       }
 
       &:active {
         .hoverArea {
           background-color: rgba($kz-color-white, 0.2);
-
-          .linkIcon {
-            opacity: 1;
-          }
         }
       }
     }
@@ -312,7 +305,6 @@ $navbar-breakpoint-condensed-large-up: 1150px;
   }
 
   @include navbar-mobile-only {
-    font-weight: normal;
     justify-content: flex-start;
     align-items: center;
     color: $kz-color-wisteria-700;

--- a/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/_styles.scss
+++ b/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/_styles.scss
@@ -7,13 +7,14 @@
 @import "~@kaizen/component-library/styles/type";
 @import "~@kaizen/component-library/styles/responsive";
 
-$ca-navigation-bar__height: 3.5 * $ca-grid;
+$ca-navigation-bar__height: 3 * $ca-grid;
+$ca-navigation-bar__spacer: $ca-grid / 2;
+$ca-navigation-bar__child-height: $ca-grid * 2;
 
 $ca-navigation-bar__animation-ease: cubic-bezier(0.55, 0.085, 0.68, 0.53);
 $ca-navigation-bar__animation-timing: 150ms;
 
-$ca-navigation-bar__link-item-height: 2 * $ca-grid;
-$ca-navigation-bar__link-item-indicator-height: 5px;
+$ca-navigation-bar__link-item-indicator-height: 0.3125rem;
 $ca-navigation-bar__link-item-margin: 18px;
 $ca-navigation-bar__link-item-margin-mobile: 10px;
 
@@ -58,84 +59,56 @@ $navbar-breakpoint-condensed-large-up: 1150px;
   }
 }
 
-@mixin navbar-responsive-spacing(
+@mixin navbar-uncollapsed-spacing(
   $margin: false,
   $padding: false,
   $start: false,
-  $end: false,
-  $large: true
+  $end: false
 ) {
-  $medium: $ca-grid / 2;
-  $desktop: $ca-grid;
-
   @include navbar-tablet-up {
     @if $margin {
       @include ca-margin(
-        $end: if($end, $medium, null),
-        $start: if($start, $medium, null)
+        $end: if($end, $ca-navigation-bar__spacer, null),
+        $start: if($start, $ca-navigation-bar__spacer, null)
       );
     }
     @if $padding {
       @include ca-padding(
-        $end: if($end, $medium, null),
-        $start: if($start, $medium, null)
+        $end: if($end, $ca-navigation-bar__spacer, null),
+        $start: if($start, $ca-navigation-bar__spacer, null)
       );
-    }
-  }
-
-  @if $large {
-    @include navbar-extended-large-up {
-      @if $margin {
-        @include ca-margin(
-          $end: if($end, $desktop, null),
-          $start: if($start, $desktop, null)
-        );
-      }
-      @if $padding {
-        @include ca-padding(
-          $end: if($end, $desktop, null),
-          $start: if($start, $desktop, null)
-        );
-      }
     }
   }
 }
 
 @mixin ca-navigation-bar__link-item {
   @extend %ca-navigation-bar__menu-item-focus;
-
   @include ca-type-reverse;
 
-  // fill parent
-  display: flex;
-  min-width: 2 * $ca-grid;
-  height: 100%;
-
-  // center child
   align-items: center;
-  justify-content: center;
-
   border-radius: $kz-border-solid-border-radius;
-
   color: rgba($kz-color-white, 0.8);
+  display: flex;
+  height: 100%;
+  justify-content: center;
+  min-width: 2 * $ca-grid;
   text-decoration: none;
   transition: background-color $ca-duration-rapid $ca-ease-in-out;
 
   // active indicator
   @include navbar-tablet-up {
+    margin-top: -$ca-navigation-bar__spacer;
+    height: $ca-navigation-bar__height;
     &::before {
       content: "";
       display: block;
-      transform: translateY(-#{$ca-navigation-bar__link-item-margin})
-        translateY(-100%);
       height: $ca-navigation-bar__link-item-indicator-height;
       width: 100%;
       position: absolute;
-      top: 0;
+      top: -100%;
       left: 0;
-      right: 0;
       background-color: $kz-color-white;
-      transition: transform $ca-navigation-bar__animation-ease
+      transition: top $ca-navigation-bar__animation-ease
         $ca-navigation-bar__animation-timing;
       border-radius: 0 0 $kz-border-borderless-border-radius
         $kz-border-borderless-border-radius;
@@ -148,14 +121,14 @@ $navbar-breakpoint-condensed-large-up: 1150px;
     color: $kz-color-white;
 
     &::before {
-      transform: translateY(-1px);
+      top: 0;
     }
   }
 
   .hoverArea {
     display: flex;
     align-items: center;
-    height: $ca-navigation-bar__link-item-height;
+    height: $ca-navigation-bar__child-height;
     padding: 0 ($ca-grid / 2);
     border-radius: $kz-border-borderless-border-radius;
     width: 100%;
@@ -191,7 +164,8 @@ $navbar-breakpoint-condensed-large-up: 1150px;
 
   @include font-heading-4;
   @include ca-inherit-baseline;
-  top: 0;
+
+  position: relative;
 
   .linkIcon {
     display: inline-flex;
@@ -361,7 +335,11 @@ $navbar-breakpoint-condensed-large-up: 1150px;
 }
 
 %ca-navigation-bar {
-  @include navbar-responsive-spacing($end: true, $padding: true);
+  @include ca-padding(
+    $end: $ca-navigation-bar__spacer,
+    $top: $ca-navigation-bar__spacer,
+    $bottom: $ca-navigation-bar__spacer
+  );
   box-sizing: border-box;
   display: flex;
   flex-direction: row;

--- a/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/components/Badge.module.scss
+++ b/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/components/Badge.module.scss
@@ -10,7 +10,6 @@
   font-weight: $ca-weight-medium;
   text-decoration: none;
   text-transform: uppercase;
-  height: $ca-navigation-bar__height;
   max-height: $ca-navigation-bar__height;
   width: $ca-navigation-bar__height;
   position: relative;

--- a/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/components/Badge.module.scss
+++ b/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/components/Badge.module.scss
@@ -10,11 +10,9 @@
   font-weight: $ca-weight-medium;
   text-decoration: none;
   text-transform: uppercase;
+  height: $ca-navigation-bar__height;
+  max-height: $ca-navigation-bar__height;
   width: $ca-navigation-bar__height;
-  max-height: 100%;
-  flex: 0 0 $ca-navigation-bar__height;
-
-  // auto 1:1 (square) aspect ratio
   position: relative;
   &::after {
     display: block;
@@ -24,12 +22,9 @@
   > * {
     @extend %ca-navigation-bar__menu-item-focus;
 
-    // fill the square
     position: absolute;
     width: 100%;
     height: 100%;
-
-    // center child
     display: flex;
     align-items: center;
     justify-content: center;

--- a/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/components/Dropdown.module.scss
+++ b/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/components/Dropdown.module.scss
@@ -4,8 +4,7 @@
 @import "../styles";
 
 .dropdown {
-  @include ca-position($top: 91%);
-
+  top: calc(100% + #{$ca-grid / 4});
   align-items: center;
   position: absolute;
   z-index: $ca-z-index-dropdown;

--- a/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/components/Menu.module.scss
+++ b/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/components/Menu.module.scss
@@ -3,8 +3,6 @@
 @import "~@kaizen/component-library/styles/layout";
 @import "../styles";
 
-$menu__square-size: 60px;
-
 .root {
   position: relative;
   margin-top: 0;
@@ -39,11 +37,11 @@ $menu__square-size: 60px;
   }
 
   .customChild {
-    @include navbar-responsive-spacing($start: true, $margin: true);
-    width: $menu__square-size;
+    @include ca-margin($start: $ca-navigation-bar__spacer);
+    width: $ca-grid * 2;
     box-sizing: border-box;
-    height: $menu__square-size;
-    max-height: $menu__square-size;
+    height: $ca-navigation-bar__child-height;
+    // max-height: $ca-navigation-bar__max-child-height;
     display: flex;
     align-items: center;
   }

--- a/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/components/Menu.module.scss
+++ b/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/components/Menu.module.scss
@@ -41,7 +41,6 @@
     width: $ca-grid * 2;
     box-sizing: border-box;
     height: $ca-navigation-bar__child-height;
-    // max-height: $ca-navigation-bar__max-child-height;
     display: flex;
     align-items: center;
   }

--- a/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/components/Menu.tsx
+++ b/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/components/Menu.tsx
@@ -62,10 +62,9 @@ export default class Menu extends React.Component<MenuProps, State> {
                 {({ toggleVisibleMenu }) => (
                   <Link
                     key={uuid()}
-                    text={heading}
+                    text={`${heading}…`}
                     href="#"
                     onClick={() => toggleVisibleMenu(heading)}
-                    hasMenu
                     opaque={opaque}
                   />
                 )}

--- a/draft-packages/zen-off-canvas/KaizenDraft/ZenOffCanvas/components/Menu.tsx
+++ b/draft-packages/zen-off-canvas/KaizenDraft/ZenOffCanvas/components/Menu.tsx
@@ -14,7 +14,7 @@ const Menu = ({ link, section }: Props) => {
   return (
     <div
       className={classNames(styles.menu, {
-        [styles.secondary]: section === "secondary",
+        [styles.final]: section === "final",
         [styles.active]: !!link.active,
       })}
       key={`${link.heading}-${uuidv4()}`}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1082,6 +1082,12 @@
   resolved "https://registry.yarnpkg.com/@csstools/convert-colors/-/convert-colors-1.4.0.tgz#ad495dc41b12e75d588c6db8b9834f08fa131eb7"
   integrity sha512-5a6wqoJV/xEdbRNKVo6I4hO3VjyDq//8q2f9I6PBAvMesJHFauXDorcNCsr9RzvsZnaWi5NYCcfyqP1QeFHFbw==
 
+"@cultureamp/elm-storybook@cultureamp/elm-storybook#0.1.0":
+  version "0.1.0"
+  resolved "https://codeload.github.com/cultureamp/elm-storybook/tar.gz/129774657a02f66a1eec2186a12f40efb389c731"
+  dependencies:
+    react-elm-components "^1.1.0"
+
 "@cultureamp/elm-storybook@cultureamp/elm-storybook#0.2.1":
   version "0.2.1"
   resolved "https://codeload.github.com/cultureamp/elm-storybook/tar.gz/c82229e769ba91c15e67257635e893363f266b7f"


### PR DESCRIPTION
- Mobile menu now uses ellipses instead of arrows to suggest sub-menu
- Navigation spacing has been reduced
- Navigation bar height has been reduced
- Divider now present between secondary menu and final menu in mobile navigation
- Fixed bug where dropdown gap was calculated in percentages
- Removed duplications from storybook story

<img width="408" alt="Screen Shot 2020-05-22 at 3 23 38 pm" src="https://user-images.githubusercontent.com/13988803/82634088-448aab80-9c40-11ea-8cc4-8b3dd1645181.png">

<img width="265" alt="Screen Shot 2020-05-22 at 3 23 24 pm" src="https://user-images.githubusercontent.com/13988803/82634132-608e4d00-9c40-11ea-82e4-d5e73d150c8d.png">

<img width="1039" alt="Screen Shot 2020-05-22 at 3 23 18 pm" src="https://user-images.githubusercontent.com/13988803/82634137-63893d80-9c40-11ea-92ba-11e1cdb218e4.png">

