### PR TITLE
feat: Create separate stylesheet for ca-grid var

### DIFF
--- a/packages/component-library/styles/grid.scss
+++ b/packages/component-library/styles/grid.scss
@@ -1,0 +1,1 @@
+$ca-grid: 1.5rem; // 24px @ default root font-size of 16px


### PR DESCRIPTION
## Changes

This simply copies the `$ca-grid` variable into its own stylesheet, `grid.scss`, which lives in the component library.

This will allow us to import from this file instead of what everyone currently has to do, which is to get `$ca-grid` from `type.scss`.