### PR TITLE
ci: Specify alpine 3.11 in publish/release steps

### DIFF
--- a/.buildkite/dockerfiles/publish.Dockerfile
+++ b/.buildkite/dockerfiles/publish.Dockerfile
@@ -1,6 +1,6 @@
-FROM alpine:latest
+FROM alpine:3.11
 
-RUN apk add --no-cache \
+RUN apk update && apk add --no-cache \
   git \
   openssh \
   python \

--- a/.buildkite/dockerfiles/release.Dockerfile
+++ b/.buildkite/dockerfiles/release.Dockerfile
@@ -1,6 +1,6 @@
-FROM node:12-alpine
+FROM node:12-alpine3.11
 
-RUN apk add --no-cache \
+RUN apk update && apk add --no-cache \
   git \
   openssh \
   python \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ x-defaults: &defaults
   volumes:
     - .:/workspace
   working_dir: /workspace
-  command: /bin/ash -c "while sleep 1000; do :; done"
+  command: /bin/sh -c "while sleep 1000; do :; done"
   environment:
     - AWS_ACCESS_KEY_ID
     - AWS_SECRET_ACCESS_KEY


### PR DESCRIPTION
Fixes an error when building these images, which was introduced when the latest tag moved to 3.12

See: https://buildkite.com/culture-amp/kaizen-design-system/builds/2780