### PR TITLE
feat: Change default behaviour for modal focus [CAP-67]

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -17,4 +17,5 @@
 /site/.cache/
 /site/public/
 /storybook/public/
+/elm-stuff/
 elm.json

--- a/draft-packages/modal/KaizenDraft/Modal/Primitives/GenericModal.scss
+++ b/draft-packages/modal/KaizenDraft/Modal/Primitives/GenericModal.scss
@@ -1,4 +1,5 @@
 @import "~@kaizen/design-tokens/sass/border";
+@import "~@kaizen/design-tokens/sass/color";
 @import "~@kaizen/design-tokens/sass/shadow";
 @import "~@kaizen/component-library/styles/animation";
 @import "~@kaizen/component-library/styles/border";

--- a/draft-packages/modal/KaizenDraft/Modal/Primitives/GenericModal.tsx
+++ b/draft-packages/modal/KaizenDraft/Modal/Primitives/GenericModal.tsx
@@ -24,7 +24,7 @@ interface Props extends ContainerProps, ModalAccessibleContextType {}
 
 const MODAL_TRANSITION_TIMEOUT = 350
 
-function GenericModalContainer(props: ContainerProps): React.ReactNode {
+function GenericModalContainer(props: ContainerProps) {
   const labelledByID = uuid()
   const describedByID = uuid()
   return (

--- a/draft-packages/modal/KaizenDraft/Modal/Primitives/GenericModal.tsx
+++ b/draft-packages/modal/KaizenDraft/Modal/Primitives/GenericModal.tsx
@@ -67,6 +67,7 @@ class GenericModal extends React.Component<Props> {
     this.preventBodyScroll()
     this.ensureAccessiblityIsMet()
     this.scrollModalToTop()
+    this.focusAccessibleLabel()
     if (this.modalLayer) {
       this.removeAriaHider = createAriaHider(this.modalLayer)
     }
@@ -140,6 +141,17 @@ class GenericModal extends React.Component<Props> {
       if (!this.scrollLayer) return
       this.scrollLayer.scrollTop = 0
     })
+  }
+
+  focusAccessibleLabel() {
+    if (this.modalLayer) {
+      const labelElement: HTMLElement | null = document.getElementById(
+        this.props.labelledByID
+      )
+      if (labelElement) {
+        labelElement.focus()
+      }
+    }
   }
 
   render(): React.ReactPortal {

--- a/draft-packages/modal/KaizenDraft/Modal/Primitives/GenericModal.tsx
+++ b/draft-packages/modal/KaizenDraft/Modal/Primitives/GenericModal.tsx
@@ -12,7 +12,7 @@ import { warn } from "@kaizen/component-library/util/console"
 
 const styles = require("./GenericModal.scss")
 
-interface ContainerProps {
+interface GenericModalContainerProps {
   readonly isOpen: boolean
   readonly children: React.ReactNode
   readonly focusLockDisabled?: boolean
@@ -20,11 +20,13 @@ interface ContainerProps {
   readonly onOutsideModalClick?: (event: React.MouseEvent) => void
 }
 
-interface Props extends ContainerProps, ModalAccessibleContextType {}
+interface GenericModalProps
+  extends GenericModalContainerProps,
+    ModalAccessibleContextType {}
 
 const MODAL_TRANSITION_TIMEOUT = 350
 
-function GenericModalContainer(props: ContainerProps) {
+function GenericModalContainer(props: GenericModalContainerProps) {
   const labelledByID = uuid()
   const describedByID = uuid()
   return (
@@ -43,7 +45,7 @@ function GenericModalContainer(props: ContainerProps) {
   )
 }
 
-class GenericModal extends React.Component<Props> {
+class GenericModal extends React.Component<GenericModalProps> {
   scrollLayer: HTMLDivElement | null = null
   modalLayer: HTMLDivElement | null = null
 
@@ -51,7 +53,7 @@ class GenericModal extends React.Component<Props> {
     if (this.props.isOpen) this.onOpen()
   }
 
-  componentDidUpdate(prevProps: Props) {
+  componentDidUpdate(prevProps: GenericModalProps) {
     const hasJustOpened = !prevProps.isOpen && this.props.isOpen
     const hasJustClosed = prevProps.isOpen && !this.props.isOpen
     if (hasJustOpened) this.onOpen()

--- a/draft-packages/modal/KaizenDraft/Modal/Primitives/ModalAccessibleContext.ts
+++ b/draft-packages/modal/KaizenDraft/Modal/Primitives/ModalAccessibleContext.ts
@@ -1,0 +1,13 @@
+import React from "react"
+
+export type ModalAccessibleContextType = {
+  labelledByID: string
+  describedByID: string
+}
+
+export const ModalAccessibleContext = React.createContext<
+  ModalAccessibleContextType
+>({
+  labelledByID: "modal-labelledby",
+  describedByID: "modal-describedby",
+})

--- a/draft-packages/modal/KaizenDraft/Modal/Primitives/ModalAccessibleDescription.tsx
+++ b/draft-packages/modal/KaizenDraft/Modal/Primitives/ModalAccessibleDescription.tsx
@@ -1,5 +1,5 @@
 import * as React from "react"
-import { ID_DESCRIBEDBY } from "./constants"
+import { ModalAccessibleContext } from "./ModalAccessibleContext"
 
 interface Props {
   readonly children: React.ReactNode
@@ -9,6 +9,10 @@ type ModalAccessibleDescription = React.FunctionComponent<Props>
 
 const ModalAccessibleDescription: ModalAccessibleDescription = ({
   children,
-}) => <div id={ID_DESCRIBEDBY}>{children}</div>
+}) => (
+  <ModalAccessibleContext.Consumer>
+    {({ describedByID }) => <div id={describedByID}>{children}</div>}
+  </ModalAccessibleContext.Consumer>
+)
 
 export default ModalAccessibleDescription

--- a/draft-packages/modal/KaizenDraft/Modal/Primitives/ModalAccessibleLabel.scss
+++ b/draft-packages/modal/KaizenDraft/Modal/Primitives/ModalAccessibleLabel.scss
@@ -1,0 +1,31 @@
+@import "~@kaizen/design-tokens/sass/border";
+@import "~@kaizen/design-tokens/sass/color";
+
+.label {
+  position: relative;
+
+  // Use JS polyfill to simulate :focus-visible, not yet supported by browsers
+  // https://github.com/WICG/focus-visible#backwards-compatibility
+  :global(.js-focus-visible) & {
+    // hide native focus ring when :focus but not :focus-visible
+    &:focus {
+      outline: none;
+    }
+
+    // show custom focus ring when :focus-visible
+    &:global(.focus-visible)::after {
+      $focus-ring-offset: ($kz-border-focus-ring-border-width * 2) + 1px;
+      content: "";
+      position: absolute;
+      background: transparent;
+      border-radius: $kz-border-focus-ring-border-radius;
+      border-width: $kz-border-focus-ring-border-width;
+      border-style: $kz-border-focus-ring-border-style;
+      border-color: $kz-color-cluny-500;
+      top: -$focus-ring-offset;
+      left: -$focus-ring-offset;
+      right: -$focus-ring-offset;
+      bottom: -$focus-ring-offset;
+    }
+  }
+}

--- a/draft-packages/modal/KaizenDraft/Modal/Primitives/ModalAccessibleLabel.tsx
+++ b/draft-packages/modal/KaizenDraft/Modal/Primitives/ModalAccessibleLabel.tsx
@@ -1,5 +1,5 @@
 import * as React from "react"
-import { ID_LABELLEDBY } from "./constants"
+import { ModalAccessibleContext } from "./ModalAccessibleContext"
 
 interface Props {
   readonly children: React.ReactNode
@@ -8,7 +8,9 @@ interface Props {
 type ModalAccessibleLabel = React.FunctionComponent<Props>
 
 const ModalAccessibleLabel: ModalAccessibleLabel = ({ children }) => (
-  <div id={ID_LABELLEDBY}>{children}</div>
+  <ModalAccessibleContext.Consumer>
+    {({ labelledByID }) => <div id={labelledByID}>{children}</div>}
+  </ModalAccessibleContext.Consumer>
 )
 
 export default ModalAccessibleLabel

--- a/draft-packages/modal/KaizenDraft/Modal/Primitives/ModalAccessibleLabel.tsx
+++ b/draft-packages/modal/KaizenDraft/Modal/Primitives/ModalAccessibleLabel.tsx
@@ -1,5 +1,6 @@
 import * as React from "react"
 import { ModalAccessibleContext } from "./ModalAccessibleContext"
+const styles = require("./ModalAccessibleLabel.scss")
 
 interface Props {
   readonly children: React.ReactNode
@@ -9,7 +10,11 @@ type ModalAccessibleLabel = React.FunctionComponent<Props>
 
 const ModalAccessibleLabel: ModalAccessibleLabel = ({ children }) => (
   <ModalAccessibleContext.Consumer>
-    {({ labelledByID }) => <div id={labelledByID}>{children}</div>}
+    {({ labelledByID }) => (
+      <div id={labelledByID} tabIndex={-1} className={styles.label}>
+        {children}
+      </div>
+    )}
   </ModalAccessibleContext.Consumer>
 )
 

--- a/draft-packages/modal/KaizenDraft/Modal/Primitives/constants.ts
+++ b/draft-packages/modal/KaizenDraft/Modal/Primitives/constants.ts
@@ -1,2 +1,0 @@
-export const ID_LABELLEDBY = "modal-labelledby"
-export const ID_DESCRIBEDBY = "modal-describedby"

--- a/draft-packages/modal/package.json
+++ b/draft-packages/modal/package.json
@@ -36,7 +36,8 @@
     "@types/classnames": "^2.2.10",
     "classnames": "^2.2.6",
     "react-focus-lock": "1.19.1",
-    "react-transition-group": "^2.9.0"
+    "react-transition-group": "^2.9.0",
+    "uuid": "^3.3.2"
   },
   "devDependencies": {
     "@cultureamp/elm-storybook": "cultureamp/elm-storybook#0.2.1",


### PR DESCRIPTION
[🎫 ](https://cultureamp.atlassian.net/jira/software/projects/CAP/boards/80?selectedIssue=CAP-67)

The existing behaviour for modals is that when they open we let the `<FocusLock>` component from the `react-focus-lock` package handle auto-focusing whatever it thinks is the "right" element to focus on (usually the first button or input element).

This isn’t ideal for a couple of reasons:

1. From an accessibility perspective, as a default, it means we can skip over framing content that is important for screen readers
2. It causes blocking issues on iOS using VoiceOver when it tries to auto-focus on a textarea — the keyboard isn’t invoked when the input is focusesd and is impossible to invoke.

After much discussion about the right default behaviour, we’ve decided that the best default rule would be to move focus to whatever the `<ModalAccessibleLabel>` is. This should be the primary label for the modal (and in the preset implementations is always the title of the modal).

While I was going through the code I realised that there was a potential ID clashing issue with the way we’re using constants for modal labels: there’s a place in Performance where we’re using two modals nested on top of one another, and so using the same ID for both modals means we could select and focus the wrong element.

To avoid that I’ve added a context that wraps the `GenericModal` that passes through dynamically generated IDs for `labelledby` and `describedby` that is consumed in `ModalAccessibleLabel` and `ModalAccessibleDescription`.