### PR TITLE
feat: add mousedown event handler

### DIFF
--- a/draft-packages/button/KaizenDraft/Button/Button.elm
+++ b/draft-packages/button/KaizenDraft/Button/Button.elm
@@ -21,6 +21,7 @@ module KaizenDraft.Button.Button exposing
     , onBlur
     , onClick
     , onFocus
+    , onMouseDown
     , preventKeydownOn
     , primary
     , reverseColor
@@ -111,6 +112,7 @@ view (Config config) label =
                 ++ onFocusAttribs config
                 ++ onBlurAttribs config
                 ++ preventKeydownAttribs config
+                ++ onMouseDownAttribs config
                 ++ automationIdAttr
                 ++ titleAttr
                 ++ buttonTypeAttribs config
@@ -160,6 +162,16 @@ preventKeydownAttribs config =
 
     else
         [ HtmlEvents.preventDefaultOn "keydown" <| Decode.map (\msg -> ( msg, True )) (Decode.oneOf config.preventKeydownOn) ]
+
+
+onMouseDownAttribs : ConfigValue msg -> List (Html.Attribute msg)
+onMouseDownAttribs config =
+    case config.onMouseDown of
+        Just mouseDownMsg ->
+            [ HtmlEvents.onMouseDown mouseDownMsg ]
+
+        Nothing ->
+            []
 
 
 onClickAttribs : ConfigValue msg -> List (Html.Attribute msg)
@@ -300,6 +312,7 @@ type alias ConfigValue msg =
     , onFocus : Maybe msg
     , onBlur : Maybe msg
     , preventKeydownOn : List (Decode.Decoder msg)
+    , onMouseDown : Maybe msg
     , href : Maybe String
     , newTabAndIUnderstandTheAccessibilityImplications : Bool
     , id : Maybe String
@@ -349,6 +362,7 @@ defaults =
     , onFocus = Nothing
     , onBlur = Nothing
     , preventKeydownOn = []
+    , onMouseDown = Nothing
     , href = Nothing
     , newTabAndIUnderstandTheAccessibilityImplications = False
     , id = Nothing
@@ -441,6 +455,11 @@ onBlur value (Config config) =
 preventKeydownOn : List (Decode.Decoder msg) -> Config msg -> Config msg
 preventKeydownOn decoders (Config config) =
     Config { config | preventKeydownOn = decoders }
+
+
+onMouseDown : msg -> Config msg -> Config msg
+onMouseDown value (Config config) =
+    Config { config | onMouseDown = Just value }
 
 
 href : String -> Config msg -> Config msg

--- a/draft-packages/button/KaizenDraft/Button/components/GenericButton.tsx
+++ b/draft-packages/button/KaizenDraft/Button/components/GenericButton.tsx
@@ -13,6 +13,7 @@ type GenericProps = {
   reversed?: boolean
   icon?: React.SVGAttributes<SVGSymbolElement>
   onClick?: (e: MouseEvent) => void
+  onMouseDown?: (e: MouseEvent) => void
   href?: string
   newTabAndIUnderstandTheAccessibilityImplications?: boolean
   type?: "submit" | "reset" | "button"
@@ -68,6 +69,7 @@ const renderButton: React.FunctionComponent<Props> = props => {
     id,
     disabled,
     onClick,
+    onMouseDown,
     type,
     disableTabFocusAndIUnderstandTheAccessibilityImplications,
   } = props
@@ -84,6 +86,7 @@ const renderButton: React.FunctionComponent<Props> = props => {
           onClick && onClick(e)
         }
       }}
+      onMouseDown={(e: any) => onMouseDown && onMouseDown(e)}
       type={type}
       data-automation-id={props.automationId}
       title={label}


### PR DESCRIPTION
Mousedown events fire before blur events and this is handy for when we need to stop native browser behaviour.

Icon buttons for example can control a RTE (Rich Text Editor) by toggling text modifiers on and off such as Bold, Italic etc. Clicking these modifier buttons will currently remove focus from the focused editor. Typically this is not an ideal flow as the cursor should not leave the editor. 

To achieve this we need to intercept the onMouseDown event of the button component which fires before the input blur. We can then `preventDefault()` and stop the editor from losing focus.

