### PR TITLE
feat: Add blur and focus callbacks to form components

### DIFF
--- a/draft-packages/button/KaizenDraft/Button/components/GenericButton.tsx
+++ b/draft-packages/button/KaizenDraft/Button/components/GenericButton.tsx
@@ -21,8 +21,8 @@ type GenericProps = {
   fullWidth?: boolean
   disableTabFocusAndIUnderstandTheAccessibilityImplications?: boolean
   analytics?: Analytics
-  onFocus?: (e: React.FocusEvent<HTMLButtonElement>) => void
-  onBlur?: (e: React.FocusEvent<HTMLButtonElement>) => void
+  onFocus?: (e: React.FocusEvent<HTMLElement>) => void
+  onBlur?: (e: React.FocusEvent<HTMLElement>) => void
 }
 
 type LabelProps = {
@@ -118,6 +118,8 @@ const renderLink: React.FunctionComponent<Props> = props => {
     href,
     onClick,
     newTabAndIUnderstandTheAccessibilityImplications,
+    onFocus,
+    onBlur,
   } = props
 
   return (
@@ -134,6 +136,8 @@ const renderLink: React.FunctionComponent<Props> = props => {
           onClick && onClick(e)
         }
       }}
+      onFocus={onFocus}
+      onBlur={onBlur}
       data-automation-id={props.automationId}
       data-analytics-click={props.analytics && props.analytics.eventName}
       data-analytics-properties={

--- a/draft-packages/button/KaizenDraft/Button/components/GenericButton.tsx
+++ b/draft-packages/button/KaizenDraft/Button/components/GenericButton.tsx
@@ -21,6 +21,8 @@ type GenericProps = {
   fullWidth?: boolean
   disableTabFocusAndIUnderstandTheAccessibilityImplications?: boolean
   analytics?: Analytics
+  onFocus?: (e: React.FocusEvent<HTMLButtonElement>) => void
+  onBlur?: (e: React.FocusEvent<HTMLButtonElement>) => void
 }
 
 type LabelProps = {
@@ -72,6 +74,8 @@ const renderButton: React.FunctionComponent<Props> = props => {
     onMouseDown,
     type,
     disableTabFocusAndIUnderstandTheAccessibilityImplications,
+    onFocus,
+    onBlur,
   } = props
   const label = props.icon && props.iconButton ? props.label : undefined
 
@@ -86,6 +90,8 @@ const renderButton: React.FunctionComponent<Props> = props => {
           onClick && onClick(e)
         }
       }}
+      onFocus={onFocus}
+      onBlur={onBlur}
       onMouseDown={(e: any) => onMouseDown && onMouseDown(e)}
       type={type}
       data-automation-id={props.automationId}

--- a/draft-packages/form/KaizenDraft/Form/CheckboxField/CheckboxField.tsx
+++ b/draft-packages/form/KaizenDraft/Form/CheckboxField/CheckboxField.tsx
@@ -11,6 +11,8 @@ export type CheckboxFieldProps = {
   labelText: string | React.ReactNode
   checkedStatus?: CheckedStatus
   onCheck?: (event: React.ChangeEvent<HTMLInputElement>) => any
+  onFocus?: (event: React.FocusEvent<HTMLInputElement>) => any
+  onBlur?: (event: React.FocusEvent<HTMLInputElement>) => any
   disabled?: boolean
   noBottomMargin?: boolean
   tabIndex?: number
@@ -25,6 +27,8 @@ const CheckboxField: CheckboxField = ({
   labelText,
   checkedStatus,
   onCheck,
+  onFocus,
+  onBlur,
   disabled = false,
   noBottomMargin = false,
   tabIndex,
@@ -52,6 +56,8 @@ const CheckboxField: CheckboxField = ({
         checkedStatus={checkedStatus}
         name={name}
         onCheck={onCheck}
+        onFocus={onFocus}
+        onBlur={onBlur}
         tabIndex={tabIndex}
       />
     </Label>

--- a/draft-packages/form/KaizenDraft/Form/Primitives/Checkbox/Checkbox.tsx
+++ b/draft-packages/form/KaizenDraft/Form/Primitives/Checkbox/Checkbox.tsx
@@ -18,6 +18,8 @@ export type CheckboxProps = {
   disabled?: boolean
   name?: string
   tabIndex?: number
+  onFocus?: (e: React.FocusEvent<HTMLInputElement>) => void
+  onBlur?: (e: React.FocusEvent<HTMLInputElement>) => void
 }
 
 type Input = React.FunctionComponent<CheckboxProps>
@@ -48,6 +50,8 @@ const Input: Input = ({
   name,
   checkedStatus = "off" as CheckedStatus,
   onCheck,
+  onFocus,
+  onBlur,
   disabled = false,
   tabIndex,
 }) => (
@@ -65,6 +69,8 @@ const Input: Input = ({
       className={classnames(styles.checkbox, "needsclick")}
       checked={getCheckedFromStatus(checkedStatus)}
       onChange={onCheck}
+      onFocus={onFocus}
+      onBlur={onBlur}
       disabled={disabled}
       ref={node => {
         if (node && checkedStatus === "mixed") {

--- a/draft-packages/form/KaizenDraft/Form/Primitives/ToggleSwitch/ToggleSwitch.tsx
+++ b/draft-packages/form/KaizenDraft/Form/Primitives/ToggleSwitch/ToggleSwitch.tsx
@@ -21,6 +21,8 @@ interface Props {
   onToggle?: (event: React.ChangeEvent<HTMLInputElement>) => any
   disabled?: boolean
   theme?: ToggleTheme
+  onFocus?: (e: React.FocusEvent<HTMLInputElement>) => void
+  onBlur?: (e: React.FocusEvent<HTMLInputElement>) => void
 }
 
 type ToggleSwitch = React.FunctionComponent<Props>
@@ -33,6 +35,8 @@ const ToggleSwitch: ToggleSwitch = ({
   onToggle,
   disabled,
   theme,
+  onFocus,
+  onBlur,
 }) => {
   const isOn = toggledStatus === ToggledStatus.ON
 
@@ -52,6 +56,8 @@ const ToggleSwitch: ToggleSwitch = ({
         className={styles.checkbox}
         checked={isOn ? true : false}
         onChange={onToggle}
+        onFocus={onFocus}
+        onBlur={onBlur}
         disabled={disabled}
       />
       <div

--- a/draft-packages/form/KaizenDraft/Form/ToggleSwitchField/ToggleSwitchField.tsx
+++ b/draft-packages/form/KaizenDraft/Form/ToggleSwitchField/ToggleSwitchField.tsx
@@ -21,6 +21,8 @@ interface Props {
   inline?: boolean
   fullWidth?: boolean
   theme?: ToggleTheme
+  onFocus?: (e: React.FocusEvent<HTMLInputElement>) => void
+  onBlur?: (e: React.FocusEvent<HTMLInputElement>) => void
 }
 
 type ToggleSwitchField = React.FunctionComponent<Props>
@@ -35,6 +37,8 @@ const ToggleSwitchField: ToggleSwitchField = ({
   inline = false,
   fullWidth = false,
   theme = ToggleTheme.DEFAULT,
+  onFocus,
+  onBlur,
 }) => (
   <FieldGroup
     id={`${id}-field-group`}
@@ -60,6 +64,8 @@ const ToggleSwitchField: ToggleSwitchField = ({
           toggledStatus={toggledStatus}
           name={name}
           onToggle={onToggle}
+          onFocus={onFocus}
+          onBlur={onBlur}
           theme={theme}
         />
       </Label>

--- a/packages/component-library/components/Button/components/GenericButton.tsx
+++ b/packages/component-library/components/Button/components/GenericButton.tsx
@@ -20,8 +20,8 @@ type GenericProps = {
   fullWidth?: boolean
   disableTabFocusAndIUnderstandTheAccessibilityImplications?: boolean
   analytics?: Analytics
-  onFocus?: (e: React.FocusEvent<HTMLButtonElement>) => void
-  onBlur?: (e: React.FocusEvent<HTMLButtonElement>) => void
+  onFocus?: (e: React.FocusEvent<HTMLElement>) => void
+  onBlur?: (e: React.FocusEvent<HTMLElement>) => void
 }
 
 type LabelProps = {
@@ -115,6 +115,8 @@ const renderLink: React.FunctionComponent<Props> = props => {
     href,
     onClick,
     newTabAndIUnderstandTheAccessibilityImplications,
+    onFocus,
+    onBlur,
   } = props
 
   return (
@@ -131,6 +133,8 @@ const renderLink: React.FunctionComponent<Props> = props => {
           onClick && onClick(e)
         }
       }}
+      onFocus={onFocus}
+      onBlur={onBlur}
       data-automation-id={props.automationId}
       data-analytics-click={props.analytics && props.analytics.eventName}
       data-analytics-properties={

--- a/packages/component-library/components/Button/components/GenericButton.tsx
+++ b/packages/component-library/components/Button/components/GenericButton.tsx
@@ -20,6 +20,8 @@ type GenericProps = {
   fullWidth?: boolean
   disableTabFocusAndIUnderstandTheAccessibilityImplications?: boolean
   analytics?: Analytics
+  onFocus?: (e: React.FocusEvent<HTMLButtonElement>) => void
+  onBlur?: (e: React.FocusEvent<HTMLButtonElement>) => void
 }
 
 type LabelProps = {
@@ -70,6 +72,8 @@ const renderButton: React.FunctionComponent<Props> = props => {
     onClick,
     type,
     disableTabFocusAndIUnderstandTheAccessibilityImplications,
+    onFocus,
+    onBlur,
   } = props
   const label = props.icon && props.iconButton ? props.label : undefined
 
@@ -84,6 +88,8 @@ const renderButton: React.FunctionComponent<Props> = props => {
           onClick && onClick(e)
         }
       }}
+      onFocus={onFocus}
+      onBlur={onBlur}
       type={type}
       data-automation-id={props.automationId}
       title={label}


### PR DESCRIPTION
With the new form validations in perform, we would like to keep track of the "touched" state of each field, as so we can determine when best to show an inline validation error.

This PR adds the `onFocus` and `onBlur` callbacks, as to allow for this.

The affected components are the Buttons, Checkboxes, and ToggleSwitches