### PR TITLE
fix: Copy inter mixins from helper packages back to legacy type.scss

### DIFF
--- a/packages/component-library/styles/type.scss
+++ b/packages/component-library/styles/type.scss
@@ -20,6 +20,11 @@ $ca-inter-font-family: "Ideal Sans A", "Ideal Sans B", $ca-default-font-family;
 $ca-ideal-sans-font-base-size: 1rem; /* 16px */
 $ca-ideal-sans-font-descender-height: 0.14;
 
+// Combine these into a Sass map ($ca-default-font) once node-sass includes libsass 3.5.0.beta.3 with this bug fix: https://github.com/sass/libsass/issues/2309
+$ca-inter-font-family: "Inter", $ca-default-font-family;
+$ca-inter-font-base-size: 1rem; /* 16px */
+$ca-inter-font-descender-height: 0.14;
+
 // Locale-specific fonts
 $ca-locale-he-font-family: "Open Sans", Tahoma, sans-serif;
 $ca-locale-ar-font-family: "Open Sans", Tahoma, sans-serif;
@@ -27,6 +32,8 @@ $ca-ideal-locale-ar-font-family: "Ideal Sans A", "Ideal Sans B", Tahoma,
   sans-serif;
 $ca-ideal-locale-he-font-family: "Ideal Sans A", "Ideal Sans B", Tahoma,
   sans-serif;
+$ca-inter-locale-ar-font-family: "Inter", Tahoma, sans-serif;
+$ca-inter-locale-he-font-family: "Inter", Tahoma, sans-serif;
 
 // Inspired by Basekick from SEEK: https://github.com/michaeltaranto/basekick
 @mixin ca-type(
@@ -94,6 +101,11 @@ $ca-ideal-locale-he-font-family: "Ideal Sans A", "Ideal Sans B", Tahoma,
 @mixin ca-type-ideal-small-bold($args...) {
   @include ca-type-ideal-small;
   font-weight: $ca-weight-semibold;
+}
+
+@mixin ca-type-inter-small-bold($args...) {
+  @include ca-type-inter-small;
+  font-weight: 600;
 }
 
 @mixin ca-type-display($args...) {
@@ -236,6 +248,119 @@ $ca-ideal-locale-he-font-family: "Ideal Sans A", "Ideal Sans B", Tahoma,
 
 @mixin ca-type-ideal-button($size: 18, $args...) {
   @include ca-type-ideal($size: $size, $weight: $ca-weight-medium, $args...);
+}
+
+// Inter styles
+
+@mixin ca-type-inter(
+  $size,
+  $weight,
+  $line-height-in-grid-units: 1,
+  $letter-spacing: normal,
+  $args...
+) {
+  @include ca-type(
+    $size-ratio: $size / 16,
+    $family: $ca-inter-font-family,
+    $base-size: $ca-inter-font-base-size,
+    $descender-height: $ca-inter-font-descender-height,
+    $line-height-in-grid-units: $line-height-in-grid-units,
+    $letter-spacing: $letter-spacing,
+    $weight: $weight,
+    $args...
+  );
+  html:lang(he) & {
+    font-family: $ca-inter-locale-he-font-family;
+  }
+  html:lang(ar) & {
+    font-family: $ca-inter-locale-ar-font-family;
+  }
+}
+
+@mixin ca-type-inter-page-title($size: 32, $args...) {
+  @include ca-type-inter(
+    $size: $size,
+    $line-height-in-grid-units: 1.5,
+    $weight: 700,
+    $args...
+  );
+}
+
+@mixin ca-type-inter-title($size: 26, $args...) {
+  @include ca-type-inter(
+    $size: $size,
+    $line-height-in-grid-units: 1.5,
+    $weight: 700,
+    $args...
+  );
+}
+
+@mixin ca-type-inter-display($size: 22, $args...) {
+  @include ca-type-inter($size: $size, $weight: 600, $args...);
+}
+
+@mixin ca-type-inter-heading($size: 18, $args...) {
+  @include ca-type-inter($size: $size, $weight: 600, $args...);
+}
+
+@mixin ca-type-inter-lede($size: 20, $args...) {
+  @include ca-type-inter($size: $size, $weight: 400, $args...);
+}
+
+@mixin ca-type-inter-body($size: 16, $args...) {
+  @include ca-type-inter($size: $size, $weight: 400, $args...);
+}
+
+@mixin ca-type-inter-body-bold($size: 16, $args...) {
+  @include ca-type-inter($size: $size, $weight: 400, $args...);
+}
+
+@mixin ca-type-inter-small($size: 14, $args...) {
+  @include ca-type-inter($size: $size, $weight: 400, $args...);
+}
+
+@mixin ca-type-inter-small-bold($size: 14, $args...) {
+  @include ca-type-inter($size: $size, $weight: 400, $args...);
+}
+
+@mixin ca-type-inter-notification($size: 15, $args...) {
+  @include ca-type-inter(
+    $size: $size,
+    $weight: $ca-weight-light,
+    $line-height-in-grid-units: 3/4,
+    $args...
+  );
+}
+
+@mixin ca-type-inter-label($size: 12, $args...) {
+  $letter-spacing-in-px: 0.5;
+  @include ca-type-inter(
+    $size: $size,
+    $weight: 600,
+    $letter-spacing: $letter-spacing-in-px / $size * 1em,
+    $args...
+  );
+  text-transform: uppercase;
+}
+
+// Deprecated, use ca-type-inter-label instead.
+@mixin ca-type-inter-labels-and-legends($args...) {
+  @include ca-type-inter-label($args...);
+}
+
+@mixin ca-type-inter-control-action($size: 16, $args...) {
+  @include ca-type-inter($size: $size, $weight: 500, $args...);
+  text-decoration: none;
+  text-decoration-skip-ink: auto;
+  color: $kz-color-cluny-500;
+  cursor: pointer;
+  &:hover {
+    text-decoration: underline;
+  }
+}
+
+@mixin ca-type-inter-button($size: 18, $args...) {
+  @include ca-type-inter($size: $size, $weight: 700, $args...);
 }
 
 @mixin debug-vertical-rhythm-grid() {


### PR DESCRIPTION
We attempted to point existing usages to the `deprecated-component-library-helpers` so that this wouldn't be necesdsary, but the Kaizen build doesn't pick everything up (thanks to scss implicit imports). We don't find out until we try to build in another repo, which is extremely time consuming. This should fix any ca-inter-xxx usages missing imports.

So, now there are two copies of these mixins, one in `packages/component-library/styles/type.scss` and one in `packages/deprecated-component-library-helpers/styles/type.scss`. The latter is the one we want to keep - we want to delete `packages/component-library/styles/type.scss` entirely but it's difficult to do, becuase there may be implicit imports that can't easily be detected (and don't even get detected by the Kaizen build)

Part of the problem is that scss files only get compiled/linted if they are used somewhere in Kaizen, such as a Storybook Story or the Kaizen Site, but we can't stop consuming repos from using untested/unlinted code. We don't have 100% storybook coverage.

The historical context of `packages/deprecated-component-library-helpers/styles/type.scss` is that we don't want consuming packages to use scss mixins at all - we want them to use react/elm Heading and Paragraph components (paragraph is supposed to be named Text, but that name was already taken). The "deprecated" mixins are intended as a temporary measure to ween consuming repos off of the legacy typography (replacing components is much harder). We _definitely_ want to get rid of `packages/deprecated-component-library-helpers/styles/type.scss` (which is currently part of core), but unfortunately it's not easy.