### PR TITLE
fix: a legacy var was accidentally renamed

### DIFF
--- a/packages/component-library/styles/type.scss
+++ b/packages/component-library/styles/type.scss
@@ -16,7 +16,8 @@ $ca-default-font-base-size: 0.875rem; /* 14px */
 $ca-default-font-descender-height: 0.115;
 
 // Combine these into a Sass map ($ca-default-font) once node-sass includes libsass 3.5.0.beta.3 with this bug fix: https://github.com/sass/libsass/issues/2309
-$ca-inter-font-family: "Ideal Sans A", "Ideal Sans B", $ca-default-font-family;
+$ca-ideal-sans-font-family: "Ideal Sans A", "Ideal Sans B",
+  $ca-default-font-family;
 $ca-ideal-sans-font-base-size: 1rem; /* 16px */
 $ca-ideal-sans-font-descender-height: 0.14;
 


### PR DESCRIPTION
As part of a sweeping rename of $ca-type-ideal-sans-xxx to $ca-type-inter-xxx, the type.scss files were meant to be left alone, but this snuck in due to human error (it me)