### PR TITLE
feat: Add focus rings to TextField & TextAreaField + reversed support for TextAreaField

### DIFF
--- a/draft-packages/button/KaizenDraft/Button/styles.scss
+++ b/draft-packages/button/KaizenDraft/Button/styles.scss
@@ -212,7 +212,7 @@ $caButton-verticalPaddingForm: calc(
 %caButtonReversed {
   &:not(:disabled) {
     background: transparent;
-    border-color: rgba($kz-color-white, 0.5);
+    border-color: rgba($kz-color-white, 0.65);
     color: $kz-color-white;
 
     &:hover {

--- a/draft-packages/form/KaizenDraft/Form/Primitives/FieldMessage/styles.scss
+++ b/draft-packages/form/KaizenDraft/Form/Primitives/FieldMessage/styles.scss
@@ -21,7 +21,7 @@ $ca-palette-input-validation-negative: $kz-color-coral-600;
   color: add-alpha($kz-color-wisteria-800, 80%);
 
   &.reversed {
-    color: $kz-color-white;
+    color: add-alpha($kz-color-white, 80%);
   }
 }
 
@@ -29,5 +29,5 @@ $ca-palette-input-validation-negative: $kz-color-coral-600;
   padding: $ca-grid / 2;
   color: $message-error-color;
   border-radius: $message-border-radius;
-  background: $kz-color-coral-100;
+  background: $kz-color-coral-300;
 }

--- a/draft-packages/form/KaizenDraft/Form/Primitives/FieldMessage/styles.scss
+++ b/draft-packages/form/KaizenDraft/Form/Primitives/FieldMessage/styles.scss
@@ -1,7 +1,6 @@
 @import "~@kaizen/design-tokens/sass/color";
 @import "~@kaizen/design-tokens/sass/border";
 @import "~@kaizen/deprecated-component-library-helpers/styles/type";
-@import "~@kaizen/deprecated-component-library-helpers/styles/color";
 
 $message-error-color: $kz-color-wisteria-800;
 $message-border-radius: $kz-border-solid-border-radius;
@@ -18,10 +17,10 @@ $ca-palette-input-validation-negative: $kz-color-coral-600;
 }
 
 .default {
-  color: add-alpha($kz-color-wisteria-800, 80%);
+  color: rgba($kz-color-wisteria-800, 0.8);
 
   &.reversed {
-    color: add-alpha($kz-color-white, 80%);
+    color: rgba($kz-color-white, 0.8);
   }
 }
 

--- a/draft-packages/form/KaizenDraft/Form/Primitives/FieldMessage/styles.scss
+++ b/draft-packages/form/KaizenDraft/Form/Primitives/FieldMessage/styles.scss
@@ -20,7 +20,7 @@ $ca-palette-input-validation-negative: $kz-color-coral-600;
   color: rgba($kz-color-wisteria-800, 0.8);
 
   &.reversed {
-    color: rgba($kz-color-white, 0.8);
+    color: $kz-color-white;
   }
 }
 

--- a/draft-packages/form/KaizenDraft/Form/Primitives/Input/Input.elm
+++ b/draft-packages/form/KaizenDraft/Form/Primitives/Input/Input.elm
@@ -46,6 +46,7 @@ styles =
         , startIconAdornment = "startIconAdornment"
         , withEndIconAdornment = "withEndIconAdornment"
         , endIconAdornment = "endIconAdornment"
+        , focusRing = "focusRing"
         }
 
 
@@ -362,5 +363,6 @@ view (Config config) =
     inputWrapperHtml
         [ startIconAdornmentHtml
         , inputHtml
+        , div [ styles.class .focusRing ] []
         , endIconAdornmentHtml
         ]

--- a/draft-packages/form/KaizenDraft/Form/Primitives/Input/Input.tsx
+++ b/draft-packages/form/KaizenDraft/Form/Primitives/Input/Input.tsx
@@ -91,6 +91,10 @@ const Input: Input = ({
       )}
     />
 
+    {/* Inputs aren't able to have pseudo elements like ::after on them,
+          so we have to create an element ourselves for the focus ring */}
+    <div className={styles.focusRing} />
+
     {endIconAdornment && (
       <div className={styles.endIconAdornment}>{endIconAdornment}</div>
     )}

--- a/draft-packages/form/KaizenDraft/Form/Primitives/Input/styles.scss
+++ b/draft-packages/form/KaizenDraft/Form/Primitives/Input/styles.scss
@@ -59,10 +59,6 @@ $input-disabled-border-alpha: 50%;
     }
   }
 
-  &:focus {
-    outline: none; // Bootstrap override
-  }
-
   &.disabled {
     &:not(.reversed) {
       background: $input-disabled-background;

--- a/draft-packages/form/KaizenDraft/Form/Primitives/Input/styles.scss
+++ b/draft-packages/form/KaizenDraft/Form/Primitives/Input/styles.scss
@@ -17,7 +17,6 @@ $ca-border-color-focus-reversed: $kz-color-cluny-300;
 
 // Vars
 $input-height: 48px;
-$input-focus-border-color-reversed: $kz-color-yuzu-500;
 $input-base-padding-horizontal: $ca-grid / 2;
 $input-icon-size: 1.25rem; // 20px
 $input-placeholder-opacity: 0.5;
@@ -217,7 +216,7 @@ $input-disabled-border-alpha: 50%;
 
   &:focus:not([disabled]),
   &:hover:focus:not([disabled]) {
-    border-color: $ca-border-color-focus;
+    border-color: $ca-border-color-hover;
   }
 
   &:focus + .focusRing {
@@ -240,7 +239,7 @@ $input-disabled-border-alpha: 50%;
 // Reversed (Dark Backgrounds)
 .input.reversed {
   color: $kz-color-white;
-  border-color: $kz-color-white;
+  border-color: rgba($kz-color-white, 0.65);
 
   @include form-input-placeholder {
     color: $kz-color-white;
@@ -248,13 +247,9 @@ $input-disabled-border-alpha: 50%;
   }
 
   &:focus:not([disabled]),
-  &:hover:focus:not([disabled]) {
-    background: rgba($kz-color-white, 0.1);
-    border-color: $input-focus-border-color-reversed;
-  }
-
   &:hover:not([disabled]) {
     background: rgba($kz-color-white, 0.1);
+    border-color: $kz-color-white;
   }
 
   &:focus + .focusRing {

--- a/draft-packages/form/KaizenDraft/Form/Primitives/Input/styles.scss
+++ b/draft-packages/form/KaizenDraft/Form/Primitives/Input/styles.scss
@@ -60,8 +60,7 @@ $input-disabled-border-alpha: 50%;
   }
 
   &:focus {
-    // override Bootstrap style
-    outline: none;
+    outline: none; // Bootstrap override
   }
 
   &.disabled {

--- a/draft-packages/form/KaizenDraft/Form/Primitives/Input/styles.scss
+++ b/draft-packages/form/KaizenDraft/Form/Primitives/Input/styles.scss
@@ -8,7 +8,8 @@
 // In the future these tokens should be better represented in
 // a separate package so they are shareable.
 $ca-border-color-focus: $kz-color-cluny-500;
-$ca-border-color-hover: $kz-color-wisteria-400;
+$ca-border-color-hover: $kz-color-wisteria-700;
+$ca-border-color-focus-reversed: $kz-color-cluny-300;
 
 // -----------------------------------------------
 // Form Input Primitive
@@ -59,6 +60,11 @@ $input-disabled-border-alpha: 50%;
     }
   }
 
+  &:focus {
+    // override Bootstrap style
+    outline: none;
+  }
+
   &.disabled {
     &:not(.reversed) {
       background: $input-disabled-background;
@@ -68,6 +74,21 @@ $input-disabled-border-alpha: 50%;
       color: add-alpha($ca-base-text-color, $input-disabled-alpha);
     }
   }
+}
+
+.input:focus + .focusRing {
+  $focus-ring-offset: 3px;
+  position: absolute;
+  background: transparent;
+  border-radius: $kz-border-focus-ring-border-radius;
+  border-width: $kz-border-focus-ring-border-width;
+  border-style: $kz-border-focus-ring-border-style;
+  border-color: transparent;
+  top: -$focus-ring-offset;
+  left: -$focus-ring-offset;
+  right: -$focus-ring-offset;
+  bottom: -$focus-ring-offset;
+  pointer-events: none;
 }
 
 ///////////////////////////////////////////////////
@@ -199,8 +220,8 @@ $input-disabled-border-alpha: 50%;
     border-color: $ca-border-color-focus;
   }
 
-  &:hover:not([disabled]) {
-    border-color: $kz-color-wisteria-700;
+  &:focus + .focusRing {
+    border-color: $ca-border-color-focus;
   }
 
   &.disabled {
@@ -234,6 +255,10 @@ $input-disabled-border-alpha: 50%;
 
   &:hover:not([disabled]) {
     background: rgba($kz-color-white, 0.1);
+  }
+
+  &:focus + .focusRing {
+    border-color: $ca-border-color-focus-reversed;
   }
 
   &.disabled {

--- a/draft-packages/form/KaizenDraft/Form/Primitives/TextArea/TextArea.tsx
+++ b/draft-packages/form/KaizenDraft/Form/Primitives/TextArea/TextArea.tsx
@@ -10,6 +10,7 @@ type Props = {
   defaultValue?: string
   placeholder?: string
   name?: string
+  reversed?: boolean
   onChange?: (event: React.ChangeEvent<HTMLTextAreaElement>) => any
   onBlur?: (event: React.FocusEvent<HTMLTextAreaElement>) => any
   onFocus?: (event: React.FocusEvent<HTMLTextAreaElement>) => any
@@ -22,6 +23,7 @@ const TextArea = (props: Props) => {
     defaultValue,
     placeholder,
     name,
+    reversed,
     rows = 3,
     onChange,
     onBlur,
@@ -32,7 +34,9 @@ const TextArea = (props: Props) => {
   return (
     <textarea
       id={id}
-      className={classnames(styles.textarea, styles.default)}
+      className={classnames(styles.textarea, styles.default, {
+        [styles.reversed]: reversed,
+      })}
       placeholder={placeholder}
       name={name}
       rows={rows}

--- a/draft-packages/form/KaizenDraft/Form/Primitives/TextArea/TextArea.tsx
+++ b/draft-packages/form/KaizenDraft/Form/Primitives/TextArea/TextArea.tsx
@@ -32,21 +32,28 @@ const TextArea = (props: Props) => {
   } = props
 
   return (
-    <textarea
-      id={id}
-      className={classnames(styles.textarea, styles.default, {
-        [styles.reversed]: reversed,
-      })}
-      placeholder={placeholder}
-      name={name}
-      rows={rows}
-      onChange={onChange}
-      onBlur={onBlur}
-      onFocus={onFocus}
-      data-automation-id={automationId}
-      value={value}
-      defaultValue={defaultValue}
-    />
+    <div className={styles.wrapper}>
+      <textarea
+        id={id}
+        className={classnames(styles.textarea, {
+          [styles.default]: !reversed,
+          [styles.reversed]: reversed,
+        })}
+        placeholder={placeholder}
+        name={name}
+        rows={rows}
+        onChange={onChange}
+        onBlur={onBlur}
+        onFocus={onFocus}
+        data-automation-id={automationId}
+        value={value}
+        defaultValue={defaultValue}
+      />
+
+      {/* Textareas aren't able to have pseudo elements like ::after on them,
+          so we have to create an element ourselves for the focus ring */}
+      <div className={styles.focusRing} />
+    </div>
   )
 }
 

--- a/draft-packages/form/KaizenDraft/Form/Primitives/TextArea/TextArea.tsx
+++ b/draft-packages/form/KaizenDraft/Form/Primitives/TextArea/TextArea.tsx
@@ -13,6 +13,7 @@ type Props = {
   name?: string
   reversed?: boolean
   status?: InputStatus
+  textAreaRef?: React.RefObject<HTMLTextAreaElement>
   onChange?: (event: React.ChangeEvent<HTMLTextAreaElement>) => any
   onBlur?: (event: React.FocusEvent<HTMLTextAreaElement>) => any
   onFocus?: (event: React.FocusEvent<HTMLTextAreaElement>) => any
@@ -28,6 +29,7 @@ const TextArea = (props: Props) => {
     reversed,
     rows = 3,
     status = "default",
+    textAreaRef,
     onChange,
     onBlur,
     onFocus,
@@ -52,6 +54,7 @@ const TextArea = (props: Props) => {
         data-automation-id={automationId}
         value={value}
         defaultValue={defaultValue}
+        ref={textAreaRef}
       />
 
       {/* Textareas aren't able to have pseudo elements like ::after on them,

--- a/draft-packages/form/KaizenDraft/Form/Primitives/TextArea/TextArea.tsx
+++ b/draft-packages/form/KaizenDraft/Form/Primitives/TextArea/TextArea.tsx
@@ -1,3 +1,4 @@
+import { InputStatus } from "@kaizen/draft-form"
 import classnames from "classnames"
 import React from "react"
 const styles = require("./styles.scss")
@@ -11,6 +12,7 @@ type Props = {
   placeholder?: string
   name?: string
   reversed?: boolean
+  status?: InputStatus
   onChange?: (event: React.ChangeEvent<HTMLTextAreaElement>) => any
   onBlur?: (event: React.FocusEvent<HTMLTextAreaElement>) => any
   onFocus?: (event: React.FocusEvent<HTMLTextAreaElement>) => any
@@ -25,6 +27,7 @@ const TextArea = (props: Props) => {
     name,
     reversed,
     rows = 3,
+    status = "default",
     onChange,
     onBlur,
     onFocus,
@@ -38,6 +41,7 @@ const TextArea = (props: Props) => {
         className={classnames(styles.textarea, {
           [styles.default]: !reversed,
           [styles.reversed]: reversed,
+          [styles.error]: status === "error",
         })}
         placeholder={placeholder}
         name={name}

--- a/draft-packages/form/KaizenDraft/Form/Primitives/TextArea/styles.scss
+++ b/draft-packages/form/KaizenDraft/Form/Primitives/TextArea/styles.scss
@@ -27,3 +27,25 @@
     color: add-alpha($kz-color-wisteria-800, 70%);
   }
 }
+
+// Reversed (Dark Backgrounds)
+.textarea.reversed {
+  color: $kz-color-white;
+  border-color: add-alpha($kz-color-white, 50%);
+  background: transparent;
+
+  @include form-input-placeholder {
+    line-height: 1.5;
+    color: $kz-color-white;
+  }
+
+  &:focus:not([disabled]),
+  &:hover:focus:not([disabled]) {
+    background: add-alpha($kz-color-white, 10%);
+    border-color: $kz-color-white;
+  }
+
+  &.error:not(:focus) {
+    border-color: $kz-color-coral-300;
+  }
+}

--- a/draft-packages/form/KaizenDraft/Form/Primitives/TextArea/styles.scss
+++ b/draft-packages/form/KaizenDraft/Form/Primitives/TextArea/styles.scss
@@ -28,10 +28,6 @@ $ca-border-color-focus-reversed: $kz-color-cluny-300;
     border-color: $kz-color-wisteria-700;
   }
 
-  &:focus {
-    outline: none; // Bootstrap override
-  }
-
   @include form-input-placeholder {
     line-height: 1.5;
     color: rgba($kz-color-wisteria-800, 0.7);

--- a/draft-packages/form/KaizenDraft/Form/Primitives/TextArea/styles.scss
+++ b/draft-packages/form/KaizenDraft/Form/Primitives/TextArea/styles.scss
@@ -29,6 +29,10 @@ $ca-border-color-focus-reversed: $kz-color-cluny-300;
     border-color: $kz-color-wisteria-700;
   }
 
+  &.error:not(:focus) {
+    border-color: $kz-color-coral-500;
+  }
+
   @include form-input-placeholder {
     line-height: 1.5;
     color: rgba($kz-color-wisteria-800, 0.7);
@@ -73,7 +77,7 @@ $ca-border-color-focus-reversed: $kz-color-cluny-300;
     border-color: $kz-color-white;
   }
 
-  &.error:not(:focus) {
+  &.error {
     border-color: $kz-color-coral-300;
   }
 

--- a/draft-packages/form/KaizenDraft/Form/Primitives/TextArea/styles.scss
+++ b/draft-packages/form/KaizenDraft/Form/Primitives/TextArea/styles.scss
@@ -29,7 +29,7 @@ $ca-border-color-focus-reversed: $kz-color-cluny-300;
   }
 
   &:focus {
-    outline: none;
+    outline: none; // Bootstrap override
   }
 
   @include form-input-placeholder {

--- a/draft-packages/form/KaizenDraft/Form/Primitives/TextArea/styles.scss
+++ b/draft-packages/form/KaizenDraft/Form/Primitives/TextArea/styles.scss
@@ -22,6 +22,7 @@ $ca-border-color-focus-reversed: $kz-color-cluny-300;
     $kz-color-wisteria-500;
   padding: $ca-grid * 0.5;
   color: $kz-color-wisteria-800;
+  display: block;
 
   &:focus,
   &:hover {

--- a/draft-packages/form/KaizenDraft/Form/Primitives/TextArea/styles.scss
+++ b/draft-packages/form/KaizenDraft/Form/Primitives/TextArea/styles.scss
@@ -1,7 +1,6 @@
 @import "~@kaizen/design-tokens/sass/color";
 @import "~@kaizen/design-tokens/sass/border";
 @import "~@kaizen/deprecated-component-library-helpers/styles/type";
-@import "~@kaizen/deprecated-component-library-helpers/styles/color";
 @import "~@kaizen/draft-form/KaizenDraft/Form/Primitives/base";
 
 // @TODO - brought through from borders.scss in component-library
@@ -35,7 +34,7 @@ $ca-border-color-focus-reversed: $kz-color-cluny-300;
 
   @include form-input-placeholder {
     line-height: 1.5;
-    color: add-alpha($kz-color-wisteria-800, 70%);
+    color: rgba($kz-color-wisteria-800, 0.7);
   }
 }
 
@@ -63,7 +62,7 @@ $ca-border-color-focus-reversed: $kz-color-cluny-300;
 // Reversed (Dark Backgrounds)
 .textarea.reversed {
   color: $kz-color-white;
-  border-color: add-alpha($kz-color-white, 50%);
+  border-color: rgba($kz-color-white, 0.65);
   background: transparent;
 
   @include form-input-placeholder {
@@ -73,7 +72,7 @@ $ca-border-color-focus-reversed: $kz-color-cluny-300;
 
   &:focus,
   &:hover {
-    background: add-alpha($kz-color-white, 10%);
+    background: rgba($kz-color-white, 0.1);
     border-color: $kz-color-white;
   }
 

--- a/draft-packages/form/KaizenDraft/Form/Primitives/TextArea/styles.scss
+++ b/draft-packages/form/KaizenDraft/Form/Primitives/TextArea/styles.scss
@@ -1,9 +1,19 @@
 @import "~@kaizen/design-tokens/sass/color";
 @import "~@kaizen/design-tokens/sass/border";
-@import "~@kaizen/component-library/styles/border";
 @import "~@kaizen/deprecated-component-library-helpers/styles/type";
 @import "~@kaizen/deprecated-component-library-helpers/styles/color";
 @import "~@kaizen/draft-form/KaizenDraft/Form/Primitives/base";
+
+// @TODO - brought through from borders.scss in component-library
+// In the future these tokens should be better represented in
+// a separate package so they are shareable.
+$ca-border-color-focus: $kz-color-cluny-500;
+$ca-border-color-hover: $kz-color-wisteria-400;
+$ca-border-color-focus-reversed: $kz-color-cluny-300;
+
+.wrapper {
+  position: relative;
+}
 
 .textarea {
   @include form-input-reset;
@@ -14,17 +24,39 @@
   padding: $ca-grid * 0.5;
   color: $kz-color-wisteria-800;
 
-  &:focus {
-    border-color: $ca-border-color-focus;
-  }
-
+  &:focus,
   &:hover {
     border-color: $kz-color-wisteria-700;
+  }
+
+  &:focus {
+    outline: none;
   }
 
   @include form-input-placeholder {
     line-height: 1.5;
     color: add-alpha($kz-color-wisteria-800, 70%);
+  }
+}
+
+.textarea:focus + .focusRing {
+  $focus-ring-offset: 3px;
+  position: absolute;
+  background: transparent;
+  border-radius: $kz-border-focus-ring-border-radius;
+  border-width: $kz-border-focus-ring-border-width;
+  border-style: $kz-border-focus-ring-border-style;
+  border-color: transparent;
+  top: -$focus-ring-offset;
+  left: -$focus-ring-offset;
+  right: -$focus-ring-offset;
+  bottom: -$focus-ring-offset;
+  pointer-events: none;
+}
+
+.textarea.default {
+  &:focus + .focusRing {
+    border-color: $ca-border-color-focus;
   }
 }
 
@@ -39,13 +71,17 @@
     color: $kz-color-white;
   }
 
-  &:focus:not([disabled]),
-  &:hover:focus:not([disabled]) {
+  &:focus,
+  &:hover {
     background: add-alpha($kz-color-white, 10%);
     border-color: $kz-color-white;
   }
 
   &.error:not(:focus) {
     border-color: $kz-color-coral-300;
+  }
+
+  &:focus + .focusRing {
+    border-color: $ca-border-color-focus-reversed;
   }
 }

--- a/draft-packages/form/KaizenDraft/Form/TextAreaField/TextAreaField.tsx
+++ b/draft-packages/form/KaizenDraft/Form/TextAreaField/TextAreaField.tsx
@@ -15,6 +15,7 @@ type Props = {
   name?: string
   value?: string
   inline?: boolean
+  reversed?: boolean
   defaultValue?: string
   validationMessage?: string
   status?: InputStatus
@@ -34,6 +35,7 @@ const TextAreaField: React.FunctionComponent<Props> = props => {
     status,
     description,
     inline,
+    reversed,
     placeholder,
     onChange,
     onBlur,
@@ -52,6 +54,7 @@ const TextAreaField: React.FunctionComponent<Props> = props => {
         automationId={`${id}-field-label`}
         htmlFor={`${id}-field-textarea`}
         labelText={labelText}
+        reversed={reversed}
       />
       <TextArea
         id={`${id}-field-textarea`}
@@ -64,6 +67,7 @@ const TextAreaField: React.FunctionComponent<Props> = props => {
         value={value}
         defaultValue={defaultValue}
         rows={rows}
+        reversed={reversed}
       />
       {validationMessage && (
         <FieldMessage
@@ -71,6 +75,7 @@ const TextAreaField: React.FunctionComponent<Props> = props => {
           automationId={`${id}-field-validation-message`}
           message={validationMessage}
           status={status}
+          reversed={reversed}
         />
       )}
       {description && (
@@ -78,6 +83,7 @@ const TextAreaField: React.FunctionComponent<Props> = props => {
           id={`${id}-field-message`}
           automationId={`${id}-field-description`}
           message={description}
+          reversed={reversed}
         />
       )}
     </FieldGroup>

--- a/draft-packages/form/KaizenDraft/Form/TextAreaField/TextAreaField.tsx
+++ b/draft-packages/form/KaizenDraft/Form/TextAreaField/TextAreaField.tsx
@@ -68,6 +68,7 @@ const TextAreaField: React.FunctionComponent<Props> = props => {
         defaultValue={defaultValue}
         rows={rows}
         reversed={reversed}
+        status={status}
       />
       {validationMessage && (
         <FieldMessage

--- a/draft-packages/form/KaizenDraft/Form/TextAreaField/TextAreaField.tsx
+++ b/draft-packages/form/KaizenDraft/Form/TextAreaField/TextAreaField.tsx
@@ -20,6 +20,7 @@ type Props = {
   validationMessage?: string
   status?: InputStatus
   description?: string
+  textAreaRef?: React.RefObject<HTMLTextAreaElement>
   onChange?: (event: React.ChangeEvent<HTMLTextAreaElement>) => any
   onBlur?: (event: React.FocusEvent<HTMLTextAreaElement>) => any
   onFocus?: (event: React.FocusEvent<HTMLTextAreaElement>) => any
@@ -37,6 +38,7 @@ const TextAreaField: React.FunctionComponent<Props> = props => {
     inline,
     reversed,
     placeholder,
+    textAreaRef,
     onChange,
     onBlur,
     onFocus,
@@ -69,6 +71,7 @@ const TextAreaField: React.FunctionComponent<Props> = props => {
         rows={rows}
         reversed={reversed}
         status={status}
+        textAreaRef={textAreaRef}
       />
       {validationMessage && (
         <FieldMessage

--- a/draft-packages/stories/TextAreaField.stories.tsx
+++ b/draft-packages/stories/TextAreaField.stories.tsx
@@ -1,3 +1,4 @@
+import colorTokens from "@kaizen/design-tokens/tokens/color.json"
 import { TextAreaField } from "@kaizen/draft-form"
 import { action } from "@storybook/addon-actions"
 import React from "react"
@@ -43,6 +44,12 @@ class WithState extends React.Component<Props> {
 const ExampleContainer: React.FunctionComponent = ({ children }) => (
   <div style={{ width: "98%", margin: "1%" }}>{children}</div>
 )
+
+const ReversedBg = {
+  parameters: {
+    backgrounds: [{ value: colorTokens.kz.color.wisteria[700], default: true }],
+  },
+}
 
 export default {
   title: "TextAreaField (React)",
@@ -186,4 +193,41 @@ export const DefaultErrorAndDesc = () => (
 
 DefaultErrorAndDesc.story = {
   name: "Default, Error & Description",
+}
+
+export const Reversed = () => (
+  <ExampleContainer>
+    <TextAreaField
+      id="reply"
+      labelText="Your reply"
+      placeholder="Write your reply..."
+      onChange={action("user input")}
+      reversed
+    />
+  </ExampleContainer>
+)
+
+Reversed.story = {
+  name: "Reversed",
+  ...ReversedBg,
+}
+
+export const ReversedErrorAndDesc = () => (
+  <ExampleContainer>
+    <TextAreaField
+      id="reply"
+      labelText="Your reply"
+      placeholder="Write your reply..."
+      onChange={action("user input")}
+      status="error"
+      validationMessage="Enter a reply"
+      description="Your reply will only be seen by you"
+      reversed
+    />
+  </ExampleContainer>
+)
+
+ReversedErrorAndDesc.story = {
+  name: "Reversed, Error & Description",
+  ...ReversedBg,
 }

--- a/draft-packages/stories/TextField.stories.tsx
+++ b/draft-packages/stories/TextField.stories.tsx
@@ -1,3 +1,4 @@
+import colorTokens from "@kaizen/design-tokens/tokens/color.json"
 import { action } from "@storybook/addon-actions"
 import React, { useCallback, useRef } from "react"
 
@@ -10,6 +11,12 @@ const userIcon = require("@kaizen/component-library/icons/user.icon.svg")
 const ExampleContainer: React.FunctionComponent = ({ children }) => (
   <div style={{ width: "98%", margin: "1%" }}>{children}</div>
 )
+
+const ReversedBg = {
+  parameters: {
+    backgrounds: [{ value: colorTokens.kz.color.wisteria[700], default: true }],
+  },
+}
 
 export default {
   title: "TextField (React)",
@@ -287,6 +294,10 @@ export const Reversed = () => (
   </ExampleContainer>
 )
 
+Reversed.story = {
+  ...ReversedBg,
+}
+
 export const ReversedIcon = () => (
   <ExampleContainer>
     <TextField
@@ -304,6 +315,7 @@ export const ReversedIcon = () => (
 
 ReversedIcon.story = {
   name: "Reversed, Icon",
+  ...ReversedBg,
 }
 
 export const ReversedDisabled = () => (
@@ -323,6 +335,7 @@ export const ReversedDisabled = () => (
 
 ReversedDisabled.story = {
   name: "Reversed, Disabled",
+  ...ReversedBg,
 }
 
 export const ReversedDisabledWValue = () => (
@@ -342,6 +355,7 @@ export const ReversedDisabledWValue = () => (
 
 ReversedDisabledWValue.story = {
   name: "Reversed, Disabled w/ value",
+  ...ReversedBg,
 }
 
 export const ReversedDisabledIcon = () => (
@@ -362,6 +376,7 @@ export const ReversedDisabledIcon = () => (
 
 ReversedDisabledIcon.story = {
   name: "Reversed, Disabled + Icon",
+  ...ReversedBg,
 }
 
 export const ReversedSuccess = () => (
@@ -381,6 +396,7 @@ export const ReversedSuccess = () => (
 
 ReversedSuccess.story = {
   name: "Reversed,  Success",
+  ...ReversedBg,
 }
 
 export const ReversedSuccessIcon = () => (
@@ -401,6 +417,7 @@ export const ReversedSuccessIcon = () => (
 
 ReversedSuccessIcon.story = {
   name: "Reversed, Success + Icon",
+  ...ReversedBg,
 }
 
 export const ReversedError = () => (
@@ -421,6 +438,7 @@ export const ReversedError = () => (
 
 ReversedError.story = {
   name: "Reversed, Error",
+  ...ReversedBg,
 }
 
 export const ReversedErrorIcon = () => (
@@ -442,6 +460,7 @@ export const ReversedErrorIcon = () => (
 
 ReversedErrorIcon.story = {
   name: "Reversed, Error + Icon",
+  ...ReversedBg,
 }
 
 export const ReversedMultipleFields = () => (
@@ -471,6 +490,7 @@ export const ReversedMultipleFields = () => (
 
 ReversedMultipleFields.story = {
   name: "Reversed, Multiple Fields",
+  ...ReversedBg,
 }
 
 export const ReversedMultipleFieldsWError = () => (
@@ -504,6 +524,7 @@ export const ReversedMultipleFieldsWError = () => (
 
 ReversedMultipleFieldsWError.story = {
   name: "Reversed, Multiple Fields w/ Error",
+  ...ReversedBg,
 }
 
 export const DefaultFocusBlurEvents = () => (

--- a/packages/component-library/styles/border.scss
+++ b/packages/component-library/styles/border.scss
@@ -4,4 +4,5 @@ $ca-box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
 $ca-border-color: $kz-color-wisteria-200;
 $ca-border-color-hover: $kz-color-wisteria-400;
 $ca-border-color-focus: $kz-color-cluny-500;
+$ca-border-color-focus-reversed: $kz-color-cluny-300;
 $ca-border-radius: 3px;

--- a/packages/component-library/styles/border.scss
+++ b/packages/component-library/styles/border.scss
@@ -4,5 +4,4 @@ $ca-box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
 $ca-border-color: $kz-color-wisteria-200;
 $ca-border-color-hover: $kz-color-wisteria-400;
 $ca-border-color-focus: $kz-color-cluny-500;
-$ca-border-color-focus-reversed: $kz-color-cluny-300;
 $ca-border-radius: 3px;


### PR DESCRIPTION
Two main things...

### Adds `reversed` support to TextAreaField:
![image](https://user-images.githubusercontent.com/1811583/84859155-e66eae00-b0af-11ea-889c-4e3aca957a7d.png)
https://dev.cultureamp.design/dug/textarea-reversed-and-zen/storybook/

### Adds focus rings to TextArea (TextAreaField) and Input (TextField), including reversed:
![image](https://user-images.githubusercontent.com/1811583/84859209-0900c700-b0b0-11ea-95e5-a2c8ab7de693.png)
![image](https://user-images.githubusercontent.com/1811583/84859241-19b13d00-b0b0-11ea-9a07-ce3aa4968be1.png)
![image](https://user-images.githubusercontent.com/1811583/84859276-29c91c80-b0b0-11ea-8a28-23669702f8bb.png)
![image](https://user-images.githubusercontent.com/1811583/84859296-3188c100-b0b0-11ea-9d06-99f5bb0c12ad.png)

I've also updated a couple of colours here and there to match Zen styling.

