### PR TITLE
fix: use specificity hack to overide bootstrap styles

### DIFF
--- a/draft-packages/form/KaizenDraft/Form/Primitives/Checkbox/styles.scss
+++ b/draft-packages/form/KaizenDraft/Form/Primitives/Checkbox/styles.scss
@@ -8,10 +8,12 @@ $checkbox-size: 24px;
 $icon-size: 24px;
 $focus-ring-offset: 2px;
 
-.checkbox {
+// override bootstrap styles
+.checkbox.checkbox {
   @include form-input-visually-hidden();
   width: $checkbox-size;
   height: $checkbox-size;
+  margin: 0;
 }
 
 .icon {


### PR DESCRIPTION
Bootstrap styles in murmur mess with the width, height and margin
properties of the kaizen checkbox. This specificity hack overrides those
styles.