### PR TITLE
feat: Create Menu component

### DIFF
--- a/draft-packages/menu/KaizenDraft/Menu/Menu.spec.tsx
+++ b/draft-packages/menu/KaizenDraft/Menu/Menu.spec.tsx
@@ -5,11 +5,6 @@ import Menu from "./Menu"
 
 afterEach(cleanup)
 
-const svgIcon = {
-  id: "my-icon",
-  viewBox: "0 0 20 20",
-}
-
 describe("Dropdown", () => {
   test("renders default view", () => {
     const { container } = render(

--- a/draft-packages/menu/KaizenDraft/Menu/Menu.spec.tsx
+++ b/draft-packages/menu/KaizenDraft/Menu/Menu.spec.tsx
@@ -1,0 +1,34 @@
+import { Button } from "@kaizen/draft-button"
+import { cleanup, fireEvent, render } from "@testing-library/react"
+import * as React from "react"
+import Menu from "./Menu"
+
+afterEach(cleanup)
+
+const svgIcon = {
+  id: "my-icon",
+  viewBox: "0 0 20 20",
+}
+
+describe("Dropdown", () => {
+  test("renders default view", () => {
+    const { container } = render(
+      <Menu button={<Button label="Button"></Button>} />
+    )
+
+    expect(container.firstChild).toMatchSnapshot()
+  })
+
+  test("shows menu when clicking on the button", () => {
+    const { container, queryByText } = render(
+      <Menu button={<Button label="Button"></Button>}>
+        <div>Item</div>
+      </Menu>
+    )
+
+    expect(queryByText("Item")).toBeFalsy()
+    const button = container.querySelector("button")
+    button && fireEvent.click(button)
+    expect(queryByText("Item")).toBeTruthy()
+  })
+})

--- a/draft-packages/menu/KaizenDraft/Menu/Menu.spec.tsx
+++ b/draft-packages/menu/KaizenDraft/Menu/Menu.spec.tsx
@@ -6,7 +6,7 @@ import Menu from "./Menu"
 afterEach(cleanup)
 
 describe("Dropdown", () => {
-  test("renders default view", () => {
+  it("renders default view", () => {
     const { container } = render(
       <Menu button={<Button label="Button"></Button>} />
     )
@@ -14,7 +14,7 @@ describe("Dropdown", () => {
     expect(container.firstChild).toMatchSnapshot()
   })
 
-  test("shows menu when clicking on the button", () => {
+  it("shows menu when clicking on the button", () => {
     const { container, queryByText } = render(
       <Menu button={<Button label="Button"></Button>}>
         <div>Item</div>

--- a/draft-packages/menu/KaizenDraft/Menu/Menu.tsx
+++ b/draft-packages/menu/KaizenDraft/Menu/Menu.tsx
@@ -1,6 +1,6 @@
 import * as React from "react"
 // TODO: get this from @kaizen/draft-button once published version offers ButtonProps
-import { Button, ButtonProps } from "../../../button"
+import { ButtonProps } from "../../../button"
 import MenuDropdown from "./MenuDropdown"
 
 const styles = require("./styles.scss")

--- a/draft-packages/menu/KaizenDraft/Menu/Menu.tsx
+++ b/draft-packages/menu/KaizenDraft/Menu/Menu.tsx
@@ -1,0 +1,82 @@
+import * as React from "react"
+// TODO: get this from @kaizen/draft-button once published version offers ButtonProps
+import { Button, ButtonProps } from "../../../button"
+import MenuDropdown from "./MenuDropdown"
+
+const styles = require("./styles.scss")
+
+type MenuState = {
+  isMenuVisible: boolean
+}
+
+export type MenuProps = {
+  button: React.ReactElement<ButtonProps>
+  menuVisible?: boolean
+  automationId?: string
+}
+
+export default class Menu extends React.Component<MenuProps, MenuState> {
+  static displayName = "Menu"
+  static defaultProps = {
+    iconPosition: "start",
+  }
+
+  dropdownButtonContainer = React.createRef<HTMLDivElement>()
+
+  constructor(props: MenuProps) {
+    super(props)
+
+    this.state = {
+      isMenuVisible: Boolean(props.menuVisible),
+    }
+  }
+
+  toggleMenu = (e: MouseEvent) => {
+    e.stopPropagation()
+
+    const currentState = this.state.isMenuVisible
+    this.setState({
+      isMenuVisible: !currentState,
+    })
+  }
+
+  hideMenu = () => {
+    this.setState({
+      isMenuVisible: false,
+    })
+  }
+
+  getPosition() {
+    return this.dropdownButtonContainer && this.dropdownButtonContainer.current
+      ? this.dropdownButtonContainer.current.getBoundingClientRect()
+      : null
+  }
+
+  renderMenuDropdown() {
+    return (
+      <MenuDropdown
+        hideMenuDropdown={this.hideMenu}
+        position={this.getPosition()}
+      >
+        {this.props.children}
+      </MenuDropdown>
+    )
+  }
+
+  render() {
+    const { automationId, button } = this.props
+    return (
+      <div
+        className={styles.dropdown}
+        data-automation-id={automationId}
+        ref={this.dropdownButtonContainer}
+      >
+        {React.cloneElement(button, {
+          onClick: this.toggleMenu,
+          onMouseDown: e => e.preventDefault(),
+        })}
+        {this.state.isMenuVisible && this.renderMenuDropdown()}
+      </div>
+    )
+  }
+}

--- a/draft-packages/menu/KaizenDraft/Menu/Menu.tsx
+++ b/draft-packages/menu/KaizenDraft/Menu/Menu.tsx
@@ -1,6 +1,5 @@
+import { ButtonProps } from "@kaizen/draft-button"
 import * as React from "react"
-// TODO: get this from @kaizen/draft-button once published version offers ButtonProps
-import { ButtonProps } from "../../../button"
 import MenuDropdown from "./MenuDropdown"
 
 const styles = require("./styles.scss")

--- a/draft-packages/menu/KaizenDraft/Menu/MenuDropdown.tsx
+++ b/draft-packages/menu/KaizenDraft/Menu/MenuDropdown.tsx
@@ -1,0 +1,80 @@
+import * as React from "react"
+
+const styles = require("./styles.scss")
+
+type MenuDropdownProps = {
+  hideMenuDropdown: () => void
+  position?: {
+    top: number
+    bottom: number
+    left: number
+    right: number
+  } | null
+}
+
+export default class MenuDropdown extends React.Component<MenuDropdownProps> {
+  static displayName = "MenuDropdown"
+  menu = React.createRef<HTMLDivElement>()
+
+  componentDidMount() {
+    document.addEventListener("click", this.handleDocumentClick, false)
+    window.addEventListener("resize", this.handleDocumentResize, false)
+    this.positionMenu()
+  }
+
+  componentWillUnmount() {
+    document.removeEventListener("click", this.handleDocumentClick, false)
+    window.removeEventListener("resize", this.handleDocumentResize, false)
+  }
+
+  positionMenu() {
+    const menu = this.menu
+
+    if (!this.props.position || !menu) {
+      return
+    }
+
+    if (menu.current) {
+      const pos = this.props.position
+      const { innerHeight } = window
+      const rect = menu.current.getBoundingClientRect()
+
+      if (pos.bottom > innerHeight - rect.height) {
+        menu.current.style.bottom = "24px"
+        menu.current.style.top = "auto"
+      } else {
+        menu.current.style.top = "24px"
+        menu.current.style.bottom = "auto"
+      }
+    }
+  }
+
+  handleDocumentClick = (e: MouseEvent) => {
+    if (
+      this.menu &&
+      this.menu.current &&
+      e.target instanceof Node &&
+      !this.menu.current.contains(e.target)
+    ) {
+      this.props.hideMenuDropdown()
+    }
+  }
+
+  handleDocumentResize = () => {
+    this.props.hideMenuDropdown()
+  }
+
+  render(): JSX.Element {
+    const { hideMenuDropdown, children } = this.props
+
+    return (
+      <div
+        className={styles.menuContainer}
+        ref={this.menu}
+        onClick={() => hideMenuDropdown()}
+      >
+        {children}
+      </div>
+    )
+  }
+}

--- a/draft-packages/menu/KaizenDraft/Menu/__snapshots__/Menu.spec.tsx.snap
+++ b/draft-packages/menu/KaizenDraft/Menu/__snapshots__/Menu.spec.tsx.snap
@@ -1,0 +1,26 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Dropdown renders default view 1`] = `
+<div
+  class="dropdown"
+>
+  <span
+    class="container"
+  >
+    <button
+      class="button"
+      type="button"
+    >
+      <span
+        class="content"
+      >
+        <span
+          class="label"
+        >
+          Button
+        </span>
+      </span>
+    </button>
+  </span>
+</div>
+`;

--- a/draft-packages/menu/KaizenDraft/Menu/components/MenuContent.module.scss
+++ b/draft-packages/menu/KaizenDraft/Menu/components/MenuContent.module.scss
@@ -1,0 +1,122 @@
+@import "~@kaizen/design-tokens/sass/color";
+@import "~@kaizen/design-tokens/sass/border";
+@import "~@kaizen/design-tokens/sass/shadow";
+@import "~@kaizen/design-tokens/sass/typography";
+@import "~@kaizen/component-library/styles/layout";
+@import "~@kaizen/component-library/styles/layers";
+@import "~@kaizen/component-library/styles/animation";
+
+$side-padding: 1/2 * $ca-grid;
+
+.menuContent {
+  background: #fff;
+  color: $kz-color-wisteria-800;
+  border-radius: $kz-border-solid-border-radius;
+  box-shadow: $kz-shadow-large-box-shadow;
+  line-height: 40px;
+  text-align: left;
+  padding: 6px 4px;
+
+  [dir="rtl"] & {
+    text-align: right;
+  }
+}
+
+.header {
+  padding: 10px $side-padding 5px;
+  color: $kz-color-wisteria-800;
+}
+
+.header__title {
+  font-family: $kz-typography-heading-6-font-family;
+  font-weight: $kz-typography-heading-6-font-weight;
+  font-size: $kz-typography-heading-6-font-size;
+  line-height: $kz-typography-heading-6-line-height;
+  letter-spacing: $kz-typography-heading-6-letter-spacing;
+  display: block;
+}
+
+.menuItem {
+  display: flex;
+  align-items: center;
+  flex: 0 0 100%;
+  box-sizing: border-box;
+  padding: 8px $side-padding;
+  min-height: 1.75 * $ca-grid;
+  border-radius: 4px;
+  font-family: $kz-typography-paragraph-body-font-family;
+  font-weight: $kz-typography-paragraph-body-font-weight;
+  font-size: $kz-typography-paragraph-body-font-size;
+  line-height: $kz-typography-paragraph-body-line-height;
+  letter-spacing: $kz-typography-paragraph-body-letter-spacing;
+  text-decoration: none;
+  color: $kz-color-wisteria-800;
+
+  cursor: default;
+
+  &:not(.menuItem--disabled) {
+    cursor: pointer;
+  }
+
+  &:hover {
+    text-decoration: none;
+  }
+
+  &.menuItem--active,
+  &:not(.menuItem--disabled):hover,
+  &:focus {
+    background: $kz-color-cluny-100;
+    color: $kz-color-cluny-500;
+
+    .menuItem__Icon {
+      color: $kz-color-cluny-500;
+    }
+
+    &.menuItem--destructive {
+      background: $kz-color-coral-100;
+      color: $kz-color-coral-600;
+
+      .menuItem__Icon {
+        color: $kz-color-coral-600;
+      }
+    }
+  }
+}
+
+// .menuItem--active {
+// This was left over from the legacy MenuList component and is here as a reminder
+// that we can use this class for any "active" menuItem states.
+// }
+
+.menuItem--disabled {
+  color: rgba($kz-color-wisteria-800, 0.3);
+}
+
+.menuItem--destructive {
+  color: $kz-color-coral-600;
+  .menuItem__Icon {
+    color: $kz-color-coral-600;
+  }
+}
+
+.menuItem__Label {
+  flex: 1;
+}
+
+.menuItem__Icon {
+  @include ca-margin($end: $ca-grid / 3);
+
+  display: flex;
+  align-self: flex-start;
+  transform: translateY(0.2em);
+  color: rgba($kz-color-wisteria-800, 0.75);
+}
+
+.separator {
+  height: 1px;
+  width: 100%;
+  border: 0;
+  background: $kz-color-wisteria-200;
+  visibility: visible;
+  margin: 5px 0;
+}

--- a/draft-packages/menu/KaizenDraft/Menu/components/MenuContent.module.scss
+++ b/draft-packages/menu/KaizenDraft/Menu/components/MenuContent.module.scss
@@ -9,13 +9,12 @@
 $side-padding: 1/2 * $ca-grid;
 
 .menuContent {
-  background: #fff;
+  background: $kz-color-white;
   color: $kz-color-wisteria-800;
   border-radius: $kz-border-solid-border-radius;
   box-shadow: $kz-shadow-large-box-shadow;
-  line-height: 40px;
-  text-align: left;
   padding: 6px 4px;
+  text-align: left;
 
   [dir="rtl"] & {
     text-align: right;
@@ -62,7 +61,6 @@ $side-padding: 1/2 * $ca-grid;
     text-decoration: none;
   }
 
-  &.menuItem--active,
   &:not(.menuItem--disabled):hover,
   &:focus {
     background: $kz-color-cluny-100;
@@ -83,11 +81,6 @@ $side-padding: 1/2 * $ca-grid;
   }
 }
 
-// .menuItem--active {
-// This was left over from the legacy MenuList component and is here as a reminder
-// that we can use this class for any "active" menuItem states.
-// }
-
 .menuItem--disabled {
   color: rgba($kz-color-wisteria-800, 0.3);
 }
@@ -100,7 +93,7 @@ $side-padding: 1/2 * $ca-grid;
 }
 
 .menuItem__Label {
-  flex: 1;
+  flex-grow: 1;
 }
 
 .menuItem__Icon {

--- a/draft-packages/menu/KaizenDraft/Menu/components/MenuContent.tsx
+++ b/draft-packages/menu/KaizenDraft/Menu/components/MenuContent.tsx
@@ -1,0 +1,10 @@
+import * as React from "react"
+const styles = require("./MenuContent.module.scss")
+
+const MenuContent = (props: { children: React.ReactNode }) => (
+  <div className={styles.menuContent}>{props.children}</div>
+)
+
+MenuContent.displayName = "MenuContent"
+
+export default MenuContent

--- a/draft-packages/menu/KaizenDraft/Menu/components/MenuHeader.tsx
+++ b/draft-packages/menu/KaizenDraft/Menu/components/MenuHeader.tsx
@@ -1,0 +1,13 @@
+import * as React from "react"
+
+const styles = require("./MenuContent.module.scss")
+
+const MenuHeader = (props: { title: string }) => (
+  <div className={styles.header}>
+    <span className={styles.header__title}>{props.title}</span>
+  </div>
+)
+
+MenuHeader.displayName = "MenuHeader"
+
+export default MenuHeader

--- a/draft-packages/menu/KaizenDraft/Menu/components/MenuItem.tsx
+++ b/draft-packages/menu/KaizenDraft/Menu/components/MenuItem.tsx
@@ -1,0 +1,76 @@
+import { Icon } from "@kaizen/component-library"
+import classNames from "classnames"
+import * as React from "react"
+
+const styles = require("./MenuContent.module.scss")
+
+const MenuItem = (props: {
+  label: string
+  action: string | ((e: React.MouseEvent<HTMLAnchorElement>) => void)
+  icon?: React.SVGAttributes<SVGSymbolElement>
+  hoverIcon?: boolean
+  active?: boolean
+  destructive?: boolean
+  disabled?: boolean
+  automationId?: string
+}) => {
+  const {
+    label,
+    icon,
+    hoverIcon,
+    action,
+    active,
+    destructive,
+    disabled,
+    automationId,
+  } = props
+
+  const wrappedLabel = <span className={styles.menuItem__Label}>{label}</span>
+  const iconNode = icon && (
+    <span className={styles.menuItem__Icon}>
+      <Icon icon={icon} role="presentation" />
+    </span>
+  )
+
+  const className = classNames({
+    [styles.menuItem]: true,
+    [styles.hoverIcon]: icon && hoverIcon,
+    [styles["menuItem--active"]]: active,
+    [styles["menuItem--destructive"]]: destructive,
+    [styles["menuItem--disabled"]]: disabled,
+  })
+
+  if (disabled) {
+    return (
+      <div className={className} data-automation-id={automationId}>
+        {iconNode}
+        {wrappedLabel}
+      </div>
+    )
+  }
+
+  if (typeof action === "string") {
+    return (
+      <a href={action} className={className} data-automation-id={automationId}>
+        {iconNode}
+        {wrappedLabel}
+      </a>
+    )
+  }
+
+  return (
+    <a
+      href="#"
+      onClick={action}
+      className={className}
+      data-automation-id={automationId}
+    >
+      {iconNode}
+      {wrappedLabel}
+    </a>
+  )
+}
+
+MenuItem.displayName = "MenuItem"
+
+export default MenuItem

--- a/draft-packages/menu/KaizenDraft/Menu/components/MenuItem.tsx
+++ b/draft-packages/menu/KaizenDraft/Menu/components/MenuItem.tsx
@@ -23,10 +23,9 @@ const MenuItem = (props: MenuItemProps) => {
     </span>
   )
 
-  const className = classNames({
-    styles.menuItem,
-    styles["menuItem--destructive"]: destructive,
-    styles["menuItem--disabled"]: disabled,
+  const className = classNames(styles.menuItem, {
+    [styles["menuItem--destructive"]]: destructive,
+    [styles["menuItem--disabled"]]: disabled,
   })
 
   if (disabled) {

--- a/draft-packages/menu/KaizenDraft/Menu/components/MenuItem.tsx
+++ b/draft-packages/menu/KaizenDraft/Menu/components/MenuItem.tsx
@@ -24,10 +24,6 @@ const MenuItem = (props: MenuItemProps) => {
   )
 
   const className = classNames({
-    [styles.menuItem]: true,
-    [styles["menuItem--destructive"]]: destructive,
-    [styles["menuItem--disabled"]]: disabled,
-  const className = classNames({
     styles.menuItem,
     styles["menuItem--destructive"]: destructive,
     styles["menuItem--disabled"]: disabled,

--- a/draft-packages/menu/KaizenDraft/Menu/components/MenuItem.tsx
+++ b/draft-packages/menu/KaizenDraft/Menu/components/MenuItem.tsx
@@ -27,6 +27,10 @@ const MenuItem = (props: MenuItemProps) => {
     [styles.menuItem]: true,
     [styles["menuItem--destructive"]]: destructive,
     [styles["menuItem--disabled"]]: disabled,
+  const className = classNames({
+    styles.menuItem,
+    styles["menuItem--destructive"]: destructive,
+    styles["menuItem--disabled"]: disabled,
   })
 
   if (disabled) {

--- a/draft-packages/menu/KaizenDraft/Menu/components/MenuItem.tsx
+++ b/draft-packages/menu/KaizenDraft/Menu/components/MenuItem.tsx
@@ -8,22 +8,11 @@ const MenuItem = (props: {
   label: string
   action: string | ((e: React.MouseEvent<HTMLAnchorElement>) => void)
   icon?: React.SVGAttributes<SVGSymbolElement>
-  hoverIcon?: boolean
-  active?: boolean
   destructive?: boolean
   disabled?: boolean
   automationId?: string
 }) => {
-  const {
-    label,
-    icon,
-    hoverIcon,
-    action,
-    active,
-    destructive,
-    disabled,
-    automationId,
-  } = props
+  const { label, icon, action, destructive, disabled, automationId } = props
 
   const wrappedLabel = <span className={styles.menuItem__Label}>{label}</span>
   const iconNode = icon && (
@@ -34,8 +23,6 @@ const MenuItem = (props: {
 
   const className = classNames({
     [styles.menuItem]: true,
-    [styles.hoverIcon]: icon && hoverIcon,
-    [styles["menuItem--active"]]: active,
     [styles["menuItem--destructive"]]: destructive,
     [styles["menuItem--disabled"]]: disabled,
   })

--- a/draft-packages/menu/KaizenDraft/Menu/components/MenuItem.tsx
+++ b/draft-packages/menu/KaizenDraft/Menu/components/MenuItem.tsx
@@ -4,14 +4,16 @@ import * as React from "react"
 
 const styles = require("./MenuContent.module.scss")
 
-const MenuItem = (props: {
+export type MenuItemProps = {
   label: string
   action: string | ((e: React.MouseEvent<HTMLAnchorElement>) => void)
   icon?: React.SVGAttributes<SVGSymbolElement>
   destructive?: boolean
   disabled?: boolean
   automationId?: string
-}) => {
+}
+
+const MenuItem = (props: MenuItemProps) => {
   const { label, icon, action, destructive, disabled, automationId } = props
 
   const wrappedLabel = <span className={styles.menuItem__Label}>{label}</span>

--- a/draft-packages/menu/KaizenDraft/Menu/components/MenuSeparator.tsx
+++ b/draft-packages/menu/KaizenDraft/Menu/components/MenuSeparator.tsx
@@ -1,0 +1,8 @@
+import * as React from "react"
+
+const styles = require("./MenuContent.module.scss")
+
+const MenuSeparator = () => <hr className={styles.separator} />
+MenuSeparator.displayName = "MenuSeparator"
+
+export default MenuSeparator

--- a/draft-packages/menu/KaizenDraft/Menu/styles.scss
+++ b/draft-packages/menu/KaizenDraft/Menu/styles.scss
@@ -1,0 +1,27 @@
+@import "~@kaizen/design-tokens/sass/border";
+@import "~@kaizen/design-tokens/sass/typography";
+@import "~@kaizen/component-library/styles/layers";
+@import "~@kaizen/deprecated-component-library-helpers/styles/type";
+@import "~@kaizen/deprecated-component-library-helpers/styles/color";
+
+$menu-container-width: 248px;
+
+.dropdown {
+  position: relative;
+}
+
+.menuContainer {
+  position: absolute;
+  width: $menu-container-width;
+  z-index: $ca-z-index-dropdown;
+  right: 0;
+
+  [dir="rtl"] & {
+    right: auto;
+    left: 0;
+  }
+}
+
+.reversedColor {
+  color: $kz-color-white;
+}

--- a/draft-packages/menu/index.ts
+++ b/draft-packages/menu/index.ts
@@ -3,3 +3,4 @@ export { default as MenuContent } from "./KaizenDraft/Menu/components/MenuConten
 export { default as MenuHeader } from "./KaizenDraft/Menu/components/MenuHeader"
 export { default as MenuItem } from "./KaizenDraft/Menu/components/MenuItem"
 export { default as MenuSeparator } from "./KaizenDraft/Menu/components/MenuSeparator"
+export { MenuItemProps } from "./KaizenDraft/Menu/components/MenuItem"

--- a/draft-packages/menu/index.ts
+++ b/draft-packages/menu/index.ts
@@ -1,0 +1,5 @@
+export { default as Menu } from "./KaizenDraft/Menu/Menu"
+export { default as MenuContent } from "./KaizenDraft/Menu/components/MenuContent"
+export { default as MenuHeader } from "./KaizenDraft/Menu/components/MenuHeader"
+export { default as MenuItem } from "./KaizenDraft/Menu/components/MenuItem"
+export { default as MenuSeparator } from "./KaizenDraft/Menu/components/MenuSeparator"

--- a/draft-packages/menu/package.json
+++ b/draft-packages/menu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kaizen/draft-menu",
-  "version": "1.5.5",
+  "version": "1.0.0",
   "description": "The draft Menu component",
   "scripts": {
     "prepublish": "tsc --project tsconfig.dist.json",

--- a/draft-packages/menu/package.json
+++ b/draft-packages/menu/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "@kaizen/draft-menu",
+  "version": "1.5.5",
+  "description": "The draft Menu component",
+  "scripts": {
+    "prepublish": "tsc --project tsconfig.dist.json",
+    "build": "yarn clean && yarn prepublish",
+    "build:watch": "yarn clean && yarn prepublish --watch",
+    "clean": "rimraf '*.d.ts' '*.js' '*.map' 'KaizenDraft/**/*.d.ts' 'KaizenDraft/**/*.js' 'KaizenDraft/**/*.map'"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/cultureamp/kaizen-design-system.git",
+    "directory": "draft-packages/menu"
+  },
+  "bugs": {
+    "url": "https://github.com/cultureamp/kaizen-design-system/issues"
+  },
+  "files": [
+    "**/*",
+    "!**/*.ts",
+    "!**/*.tsx",
+    "**/*.d.ts",
+    "!**/*.spec.*",
+    "!**/*.snap",
+    "!draft-templates",
+    "!stories",
+    "!tsconfig.dist.json"
+  ],
+  "author": "",
+  "private": false,
+  "license": "MIT",
+  "dependencies": {
+    "@kaizen/component-library": "^7.23.0",
+    "@types/classnames": "^2.2.10",
+    "classnames": "^2.2.6"
+  },
+  "devDependencies": {
+    "rimraf": "^3.0.2"
+  },
+  "peerDependencies": {
+    "@kaizen/design-tokens": "1.6.0",
+    "react": "^16.9.0"
+  }
+}

--- a/draft-packages/menu/tsconfig.dist.json
+++ b/draft-packages/menu/tsconfig.dist.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "allowJs": false,
+    "declaration": true,
+    "noEmit": false,
+    "sourceMap": true
+  }
+}

--- a/draft-packages/stories/Menu.stories.tsx
+++ b/draft-packages/stories/Menu.stories.tsx
@@ -1,0 +1,137 @@
+import * as colorTokens from "@kaizen/design-tokens/tokens/color.json"
+import { Button, IconButton } from "@kaizen/draft-button"
+const chevronDown = require("@kaizen/component-library/icons/chevron-down.icon.svg")
+  .default
+const duplicateIcon = require("@kaizen/component-library/icons/duplicate.icon.svg")
+  .default
+const editIcon = require("@kaizen/component-library/icons/edit.icon.svg")
+  .default
+const trashIcon = require("@kaizen/component-library/icons/trash.icon.svg")
+  .default
+const kebabIcon = require("@kaizen/component-library/icons/kebab.icon.svg")
+  .default
+const meatballsIcon = require("@kaizen/component-library/icons/meatballs.icon.svg")
+  .default
+import { action } from "@storybook/addon-actions"
+import * as React from "react"
+
+import { Menu, MenuContent, MenuHeader, MenuItem, MenuSeparator } from "../menu"
+
+const StoryWrapper = ({ children }) => (
+  <div style={{ display: "flex", justifyContent: "center", marginTop: "1rem" }}>
+    <div style={{ display: "inline-block" }}>{children}</div>
+  </div>
+)
+
+const MenuInstance: React.FunctionComponent = () => (
+  <MenuContent>
+    <MenuItem action="https://www.cultureamp.com/" label="Menu link" />
+    <MenuItem action="https://www.cultureamp.com/" label="Menu link" />
+    <MenuItem action="https://www.cultureamp.com/" label="Menu link" />
+    <MenuSeparator />
+    <MenuHeader title="Other actions" />
+    <MenuItem
+      action={(e: any) => {
+        e.preventDefault()
+        action("I am an onClick handler")()
+      }}
+      icon={duplicateIcon}
+      label="Menu button but the label is too long"
+    />
+    <MenuItem
+      action={(e: any) => {
+        e.preventDefault()
+        action("I am an onClick handler")()
+      }}
+      icon={editIcon}
+      label="Menu button"
+    />
+
+    <MenuItem
+      action="https://www.cultureamp.com/"
+      icon={trashIcon}
+      destructive
+      label="Menu button"
+    />
+    <MenuItem
+      action="https://www.cultureamp.com/"
+      disabled
+      label="Menu button"
+    />
+  </MenuContent>
+)
+
+export default {
+  title: "Menu (React)",
+  component: Menu,
+  parameters: {
+    info: {
+      text: `
+        import { Menu, MenuHeader, MenuItem, MenuContent, MenuSeparator } from "@kaizen/draft-menu";
+      `,
+    },
+  },
+}
+
+export const DefaultMeatball = () => (
+  <StoryWrapper>
+    <Menu button={<IconButton label="" icon={meatballsIcon} />}>
+      <MenuInstance />
+    </Menu>
+  </StoryWrapper>
+)
+
+DefaultMeatball.story = {
+  name: "Default (Meatball)",
+}
+
+export const DefaultKebab = () => (
+  <StoryWrapper>
+    <Menu button={<IconButton label="" icon={kebabIcon} />}>
+      <MenuInstance />
+    </Menu>
+  </StoryWrapper>
+)
+
+DefaultKebab.story = {
+  name: "Default (Kebab)",
+}
+
+export const LabelAndIcon = () => (
+  <StoryWrapper>
+    <Menu
+      button={<Button label="Label" icon={chevronDown} iconPosition="end" />}
+    >
+      <MenuInstance />
+    </Menu>
+  </StoryWrapper>
+)
+
+LabelAndIcon.story = {
+  name: "Label and Icon",
+}
+
+export const LabelAndIconReversed = () => (
+  <StoryWrapper>
+    <Menu
+      button={
+        <Button label="Label" icon={chevronDown} iconPosition="end" reversed />
+      }
+    >
+      <MenuInstance />
+    </Menu>
+  </StoryWrapper>
+)
+
+LabelAndIconReversed.story = {
+  name: "Label and Icon (reversed)",
+  parameters: {
+    backgrounds: [
+      {
+        name: "Wisteria 700",
+        value: colorTokens.kz.color.wisteria[700],
+        default: true,
+      },
+    ],
+  },
+}


### PR DESCRIPTION
## Changes

- Creates a new draft component called `Menu`. (We had discussions about the name – `dropdown`, `dropdown-menu` are already names of draft packages, which limited the choices here.)
- This component mixes together the existing `Dropdown` and `MenuList` components into one thing, while exposing the Menu stuff for consumers to build their own menus.
- It allows consumers to pass in any Button they want, including IconButtons (such as kebabs/meatball icons).

![image](https://user-images.githubusercontent.com/6406263/84975734-88060600-b169-11ea-9051-f4c2d05c54db.png)


## Background

A number of engineers have never been happy with the dropdown/menu situation. We currently have two components, `Dropdown` and `MenuList`. `MenuList` is just the content that fills the dropdown menu container, and `Dropdown` provided the container and the clickable button/control action/icon.

A major problem with `Dropdown` is that it duplicated its own visual clickable action, instead of letting the user pass in whatever they wanted. This meant that even after we uplifted the `Button` component, dropdown buttons still looked inconsistent and out of date.

Also, the separation of `Dropdown` and `MenuList` (along with an Elm version in a separate package called `dropdown-menu`) is potentially confusing for consumers.

## UI Kit design

The designs are based on the Menu sticker sheet in the UI Kit, [available here](https://www.figma.com/file/GMxm8rvDCbj0Xw3TQWBZ8b/Zen-UI-Kit?node-id=6262%3A0):

![image](https://user-images.githubusercontent.com/6406263/84975768-a10eb700-b169-11ea-8cdb-a060f3d3e56e.png)
