### PR TITLE
feat: Expose ButtonProps

### DIFF
--- a/draft-packages/button/index.ts
+++ b/draft-packages/button/index.ts
@@ -1,2 +1,3 @@
 export { default as Button } from "./KaizenDraft/Button/Button"
 export { default as IconButton } from "./KaizenDraft/Button/IconButton"
+export { ButtonProps } from "./KaizenDraft/Button/components/GenericButton"

--- a/draft-packages/button/index.ts
+++ b/draft-packages/button/index.ts
@@ -1,3 +1,4 @@
 export { default as Button } from "./KaizenDraft/Button/Button"
 export { default as IconButton } from "./KaizenDraft/Button/IconButton"
 export { ButtonProps } from "./KaizenDraft/Button/components/GenericButton"
+export { IconButtonProps } from "./KaizenDraft/Button/components/GenericButton"


### PR DESCRIPTION
## Changes

In order for other components to enforce type restrictions in their APIs to force consumers to pass in a Button component, we need to expose the props so that they can be accessed.

Two use cases for this are:
1. In TitleBlockZen, where we may choose to accept only Buttons as children,
2. In Menu, where we only want a Button to be used as the clickable area (for now).