### PR TITLE
fix: correct font weights for legacy ca-type paragraph bold mixins

### DIFF
--- a/packages/component-library/styles/type.scss
+++ b/packages/component-library/styles/type.scss
@@ -313,7 +313,7 @@ $ca-inter-locale-he-font-family: "Inter", Tahoma, sans-serif;
 }
 
 @mixin ca-type-inter-body-bold($size: 16, $args...) {
-  @include ca-type-inter($size: $size, $weight: 400, $args...);
+  @include ca-type-inter($size: $size, $weight: 600, $args...);
 }
 
 @mixin ca-type-inter-small($size: 14, $args...) {
@@ -321,7 +321,7 @@ $ca-inter-locale-he-font-family: "Inter", Tahoma, sans-serif;
 }
 
 @mixin ca-type-inter-small-bold($size: 14, $args...) {
-  @include ca-type-inter($size: $size, $weight: 400, $args...);
+  @include ca-type-inter($size: $size, $weight: 600, $args...);
 }
 
 @mixin ca-type-inter-notification($size: 15, $args...) {

--- a/packages/deprecated-component-library-helpers/styles/type.scss
+++ b/packages/deprecated-component-library-helpers/styles/type.scss
@@ -315,7 +315,7 @@ $ca-inter-locale-he-font-family: "Inter", Tahoma, sans-serif;
 }
 
 @mixin ca-type-inter-body-bold($size: 16, $args...) {
-  @include ca-type-inter($size: $size, $weight: 400, $args...);
+  @include ca-type-inter($size: $size, $weight: 600, $args...);
 }
 
 @mixin ca-type-inter-small($size: 14, $args...) {
@@ -323,7 +323,7 @@ $ca-inter-locale-he-font-family: "Inter", Tahoma, sans-serif;
 }
 
 @mixin ca-type-inter-small-bold($size: 14, $args...) {
-  @include ca-type-inter($size: $size, $weight: 400, $args...);
+  @include ca-type-inter($size: $size, $weight: 600, $args...);
 }
 
 @mixin ca-type-inter-notification($size: 15, $args...) {


### PR DESCRIPTION
These were incorrectly set to `400` which as the same as the regular styles.

FYI, the reason that there are two copies of these mixins (`packages/component-library/styles/type.scss` and `packages/deprecated-component-library-helpers/styles/type.scss`), is that originally we deleted the ones in `packages/component-library/styles/type.scss` but ran into a problem where a consuming package was using an older version of a package that was expecting them due to peer dependencies (it's confusing). 

Once all consuming repos and packages have been upgraded, we will be able to delete `packages/component-library/styles/type.scss` which should be considered deprecated+++