### PR TITLE
fix: Specify box-sizing so layout is consistent without depending on the consuming app

### DIFF
--- a/draft-packages/title-block/KaizenDraft/TitleBlock/TitleBlock.scss
+++ b/draft-packages/title-block/KaizenDraft/TitleBlock/TitleBlock.scss
@@ -31,6 +31,8 @@
   padding: 0 $ca-layout-side-padding;
   height: $ca-layout-title-block-height;
   margin: 0 auto;
+  // Specifying this explicity in case the consuming app don't have this specified by default
+  box-sizing: border-box;
 
   @include ca-media-tablet {
     height: $ca-layout-title-block-tablet-height;


### PR DESCRIPTION
Using titleblock in a new repo causes some layout inconsistencies due to box-sizing. Ideally the component should not need to rely on the consuming app's style to have consistent layout.

Local verification using yarn link confirms the layout inconsistency issue is fixed.