### PR TITLE
fix: Disable pointer-events on input wrapper for Radio

### DIFF
--- a/draft-packages/radio/KaizenDraft/Radio/styles.scss
+++ b/draft-packages/radio/KaizenDraft/Radio/styles.scss
@@ -12,7 +12,9 @@
 
   label {
     -webkit-tap-highlight-color: transparent;
-    input[type="radio"] {
+
+    // Disable pointer-events on the wrapper for the <RadioInput> primitive
+    > div:first-child {
       pointer-events: none;
     }
 


### PR DESCRIPTION
Same follow-up as https://github.com/cultureamp/kaizen-design-system/pull/556 which replicates the behaviour for `<Radio>`.