### PR TITLE
feat: Add automation ids to modal container and actions

### DIFF
--- a/draft-packages/modal/KaizenDraft/Modal/Presets/ConfirmationModal.tsx
+++ b/draft-packages/modal/KaizenDraft/Modal/Presets/ConfirmationModal.tsx
@@ -28,6 +28,7 @@ interface Props {
   readonly onDismiss: () => void
   readonly confirmLabel?: string
   readonly dismissLabel?: string
+  readonly automationId?: string
   readonly children: React.ReactNode
 }
 
@@ -53,12 +54,14 @@ const ConfirmationModal = ({
   onDismiss,
   confirmLabel = "Confirm",
   dismissLabel = "Cancel",
+  automationId,
   children,
 }: Props) => (
   <GenericModal
     isOpen={isOpen}
     onEscapeKeyup={onDismiss}
     onOutsideModalClick={onDismiss}
+    automationId={automationId}
   >
     <div className={styles.modal}>
       <ModalHeader unpadded reversed onDismiss={onDismiss}>
@@ -94,6 +97,7 @@ const ConfirmationModal = ({
           { label: dismissLabel, action: onDismiss },
         ]}
         appearance={type === "negative" ? "destructive" : "primary"}
+        automationId={automationId}
       />
     </div>
   </GenericModal>

--- a/draft-packages/modal/KaizenDraft/Modal/Presets/InformationModal.tsx
+++ b/draft-packages/modal/KaizenDraft/Modal/Presets/InformationModal.tsx
@@ -18,6 +18,7 @@ interface Props {
   readonly onConfirm?: () => void
   readonly onDismiss: () => void
   readonly confirmLabel?: string
+  readonly automationId?: string
   readonly renderBackground?: () => React.ReactNode
   readonly children: React.ReactNode
 }
@@ -30,6 +31,7 @@ const InformationModal = ({
   onConfirm,
   onDismiss,
   confirmLabel = "Confirm",
+  automationId,
   renderBackground,
   children,
 }: Props) => (
@@ -37,6 +39,7 @@ const InformationModal = ({
     isOpen={isOpen}
     onEscapeKeyup={onDismiss}
     onOutsideModalClick={onDismiss}
+    automationId={automationId}
   >
     <div className={styles.modal}>
       {renderBackground && renderBackground()}
@@ -60,6 +63,7 @@ const InformationModal = ({
         <ModalFooter
           actions={[{ label: confirmLabel, action: onConfirm }]}
           appearance={"primary"}
+          automationId={automationId}
         />
       )}
     </div>

--- a/draft-packages/modal/KaizenDraft/Modal/Presets/InputEditModal.tsx
+++ b/draft-packages/modal/KaizenDraft/Modal/Presets/InputEditModal.tsx
@@ -22,6 +22,7 @@ interface Props {
   readonly localeDirection?: "rtl" | "ltr"
   readonly submitLabel?: string
   readonly dismissLabel?: string
+  readonly automationId?: string
   readonly children: React.ReactNode
   readonly submitDisabled?: boolean
 }
@@ -37,6 +38,7 @@ const InputEditModal = ({
   localeDirection = "ltr",
   submitLabel = "Submit",
   dismissLabel = "Cancel",
+  automationId,
   children,
   submitDisabled = false,
 }: Props) => (
@@ -44,6 +46,7 @@ const InputEditModal = ({
     isOpen={isOpen}
     onEscapeKeyup={onDismiss}
     onOutsideModalClick={onDismiss}
+    automationId={automationId}
   >
     <div className={styles.modal} dir={localeDirection}>
       <ModalHeader unpadded onDismiss={onDismiss}>
@@ -66,6 +69,7 @@ const InputEditModal = ({
           { label: dismissLabel, action: onDismiss },
         ]}
         appearance={type === "negative" ? "destructive" : "primary"}
+        automationId={automationId}
       />
     </div>
   </GenericModal>

--- a/draft-packages/modal/KaizenDraft/Modal/Primitives/GenericModal.tsx
+++ b/draft-packages/modal/KaizenDraft/Modal/Primitives/GenericModal.tsx
@@ -18,6 +18,7 @@ interface GenericModalContainerProps {
   readonly focusLockDisabled?: boolean
   readonly onEscapeKeyup?: (event: KeyboardEvent) => void
   readonly onOutsideModalClick?: (event: React.MouseEvent) => void
+  readonly automationId?: string
 }
 
 interface GenericModalProps
@@ -157,7 +158,12 @@ class GenericModal extends React.Component<GenericModalProps> {
   }
 
   render(): React.ReactPortal {
-    const { isOpen, children, focusLockDisabled = false } = this.props
+    const {
+      isOpen,
+      children,
+      focusLockDisabled = false,
+      automationId,
+    } = this.props
 
     return createPortal(
       <CSSTransition
@@ -188,6 +194,7 @@ class GenericModal extends React.Component<GenericModalProps> {
                 aria-describedby={this.props.describedByID}
                 className={styles.modalLayer}
                 ref={modalLayer => (this.modalLayer = modalLayer)}
+                data-automation-id={automationId}
               >
                 {children}
               </div>

--- a/draft-packages/modal/KaizenDraft/Modal/Primitives/ModalFooter.tsx
+++ b/draft-packages/modal/KaizenDraft/Modal/Primitives/ModalFooter.tsx
@@ -14,12 +14,13 @@ interface Props {
     disabled?: boolean
   }>
   readonly appearance?: "primary" | "destructive"
+  readonly automationId?: string
 }
 
 type ModalFooter = React.FunctionComponent<Props>
 
 const ModalFooter: ModalFooter = props => {
-  const { unpadded, actions, appearance = "primary" } = props
+  const { unpadded, actions, appearance = "primary", automationId } = props
 
   return (
     <GenericModalSection unpadded={unpadded}>
@@ -35,6 +36,7 @@ const ModalFooter: ModalFooter = props => {
               destructive={index === 0 && appearance === "destructive"}
               secondary={index > 0}
               disabled={a.disabled}
+              automationId={`${automationId}-action-${index}`}
             />
           </div>
         ))}


### PR DESCRIPTION
Allows us to put automation ids on all types of modals. It will add the automation id to the container and then on each button with a `-action-[index]` suffix.