### PR TITLE
ci: relinquish control of draft packages

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -4,10 +4,9 @@
 # Require Design Systems Team approval for any new packages or this file
 /CODEOWNERS @cultureamp/design-systems
 /packages/ @cultureamp/design-systems
-/draft-packages/ @cultureamp/design-systems
+/draft-packages/ @ghost
 
 # Exclude modifications to existing packages by assigning it to no one
-/packages/component-library @ghost
 /packages/hosted-assets @ghost
 
 # Pipelines are maintained by Delivery Engineering:


### PR DESCRIPTION
## About 
Draft packages were separated from "core Kaizen" with the intention of teams having the ability to iterate quickly on components, while not affecting other stable components in the system.

Now that they've been around for a little while, and we have [better support for creating components](https://github.com/cultureamp/kaizen-design-system/tree/master/packages/generator) and slightly better [quality control](https://github.com/cultureamp/kaizen-design-system/pull/545) and [testing](https://github.com/cultureamp/kaizen-design-system/pull/224) we're in a position to ease up the need for DST to review all changes draft components. We hope that teams still reach out to us if they need our support or they're unsure about how to contribute.