### PR TITLE
feat: Add layout token for nav bar height

### DIFF
--- a/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/_styles.scss
+++ b/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/_styles.scss
@@ -1,13 +1,13 @@
 @import "~@kaizen/design-tokens/sass/color";
 @import "~@kaizen/design-tokens/sass/border";
 @import "~@kaizen/design-tokens/sass/typography";
+@import "~@kaizen/design-tokens/sass/layout";
 @import "~@kaizen/component-library/styles/fonts";
 @import "~@kaizen/component-library/styles/animation";
 @import "~@kaizen/component-library/styles/color";
 @import "~@kaizen/component-library/styles/type";
 @import "~@kaizen/component-library/styles/responsive";
 
-$ca-navigation-bar__height: 3 * $ca-grid;
 $ca-navigation-bar__spacer: $ca-grid / 2;
 $ca-navigation-bar__child-height: $ca-grid * 2;
 
@@ -99,7 +99,7 @@ $navbar-breakpoint-condensed-large-up: 1150px;
   // active indicator
   @include navbar-tablet-up {
     margin-top: -$ca-navigation-bar__spacer;
-    height: $ca-navigation-bar__height;
+    height: $kz-layout-navigation-bar-height;
     &::before {
       content: "";
       display: block;
@@ -337,8 +337,8 @@ $navbar-breakpoint-condensed-large-up: 1150px;
   flex-direction: row;
   align-items: center;
   background-color: $kz-color-wisteria-700;
-  height: $ca-navigation-bar__height;
-  max-height: $ca-navigation-bar__height;
+  height: $kz-layout-navigation-bar-height;
+  max-height: $kz-layout-navigation-bar-height;
   width: 100%;
   position: fixed;
 

--- a/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/components/Badge.module.scss
+++ b/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/components/Badge.module.scss
@@ -1,7 +1,7 @@
 @import "~@kaizen/design-tokens/sass/color";
 @import "~@kaizen/component-library/styles/color";
-@import "~@kaizen/component-library/styles/type";
 @import "~@kaizen/component-library/styles/layout";
+@import "~@kaizen/component-library/styles/type";
 @import "../styles";
 
 .badge {
@@ -10,8 +10,8 @@
   font-weight: $ca-weight-medium;
   text-decoration: none;
   text-transform: uppercase;
-  max-height: $ca-navigation-bar__height;
-  width: $ca-navigation-bar__height;
+  max-height: $kz-layout-navigation-bar-height;
+  width: $kz-layout-navigation-bar-height;
   position: relative;
   &::after {
     display: block;

--- a/packages/design-tokens/less/layout.less
+++ b/packages/design-tokens/less/layout.less
@@ -3,5 +3,6 @@
 @kz-layout-content-max-width: 1392px;
 @kz-layout-content-side-margin: 72px;
 @kz-layout-mobile-actions-drawer-height: 60px;
+@kz-layout-navigation-bar-height: 72px;
 @kz-layout-breakpoints-medium: 768px;
 @kz-layout-breakpoints-large: 1080px;

--- a/packages/design-tokens/sass/layout.scss
+++ b/packages/design-tokens/sass/layout.scss
@@ -3,5 +3,6 @@
 $kz-layout-content-max-width: 1392px;
 $kz-layout-content-side-margin: 72px;
 $kz-layout-mobile-actions-drawer-height: 60px;
+$kz-layout-navigation-bar-height: 72px;
 $kz-layout-breakpoints-medium: 768px;
 $kz-layout-breakpoints-large: 1080px;

--- a/packages/design-tokens/tokens/layout.json
+++ b/packages/design-tokens/tokens/layout.json
@@ -4,6 +4,7 @@
       "contentMaxWidth": "1392px",
       "contentSideMargin": "72px",
       "mobileActionsDrawerHeight": "60px",
+      "navigationBarHeight": "72px",
       "breakpoints": {
         "medium": "768px",
         "large": "1080px"


### PR DESCRIPTION
## Changes

• Add a new layout token for navigation bar height

## Background

This is currently in more than one place, and could conceivably pop up in more places (e.g. setting the top margin on a page underneath the nav bar) so it would be good to have a single implementation of it.