### PR TITLE
feat: add colour scheme to navigation bar

### DIFF
--- a/draft-packages/stories/ZenNavigationBar.stories.tsx
+++ b/draft-packages/stories/ZenNavigationBar.stories.tsx
@@ -277,10 +277,102 @@ export const ContentColors = () => (
   </ZenNavigationBar>
 )
 
+export const AdminColours = () => (
+  <ZenNavigationBar
+    onNavigationChange={handleNavigationChange}
+    colorScheme="admin"
+  >
+    {{
+      primary: [
+        <Link text="Home" href="/" active />,
+        <Link text="Surveys" href="/" />,
+        <Link
+          text="Performance"
+          href="/"
+          badge={{ kind: "new", text: "New" }}
+        />,
+        <Link
+          icon={supportIcon}
+          text="Inbox"
+          href="/"
+          badge={{ kind: "notification", text: "55" }}
+        />,
+      ],
+      secondary: [
+        <Menu
+          heading="Custom menu..."
+          items={[
+            {
+              label: "About Culture Amp",
+              url: "https://www.cultureamp.com/",
+            },
+            {
+              label: "Contribute to this guide",
+              url:
+                "https://github.com/cultureamp/cultureamp-style-guide/tree/master/guide",
+            },
+            {
+              label: "Sign out",
+              url: "http://localhost:3000/session/sign_out",
+              method: "delete",
+            },
+            {
+              label: "Stop Masquerading",
+              url: "http://localhost:3000/admin/masquerade/",
+              method: "delete",
+            },
+          ]}
+        >
+          {accountMenuBtn}
+        </Menu>,
+      ],
+      final: [
+        <Link
+          icon={supportIcon}
+          text="Support"
+          href="http://academy.cultureamp.com/"
+        />,
+        <Link
+          icon={academyIcon}
+          text="Academy"
+          href="http://academy.cultureamp.com/"
+        />,
+        <Menu
+          heading="Custom menu..."
+          items={[
+            {
+              label: "About Culture Amp",
+              url: "https://www.cultureamp.com/",
+            },
+            {
+              label: "Contribute to this guide",
+              url:
+                "https://github.com/cultureamp/cultureamp-style-guide/tree/master/guide",
+            },
+            {
+              label: "Sign out",
+              url: "http://localhost:3000/session/sign_out",
+              method: "delete",
+            },
+            {
+              label: "Stop Masquerading",
+              url: "http://localhost:3000/admin/masquerade/",
+              method: "delete",
+            },
+          ]}
+        >
+          {accountMenuBtn}
+        </Menu>,
+      ],
+    }}
+  </ZenNavigationBar>
+)
+
 export const WithFooterAndHeaderComponents = () => (
   <ZenNavigationBar
     onNavigationChange={handleNavigationChange}
     footerComponent={footerComponent}
+    colorScheme="admin"
     headerComponent={{
       mobile: mobileHeaderComponent,
       desktop: (

--- a/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/NavigationBar.tsx
+++ b/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/NavigationBar.tsx
@@ -8,7 +8,12 @@ import Badge from "./components/Badge"
 import Link from "./components/Link"
 import Menu from "./components/Menu"
 import { NavBarContext } from "./context"
-import { Navigation, NavigationChange, NavigationItem } from "./types"
+import {
+  ColorScheme,
+  Navigation,
+  NavigationChange,
+  NavigationItem,
+} from "./types"
 
 const styles = require("./NavigationBar.module.scss")
 
@@ -29,8 +34,6 @@ type Props = {
 type State = {
   mobileKey: number
 }
-
-export type ColorScheme = "cultureamp" | "kaizen" | "content"
 
 export default class NavigationBar extends React.Component<Props, State> {
   static displayName = "NavigationBar"
@@ -94,7 +97,9 @@ export default class NavigationBar extends React.Component<Props, State> {
               >
                 {headerComponent ? (
                   <span className={styles.headerSlot}>
-                    {headerComponent.desktop}
+                    {React.cloneElement(headerComponent.desktop, {
+                      colorScheme,
+                    })}
                   </span>
                 ) : (
                   this.renderBadge()
@@ -144,7 +149,7 @@ export default class NavigationBar extends React.Component<Props, State> {
         ...linkProps,
         opaque: isFinal,
         small: isFinal,
-        content: this.props.colorScheme === "content",
+        colorScheme: this.props.colorScheme,
       },
     }
     const key = "href" in linkProps ? linkProps.href : linkProps.heading

--- a/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/NavigationBar.tsx
+++ b/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/NavigationBar.tsx
@@ -24,8 +24,8 @@ type Props = {
   badgeHref?: string
   onNavigationChange: NavigationChange
   headerComponent?: {
-    desktop: React.ReactNode
-    mobile: React.ReactNode
+    desktop: React.ReactElement
+    mobile: React.ReactElement
   }
   footerComponent?: React.ReactNode
   children?: Navigation
@@ -97,9 +97,10 @@ export default class NavigationBar extends React.Component<Props, State> {
               >
                 {headerComponent ? (
                   <span className={styles.headerSlot}>
-                    {React.cloneElement(headerComponent.desktop, {
-                      colorScheme,
-                    })}
+                    {headerComponent.desktop &&
+                      React.cloneElement(headerComponent.desktop, {
+                        colorScheme,
+                      })}
                   </span>
                 ) : (
                   this.renderBadge()

--- a/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/_styles.scss
+++ b/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/_styles.scss
@@ -269,6 +269,7 @@ $navbar-breakpoint-condensed-large-up: 1150px;
   }
 
   @include navbar-tablet-up {
+    &.admin,
     &.content {
       color: rgba($kz-color-wisteria-800, 0.7);
 
@@ -348,6 +349,10 @@ $navbar-breakpoint-condensed-large-up: 1150px;
 
   &.content {
     background: $kz-color-cluny-200;
+  }
+
+  &.admin {
+    background: $kz-color-white;
   }
 }
 

--- a/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/components/Badge.module.scss
+++ b/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/components/Badge.module.scss
@@ -6,7 +6,7 @@
 
 .badge {
   background-color: $kz-color-coral-500;
-  color: #fff;
+  color: $kz-color-white;
   font-weight: $ca-weight-medium;
   text-decoration: none;
   text-transform: uppercase;

--- a/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/components/Link.tsx
+++ b/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/components/Link.tsx
@@ -64,15 +64,18 @@ export default class Link extends React.PureComponent<LinkProps> {
         )}
 
         <a
-          className={classNames(styles.link, {
-            [styles.active]: active,
-            [styles.containsText]: !!text,
-            [styles.opaque]: opaque,
-            [styles.small]: small,
-            [styles.menuOpen]: hasMenu && menuOpen,
-            [styles[colorScheme]]: !!colorScheme,
-            [styles.extendedNavigation]: hasExtendedNavigation,
-          })}
+          className={classNames([
+            styles.link,
+            ...(colorScheme ? [styles[colorScheme]] : []),
+            {
+              [styles.active]: active,
+              [styles.containsText]: !!text,
+              [styles.opaque]: opaque,
+              [styles.small]: small,
+              [styles.menuOpen]: hasMenu && menuOpen,
+              [styles.extendedNavigation]: hasExtendedNavigation,
+            },
+          ])}
           tabIndex={0}
           onClick={event => {
             onClick && onClick(event)

--- a/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/components/Link.tsx
+++ b/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/components/Link.tsx
@@ -39,7 +39,7 @@ export default class Link extends React.PureComponent<LinkProps> {
       onClick,
       small,
       menuOpen,
-      content,
+      colorScheme,
       tooltip,
     } = this.props
 
@@ -70,7 +70,7 @@ export default class Link extends React.PureComponent<LinkProps> {
             [styles.opaque]: opaque,
             [styles.small]: small,
             [styles.menuOpen]: hasMenu && menuOpen,
-            [styles.content]: content,
+            [styles[colorScheme]]: !!colorScheme,
             [styles.extendedNavigation]: hasExtendedNavigation,
           })}
           tabIndex={0}

--- a/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/components/Menu.tsx
+++ b/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/components/Menu.tsx
@@ -75,16 +75,19 @@ export default class Menu extends React.Component<MenuProps, State> {
           ) : (
             <nav className={styles.root} ref={this.rootRef}>
               <button
-                className={classNames(styles.button, {
-                  [styles.opaque]: opaque,
-                  [styles.small]: small,
-                  [styles.buttonLink]: !children,
-                  [styles.linkText]: !!heading,
-                  [styles.menuOpen]: this.state.open,
-                  [styles.active]: active,
-                  [styles.extendedNavigation]: hasExtendedNavigation,
-                  [styles[colorScheme]]: !!colorScheme,
-                })}
+                className={classNames([
+                  styles.button,
+                  ...(colorScheme ? [styles[colorScheme]] : []),
+                  {
+                    [styles.opaque]: opaque,
+                    [styles.small]: small,
+                    [styles.buttonLink]: !children,
+                    [styles.linkText]: !!heading,
+                    [styles.menuOpen]: this.state.open,
+                    [styles.active]: active,
+                    [styles.extendedNavigation]: hasExtendedNavigation,
+                  },
+                ])}
                 onClick={this.toggle}
                 aria-expanded={this.state.open}
                 data-automation-id={automationId}

--- a/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/components/Menu.tsx
+++ b/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/components/Menu.tsx
@@ -7,7 +7,7 @@ import { OffCanvasContext, ZenOffCanvas } from "@kaizen/draft-zen-off-canvas"
 import classNames from "classnames"
 import Media from "react-media"
 import { NavBarContext } from "../context"
-import { MenuProps, NavigationItem } from "../types"
+import { ColorScheme, MenuProps, NavigationItem } from "../types"
 import Dropdown from "./Dropdown"
 import Link from "./Link"
 import MenuGroup from "./MenuGroup"
@@ -51,6 +51,7 @@ export default class Menu extends React.Component<MenuProps, State> {
       icon,
       items,
       header,
+      colorScheme,
     } = this.props
 
     return (
@@ -82,6 +83,7 @@ export default class Menu extends React.Component<MenuProps, State> {
                   [styles.menuOpen]: this.state.open,
                   [styles.active]: active,
                   [styles.extendedNavigation]: hasExtendedNavigation,
+                  [styles[colorScheme]]: !!colorScheme,
                 })}
                 onClick={this.toggle}
                 aria-expanded={this.state.open}

--- a/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/types.ts
+++ b/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/types.ts
@@ -1,5 +1,7 @@
 import { default as React, ReactElement } from "react"
 
+export type ColorScheme = "cultureamp" | "kaizen" | "content" | "admin"
+
 export type Navigation = {
   primary?: NavigationItem[]
   secondary?: NavigationItem[]
@@ -29,7 +31,7 @@ export type LinkProps = {
   }
   opaque?: boolean
   small?: boolean
-  content?: boolean
+  colorScheme?: ColorScheme
   tooltip?: string
 }
 
@@ -43,6 +45,7 @@ export type MenuProps = {
   icon?: React.SVGAttributes<SVGSymbolElement>
   opaque?: boolean
   small?: boolean
+  colorScheme?: ColorScheme
 }
 
 export type MenuItemProps = {

--- a/draft-packages/zen-off-canvas/KaizenDraft/ZenOffCanvas/OffCanvas.module.scss
+++ b/draft-packages/zen-off-canvas/KaizenDraft/ZenOffCanvas/OffCanvas.module.scss
@@ -16,6 +16,7 @@ $menu-footer-height: 80px;
   position: fixed;
   height: 100vh;
   width: 100%;
+  max-width: 375px;
   top: 0;
   left: 0;
   transform: translate3d(-120%, 0, 0);

--- a/draft-packages/zen-off-canvas/KaizenDraft/ZenOffCanvas/ZenOffCanvas.tsx
+++ b/draft-packages/zen-off-canvas/KaizenDraft/ZenOffCanvas/ZenOffCanvas.tsx
@@ -1,6 +1,6 @@
 import * as React from "react"
 
-import { ColorScheme } from "@kaizen/draft-zen-navigation-bar/KaizenDraft/ZenNavigationBar/NavigationBar"
+import { ColorScheme } from "@kaizen/draft-zen-navigation-bar/KaizenDraft/ZenNavigationBar/types"
 import classNames from "classnames"
 import Header from "./components/Header"
 import Menu from "./components/Menu"

--- a/draft-packages/zen-off-canvas/KaizenDraft/ZenOffCanvas/components/Header.tsx
+++ b/draft-packages/zen-off-canvas/KaizenDraft/ZenOffCanvas/components/Header.tsx
@@ -1,6 +1,6 @@
 import * as React from "react"
 
-import { ColorScheme } from "@kaizen/draft-zen-navigation-bar/KaizenDraft/ZenNavigationBar/NavigationBar"
+import { ColorScheme } from "@kaizen/draft-zen-navigation-bar/KaizenDraft/ZenNavigationBar/types"
 import classNames from "classnames"
 const closeIcon = require("@kaizen/component-library/icons/close.icon.svg")
   .default


### PR DESCRIPTION
Will be used on performance admin pages:
https://www.figma.com/file/q4kRnrtKZnzo2nx2jkyXeD/Perform-headers?node-id=61%3A12160

<img width="1365" alt="Screen Shot 2020-06-26 at 11 27 41 am" src="https://user-images.githubusercontent.com/13988803/85810991-10a32880-b7a0-11ea-8887-3aa9e37f2547.png">
