### PR TITLE
fix: Add clear button to React Select implementation

### DIFF
--- a/draft-packages/select/KaizenDraft/Select/Select.tsx
+++ b/draft-packages/select/KaizenDraft/Select/Select.tsx
@@ -9,7 +9,7 @@ import { Icon } from "@kaizen/component-library"
 
 const chevronDownIcon = require("@kaizen/component-library/icons/chevron-down.icon.svg")
   .default
-const closeIcon = require("@kaizen/component-library/icons/close.icon.svg")
+const clearIcon = require("@kaizen/component-library/icons/clear.icon.svg")
   .default
 
 const styles = require("./styles.react.scss")
@@ -116,6 +116,6 @@ const MultiValue: typeof components.MultiValue = props => (
 
 const ClearIndicator: typeof components.ClearIndicator = props => (
   <components.ClearIndicator {...props}>
-    <Icon icon={closeIcon} role="presentation" />
+    <Icon icon={clearIcon} role="presentation" />
   </components.ClearIndicator>
 )

--- a/draft-packages/select/KaizenDraft/Select/Select.tsx
+++ b/draft-packages/select/KaizenDraft/Select/Select.tsx
@@ -9,6 +9,8 @@ import { Icon } from "@kaizen/component-library"
 
 const chevronDownIcon = require("@kaizen/component-library/icons/chevron-down.icon.svg")
   .default
+const closeIcon = require("@kaizen/component-library/icons/close.icon.svg")
+  .default
 
 const styles = require("./styles.react.scss")
 
@@ -27,7 +29,7 @@ export const Select = (props: ReactSelectProps) => {
         NoOptionsMessage,
         SingleValue,
         MultiValue,
-        ClearIndicator: null,
+        ClearIndicator,
         IndicatorSeparator: null,
       }}
       className={classNames(styles.container, props.className)}
@@ -110,4 +112,10 @@ const SingleValue: typeof components.SingleValue = props => (
 
 const MultiValue: typeof components.MultiValue = props => (
   <components.MultiValue {...props} className={styles.multiValue} />
+)
+
+const ClearIndicator: typeof components.ClearIndicator = props => (
+  <components.ClearIndicator {...props}>
+    <Icon icon={closeIcon} role="presentation" />
+  </components.ClearIndicator>
 )

--- a/draft-packages/stories/Select.stories.tsx
+++ b/draft-packages/stories/Select.stories.tsx
@@ -73,6 +73,17 @@ export const Single = () => (
   </StoryContainer>
 )
 
+export const SingleClearable = () => (
+  <StoryContainer>
+    <Select
+      options={options}
+      placeholder="Placeholder"
+      isSearchable={false}
+      isClearable={true}
+    />
+  </StoryContainer>
+)
+
 export const SingleSearchable = () => (
   <StoryContainer>
     <Select options={options} placeholder="Placeholder" />


### PR DESCRIPTION
The implementation of draft-select rendered `null` for the `ClearIndicator` component. This meant you could use `isClearable` as a prop but it would not actually render the button to allow you to clear it.

![clear](https://user-images.githubusercontent.com/4353/85997648-1bceb080-ba4d-11ea-84f8-eab0e25354b1.gif)
