### PR TITLE
fix: Remove IconButton opacity styles

### DIFF
--- a/draft-packages/button/KaizenDraft/Button/Button.elm
+++ b/draft-packages/button/KaizenDraft/Button/Button.elm
@@ -61,7 +61,6 @@ view (Config config) label =
                 , ( .primary, config.variant == Primary )
                 , ( .secondary, config.variant == Secondary )
                 , ( .iconButton, config.iconButton )
-                , ( .reversedIconButton, config.iconButton && config.reversed )
                 , ( .destructive, config.variant == Destructive )
                 , ( .form, config.form )
                 , ( .reversed, config.reversed )
@@ -273,7 +272,6 @@ styles =
         , primary = "primary"
         , secondary = "secondary"
         , iconButton = "iconButton"
-        , reversedIconButton = "reversedIconButton"
         , destructive = "destructive"
         , secondaryDestructive = "secondaryDestructive"
         , form = "form"

--- a/draft-packages/button/KaizenDraft/Button/components/GenericButton.module.scss
+++ b/draft-packages/button/KaizenDraft/Button/components/GenericButton.module.scss
@@ -18,11 +18,6 @@
 
 .iconButton {
   @extend %caButtonIconButton;
-  composes: interactiveIconWrapper from "~@kaizen/component-library/components/Icon/Icon.module.scss";
-}
-
-.reversedIconButton {
-  composes: reversedInteractiveIconWrapper from "~@kaizen/component-library/components/Icon/Icon.module.scss";
 }
 
 .destructive {

--- a/draft-packages/button/KaizenDraft/Button/components/GenericButton.tsx
+++ b/draft-packages/button/KaizenDraft/Button/components/GenericButton.tsx
@@ -164,7 +164,6 @@ const buttonClass = (props: Props) => {
     [styles.reverseColorSeedling]: props.reverseColor === "seedling",
     [styles.reverseColorWisteria]: props.reverseColor === "wisteria",
     [styles.reverseColorYuzu]: props.reverseColor === "yuzu",
-    [styles.reversedIconButton]: props.iconButton && props.reversed,
   })
 }
 

--- a/draft-packages/button/KaizenDraft/Button/styles.scss
+++ b/draft-packages/button/KaizenDraft/Button/styles.scss
@@ -52,6 +52,7 @@ $caButton-verticalPaddingForm: calc(
   position: relative;
   text-align: center;
   cursor: pointer;
+  text-align: center;
 
   // looking for padding? See %caButtonContent
 

--- a/draft-packages/button/KaizenDraft/Button/styles.scss
+++ b/draft-packages/button/KaizenDraft/Button/styles.scss
@@ -382,10 +382,6 @@ $caButton-verticalPaddingForm: calc(
 %caButtonIconButton {
   width: $caButton-height;
 
-  &:not(:disabled) {
-    cursor: pointer;
-  }
-
   // Reset for various states and variants
   &:not(:disabled),
   &:disabled {
@@ -411,6 +407,8 @@ $caButton-verticalPaddingForm: calc(
   }
 
   &:not(:disabled) {
+    cursor: pointer;
+
     &:hover,
     &:active,
     :global(.js-focus-visible) &:global(.focus-visible) {

--- a/draft-packages/button/KaizenDraft/Button/styles.scss
+++ b/draft-packages/button/KaizenDraft/Button/styles.scss
@@ -116,6 +116,7 @@ $caButton-verticalPaddingForm: calc(
     background: $kz-color-white;
     border-color: $kz-color-wisteria-500;
     color: $kz-color-wisteria-800;
+    cursor: default;
   }
 }
 
@@ -458,10 +459,13 @@ $caButton-verticalPaddingForm: calc(
     &:hover,
     &:active {
       color: $kz-color-coral-600;
+      background-color: $kz-color-coral-100;
     }
 
     :global(.js-focus-visible) &:global(.focus-visible) {
-      border-color: $kz-color-cluny-500;
+      color: $kz-color-coral-600;
+      background-color: $kz-color-coral-100;
+      border-color: $kz-border-borderless-border-color;
     }
   }
 }

--- a/draft-packages/button/KaizenDraft/Button/styles.scss
+++ b/draft-packages/button/KaizenDraft/Button/styles.scss
@@ -51,6 +51,7 @@ $caButton-verticalPaddingForm: calc(
   border-radius: $kz-border-solid-border-radius;
   position: relative;
   text-align: center;
+  cursor: pointer;
 
   // looking for padding? See %caButtonContent
 
@@ -297,7 +298,7 @@ $caButton-verticalPaddingForm: calc(
       }
 
       :global(.js-focus-visible) &:global(.focus-visible) {
-        border-color: $kz-color-cluny-300;
+        border-color: $kz-border-borderless-border-color;
         color: $kz-color-white;
       }
     }
@@ -381,6 +382,10 @@ $caButton-verticalPaddingForm: calc(
 %caButtonIconButton {
   width: $caButton-height;
 
+  &:not(:disabled) {
+    cursor: pointer;
+  }
+
   // Reset for various states and variants
   &:not(:disabled),
   &:disabled {
@@ -404,6 +409,31 @@ $caButton-verticalPaddingForm: calc(
       }
     }
   }
+
+  &:not(:disabled) {
+    &:hover,
+    &:active,
+    :global(.js-focus-visible) &:global(.focus-visible) {
+      color: $kz-color-cluny-500;
+      background: $kz-color-cluny-100;
+      border-color: $kz-border-borderless-border-color;
+    }
+  }
+
+  &%caButtonReversed {
+    &:not(:disabled) {
+      color: $kz-color-white;
+
+      &:hover,
+      &:active,
+      :global(.js-focus-visible) &:global(.focus-visible) {
+        color: $kz-color-white;
+        background: rgba($kz-color-white, 0.1);
+        border-color: $kz-border-borderless-border-color;
+      }
+    }
+  }
+
   &%caButtonReversed,
   :global(.js-focus-visible) &:global(.focus-visible) {
     %caButtonContent {

--- a/draft-packages/button/KaizenDraft/Button/styles.scss
+++ b/draft-packages/button/KaizenDraft/Button/styles.scss
@@ -394,7 +394,7 @@ $caButton-verticalPaddingForm: calc(
     &:active,
     &%caButtonPrimary,
     &%caButtonSecondary {
-      color: $kz-color-wisteria-800;
+      color: inherit;
       background: none;
       border-color: $kz-border-borderless-border-color;
 

--- a/draft-packages/stories/IconButton.stories.tsx
+++ b/draft-packages/stories/IconButton.stories.tsx
@@ -1,3 +1,4 @@
+import * as colorTokens from "@kaizen/design-tokens/tokens/color.json"
 import { IconButton } from "../button"
 const configureIcon = require("@kaizen/component-library/icons/configure.icon.svg")
   .default
@@ -8,8 +9,14 @@ export default {
   title: "IconButton (React)",
 }
 
+const StoryWrapper = ({ children }) => (
+  <div style={{ color: colorTokens.kz.color.wisteria[800] }}>{children}</div>
+)
+
 export const DefaultKaizenSiteDemo = () => (
-  <IconButton icon={configureIcon} label="Label" automationId="demo-button" />
+  <StoryWrapper>
+    <IconButton icon={configureIcon} label="Label" automationId="demo-button" />
+  </StoryWrapper>
 )
 
 DefaultKaizenSiteDemo.story = {
@@ -17,16 +24,20 @@ DefaultKaizenSiteDemo.story = {
 }
 
 export const Hyperlink = () => (
-  <IconButton icon={configureIcon} label="Label" href="//example.com" />
+  <StoryWrapper>
+    <IconButton icon={configureIcon} label="Label" href="//example.com" />
+  </StoryWrapper>
 )
 
 export const HyperlinkWOnClick = () => (
-  <IconButton
-    icon={configureIcon}
-    label="Label"
-    href="//example.com"
-    onClick={action("I am an onClick handler")}
-  />
+  <StoryWrapper>
+    <IconButton
+      icon={configureIcon}
+      label="Label"
+      href="//example.com"
+      onClick={action("I am an onClick handler")}
+    />
+  </StoryWrapper>
 )
 
 HyperlinkWOnClick.story = {
@@ -34,20 +45,26 @@ HyperlinkWOnClick.story = {
 }
 
 export const Disabled = () => (
-  <IconButton icon={configureIcon} label="Label" disabled={true} />
+  <StoryWrapper>
+    <IconButton icon={configureIcon} label="Label" disabled={true} />
+  </StoryWrapper>
 )
 
 export const Destructive = () => (
-  <IconButton icon={configureIcon} label="Label" destructive={true} />
+  <StoryWrapper>
+    <IconButton icon={configureIcon} label="Label" destructive={true} />
+  </StoryWrapper>
 )
 
 export const DestructiveDisabled = () => (
-  <IconButton
-    icon={configureIcon}
-    label="Label"
-    destructive={true}
-    disabled={true}
-  />
+  <StoryWrapper>
+    <IconButton
+      icon={configureIcon}
+      label="Label"
+      destructive={true}
+      disabled={true}
+    />
+  </StoryWrapper>
 )
 
 DestructiveDisabled.story = {
@@ -55,16 +72,20 @@ DestructiveDisabled.story = {
 }
 
 export const Reversed = () => (
-  <IconButton icon={configureIcon} label="Label" reversed />
+  <StoryWrapper>
+    <IconButton icon={configureIcon} label="Label" reversed />
+  </StoryWrapper>
 )
 
 export const ReversedDisabled = () => (
-  <IconButton
-    icon={configureIcon}
-    label="Label"
-    reversed={true}
-    disabled={true}
-  />
+  <StoryWrapper>
+    <IconButton
+      icon={configureIcon}
+      label="Label"
+      reversed={true}
+      disabled={true}
+    />
+  </StoryWrapper>
 )
 
 ReversedDisabled.story = {
@@ -72,7 +93,9 @@ ReversedDisabled.story = {
 }
 
 export const FormDiscouraged = () => (
-  <IconButton icon={configureIcon} label="Label" form={true} />
+  <StoryWrapper>
+    <IconButton icon={configureIcon} label="Label" form={true} />
+  </StoryWrapper>
 )
 
 FormDiscouraged.story = {


### PR DESCRIPTION
## Background 

Icon Buttons currently do this on hover:

![2020-06-30 15 29 25](https://user-images.githubusercontent.com/6406263/86087092-a9aaaa00-bae6-11ea-94bb-326a7034c122.gif)
![2020-06-30 15 30 23](https://user-images.githubusercontent.com/6406263/86087094-aca59a80-bae6-11ea-8a6e-8d52d4a9bc85.gif)

This is particularly a problem on a "reversed" background, where:
- the button takes on _less_ contrast on hover,
- the fact that the hover state is a transition rather than instantaneous makes it hard to see, and
- the hover state is inconsistent with other types of Buttons.

Eventually, the vision is that Icon Buttons will look like the sticker sheet (rounded touch point backgrounds), so this PR is just a temporary measure to make the Title Block rollout look fresher.

Note that because this is only a change to the new draft package of Button which is not widely used yet, there's less to worry about in terms of pre-existing Icon Buttons.

## Changes

- Removes the `interactiveIconWrapper` dependency on the `Icon` component that was being used via CSS Modules `composes`, which applies opacity-related rules
- Removes the `reversedIconButton` class from the styles and React & Elm components – it was only there for the Icon wrapper mentioned above
- Changes the cursor to `cursor: pointer` to make it easier to notice that buttons are interactive