### PR TITLE
feat: Menu is now left aligned by default

### DIFF
--- a/draft-packages/menu/KaizenDraft/Menu/Menu.tsx
+++ b/draft-packages/menu/KaizenDraft/Menu/Menu.tsx
@@ -9,6 +9,7 @@ type MenuState = {
 }
 
 export type MenuProps = {
+  align?: "left" | "right"
   button: React.ReactElement<ButtonProps>
   menuVisible?: boolean
   automationId?: string
@@ -18,6 +19,7 @@ export default class Menu extends React.Component<MenuProps, MenuState> {
   static displayName = "Menu"
   static defaultProps = {
     iconPosition: "start",
+    align: "left",
   }
 
   dropdownButtonContainer = React.createRef<HTMLDivElement>()
@@ -56,6 +58,7 @@ export default class Menu extends React.Component<MenuProps, MenuState> {
       <MenuDropdown
         hideMenuDropdown={this.hideMenu}
         position={this.getPosition()}
+        align={this.props.align}
       >
         {this.props.children}
       </MenuDropdown>

--- a/draft-packages/menu/KaizenDraft/Menu/MenuDropdown.tsx
+++ b/draft-packages/menu/KaizenDraft/Menu/MenuDropdown.tsx
@@ -1,3 +1,4 @@
+import classnames from "classnames"
 import * as React from "react"
 
 const styles = require("./styles.scss")
@@ -10,6 +11,7 @@ type MenuDropdownProps = {
     left: number
     right: number
   } | null
+  align?: "left" | "right"
 }
 
 export default class MenuDropdown extends React.Component<MenuDropdownProps> {
@@ -39,13 +41,8 @@ export default class MenuDropdown extends React.Component<MenuDropdownProps> {
       const { innerHeight } = window
       const rect = menu.current.getBoundingClientRect()
 
-      if (pos.bottom > innerHeight - rect.height) {
-        menu.current.style.bottom = "24px"
-        menu.current.style.top = "auto"
-      } else {
-        menu.current.style.top = "24px"
-        menu.current.style.bottom = "auto"
-      }
+      menu.current.style.bottom =
+        pos.bottom > innerHeight - rect.height ? "24px" : "auto"
     }
   }
 
@@ -65,11 +62,13 @@ export default class MenuDropdown extends React.Component<MenuDropdownProps> {
   }
 
   render(): JSX.Element {
-    const { hideMenuDropdown, children } = this.props
+    const { hideMenuDropdown, children, align = "left" } = this.props
 
     return (
       <div
-        className={styles.menuContainer}
+        className={classnames(styles.menuContainer, {
+          [styles.alignRight]: align == "right",
+        })}
         ref={this.menu}
         onClick={() => hideMenuDropdown()}
       >

--- a/draft-packages/menu/KaizenDraft/Menu/components/MenuContent.module.scss
+++ b/draft-packages/menu/KaizenDraft/Menu/components/MenuContent.module.scss
@@ -9,6 +9,7 @@
 $side-padding: 1/2 * $ca-grid;
 
 .menuContent {
+  box-sizing: border-box;
   background: $kz-color-white;
   color: $kz-color-wisteria-800;
   border-radius: $kz-border-solid-border-radius;

--- a/draft-packages/menu/KaizenDraft/Menu/styles.scss
+++ b/draft-packages/menu/KaizenDraft/Menu/styles.scss
@@ -14,8 +14,17 @@ $menu-container-width: 248px;
   position: absolute;
   width: $menu-container-width;
   z-index: $ca-z-index-dropdown;
-  right: 0;
+  left: 0;
 
+  [dir="rtl"] & {
+    left: auto;
+    right: 0;
+  }
+}
+
+.alignRight {
+  right: 0;
+  left: auto;
   [dir="rtl"] & {
     right: auto;
     left: 0;

--- a/draft-packages/menu/KaizenDraft/Menu/styles.scss
+++ b/draft-packages/menu/KaizenDraft/Menu/styles.scss
@@ -1,5 +1,6 @@
 @import "~@kaizen/design-tokens/sass/border";
 @import "~@kaizen/design-tokens/sass/typography";
+@import "~@kaizen/design-tokens/sass/spacing";
 @import "~@kaizen/component-library/styles/layers";
 @import "~@kaizen/deprecated-component-library-helpers/styles/type";
 @import "~@kaizen/deprecated-component-library-helpers/styles/color";
@@ -11,6 +12,7 @@ $menu-container-width: 248px;
 }
 
 .menuContainer {
+  margin-top: $kz-spacing-xs;
   position: absolute;
   width: $menu-container-width;
   z-index: $ca-z-index-dropdown;

--- a/draft-packages/stories/Menu.stories.tsx
+++ b/draft-packages/stories/Menu.stories.tsx
@@ -135,3 +135,21 @@ export const DefaultKebab = () => (
 DefaultKebab.story = {
   name: "Default (Kebab)",
 }
+
+export const LabelAndIconBottom = () => (
+  <StoryWrapper>
+    <div style={{ marginTop: "400px" }}></div>
+    <Menu
+      button={<Button label="Label" icon={chevronDown} iconPosition="end" />}
+    >
+      <MenuInstance />
+    </Menu>
+  </StoryWrapper>
+)
+
+LabelAndIconBottom.story = {
+  name: "Label and Icon (bottom of screen)",
+  parameters: {
+    viewport: { defaultViewport: "mobile1" },
+  },
+}

--- a/draft-packages/stories/Menu.stories.tsx
+++ b/draft-packages/stories/Menu.stories.tsx
@@ -114,7 +114,7 @@ LabelAndIconReversed.story = {
 
 export const DefaultMeatball = () => (
   <StoryWrapper>
-    <Menu button={<IconButton label="" icon={meatballsIcon} />}>
+    <Menu button={<IconButton label="" icon={meatballsIcon} />} align="right">
       <MenuInstance />
     </Menu>
   </StoryWrapper>
@@ -126,7 +126,7 @@ DefaultMeatball.story = {
 
 export const DefaultKebab = () => (
   <StoryWrapper>
-    <Menu button={<IconButton label="" icon={kebabIcon} />}>
+    <Menu button={<IconButton label="" icon={kebabIcon} />} align="right">
       <MenuInstance />
     </Menu>
   </StoryWrapper>


### PR DESCRIPTION
⚠️ This PR contains a BREAKING CHANGE ⚠️ 

Storybook previews: https://dev.cultureamp.design/dst/menu-align-left-right/storybook-static/?path=/story/menu-react--label-and-icon

#### `align="left"` (this is now the default)
![image](https://user-images.githubusercontent.com/702885/86305982-5e170e00-bc56-11ea-8bb6-918082835af8.png)

#### optional `align="right"`
![image](https://user-images.githubusercontent.com/702885/86306014-7d15a000-bc56-11ea-8b10-e1a9da00447e.png)



# Changes:

### BREAKING CHANGE: Menu is now left aligned by default 
adds an `align` prop to Menu and MenuDropdown with options `"left"` and `"right"`. Previously rigtht-aligned
was the only option. Now left aligned is an option and it becomes the default. ⚠️ **Consumers must add `align="right"`
to any existing usages to retain identical functionality.** ⚠️ 

### feat: further Zenify the MenuDropdown component
- there is now a small gap between the button and the dropdown
- the dropdown is flush to the left/right of the button

### docs: add story for edge case where button is at bottom of screen
The Menu had some functionality so that it would still appear on screen if the bottom of the dropdown dissapears below
the bottom of the screen. I added this story to make sure I hadn't broken that functionality. This edge case isn't styled perfectly, but it seemed not worth worrying about as it's such an extreme edge case.
https://dev.cultureamp.design/dst/menu-align-left-right/storybook-static/?path=/story/menu-react--label-and-icon-bottom