### PR TITLE
feat: Add missing paragraphBodyBold typography token

### DIFF
--- a/packages/design-tokens/tokens/typography.json
+++ b/packages/design-tokens/tokens/typography.json
@@ -106,23 +106,9 @@
         "lineHeight": "1.5rem",
         "letterSpacing": "normal"
       },
-      "paragraphBodyBold": {
-        "fontFamily": "\"Inter\", \"Noto Sans\", Helvetica, Arial, sans-serif;",
-        "fontWeight": "600",
-        "fontSize": "1rem",
-        "lineHeight": "1.5rem",
-        "letterSpacing": "normal"
-      },
       "paragraphSmall": {
         "fontFamily": "\"Inter\", \"Noto Sans\", Helvetica, Arial, sans-serif;",
         "fontWeight": "400",
-        "fontSize": "0.875rem",
-        "lineHeight": "1.125rem",
-        "letterSpacing": "normal"
-      },
-      "paragraphSmallBold": {
-        "fontFamily": "\"Inter\", \"Noto Sans\", Helvetica, Arial, sans-serif;",
-        "fontWeight": "600",
         "fontSize": "0.875rem",
         "lineHeight": "1.125rem",
         "letterSpacing": "normal"
@@ -134,12 +120,8 @@
         "lineHeight": "1.125rem",
         "letterSpacing": "normal"
       },
-      "paragraphExtraSmallBold": {
-        "fontFamily": "\"Inter\", \"Noto Sans\", Helvetica, Arial, sans-serif;",
-        "fontWeight": "600",
-        "fontSize": "0.75rem",
-        "lineHeight": "1.125rem",
-        "letterSpacing": "normal"
+      "paragraphBold": {
+        "fontWeight": "600"
       },
       "buttonPrimary": {
         "fontFamily": "\"Inter\", \"Noto Sans\", Helvetica, Arial, sans-serif;",

--- a/packages/design-tokens/tokens/typography.json
+++ b/packages/design-tokens/tokens/typography.json
@@ -106,6 +106,13 @@
         "lineHeight": "1.5rem",
         "letterSpacing": "normal"
       },
+      "paragraphBodyBold": {
+        "fontFamily": "\"Inter\", \"Noto Sans\", Helvetica, Arial, sans-serif;",
+        "fontWeight": "600",
+        "fontSize": "1rem",
+        "lineHeight": "1.5rem",
+        "letterSpacing": "normal"
+      },
       "paragraphSmall": {
         "fontFamily": "\"Inter\", \"Noto Sans\", Helvetica, Arial, sans-serif;",
         "fontWeight": "400",

--- a/packages/design-tokens/tokens/typography.ts
+++ b/packages/design-tokens/tokens/typography.ts
@@ -1,15 +1,21 @@
 import * as typographyTokens from "./typography.json"
 
+type TypeDefinition = {
+  fontFamily: string
+  fontWeight: string
+  fontSize: string
+  lineHeight: string
+  letterSpacing: string
+}
+
+type TypeWeightVariant = {
+  fontWeight: string
+}
+
 export interface Typography {
   kz: {
     typography: {
-      [key: string]: {
-        fontFamily: string
-        fontWeight: string
-        fontSize: string
-        lineHeight: string
-        letterSpacing: string
-      }
+      [key: string]: TypeDefinition | TypeWeightVariant
     }
   }
 }


### PR DESCRIPTION
Adds a `paragraphBodyBold` token to match the small/extra-small versions.

I’ve run the build script locally to check the output and diff gives me these additional lines (no removals):

Sass:

```scss
$kz-typography-paragraph-body-bold-font-family: "Inter", "Noto Sans", Helvetica,
  Arial, sans-serif;
$kz-typography-paragraph-body-bold-font-weight: 600;
$kz-typography-paragraph-body-bold-font-size: 1rem;
$kz-typography-paragraph-body-bold-line-height: 1.5rem;
$kz-typography-paragraph-body-bold-letter-spacing: normal;
```

Less:

```less
@kz-typography-paragraph-body-bold-font-family: "Inter", "Noto Sans", Helvetica,
  Arial, sans-serif;
@kz-typography-paragraph-body-bold-font-weight: 600;
@kz-typography-paragraph-body-bold-font-size: 1rem;
@kz-typography-paragraph-body-bold-line-height: 1.5rem;
@kz-typography-paragraph-body-bold-letter-spacing: normal;
```