### PR TITLE
feat: StatelessMenu

### DIFF
--- a/draft-packages/menu/KaizenDraft/Menu/Menu.spec.tsx
+++ b/draft-packages/menu/KaizenDraft/Menu/Menu.spec.tsx
@@ -8,7 +8,9 @@ afterEach(cleanup)
 describe("Dropdown", () => {
   it("renders default view", () => {
     const { container } = render(
-      <Menu button={<Button label="Button"></Button>} />
+      <Menu button={<Button label="Button"></Button>}>
+        <div>Item</div>
+      </Menu>
     )
 
     expect(container.firstChild).toMatchSnapshot()

--- a/draft-packages/menu/KaizenDraft/Menu/Menu.tsx
+++ b/draft-packages/menu/KaizenDraft/Menu/Menu.tsx
@@ -13,6 +13,7 @@ export type MenuProps = {
   button: React.ReactElement<ButtonProps>
   menuVisible?: boolean
   automationId?: string
+  children: React.ReactNode
 }
 
 type Menu = React.FunctionComponent<MenuProps>

--- a/draft-packages/menu/KaizenDraft/Menu/Menu.tsx
+++ b/draft-packages/menu/KaizenDraft/Menu/Menu.tsx
@@ -1,5 +1,5 @@
 import { ButtonProps } from "@kaizen/draft-button"
-import * as React from "react"
+import React, { useState } from "react"
 import MenuDropdown from "./MenuDropdown"
 
 const styles = require("./styles.scss")
@@ -15,70 +15,66 @@ export type MenuProps = {
   automationId?: string
 }
 
-export default class Menu extends React.Component<MenuProps, MenuState> {
-  static displayName = "Menu"
-  static defaultProps = {
-    iconPosition: "start",
-    align: "left",
+type Menu = React.FunctionComponent<MenuProps>
+
+const Menu: Menu = (props: MenuProps) => {
+  const { align = "left" } = props
+
+  const initializedProps = { ...props, align }
+
+  const dropdownButtonContainer = React.createRef<HTMLDivElement>()
+
+  const [isMenuVisible, setIsMenuVisible] = useState(
+    initializedProps.menuVisible
+  )
+
+  const toggleMenu = () => {
+    setIsMenuVisible(!isMenuVisible)
   }
 
-  dropdownButtonContainer = React.createRef<HTMLDivElement>()
-
-  constructor(props: MenuProps) {
-    super(props)
-
-    this.state = {
-      isMenuVisible: Boolean(props.menuVisible),
-    }
+  const hideMenu = () => {
+    setIsMenuVisible(false)
   }
 
-  toggleMenu = (e: MouseEvent) => {
-    e.stopPropagation()
-
-    const currentState = this.state.isMenuVisible
-    this.setState({
-      isMenuVisible: !currentState,
-    })
-  }
-
-  hideMenu = () => {
-    this.setState({
-      isMenuVisible: false,
-    })
-  }
-
-  getPosition() {
-    return this.dropdownButtonContainer && this.dropdownButtonContainer.current
-      ? this.dropdownButtonContainer.current.getBoundingClientRect()
+  const getPosition = () => {
+    return dropdownButtonContainer && dropdownButtonContainer.current
+      ? dropdownButtonContainer.current.getBoundingClientRect()
       : null
   }
 
-  renderMenuDropdown() {
+  const renderMenuDropdown = () => {
     return (
       <MenuDropdown
-        hideMenuDropdown={this.hideMenu}
-        position={this.getPosition()}
-        align={this.props.align}
+        hideMenuDropdown={hideMenu}
+        position={getPosition()}
+        align={initializedProps.align}
       >
-        {this.props.children}
+        {initializedProps.children}
       </MenuDropdown>
     )
   }
 
-  render() {
-    const { automationId, button } = this.props
+  const render = () => {
+    const { automationId, button } = initializedProps
     return (
       <div
         className={styles.dropdown}
         data-automation-id={automationId}
-        ref={this.dropdownButtonContainer}
+        ref={dropdownButtonContainer}
       >
         {React.cloneElement(button, {
-          onClick: this.toggleMenu,
+          onClick: e => {
+            e.preventDefault()
+            toggleMenu()
+          },
           onMouseDown: e => e.preventDefault(),
         })}
-        {this.state.isMenuVisible && this.renderMenuDropdown()}
+        {isMenuVisible && renderMenuDropdown()}
       </div>
     )
   }
+
+  return render()
 }
+
+export default Menu

--- a/draft-packages/menu/KaizenDraft/Menu/Menu.tsx
+++ b/draft-packages/menu/KaizenDraft/Menu/Menu.tsx
@@ -29,66 +29,15 @@ const Menu: Menu = (props: MenuProps) => {
     initializedProps.menuVisible
   )
 
-  const toggleMenu = () => {
+  const toggleMenuDropdown = () => {
     setIsMenuVisible(!isMenuVisible)
   }
 
-  const hideMenu = () => {
+  const hideMenuDropdown = () => {
     setIsMenuVisible(false)
   }
 
   const { automationId, button, children } = initializedProps
-  const menu = renderMenuDropdown({
-    align,
-    children,
-    dropdownButtonContainer,
-    hideMenuDropdown: hideMenu,
-  })
-  return (
-    <div
-      className={styles.dropdown}
-      data-automation-id={automationId}
-      ref={dropdownButtonContainer}
-    >
-      {React.cloneElement(button, {
-        onClick: e => {
-          e.preventDefault()
-          toggleMenu()
-        },
-        onMouseDown: e => e.preventDefault(),
-      })}
-      {isMenuVisible ? menu : null}
-    </div>
-  )
-}
-
-export type StatelessMenuProps = {
-  isMenuVisible: boolean
-  toggleMenuDropdown: any // TODO!
-  hideMenuDropdown: any
-  renderButton: (args: {
-    onClick: () => void
-    onMouseDown: (e: any) => void
-  }) => React.ReactElement
-} & MenuProps
-
-export const StatelessMenu: React.FunctionComponent<StatelessMenuProps> = ({
-  align = "left",
-  automationId,
-  renderButton,
-  isMenuVisible,
-  toggleMenuDropdown,
-  hideMenuDropdown,
-  children,
-}) => {
-  const dropdownButtonContainer = React.createRef<HTMLDivElement>()
-
-  const menuButton = renderButton({
-    onMouseDown: (e: any) => e.preventDefault(),
-    onClick: () => {
-      toggleMenuDropdown()
-    },
-  })
   const menu = renderMenuDropdown({
     align,
     children,
@@ -101,10 +50,24 @@ export const StatelessMenu: React.FunctionComponent<StatelessMenuProps> = ({
       data-automation-id={automationId}
       ref={dropdownButtonContainer}
     >
-      {menuButton}
+      {React.cloneElement(button, {
+        onClick: e => {
+          e.preventDefault()
+          toggleMenuDropdown()
+        },
+        onMouseDown: e => e.preventDefault(),
+      })}
       {isMenuVisible ? menu : null}
     </div>
   )
+}
+
+const toggleMenuDropdown = (isMenuVisible, setIsMenuVisible) => {
+  setIsMenuVisible(!isMenuVisible)
+}
+
+const hideMenu = setIsMenuVisible => {
+  setIsMenuVisible(false)
 }
 
 const renderMenuDropdown = ({

--- a/draft-packages/menu/KaizenDraft/Menu/Menu.tsx
+++ b/draft-packages/menu/KaizenDraft/Menu/Menu.tsx
@@ -43,8 +43,8 @@ const Menu: Menu = props => {
     dropdownButtonContainer,
     hideMenuDropdown,
     menuButton: React.cloneElement(button, {
-      onClick: e => {
-        e.preventDefault()
+      onClick: (e: any) => {
+        e.stopPropagation()
         toggleMenuDropdown()
       },
       onMouseDown: e => e.preventDefault(),

--- a/draft-packages/menu/KaizenDraft/Menu/Menu.tsx
+++ b/draft-packages/menu/KaizenDraft/Menu/Menu.tsx
@@ -18,11 +18,11 @@ type StatefulMenuProps = {
 type Menu = React.FunctionComponent<GenericMenuProps & StatefulMenuProps>
 
 const Menu: Menu = props => {
-  const { align = "left" } = props
+  const { align = "left", menuVisible = false } = props
 
   const dropdownButtonContainer = React.createRef<HTMLDivElement>()
 
-  const [isMenuVisible, setIsMenuVisible] = useState(props.menuVisible)
+  const [isMenuVisible, setIsMenuVisible] = useState<boolean>(menuVisible)
 
   const toggleMenuDropdown = () => {
     setIsMenuVisible(!isMenuVisible)
@@ -35,6 +35,11 @@ const Menu: Menu = props => {
   const { automationId, button, children } = props
 
   return render({
+    ...props,
+    align,
+    isMenuVisible,
+    dropdownButtonContainer,
+    hideMenuDropdown,
     menuButton: React.cloneElement(button, {
       onClick: e => {
         e.preventDefault()
@@ -42,55 +47,38 @@ const Menu: Menu = props => {
       },
       onMouseDown: e => e.preventDefault(),
     }),
-    isMenuVisible,
-    automationId,
-    dropdownButtonContainer,
-    align,
-    children,
-    hideMenuDropdown,
   })
 }
 
-export const renderMenuDropdown = ({
-  align,
-  children,
-  dropdownButtonContainer,
-  hideMenuDropdown,
-}) => {
+type RenderProps = {
+  menuButton: React.ReactElement
+  isMenuVisible: boolean
+  dropdownButtonContainer: React.RefObject<HTMLDivElement>
+  hideMenuDropdown: () => void
+}
+
+export const renderMenuDropdown = (props: GenericMenuProps & RenderProps) => {
   return (
     <MenuDropdown
-      position={getPosition(dropdownButtonContainer)}
-      align={align}
-      hideMenuDropdown={hideMenuDropdown}
+      position={getPosition(props.dropdownButtonContainer)}
+      align={props.align}
+      hideMenuDropdown={props.hideMenuDropdown}
     >
-      {children}
+      {props.children}
     </MenuDropdown>
   )
 }
 
-export const render = ({
-  menuButton,
-  isMenuVisible,
-  automationId,
-  dropdownButtonContainer,
-  align,
-  children,
-  hideMenuDropdown,
-}) => {
-  const menu = renderMenuDropdown({
-    align,
-    children,
-    dropdownButtonContainer,
-    hideMenuDropdown,
-  })
+export const render = (props: GenericMenuProps & RenderProps) => {
+  const menu = renderMenuDropdown(props)
   return (
     <div
       className={styles.dropdown}
-      data-automation-id={automationId}
-      ref={dropdownButtonContainer}
+      data-automation-id={props.automationId}
+      ref={props.dropdownButtonContainer}
     >
-      {menuButton}
-      {isMenuVisible ? menu : null}
+      {props.menuButton}
+      {props.isMenuVisible ? menu : null}
     </div>
   )
 }

--- a/draft-packages/menu/KaizenDraft/Menu/Menu.tsx
+++ b/draft-packages/menu/KaizenDraft/Menu/Menu.tsx
@@ -4,30 +4,25 @@ import MenuDropdown from "./MenuDropdown"
 
 const styles = require("./styles.scss")
 
-type MenuState = {
-  isMenuVisible: boolean
-}
-
-export type MenuProps = {
+export type GenericMenuProps = {
   align?: "left" | "right"
-  button: React.ReactElement<ButtonProps>
   menuVisible?: boolean
   automationId?: string
   children: React.ReactNode
 }
 
-type Menu = React.FunctionComponent<MenuProps>
+type StatefulMenuProps = {
+  button: React.ReactElement<ButtonProps>
+}
 
-const Menu: Menu = (props: MenuProps) => {
+type Menu = React.FunctionComponent<GenericMenuProps & StatefulMenuProps>
+
+const Menu: Menu = props => {
   const { align = "left" } = props
-
-  const initializedProps = { ...props, align }
 
   const dropdownButtonContainer = React.createRef<HTMLDivElement>()
 
-  const [isMenuVisible, setIsMenuVisible] = useState(
-    initializedProps.menuVisible
-  )
+  const [isMenuVisible, setIsMenuVisible] = useState(props.menuVisible)
 
   const toggleMenuDropdown = () => {
     setIsMenuVisible(!isMenuVisible)
@@ -37,40 +32,26 @@ const Menu: Menu = (props: MenuProps) => {
     setIsMenuVisible(false)
   }
 
-  const { automationId, button, children } = initializedProps
-  const menu = renderMenuDropdown({
+  const { automationId, button, children } = props
+
+  return render({
+    menuButton: React.cloneElement(button, {
+      onClick: e => {
+        e.preventDefault()
+        toggleMenuDropdown()
+      },
+      onMouseDown: e => e.preventDefault(),
+    }),
+    isMenuVisible,
+    automationId,
+    dropdownButtonContainer,
     align,
     children,
-    dropdownButtonContainer,
     hideMenuDropdown,
   })
-  return (
-    <div
-      className={styles.dropdown}
-      data-automation-id={automationId}
-      ref={dropdownButtonContainer}
-    >
-      {React.cloneElement(button, {
-        onClick: e => {
-          e.preventDefault()
-          toggleMenuDropdown()
-        },
-        onMouseDown: e => e.preventDefault(),
-      })}
-      {isMenuVisible ? menu : null}
-    </div>
-  )
 }
 
-const toggleMenuDropdown = (isMenuVisible, setIsMenuVisible) => {
-  setIsMenuVisible(!isMenuVisible)
-}
-
-const hideMenu = setIsMenuVisible => {
-  setIsMenuVisible(false)
-}
-
-const renderMenuDropdown = ({
+export const renderMenuDropdown = ({
   align,
   children,
   dropdownButtonContainer,
@@ -84,6 +65,33 @@ const renderMenuDropdown = ({
     >
       {children}
     </MenuDropdown>
+  )
+}
+
+export const render = ({
+  menuButton,
+  isMenuVisible,
+  automationId,
+  dropdownButtonContainer,
+  align,
+  children,
+  hideMenuDropdown,
+}) => {
+  const menu = renderMenuDropdown({
+    align,
+    children,
+    dropdownButtonContainer,
+    hideMenuDropdown,
+  })
+  return (
+    <div
+      className={styles.dropdown}
+      data-automation-id={automationId}
+      ref={dropdownButtonContainer}
+    >
+      {menuButton}
+      {isMenuVisible ? menu : null}
+    </div>
   )
 }
 

--- a/draft-packages/menu/KaizenDraft/Menu/Menu.tsx
+++ b/draft-packages/menu/KaizenDraft/Menu/Menu.tsx
@@ -57,8 +57,8 @@ type RenderProps = {
   hideMenuDropdown: () => void
 }
 
-export const renderMenuDropdown = (props: GenericMenuProps & RenderProps) => {
-  return (
+export const render = (props: GenericMenuProps & RenderProps) => {
+  const menu = (
     <MenuDropdown
       position={getPosition(props.dropdownButtonContainer)}
       align={props.align}
@@ -67,10 +67,6 @@ export const renderMenuDropdown = (props: GenericMenuProps & RenderProps) => {
       {props.children}
     </MenuDropdown>
   )
-}
-
-export const render = (props: GenericMenuProps & RenderProps) => {
-  const menu = renderMenuDropdown(props)
   return (
     <div
       className={styles.dropdown}

--- a/draft-packages/menu/KaizenDraft/Menu/Menu.tsx
+++ b/draft-packages/menu/KaizenDraft/Menu/Menu.tsx
@@ -36,45 +36,97 @@ const Menu: Menu = (props: MenuProps) => {
     setIsMenuVisible(false)
   }
 
-  const getPosition = () => {
-    return dropdownButtonContainer && dropdownButtonContainer.current
-      ? dropdownButtonContainer.current.getBoundingClientRect()
-      : null
-  }
+  const { automationId, button, children } = initializedProps
+  const menu = renderMenuDropdown({
+    align,
+    children,
+    dropdownButtonContainer,
+    hideMenuDropdown: hideMenu,
+  })
+  return (
+    <div
+      className={styles.dropdown}
+      data-automation-id={automationId}
+      ref={dropdownButtonContainer}
+    >
+      {React.cloneElement(button, {
+        onClick: e => {
+          e.preventDefault()
+          toggleMenu()
+        },
+        onMouseDown: e => e.preventDefault(),
+      })}
+      {isMenuVisible ? menu : null}
+    </div>
+  )
+}
 
-  const renderMenuDropdown = () => {
-    return (
-      <MenuDropdown
-        hideMenuDropdown={hideMenu}
-        position={getPosition()}
-        align={initializedProps.align}
-      >
-        {initializedProps.children}
-      </MenuDropdown>
-    )
-  }
+export type StatelessMenuProps = {
+  isMenuVisible: boolean
+  toggleMenuDropdown: any // TODO!
+  hideMenuDropdown: any
+  renderButton: (args: {
+    onClick: () => void
+    onMouseDown: (e: any) => void
+  }) => React.ReactElement
+} & MenuProps
 
-  const render = () => {
-    const { automationId, button } = initializedProps
-    return (
-      <div
-        className={styles.dropdown}
-        data-automation-id={automationId}
-        ref={dropdownButtonContainer}
-      >
-        {React.cloneElement(button, {
-          onClick: e => {
-            e.preventDefault()
-            toggleMenu()
-          },
-          onMouseDown: e => e.preventDefault(),
-        })}
-        {isMenuVisible && renderMenuDropdown()}
-      </div>
-    )
-  }
+export const StatelessMenu: React.FunctionComponent<StatelessMenuProps> = ({
+  align = "left",
+  automationId,
+  renderButton,
+  isMenuVisible,
+  toggleMenuDropdown,
+  hideMenuDropdown,
+  children,
+}) => {
+  const dropdownButtonContainer = React.createRef<HTMLDivElement>()
 
-  return render()
+  const menuButton = renderButton({
+    onMouseDown: (e: any) => e.preventDefault(),
+    onClick: () => {
+      toggleMenuDropdown()
+    },
+  })
+  const menu = renderMenuDropdown({
+    align,
+    children,
+    dropdownButtonContainer,
+    hideMenuDropdown,
+  })
+  return (
+    <div
+      className={styles.dropdown}
+      data-automation-id={automationId}
+      ref={dropdownButtonContainer}
+    >
+      {menuButton}
+      {isMenuVisible ? menu : null}
+    </div>
+  )
+}
+
+const renderMenuDropdown = ({
+  align,
+  children,
+  dropdownButtonContainer,
+  hideMenuDropdown,
+}) => {
+  return (
+    <MenuDropdown
+      position={getPosition(dropdownButtonContainer)}
+      align={align}
+      hideMenuDropdown={hideMenuDropdown}
+    >
+      {children}
+    </MenuDropdown>
+  )
+}
+
+const getPosition = dropdownButtonContainer => {
+  return dropdownButtonContainer && dropdownButtonContainer.current
+    ? dropdownButtonContainer.current.getBoundingClientRect()
+    : null
 }
 
 export default Menu

--- a/draft-packages/menu/KaizenDraft/Menu/Menu.tsx
+++ b/draft-packages/menu/KaizenDraft/Menu/Menu.tsx
@@ -34,7 +34,7 @@ const Menu: Menu = props => {
     setIsMenuVisible(false)
   }
 
-  const { automationId, button, children } = props
+  const { button } = props
 
   return render({
     ...props,
@@ -47,7 +47,7 @@ const Menu: Menu = props => {
         e.stopPropagation()
         toggleMenuDropdown()
       },
-      onMouseDown: e => e.preventDefault(),
+      onMouseDown: (e: any) => e.preventDefault(),
     }),
   })
 }
@@ -81,7 +81,9 @@ export const render = (props: GenericMenuProps & RenderProps) => {
   )
 }
 
-const getPosition = dropdownButtonContainer => {
+const getPosition = (
+  dropdownButtonContainer: React.RefObject<HTMLDivElement>
+) => {
   return dropdownButtonContainer && dropdownButtonContainer.current
     ? dropdownButtonContainer.current.getBoundingClientRect()
     : null

--- a/draft-packages/menu/KaizenDraft/Menu/Menu.tsx
+++ b/draft-packages/menu/KaizenDraft/Menu/Menu.tsx
@@ -15,7 +15,9 @@ type StatefulMenuProps = {
   button: React.ReactElement<ButtonProps>
 }
 
-type Menu = React.FunctionComponent<GenericMenuProps & StatefulMenuProps>
+export type MenuProps = GenericMenuProps & StatefulMenuProps
+
+type Menu = React.FunctionComponent<MenuProps>
 
 const Menu: Menu = props => {
   const { align = "left", menuVisible = false } = props

--- a/draft-packages/menu/KaizenDraft/Menu/Menu.tsx
+++ b/draft-packages/menu/KaizenDraft/Menu/Menu.tsx
@@ -1,5 +1,5 @@
 import { ButtonProps } from "@kaizen/draft-button"
-import React, { useState } from "react"
+import React, { useRef, useState } from "react"
 import MenuDropdown from "./MenuDropdown"
 
 const styles = require("./styles.scss")
@@ -22,7 +22,7 @@ type Menu = React.FunctionComponent<MenuProps>
 const Menu: Menu = props => {
   const { align = "left", menuVisible = false } = props
 
-  const dropdownButtonContainer = React.createRef<HTMLDivElement>()
+  const dropdownButtonContainer: React.RefObject<HTMLDivElement> = useRef(null)
 
   const [isMenuVisible, setIsMenuVisible] = useState<boolean>(menuVisible)
 

--- a/draft-packages/menu/KaizenDraft/Menu/StatelessMenu.tsx
+++ b/draft-packages/menu/KaizenDraft/Menu/StatelessMenu.tsx
@@ -9,7 +9,7 @@ export type StatelessMenuProps = {
   toggleMenuDropdown: () => void
   hideMenuDropdown: () => void
   renderButton: (args: {
-    onClick: () => void
+    onClick: (e: any) => void
     onMouseDown: (e: any) => void
   }) => React.ReactElement
 }
@@ -21,7 +21,8 @@ export const StatelessMenu: React.FunctionComponent<Props> = (props: Props) => {
 
   const menuButton = props.renderButton({
     onMouseDown: (e: any) => e.preventDefault(),
-    onClick: () => {
+    onClick: (e: any) => {
+      e.stopPropagation()
       props.toggleMenuDropdown()
     },
   })

--- a/draft-packages/menu/KaizenDraft/Menu/StatelessMenu.tsx
+++ b/draft-packages/menu/KaizenDraft/Menu/StatelessMenu.tsx
@@ -1,6 +1,6 @@
 import { default as React, ReactElement } from "react"
 
-import { MenuProps } from "./Menu"
+import { MenuProps, renderMenuDropdown } from "./Menu"
 import MenuDropdown from "./MenuDropdown"
 const styles = require("./styles.scss")
 
@@ -49,26 +49,4 @@ export const StatelessMenu: React.FunctionComponent<StatelessMenuProps> = ({
   )
 }
 
-const renderMenuDropdown = ({
-  align,
-  children,
-  dropdownButtonContainer,
-  hideMenuDropdown,
-}) => {
-  return (
-    <MenuDropdown
-      position={getPosition(dropdownButtonContainer)}
-      align={align}
-      hideMenuDropdown={hideMenuDropdown}
-    >
-      {children}
-    </MenuDropdown>
-  )
-}
-
-// TODO: add types
-const getPosition = dropdownButtonContainer => {
-  return dropdownButtonContainer && dropdownButtonContainer.current
-    ? dropdownButtonContainer.current.getBoundingClientRect()
-    : null
-}
+export default StatelessMenu

--- a/draft-packages/menu/KaizenDraft/Menu/StatelessMenu.tsx
+++ b/draft-packages/menu/KaizenDraft/Menu/StatelessMenu.tsx
@@ -1,6 +1,6 @@
 import { default as React, ReactElement } from "react"
 
-import { MenuProps, renderMenuDropdown } from "./Menu"
+import { GenericMenuProps, render } from "./Menu"
 import MenuDropdown from "./MenuDropdown"
 const styles = require("./styles.scss")
 
@@ -12,7 +12,7 @@ export type StatelessMenuProps = {
     onClick: () => void
     onMouseDown: (e: any) => void
   }) => React.ReactElement
-} & MenuProps
+} & GenericMenuProps
 
 export const StatelessMenu: React.FunctionComponent<StatelessMenuProps> = ({
   align = "left",
@@ -31,22 +31,15 @@ export const StatelessMenu: React.FunctionComponent<StatelessMenuProps> = ({
       toggleMenuDropdown()
     },
   })
-  const menu = renderMenuDropdown({
+  return render({
+    menuButton,
+    isMenuVisible,
+    automationId,
+    dropdownButtonContainer,
     align,
     children,
-    dropdownButtonContainer,
     hideMenuDropdown,
   })
-  return (
-    <div
-      className={styles.dropdown}
-      data-automation-id={automationId}
-      ref={dropdownButtonContainer}
-    >
-      {menuButton}
-      {isMenuVisible ? menu : null}
-    </div>
-  )
 }
 
 export default StatelessMenu

--- a/draft-packages/menu/KaizenDraft/Menu/StatelessMenu.tsx
+++ b/draft-packages/menu/KaizenDraft/Menu/StatelessMenu.tsx
@@ -1,0 +1,68 @@
+import * as React from "react"
+
+import { MenuProps } from "./Menu"
+import MenuDropdown from "./MenuDropdown"
+const styles = require("./styles.scss")
+
+export type StatelessMenuProps = {
+  isMenuVisible: boolean
+  toggleMenuDropdown: any // TODO!
+  hideMenuDropdown: any
+} & MenuProps
+
+export const StatelessMenu: React.FunctionComponent<StatelessMenuProps> = ({
+  align = "left",
+  automationId,
+  button,
+  isMenuVisible,
+  toggleMenuDropdown,
+  hideMenuDropdown,
+  children,
+}) => {
+  const dropdownButtonContainer = React.createRef<HTMLDivElement>()
+  return (
+    <div
+      className={styles.dropdown}
+      data-automation-id={automationId}
+      ref={dropdownButtonContainer}
+    >
+      {React.cloneElement(button, {
+        onClick: () => {
+          toggleMenuDropdown()
+        },
+        onMouseDown: (e: any) => e.preventDefault(), // TODO any
+      })}
+      {isMenuVisible &&
+        renderMenuDropdown({
+          align,
+          children,
+          dropdownButtonContainer,
+          hideMenuDropdown,
+        })}
+    </div>
+  )
+}
+
+const renderMenuDropdown = ({
+  align,
+  children,
+  dropdownButtonContainer,
+  hideMenuDropdown,
+}) => {
+  return (
+    <MenuDropdown
+      position={getPosition(dropdownButtonContainer)}
+      align={align}
+      hideMenuDropdown={hideMenuDropdown}
+    >
+      {children}
+    </MenuDropdown>
+  )
+}
+
+// TODO: add types
+const getPosition = dropdownButtonContainer => {
+  return dropdownButtonContainer && dropdownButtonContainer.current
+    ? dropdownButtonContainer.current.getBoundingClientRect()
+    : null
+}

--- a/draft-packages/menu/KaizenDraft/Menu/StatelessMenu.tsx
+++ b/draft-packages/menu/KaizenDraft/Menu/StatelessMenu.tsx
@@ -1,4 +1,4 @@
-import * as React from "react"
+import { default as React, ReactElement } from "react"
 
 import { MenuProps } from "./Menu"
 import MenuDropdown from "./MenuDropdown"
@@ -8,37 +8,43 @@ export type StatelessMenuProps = {
   isMenuVisible: boolean
   toggleMenuDropdown: any // TODO!
   hideMenuDropdown: any
+  renderButton: (args: {
+    onClick: () => void
+    onMouseDown: (e: any) => void
+  }) => React.ReactElement
 } & MenuProps
 
 export const StatelessMenu: React.FunctionComponent<StatelessMenuProps> = ({
   align = "left",
   automationId,
-  button,
+  renderButton,
   isMenuVisible,
   toggleMenuDropdown,
   hideMenuDropdown,
   children,
 }) => {
   const dropdownButtonContainer = React.createRef<HTMLDivElement>()
+
+  const menuButton = renderButton({
+    onMouseDown: (e: any) => e.preventDefault(),
+    onClick: () => {
+      toggleMenuDropdown()
+    },
+  })
+  const menu = renderMenuDropdown({
+    align,
+    children,
+    dropdownButtonContainer,
+    hideMenuDropdown,
+  })
   return (
     <div
       className={styles.dropdown}
       data-automation-id={automationId}
       ref={dropdownButtonContainer}
     >
-      {React.cloneElement(button, {
-        onClick: () => {
-          toggleMenuDropdown()
-        },
-        onMouseDown: (e: any) => e.preventDefault(), // TODO any
-      })}
-      {isMenuVisible &&
-        renderMenuDropdown({
-          align,
-          children,
-          dropdownButtonContainer,
-          hideMenuDropdown,
-        })}
+      {menuButton}
+      {isMenuVisible ? menu : null}
     </div>
   )
 }

--- a/draft-packages/menu/KaizenDraft/Menu/StatelessMenu.tsx
+++ b/draft-packages/menu/KaizenDraft/Menu/StatelessMenu.tsx
@@ -6,8 +6,8 @@ const styles = require("./styles.scss")
 
 export type StatelessMenuProps = {
   isMenuVisible: boolean
-  toggleMenuDropdown: any // TODO!
-  hideMenuDropdown: any
+  toggleMenuDropdown: () => void
+  hideMenuDropdown: () => void
   renderButton: (args: {
     onClick: () => void
     onMouseDown: (e: any) => void

--- a/draft-packages/menu/KaizenDraft/Menu/StatelessMenu.tsx
+++ b/draft-packages/menu/KaizenDraft/Menu/StatelessMenu.tsx
@@ -14,7 +14,7 @@ export type StatelessMenuProps = {
   }) => React.ReactElement
 }
 
-type Props = StatelessMenuProps & GenericMenuProps
+export type Props = StatelessMenuProps & GenericMenuProps
 
 export const StatelessMenu: React.FunctionComponent<Props> = (props: Props) => {
   const dropdownButtonContainer = React.createRef<HTMLDivElement>()

--- a/draft-packages/menu/KaizenDraft/Menu/StatelessMenu.tsx
+++ b/draft-packages/menu/KaizenDraft/Menu/StatelessMenu.tsx
@@ -1,7 +1,6 @@
-import { default as React, ReactElement } from "react"
+import { default as React, ReactElement, useRef } from "react"
 
 import { GenericMenuProps, render } from "./Menu"
-import MenuDropdown from "./MenuDropdown"
 const styles = require("./styles.scss")
 
 export type StatelessMenuProps = {
@@ -17,7 +16,7 @@ export type StatelessMenuProps = {
 export type Props = StatelessMenuProps & GenericMenuProps
 
 export const StatelessMenu: React.FunctionComponent<Props> = (props: Props) => {
-  const dropdownButtonContainer = React.createRef<HTMLDivElement>()
+  const dropdownButtonContainer = useRef(null)
 
   const menuButton = props.renderButton({
     onMouseDown: (e: any) => e.preventDefault(),

--- a/draft-packages/menu/KaizenDraft/Menu/StatelessMenu.tsx
+++ b/draft-packages/menu/KaizenDraft/Menu/StatelessMenu.tsx
@@ -12,34 +12,20 @@ export type StatelessMenuProps = {
     onClick: () => void
     onMouseDown: (e: any) => void
   }) => React.ReactElement
-} & GenericMenuProps
+}
 
-export const StatelessMenu: React.FunctionComponent<StatelessMenuProps> = ({
-  align = "left",
-  automationId,
-  renderButton,
-  isMenuVisible,
-  toggleMenuDropdown,
-  hideMenuDropdown,
-  children,
-}) => {
+type Props = StatelessMenuProps & GenericMenuProps
+
+export const StatelessMenu: React.FunctionComponent<Props> = (props: Props) => {
   const dropdownButtonContainer = React.createRef<HTMLDivElement>()
 
-  const menuButton = renderButton({
+  const menuButton = props.renderButton({
     onMouseDown: (e: any) => e.preventDefault(),
     onClick: () => {
-      toggleMenuDropdown()
+      props.toggleMenuDropdown()
     },
   })
-  return render({
-    menuButton,
-    isMenuVisible,
-    automationId,
-    dropdownButtonContainer,
-    align,
-    children,
-    hideMenuDropdown,
-  })
+  return render({ ...props, dropdownButtonContainer, menuButton })
 }
 
 export default StatelessMenu

--- a/draft-packages/menu/index.ts
+++ b/draft-packages/menu/index.ts
@@ -1,4 +1,5 @@
-export { default as Menu, StatelessMenu } from "./KaizenDraft/Menu/Menu"
+export { default as Menu } from "./KaizenDraft/Menu/Menu"
+export { default as StatelessMenu } from "./KaizenDraft/Menu/StatelessMenu"
 export { default as MenuContent } from "./KaizenDraft/Menu/components/MenuContent"
 export { default as MenuHeader } from "./KaizenDraft/Menu/components/MenuHeader"
 export { default as MenuItem } from "./KaizenDraft/Menu/components/MenuItem"

--- a/draft-packages/menu/index.ts
+++ b/draft-packages/menu/index.ts
@@ -1,4 +1,4 @@
-export { default as Menu } from "./KaizenDraft/Menu/Menu"
+export { default as Menu, StatelessMenu } from "./KaizenDraft/Menu/Menu"
 export { default as MenuContent } from "./KaizenDraft/Menu/components/MenuContent"
 export { default as MenuHeader } from "./KaizenDraft/Menu/components/MenuHeader"
 export { default as MenuItem } from "./KaizenDraft/Menu/components/MenuItem"

--- a/draft-packages/stories/Menu.stories.tsx
+++ b/draft-packages/stories/Menu.stories.tsx
@@ -1,5 +1,5 @@
-import * as colorTokens from "@kaizen/design-tokens/tokens/color.json"
 import { Box, Paragraph } from "@kaizen/component-library"
+import * as colorTokens from "@kaizen/design-tokens/tokens/color.json"
 import { Button, IconButton } from "@kaizen/draft-button"
 const chevronDown = require("@kaizen/component-library/icons/chevron-down.icon.svg")
   .default
@@ -163,51 +163,52 @@ LabelAndIconBottom.story = {
   },
 }
 
-export const DefaultStatelessMenu = () => {
-  const StatelessMenuExample = props => {
-    const [isMenuVisible, setIsMenuVisible] = useState(false)
+const StatelessMenuExample = props => {
+  const [isMenuVisible, setIsMenuVisible] = useState(false)
 
-    const toggleMenu = () => {
-      setIsMenuVisible(!isMenuVisible)
-    }
-
-    const hideMenu = () => {
-      setIsMenuVisible(false)
-    }
-
-    const label = `I'm ${isMenuVisible ? "open!" : "closed!"}`
-
-    return (
-      <div>
-        <Button
-          secondary={true}
-          onClick={() => toggleMenu()}
-          label="Toggle Menu"
-        />
-        <Button secondary={true} onClick={() => hideMenu()} label="Hide Menu" />
-        <Paragraph variant="body">
-          I'm {isMenuVisible ? "open!" : "closed!"}
-        </Paragraph>
-        <StatelessMenu
-          isMenuVisible={isMenuVisible}
-          toggleMenuDropdown={toggleMenu}
-          hideMenuDropdown={hideMenu}
-          renderButton={buttonProps => (
-            <Button
-              label="Label"
-              icon={isMenuVisible ? chevronUp : chevronDown}
-              iconPosition="end"
-              {...buttonProps}
-            />
-          )}
-        >
-          <div onClick={e => e.stopPropagation()}>
-            <MenuInstance />
-          </div>
-        </StatelessMenu>
-      </div>
-    )
+  const toggleMenu = () => {
+    setIsMenuVisible(!isMenuVisible)
   }
+
+  const hideMenu = () => {
+    setIsMenuVisible(false)
+  }
+
+  const label = `I'm ${isMenuVisible ? "open!" : "closed!"}`
+
+  return (
+    <div>
+      <Button
+        secondary={true}
+        onClick={() => toggleMenu()}
+        label="Toggle Menu"
+      />
+      <Button secondary={true} onClick={() => hideMenu()} label="Hide Menu" />
+      <Paragraph variant="body">
+        I'm {isMenuVisible ? "open!" : "closed!"}
+      </Paragraph>
+      <StatelessMenu
+        isMenuVisible={isMenuVisible}
+        toggleMenuDropdown={toggleMenu}
+        hideMenuDropdown={hideMenu}
+        renderButton={buttonProps => (
+          <Button
+            label="Label"
+            icon={isMenuVisible ? chevronUp : chevronDown}
+            iconPosition="end"
+            {...buttonProps}
+          />
+        )}
+      >
+        <div onClick={e => e.stopPropagation()}>
+          <MenuInstance />
+        </div>
+      </StatelessMenu>
+    </div>
+  )
+}
+
+export const DefaultStatelessMenu = () => {
   return (
     <StoryWrapper>
       <Box p={1}>

--- a/draft-packages/stories/Menu.stories.tsx
+++ b/draft-packages/stories/Menu.stories.tsx
@@ -16,8 +16,14 @@ const meatballsIcon = require("@kaizen/component-library/icons/meatballs.icon.sv
   .default
 import { action } from "@storybook/addon-actions"
 import React, { useState } from "react"
-import { Menu, MenuContent, MenuHeader, MenuItem, MenuSeparator } from "../menu"
-import { StatelessMenu } from "../menu/KaizenDraft/Menu/StatelessMenu"
+import {
+  Menu,
+  MenuContent,
+  MenuHeader,
+  MenuItem,
+  MenuSeparator,
+  StatelessMenu,
+} from "../menu"
 import { Paragraph, Box } from "@kaizen/component-library"
 
 const StoryWrapper = ({ children }) => (

--- a/draft-packages/stories/Menu.stories.tsx
+++ b/draft-packages/stories/Menu.stories.tsx
@@ -2,6 +2,8 @@ import * as colorTokens from "@kaizen/design-tokens/tokens/color.json"
 import { Button, IconButton } from "@kaizen/draft-button"
 const chevronDown = require("@kaizen/component-library/icons/chevron-down.icon.svg")
   .default
+const chevronUp = require("@kaizen/component-library/icons/chevron-up.icon.svg")
+  .default
 const duplicateIcon = require("@kaizen/component-library/icons/duplicate.icon.svg")
   .default
 const editIcon = require("@kaizen/component-library/icons/edit.icon.svg")
@@ -13,9 +15,10 @@ const kebabIcon = require("@kaizen/component-library/icons/kebab.icon.svg")
 const meatballsIcon = require("@kaizen/component-library/icons/meatballs.icon.svg")
   .default
 import { action } from "@storybook/addon-actions"
-import * as React from "react"
-
+import React, { useState } from "react"
 import { Menu, MenuContent, MenuHeader, MenuItem, MenuSeparator } from "../menu"
+import { StatelessMenu } from "../menu/KaizenDraft/Menu/StatelessMenu"
+import { Paragraph, Box } from "@kaizen/component-library"
 
 const StoryWrapper = ({ children }) => (
   <div style={{ display: "flex", justifyContent: "center", marginTop: "1rem" }}>
@@ -152,4 +155,79 @@ LabelAndIconBottom.story = {
   parameters: {
     viewport: { defaultViewport: "mobile1" },
   },
+}
+
+export const DefaultStatelessMenu = () => {
+  const StatelessMenuExample = props => {
+    const [isMenuVisible, setIsMenuVisible] = useState(false)
+
+    const toggleMenu = () => {
+      setIsMenuVisible(!isMenuVisible)
+    }
+
+    const hideMenu = () => {
+      setIsMenuVisible(false)
+    }
+
+    const label = `I'm ${isMenuVisible ? "open!" : "closed!"}`
+
+    return (
+      <div>
+        <Button
+          secondary={true}
+          onClick={() => toggleMenu()}
+          label="Toggle Menu"
+        />
+        <Button secondary={true} onClick={() => hideMenu()} label="Hide Menu" />
+        <Paragraph variant="body">
+          I'm {isMenuVisible ? "open!" : "closed!"}
+        </Paragraph>
+        <StatelessMenu
+          isMenuVisible={isMenuVisible}
+          toggleMenuDropdown={toggleMenu}
+          hideMenuDropdown={hideMenu}
+          renderButton={buttonProps => (
+            <Button
+              label="Label"
+              icon={isMenuVisible ? chevronUp : chevronDown}
+              iconPosition="end"
+              {...buttonProps}
+            />
+          )}
+        >
+          <div onClick={e => e.stopPropagation()}>
+            <MenuInstance />
+          </div>
+        </StatelessMenu>
+      </div>
+    )
+  }
+  return (
+    <StoryWrapper>
+      <Box p={1}>
+        <StatelessMenuExample />
+      </Box>
+      <Box p={1}>
+        <Paragraph variant="body">
+          Use the StatelessMenu component if you need to{" "}
+          <a href="https://reactjs.org/docs/lifting-state-up.html">
+            lift state
+          </a>{" "}
+          from the Menu component. This gives the flexibility to be able to
+          control the state of the dropdown however you like and respond to
+          state changes, but it requires more work to configure. It can be used
+          instead of `Menu` if this level of flexibility is required. This
+          component is used in the FilterDrawer component. View the source code{" "}
+          <a href="https://github.com/cultureamp/kaizen-design-system/blob/master/draft-packages/stories/Menu.stories.tsx">
+            here
+          </a>
+          .
+        </Paragraph>
+      </Box>
+    </StoryWrapper>
+  )
+}
+
+DefaultStatelessMenu.story = {
+  name: "StatelessMenu (example usage)",
 }

--- a/draft-packages/stories/Menu.stories.tsx
+++ b/draft-packages/stories/Menu.stories.tsx
@@ -1,4 +1,5 @@
 import * as colorTokens from "@kaizen/design-tokens/tokens/color.json"
+import { Box, Paragraph } from "@kaizen/component-library"
 import { Button, IconButton } from "@kaizen/draft-button"
 const chevronDown = require("@kaizen/component-library/icons/chevron-down.icon.svg")
   .default
@@ -24,7 +25,6 @@ import {
   MenuSeparator,
   StatelessMenu,
 } from "../menu"
-import { Paragraph, Box } from "@kaizen/component-library"
 
 const StoryWrapper = ({ children }) => (
   <div style={{ display: "flex", justifyContent: "center", marginTop: "1rem" }}>


### PR DESCRIPTION
## Overview

`StatelessMenu` is the same as `Menu` but it does not have any internal state. The consumer holds the state and is responsible for passing the state to the component, and handling user interactions that change that state. This provides much more flexibility than `Menu`, but comes at the cost of needing more setup code.

## Storybook Story
Story for `StatelessMenu` demonstrating some things you can do: https://dev.cultureamp.design/dst/stateless-menu/storybook-static/?path=/story/menu-react--default-stateless-menu

## Summary of changes:

- New module `StatelessMenu` which tries to re-use as much code from
- In order to achieve code reuse, Menu was significantly refactored to use hooks, so that re-usable view functions could be extracted and re-used between Menu and StatelessMenu. The diff is huge and probably impossible to read - you're better off looking at the file directly for code review.
- Unlike `Menu`, `StatelessMenu` does not use React.cloneElement to add the button event handlers. Rather you provide afunction that renders a button and takes event handlers as an argument (which could be considered a "render prop" or more generally a higher-order function - a function that takes a function as an argument). I ran into a problem for FilterDrawer when I tried to pass in a custom component (a FunctionComponent), where the even listeners weren't added. I found a workaround by using a plain-old function rather than a FunctionComponent, but it was very unexpected. In any case, I think that a higher-order function is a better  approach - `cloneElement` can be very unpredictable and susceptible to race conditions as it mutates the actual DOM (which goes against the grain of React's design). I would have preferred to refactor `Menu` to also not use `cloneElement` but that would be a breaking change. This has also lead to the implementation being more complicated.

## Thoughts:

I think there's a big trade-off between these 3 options:

1. Only support the stateful component. This is easiest for consumers and keeps the code the simplest. The problem is, that it might make it impossible to do some things or you need to rely on massive hacks, such as using `Ref`'s to be able to influence the state from outside the component, or you need two sources of truth of the state - one inside the component and one outside and try to keep them in sync (which is never a good thing)
2. Only support the stateless component. This is  The Elm Way ™️ . I like it because it's the most flexible - you never have to "lift" state. The problem with lifting state is that it causes a major breaking change when you decide at some point that the component should have been stateless because it's too inflexible being stateful. However, I have to admit it does add a lot of boilerplate for simple cases where you can't imagine a need to have access to the state.
3. Provide stateful and stateless components. When you find a need to "lift" state you can add an extra "stateless" component, which is what this PR does. It does not require a breaking change, which is nice. Also, the stateless version can be considered the "expert" version for when you need to do custom things (while the stateful versions remains the easy to use one). The tradeoff is that I think the implementation becomes quite complex as you should share view code between the two versions (the views should be identical, and there's a huge potential for divergence and bugs and inconsistencies if you don't).  It's far simpler having one implementation (stateful or stateless) I think this makes the code pretty hard to read (that's my excuse for how hard to read the code now is!)

All in all,  I think Option 3 is the best set of tradeoffs for this component and situation.

I'm more than happy to got through this over Zoom to answer any questions!
