### PR TITLE
feat: abillity to add additional content to GenericButton

### DIFF
--- a/draft-packages/button/KaizenDraft/Button/FilterDrawerButton.module.scss
+++ b/draft-packages/button/KaizenDraft/Button/FilterDrawerButton.module.scss
@@ -1,0 +1,17 @@
+@import "~@kaizen/design-tokens/sass/color";
+@import "~@kaizen/design-tokens/sass/border";
+
+// The button used for the Filter Drawer component is similar to the
+// standard secondary reversed button, but has a background when
+// no hovering as it needs to look more like a button. Rather than adding this
+// snowflake button style to the core Button component, this is achieved by
+// faking it with a surrounding div.
+.buttonEdgeCaseStyling {
+  display: inline-block;
+  border-radius: $kz-border-borderless-border-radius;
+  background-color: rgba($kz-color-cluny-400, 0.1);
+
+  .reversed & {
+    background-color: rgba($kz-color-white, 0.1);
+  }
+}

--- a/draft-packages/button/KaizenDraft/Button/FilterDrawerButton.tsx
+++ b/draft-packages/button/KaizenDraft/Button/FilterDrawerButton.tsx
@@ -12,7 +12,7 @@ const styles = require("./FilterDrawerButton.module.scss")
 
 type FilterButtonProps = {
   labelText: string
-  numFiltersEnabled: number
+  numberOfFiltersEnabled: number
   onClick: (e: any) => void
   onMouseDown: (e: any) => void
   reversed?: boolean
@@ -20,7 +20,7 @@ type FilterButtonProps = {
 
 export const FilterDrawerButton = ({
   labelText,
-  numFiltersEnabled,
+  numberOfFiltersEnabled,
   onClick,
   onMouseDown,
   reversed,
@@ -36,7 +36,7 @@ export const FilterDrawerButton = ({
       label={labelText}
       icon={filterIcon}
       iconPosition="start"
-      additionalContent={renderBadge(numFiltersEnabled)}
+      additionalContent={renderBadge(numberOfFiltersEnabled)}
       onClick={onClick}
       onMouseDown={onMouseDown}
     />
@@ -47,7 +47,7 @@ const ButtonAllowingAdditionalContent = (
   props: GenericProps & LabelProps & AdditionalContentProps
 ) => <GenericButton {...props} />
 
-const renderBadge = (numFiltersEnabled: number) =>
-  numFiltersEnabled > 0 ? (
-    <Badge variant="active">{String(numFiltersEnabled)}</Badge>
+const renderBadge = (numberOfFiltersEnabled: number) =>
+  numberOfFiltersEnabled > 0 ? (
+    <Badge variant="active">{String(numberOfFiltersEnabled)}</Badge>
   ) : null

--- a/draft-packages/button/KaizenDraft/Button/FilterDrawerButton.tsx
+++ b/draft-packages/button/KaizenDraft/Button/FilterDrawerButton.tsx
@@ -1,0 +1,53 @@
+import { Badge } from "@kaizen/draft-badge"
+import classnames from "classnames"
+import * as React from "react"
+import GenericButton, {
+  AdditionalContentProps,
+  GenericProps,
+  LabelProps,
+} from "./components/GenericButton"
+const filterIcon = require("@kaizen/component-library/icons/filter.icon.svg")
+  .default
+const styles = require("./FilterDrawerButton.module.scss")
+
+type FilterButtonProps = {
+  labelText: string
+  numFiltersEnabled: number
+  onClick: (e: any) => void
+  onMouseDown: (e: any) => void
+  reversed?: boolean
+}
+
+export const FilterDrawerButton = ({
+  labelText,
+  numFiltersEnabled,
+  onClick,
+  onMouseDown,
+  reversed,
+}: FilterButtonProps) => (
+  <div
+    className={classnames(styles.buttonEdgeCaseStyling, {
+      [styles.reversed]: reversed,
+    })}
+  >
+    <ButtonAllowingAdditionalContent
+      secondary={true}
+      reversed={reversed}
+      label={labelText}
+      icon={filterIcon}
+      iconPosition="start"
+      additionalContent={renderBadge(numFiltersEnabled)}
+      onClick={onClick}
+      onMouseDown={onMouseDown}
+    />
+  </div>
+)
+
+const ButtonAllowingAdditionalContent = (
+  props: GenericProps & LabelProps & AdditionalContentProps
+) => <GenericButton {...props} />
+
+const renderBadge = (numFiltersEnabled: number) =>
+  numFiltersEnabled > 0 ? (
+    <Badge variant="active">{String(numFiltersEnabled)}</Badge>
+  ) : null

--- a/draft-packages/button/KaizenDraft/Button/components/GenericButton.tsx
+++ b/draft-packages/button/KaizenDraft/Button/components/GenericButton.tsx
@@ -23,6 +23,7 @@ type GenericProps = {
   analytics?: Analytics
   onFocus?: (e: React.FocusEvent<HTMLElement>) => void
   onBlur?: (e: React.FocusEvent<HTMLElement>) => void
+  additionalContent?: React.ReactNode
 }
 
 type LabelProps = {
@@ -175,6 +176,7 @@ const renderContent: React.FunctionComponent<Props> = props => (
       <span className={styles.label}>{props.label}</span>
     )}
     {props.icon && props.iconPosition === "end" && renderIcon(props.icon)}
+    {props.additionalContent}
   </span>
 )
 

--- a/draft-packages/button/KaizenDraft/Button/components/GenericButton.tsx
+++ b/draft-packages/button/KaizenDraft/Button/components/GenericButton.tsx
@@ -4,7 +4,7 @@ import * as React from "react"
 
 const styles = require("./GenericButton.module.scss")
 
-type GenericProps = {
+export type GenericProps = {
   id?: string
   label: string
   destructive?: boolean
@@ -23,10 +23,13 @@ type GenericProps = {
   analytics?: Analytics
   onFocus?: (e: React.FocusEvent<HTMLElement>) => void
   onBlur?: (e: React.FocusEvent<HTMLElement>) => void
+}
+
+export type AdditionalContentProps = {
   additionalContent?: React.ReactNode
 }
 
-type LabelProps = {
+export type LabelProps = {
   iconPosition?: "start" | "end"
   primary?: boolean
   secondary?: boolean
@@ -43,7 +46,7 @@ export type ButtonProps = GenericProps & LabelProps
 
 type Props = ButtonProps & {
   iconButton?: boolean
-}
+} & AdditionalContentProps
 
 const GenericButton: React.FunctionComponent<Props> = props => {
   return (

--- a/draft-packages/button/KaizenDraft/Button/styles.scss
+++ b/draft-packages/button/KaizenDraft/Button/styles.scss
@@ -365,11 +365,11 @@ $caButton-verticalPaddingForm: calc(
   }
 
   &:not(:first-child) {
-    @include ca-margin($start: 0.5em);
+    @include ca-margin($start: 0.5em, $end: null);
   }
 
   &:not(:last-child) {
-    @include ca-margin($end: 0.5em);
+    @include ca-margin($end: 0.5em, $start: null);
   }
 }
 

--- a/draft-packages/stories/Button.stories.tsx
+++ b/draft-packages/stories/Button.stories.tsx
@@ -316,7 +316,7 @@ export const DefaultFilterDrawerButton = () => {
   return (
     <FilterDrawerButton
       labelText="Filter"
-      numFiltersEnabled={3}
+      numberOfFiltersEnabled={3}
       onClick={_ => null}
       onMouseDown={_ => null}
     />
@@ -332,7 +332,7 @@ export const ReversedFilterDrawerButton = () => {
     <FilterDrawerButton
       labelText="Filter"
       reversed={true}
-      numFiltersEnabled={3}
+      numberOfFiltersEnabled={3}
       onClick={_ => null}
       onMouseDown={_ => null}
     />

--- a/draft-packages/stories/Button.stories.tsx
+++ b/draft-packages/stories/Button.stories.tsx
@@ -1,9 +1,12 @@
+import * as colorTokens from "@kaizen/design-tokens/tokens/color.json"
 import { Button } from "../button"
 const configureIcon = require("@kaizen/component-library/icons/configure.icon.svg")
   .default
-import * as colorTokens from "@kaizen/design-tokens/tokens/color.json"
+const guidanceIcon = require("@kaizen/component-library/icons/guidance.icon.svg")
+  .default
+import { Badge } from "@kaizen/draft-badge"
 import { action } from "@storybook/addon-actions"
-import * as React from "react"
+import React, { useState } from "react"
 
 export default {
   title: "Button (Zen) (React)",
@@ -310,3 +313,52 @@ export const MultipleButtons = () => (
     <Button label="Exit" automationId="demo-button-2" />
   </div>
 )
+
+export const AdditionalContent = () => {
+  const CounterButton = () => {
+    const [counter, setCounter] = useState(1)
+
+    const increaseCounter = () => setCounter(counter + 1)
+
+    return (
+      <div>
+        <Button
+          label="Count"
+          automationId="demo-button-1"
+          additionalContent={<Badge variant="active">{String(counter)}</Badge>}
+          onClick={() => increaseCounter()}
+        />
+      </div>
+    )
+  }
+  return <CounterButton />
+}
+
+AdditionalContent.story = {
+  name: "Default + Additional Content (usage example)",
+}
+
+export const IconWithAdditionalContent = () => {
+  const CounterButton = () => {
+    const [counter, setCounter] = useState(1)
+
+    const increaseCounter = () => setCounter(counter + 1)
+
+    return (
+      <div>
+        <Button
+          label="New Idea"
+          automationId="demo-button-1"
+          additionalContent={<Badge variant="active">{String(counter)}</Badge>}
+          onClick={() => increaseCounter()}
+          icon={guidanceIcon}
+        />
+      </div>
+    )
+  }
+  return <CounterButton />
+}
+
+IconWithAdditionalContent.story = {
+  name: "Default + Icon + Additional Content (usage example)",
+}

--- a/draft-packages/stories/Button.stories.tsx
+++ b/draft-packages/stories/Button.stories.tsx
@@ -1,12 +1,10 @@
 import * as colorTokens from "@kaizen/design-tokens/tokens/color.json"
 import { Button } from "../button"
+import { FilterDrawerButton } from "../button/KaizenDraft/Button/FilterDrawerButton"
 const configureIcon = require("@kaizen/component-library/icons/configure.icon.svg")
   .default
-const guidanceIcon = require("@kaizen/component-library/icons/guidance.icon.svg")
-  .default
-import { Badge } from "@kaizen/draft-badge"
 import { action } from "@storybook/addon-actions"
-import React, { useState } from "react"
+import React from "react"
 
 export default {
   title: "Button (Zen) (React)",
@@ -314,51 +312,42 @@ export const MultipleButtons = () => (
   </div>
 )
 
-export const AdditionalContent = () => {
-  const CounterButton = () => {
-    const [counter, setCounter] = useState(1)
-
-    const increaseCounter = () => setCounter(counter + 1)
-
-    return (
-      <div>
-        <Button
-          label="Count"
-          automationId="demo-button-1"
-          additionalContent={<Badge variant="active">{String(counter)}</Badge>}
-          onClick={() => increaseCounter()}
-        />
-      </div>
-    )
-  }
-  return <CounterButton />
+export const DefaultFilterDrawerButton = () => {
+  return (
+    <FilterDrawerButton
+      labelText="Filter"
+      numFiltersEnabled={3}
+      onClick={_ => null}
+      onMouseDown={_ => null}
+    />
+  )
 }
 
-AdditionalContent.story = {
-  name: "Default + Additional Content (usage example)",
+DefaultFilterDrawerButton.story = {
+  name: "FilterDrawerButton, default",
 }
 
-export const IconWithAdditionalContent = () => {
-  const CounterButton = () => {
-    const [counter, setCounter] = useState(1)
-
-    const increaseCounter = () => setCounter(counter + 1)
-
-    return (
-      <div>
-        <Button
-          label="New Idea"
-          automationId="demo-button-1"
-          additionalContent={<Badge variant="active">{String(counter)}</Badge>}
-          onClick={() => increaseCounter()}
-          icon={guidanceIcon}
-        />
-      </div>
-    )
-  }
-  return <CounterButton />
+export const ReversedFilterDrawerButton = () => {
+  return (
+    <FilterDrawerButton
+      labelText="Filter"
+      reversed={true}
+      numFiltersEnabled={3}
+      onClick={_ => null}
+      onMouseDown={_ => null}
+    />
+  )
 }
 
-IconWithAdditionalContent.story = {
-  name: "Default + Icon + Additional Content (usage example)",
+ReversedFilterDrawerButton.story = {
+  name: "FilterDrawerButton, reversed",
+  parameters: {
+    backgrounds: [
+      {
+        name: "Wisteria 700",
+        value: colorTokens.kz.color.wisteria[700],
+        default: true,
+      },
+    ],
+  },
 }


### PR DESCRIPTION
## The main change: the additionalContent prop for Generic Button (React)

Adds an optional `additionalContent?: React.ReactNode` prop to `GenericButton`. Can be any React node. Additional content appears to right of the button. Note that this can only be applied to GenericButton, not `Button` or `IconButton`. What this means is that you can't add additionalContent to Button, or IconButton, but you can create a new button type that can take the additionalContent prop. The motivation for this is to be able to add a `Badge` to the `FilterDrawerButton`, which will be used in the `Filter Drawer` component (currently a separate PR that's waiting on this one).

This enables us to create a variant of Button, without needing to change the Button or IconButton APIs (the existing "concrete" buttons). This does require one **slightly controversional change**: `GenericProps` and `LabelProps` are now publicly exported, so consumer may construct new button components which we don't really want. That being said, there was nothing stopping people just copying the props, or using the `any` type, so 🤷‍♂️ .

Other approaches explored:
- Completely fork `Button` and `GenericButton` to make `FilterDrawerButton` ❌  (too much code duplication and too hard to maintain)
- add `additionalContent` to Button (too much flexibility - we don't want people putting random content inside the Button component)  ❌ 
- add a `badge` prop to Button (still too much flexibility, and needing to deal with unwanted prop combinations like `iconPosition="end"`) ❌ 
- add a `variant="filter-drawer-button"` prop to Button. It does not seem worth adding a lot of extra complexity to Button just to support a variant that's used internally inside one component and shouldn't be used anywhere else. ❌ 


## The FilterDrawerButton component

This PR adds a FilterDrawerButton component to `@kaizen/draft-button` (and adds stories) but the only reason it's in this PR, is to dogfood the change to the GenericButton API (to make sure the types are correct and that it works). I intend to move it out of this package into the future `@kaizen/draft-filter-drawer` package. I could have done this all inside the Filter Drawer PR to avoid the move, but that's already a very large PR, and this is fairly pretty big API design decision, so I wanted this PR to be small.

https://dev.cultureamp.design/dst/button-additional-content/storybook-static/?path=/story/button-zen-react--reversed-filter-drawer-button

![image](https://user-images.githubusercontent.com/702885/86757345-691ed380-c086-11ea-8974-983840609a7e.png)


### Chromatic
https://www.chromatic.com/build?appId=5e12c297b9d9020020789ca3&number=192
You should see that this hasn't introduced any regressions to `Button` or `IconButton`