### PR TITLE
fix: add min-width and text-align:center to Badge

### DIFF
--- a/draft-packages/badge/KaizenDraft/Badge/styles.module.scss
+++ b/draft-packages/badge/KaizenDraft/Badge/styles.module.scss
@@ -16,6 +16,8 @@ $small: $ca-grid;
   letter-spacing: $kz-typography-paragraph-extra-small-bold-letter-spacing;
   line-height: $kz-typography-paragraph-extra-small-bold-line-height;
   padding: 1px $kz-spacing-xs;
+  min-width: 8px;
+  text-align: center;
 }
 
 .default {

--- a/draft-packages/stories/Badge.stories.tsx
+++ b/draft-packages/stories/Badge.stories.tsx
@@ -13,7 +13,7 @@ DefaultStory.story = {
   name: "Default (Kaizen Site Demo)",
 }
 
-export const Active = () => <Badge variant="active">3</Badge>
+export const Active = () => <Badge variant="active">1</Badge>
 
 Active.story = {
   name: "Active",


### PR DESCRIPTION
This stops the badge going narrower than a perfect circle when the content is narrow (a "1" for example)