### PR TITLE
fix: Ensure headers meet WCAG contrast

### DIFF
--- a/draft-packages/modal/KaizenDraft/Modal/Presets/ConfirmationModal.scss
+++ b/draft-packages/modal/KaizenDraft/Modal/Presets/ConfirmationModal.scss
@@ -25,7 +25,7 @@
 }
 
 .positiveHeader {
-  background-color: $kz-color-seedling-400;
+  background-color: $kz-color-seedling-500;
 
   @include ca-media-tablet-and-up {
     background-image: url("../backgrounds/brush-positive.png");
@@ -44,7 +44,7 @@
 }
 
 .negativeHeader {
-  background-color: $kz-color-coral-400;
+  background-color: $kz-color-coral-500;
 
   @include ca-media-tablet-and-up {
     background-image: url("../backgrounds/brush-negative.png");


### PR DESCRIPTION
Some of the header colours in the ConfirmationModal do not meet WCAG contrast requirements. This nudges them up a shade to ensure they do.

The modal headers are intended to be uplifted in the not-too-distant-future to these colours anyway, but good to have them accessible in the interim.