### PR TITLE
fix: Use bool for TitleBlockZen "primary" btn prop

### DIFF
--- a/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/TitleBlockZen.tsx
+++ b/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/TitleBlockZen.tsx
@@ -78,7 +78,7 @@ export type MenuGroup = {
  */
 export type PrimaryActionProps =
   | MenuGroup
-  | (ButtonWithOnClickOrHref & { primary: true })
+  | (ButtonWithOnClickOrHref & { primary: boolean })
 
 /**
  * ### SecondaryActionsProps


### PR DESCRIPTION
I had previously attempted to force a value of `true` for the `primary` prop when the consumer passes in a button as the `primaryAction` of TitleBlockZen:
```
export type PrimaryActionProps =
  | MenuGroup
  | (ButtonWithOnClickOrHref & { primary: true })
```
However TS does not work this way – it treats `true` as a _type_ rather than a value, leading to weird issues on the consumer side, such as this:
![2020-07-03 11 41 40](https://user-images.githubusercontent.com/6406263/86427003-79ece380-bd2c-11ea-9c4e-4cffcc746249.gif)


It now simply uses a `boolean` type, which can be false, but does its job of forcing the consumer to make a conscious decision about whether or not the button is a Primary one, which was the original intention.
```
export type PrimaryActionProps =
  | MenuGroup
  | (ButtonWithOnClickOrHref & { primary: boolean })
```