### PR TITLE
feat: add dropdownWidth prop to Menu

### DIFF
--- a/draft-packages/menu/KaizenDraft/Menu/Menu.tsx
+++ b/draft-packages/menu/KaizenDraft/Menu/Menu.tsx
@@ -5,10 +5,33 @@ import MenuDropdown from "./MenuDropdown"
 const styles = require("./styles.scss")
 
 export type GenericMenuProps = {
+  /**
+   * Whether the menu is to be used on the left or right
+   * side of the viewport. If left, the left of the dropdown
+   * is aligned to the left of the button (and vice versa)
+   * @default "left"
+   */
   align?: "left" | "right"
+
+  /**
+   * The width of the dropdown.
+   * "default": a fixed width of 248px
+   * "contain": contain the children's width (will be same width as children)
+   * @default "default"
+   */
   dropdownWidth?: "default" | "contain"
+
+  /**
+   * The initial state of the dropdown. Once initalised, further changes to this
+   * prop will not have any affect, as the state is handled internally to the component.
+   * @default: false
+   */
   menuVisible?: boolean
   automationId?: string
+
+  /**
+   * The content to appear inside the dropdown when it is open
+   */
   children: React.ReactNode
 }
 

--- a/draft-packages/menu/KaizenDraft/Menu/Menu.tsx
+++ b/draft-packages/menu/KaizenDraft/Menu/Menu.tsx
@@ -6,6 +6,7 @@ const styles = require("./styles.scss")
 
 export type GenericMenuProps = {
   align?: "left" | "right"
+  dropdownWidth?: "default" | "contain"
   menuVisible?: boolean
   automationId?: string
   children: React.ReactNode
@@ -20,7 +21,11 @@ export type MenuProps = GenericMenuProps & StatefulMenuProps
 type Menu = React.FunctionComponent<MenuProps>
 
 const Menu: Menu = props => {
-  const { align = "left", menuVisible = false } = props
+  const {
+    align = "left",
+    dropdownWidth = "default",
+    menuVisible = false,
+  } = props
 
   const dropdownButtonContainer: React.RefObject<HTMLDivElement> = useRef(null)
 
@@ -65,6 +70,7 @@ export const render = (props: GenericMenuProps & RenderProps) => {
       position={getPosition(props.dropdownButtonContainer)}
       align={props.align}
       hideMenuDropdown={props.hideMenuDropdown}
+      width={props.dropdownWidth}
     >
       {props.children}
     </MenuDropdown>

--- a/draft-packages/menu/KaizenDraft/Menu/MenuDropdown.tsx
+++ b/draft-packages/menu/KaizenDraft/Menu/MenuDropdown.tsx
@@ -12,6 +12,7 @@ type MenuDropdownProps = {
     right: number
   } | null
   align?: "left" | "right"
+  width?: "default" | "contain"
 }
 
 export default class MenuDropdown extends React.Component<MenuDropdownProps> {
@@ -62,11 +63,17 @@ export default class MenuDropdown extends React.Component<MenuDropdownProps> {
   }
 
   render(): JSX.Element {
-    const { hideMenuDropdown, children, align = "left" } = this.props
+    const {
+      hideMenuDropdown,
+      children,
+      align = "left",
+      width = "default",
+    } = this.props
 
     return (
       <div
         className={classnames(styles.menuContainer, {
+          [styles.defaultWidth]: width == "default",
           [styles.alignRight]: align == "right",
         })}
         ref={this.menu}

--- a/draft-packages/menu/KaizenDraft/Menu/styles.scss
+++ b/draft-packages/menu/KaizenDraft/Menu/styles.scss
@@ -14,14 +14,18 @@ $menu-container-width: 248px;
 .menuContainer {
   margin-top: $kz-spacing-xs;
   position: absolute;
-  width: $menu-container-width;
   z-index: $ca-z-index-dropdown;
   left: 0;
+  width: auto;
 
   [dir="rtl"] & {
     left: auto;
     right: 0;
   }
+}
+
+.defaultWidth {
+  width: $menu-container-width;
 }
 
 .alignRight {

--- a/draft-packages/stories/Menu.stories.tsx
+++ b/draft-packages/stories/Menu.stories.tsx
@@ -238,3 +238,22 @@ export const DefaultStatelessMenu = () => {
 DefaultStatelessMenu.story = {
   name: "StatelessMenu (example usage)",
 }
+
+export const DropdownWidthContain = () => (
+  <StoryWrapper>
+    <Menu
+      button={<Button label="Label" icon={chevronDown} iconPosition="end" />}
+      dropdownWidth="contain"
+    >
+      <MenuContent>
+        <div style={{ width: "500px" }}>
+          The dropdown is as wide as this 500px div
+        </div>
+      </MenuContent>
+    </Menu>
+  </StoryWrapper>
+)
+
+DropdownWidthContain.story = {
+  name: 'Label and Icon (dropdownWidth="contain")',
+}


### PR DESCRIPTION
## A new `dropdownWidth` prop for the `Menu` component
`dropdownWidth="default"` (the default: fixed width at 248px, this is a non-breaking change)
https://dev.cultureamp.design/dst/menu-dropdownwidth-prop/storybook-static/?path=/story/menu-react--default-kebab
![image](https://user-images.githubusercontent.com/702885/86437588-27b9bb80-bd48-11ea-83bd-ecb3f70932eb.png)

`dropdownWidth="contain"` (optional)
https://dev.cultureamp.design/dst/menu-dropdownwidth-prop/storybook-static/?path=/story/menu-react--dropdown-width-contain
![image](https://user-images.githubusercontent.com/702885/86437628-3d2ee580-bd48-11ea-8046-39ad0be4e96e.png)

**I also added some JSDocs to the Menu props while I was at it**
