### PR TITLE
fix: Make TitleBlockZen hamburger render only when handler is provided

### DIFF
--- a/draft-packages/stories/TitleBlockZen.stories.tsx
+++ b/draft-packages/stories/TitleBlockZen.stories.tsx
@@ -80,6 +80,9 @@ export const Default = () => (
         icon: starIcon,
       },
     ]}
+    handleHamburgerClick={() => {
+      alert("Hamburger clicked")
+    }}
     breadcrumb={{
       path: "#",
       text: "Back to home",
@@ -131,6 +134,9 @@ export const DefaultWithMenuButton = () => (
       reversed: true,
     }}
     secondaryActions={SECONDARY_ACTIONS}
+    handleHamburgerClick={() => {
+      alert("Hamburger clicked")
+    }}
     breadcrumb={{
       path: "#",
       text: "Back to home",
@@ -162,6 +168,9 @@ export const AdminVariant = () => (
     primaryAction={{ label: "Primary link", primary: true, href: "#" }}
     defaultAction={{ label: "Default link", href: "#" }}
     secondaryActions={SECONDARY_ACTIONS}
+    handleHamburgerClick={() => {
+      alert("Hamburger clicked")
+    }}
     breadcrumb={{
       path: "#",
       text: "Back to home",
@@ -182,6 +191,9 @@ export const AdminVariantWithNavTabs = () => (
     primaryAction={{ label: "Primary link", primary: true, href: "#" }}
     defaultAction={{ label: "Default link", href: "#" }}
     secondaryActions={SECONDARY_ACTIONS}
+    handleHamburgerClick={() => {
+      alert("Hamburger clicked")
+    }}
     breadcrumb={{
       path: "#",
       text: "Back to home",
@@ -229,6 +241,9 @@ export const EducationVariant = () => (
         icon: starIcon,
       },
     ]}
+    handleHamburgerClick={() => {
+      alert("Hamburger clicked")
+    }}
     breadcrumb={{
       path: "#",
       text: "Back to home",
@@ -261,6 +276,9 @@ export const Engagement = () => (
       href: "#",
     }}
     secondaryActions={SECONDARY_ACTIONS}
+    handleHamburgerClick={() => {
+      alert("Hamburger clicked")
+    }}
     breadcrumb={{
       path: "#",
       text: "Back to home",
@@ -319,6 +337,9 @@ export const Performance = () => (
         icon: starIcon,
       },
     ]}
+    handleHamburgerClick={() => {
+      alert("Hamburger clicked")
+    }}
     breadcrumb={{
       path: "#",
       text: "Back to home",
@@ -381,6 +402,9 @@ export const LongLabels = () => (
         icon: starIcon,
       },
     ]}
+    handleHamburgerClick={() => {
+      alert("Hamburger clicked")
+    }}
     breadcrumb={{
       path: "#",
       text: "Drehen Sie sich um und kehren Sie zur Startseite zurück",
@@ -447,6 +471,9 @@ export const DefaultWithContent = () => (
         href: "#",
       }}
       secondaryActions={SECONDARY_ACTIONS}
+      handleHamburgerClick={() => {
+        alert("Hamburger clicked")
+      }}
       breadcrumb={{
         path: "#",
         text: "Back to home",
@@ -565,6 +592,9 @@ export const DefaultNoSecondary = () => (
       reversed: true,
       href: "#",
     }}
+    handleHamburgerClick={() => {
+      alert("Hamburger clicked")
+    }}
     breadcrumb={{
       path: "#",
       text: "Back to home",
@@ -597,6 +627,9 @@ export const DefaultOnlyPrimary = () => (
       reversed: true,
       primary: true,
       href: "#",
+    }}
+    handleHamburgerClick={() => {
+      alert("Hamburger clicked")
     }}
     breadcrumb={{
       path: "#",

--- a/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/TitleBlockZen.scss
+++ b/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/TitleBlockZen.scss
@@ -255,6 +255,10 @@ $tab-container-height-small: $ca-grid * 2.5;
   @include ca-margin($end: $ca-grid * 2/3);
   color: $kz-color-white;
 
+  &:hover {
+    cursor: pointer;
+  }
+
   .educationVariant &,
   .adminVariant & {
     color: $kz-color-wisteria-800;

--- a/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/TitleBlockZen.tsx
+++ b/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/TitleBlockZen.tsx
@@ -385,16 +385,18 @@ const TitleBlockZen = ({
               <div className={styles.titleAndAdjacent}>
                 {breadcrumb && renderBreadcrumb(breadcrumb, textDirection)}
                 <div className={styles.titleAndAdjacentNotBreadcrumb}>
-                  <div
-                    className={styles.hamburger}
-                    onClick={handleHamburgerClick}
-                  >
-                    <Icon
-                      icon={hamburgerIcon}
-                      role="presentation"
-                      title="Open menu"
-                    />
-                  </div>
+                  {handleHamburgerClick && (
+                    <div
+                      className={styles.hamburger}
+                      onClick={handleHamburgerClick}
+                    >
+                      <Icon
+                        icon={hamburgerIcon}
+                        role="presentation"
+                        title="Open menu"
+                      />
+                    </div>
+                  )}
                   {avatar && renderAvatar(avatar)}
                   <div className={styles.titleAndSubtitle}>
                     <div className={styles.titleAndSubtitleInner}>


### PR DESCRIPTION
- Consumer must now provide a `handleHamburgerClick` prop for the hamburger to render
- I updated all TitleBlockZen stories to provide that prop (it's the intended look)
- I also added a `cursor: pointer` to the hover state in case the hamburger is ever used on desktop (it only shows at viewport sizes under 1080px).