### PR TITLE
ci: Run yarn before running Storybook

### DIFF
--- a/check-install.sh
+++ b/check-install.sh
@@ -1,6 +1,0 @@
-#!/bin/sh
-yarn check --integrity
-
-if [[ $? -eq 1 ]]; then
-  echo "\nERROR - Missing packages. Run yarn install before running storybook"
-fi

--- a/check-install.sh
+++ b/check-install.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+yarn check --integrity
+
+if [[ $? -eq 1 ]]; then
+  echo "\nERROR - Missing packages. Run yarn install before running storybook"
+fi

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   },
   "scripts": {
     "ts-node": "TS_NODE_TRANSPILE_ONLY=true ts-node --project storybook/tsconfig.storybook.json",
-    "storybook": "yarn ts-node node_modules/.bin/start-storybook -c storybook",
+    "install-check": "sh check-install.sh",
+    "storybook": "yarn install-check && yarn ts-node node_modules/.bin/start-storybook -c storybook",
     "storybook:build": "yarn ts-node node_modules/.bin/build-storybook -c storybook -o storybook/public",
     "gatsby": "yarn workspace site gatsby",
     "tslint": "tslint --project .",

--- a/package.json
+++ b/package.json
@@ -11,8 +11,7 @@
   },
   "scripts": {
     "ts-node": "TS_NODE_TRANSPILE_ONLY=true ts-node --project storybook/tsconfig.storybook.json",
-    "install-check": "sh check-install.sh",
-    "storybook": "yarn install-check && yarn ts-node node_modules/.bin/start-storybook -c storybook",
+    "storybook": "yarn install && yarn ts-node node_modules/.bin/start-storybook -c storybook",
     "storybook:build": "yarn ts-node node_modules/.bin/build-storybook -c storybook -o storybook/public",
     "gatsby": "yarn workspace site gatsby",
     "tslint": "tslint --project .",


### PR DESCRIPTION
## About 
We've had a query about storybook not working locally, which is a result of developers not running `yarn install` after pulling a branch. This PR adds `yarn install` to the `storybook` script. 

I was initially worried this would add extra time to run storybook, but in real terms it only adds an additional ~1-2s to the script (assuming the branch is up to date):

```
$ time yarn
yarn install v1.22.4
[1/5] 🔍  Validating package.json...
[2/5] 🔍  Resolving packages...
success Already up-to-date.
✨  Done in 0.97s.

real    0m1.282s
user    0m1.589s
```

In my first attempt I wrote a bash script that runs `yarn check --integrity`, [but that will be removed in the near future,](https://github.com/yarnpkg/rfcs/pull/106) and takes a little bit of time.