### PR TITLE
feat: add `id` prop to MenuDropdown and Menu

### DIFF
--- a/draft-packages/menu/KaizenDraft/Menu/Menu.tsx
+++ b/draft-packages/menu/KaizenDraft/Menu/Menu.tsx
@@ -28,6 +28,7 @@ export type GenericMenuProps = {
    */
   menuVisible?: boolean
   automationId?: string
+  dropdownId?: string
 
   /**
    * The content to appear inside the dropdown when it is open
@@ -94,6 +95,7 @@ export const render = (props: GenericMenuProps & RenderProps) => {
       align={props.align}
       hideMenuDropdown={props.hideMenuDropdown}
       width={props.dropdownWidth}
+      id={props.dropdownId}
     >
       {props.children}
     </MenuDropdown>

--- a/draft-packages/menu/KaizenDraft/Menu/MenuDropdown.tsx
+++ b/draft-packages/menu/KaizenDraft/Menu/MenuDropdown.tsx
@@ -4,6 +4,7 @@ import * as React from "react"
 const styles = require("./styles.scss")
 
 type MenuDropdownProps = {
+  id?: string
   hideMenuDropdown: () => void
   position?: {
     top: number
@@ -72,6 +73,7 @@ export default class MenuDropdown extends React.Component<MenuDropdownProps> {
 
     return (
       <div
+        id={this.props.id}
         className={classnames(styles.menuContainer, {
           [styles.defaultWidth]: width == "default",
           [styles.alignRight]: align == "right",

--- a/draft-packages/stories/Menu.stories.tsx
+++ b/draft-packages/stories/Menu.stories.tsx
@@ -86,6 +86,7 @@ export const LabelAndIcon = () => (
   <StoryWrapper>
     <Menu
       button={<Button label="Label" icon={chevronDown} iconPosition="end" />}
+      dropdownId="dropdown"
     >
       <MenuInstance />
     </Menu>


### PR DESCRIPTION
Adds the ability to pass a `dropdownId` prop to Menu, which is used by the internal `MenuDropdown` component.
![image](https://user-images.githubusercontent.com/702885/86670423-f424ad00-c037-11ea-978f-40d07d0e37bb.png)
