### PR TITLE
docs: Remove add-alpha from color guidelines

### DIFF
--- a/site/docs/guidelines/color.mdx
+++ b/site/docs/guidelines/color.mdx
@@ -4,8 +4,8 @@ navTitle: Color
 summaryParagraph: Our color palette is built with our core principles and guidelines as its foundation. We are committed to complying with WCAG AA standard contrast ratios.
 tags: ["Palette"]
 needToKnow:
-  - Use official color palette colors, variables and helpers (add-alpha) for all color CSS declarations. Never hard-code a color without a variable.
-  - Use add-alpha (to add transparency) when the color needs to blend with different backgrounds.
+  - Use official color palette colors and variables for all color CSS declarations. Never hard-code a color without a variable.
+  - Use rgba() to add transparency when the color needs to blend with different backgrounds.
 ---
 
 import WhenToUseAndWhenNotToUse from "docs-components/WhenToUseAndWhenNotToUse"
@@ -71,7 +71,9 @@ To learn more, Culture Amp employees can visit the [Color page in Figma](https:/
 ## To keep in mind
 
 - Contrast and accessibility is crucial. To [consider everyone](/language/voiceandtone/), we use color contrast ratios that adhered to [WCAG 2.0 AA](https://www.w3.org/TR/WCAG20/#visual-audio-contrast-contrast) guidelines.
-- Use our official color palette variables and helpers (`add-alpha`) for all color CSS declarations.
+- Use our official color palette variables for all color CSS declarations.
+- Use `rgba()` to add transparency to a color, e.g. `rgba($kz-color-wisteria-800, 0.8)`.
+- Please avoid using the deprecated custom helper `add-alpha()`, as it requires importing a deprecated module and will not break the build when it is missing.
 - Be mindful of color psychology associations and cultural values (such as red symbolizing danger versus good luck).
 
 ### Links


### PR DESCRIPTION
## Changes

• Remove the advice to use the custom helper `add-alpha()` from the Kaizen SIte color guidelines.
• Recommend users use the built-in `rgba()` instead.

## Background

Until now we have unofficially been following a policy of recommending that users do not use `add-alpha()` for transparency, and instead use the built-in function `rgba()`.

But since this is not set in stone anywhere, this is confusing, and is made worse by the fact that the Kaizen Site is encouraging the opposite.

## Why `add-alpha` is bad

Firstly, `add-alpha()` was always a redundant function. It does the same thing as `rgba()`, but with a slightly different API – a percentage instead of a decimal for the alpha value. I wrote it when I created `add-tint()` and `add-shade()` because I thought the consistency would be more intuitive to users if all 3 functions operated the same way. Now that we no longer use `add-tint()` and `add-shade()`, this already flimsy argument for `add-alpha()` is no longer valid.

Secondly and more importantly, **custom Sass functions do not break the build when they are missing**. This led to the following bug in production, when we did a sweep of import line updates in Murmur and then removed custom Sass functions that were being depended on via two layers of imports:

https://github.com/cultureamp/murmur/pull/12093

`rgba()` is built in to Sass, and does not require any imports, thus making our CSS less brittle. It isn't a perfect solution, but it will lead to fewer bugs in production than `add-alpha()`.

Removing `add-alpha()` completely from the codebase is also a step towards removing imports of the deprecated `color.scss` from both the component library and deprecated-helpers package, since many files in consuming repos are importing those solely for the purpose of accessing `add-alpha()`.