### PR TITLE
docs: update UI guidance for secondary selects

### DIFF
--- a/draft-packages/select/KaizenDraft/Select/README.mdx
+++ b/draft-packages/select/KaizenDraft/Select/README.mdx
@@ -21,10 +21,6 @@ import WhenNotToUse from "docs-components/WhenNotToUse"
 
 <iframe style="border: none;" width="744" height="450" src="https://www.figma.com/embed?embed_host=share&url=https%3A%2F%2Fwww.figma.com%2Ffile%2Fe3TyAOZKfLg9cA01Iy1Mgm%2FKaizen-Site-embed%3Fnode-id%3D205%253A13065" allowfullscreen></iframe>
 
-<iframe style="border: none;" width="744" height="450" src="https://www.figma.com/embed?embed_host=share&url=https%3A%2F%2Fwww.figma.com%2Ffile%2Fe3TyAOZKfLg9cA01Iy1Mgm%2FKaizen-Site-embed%3Fnode-id%3D205%253A12068" allowfullscreen></iframe>
-
-<iframe style="border: none;" width="744" height="450" src="https://www.figma.com/embed?embed_host=share&url=https%3A%2F%2Fwww.figma.com%2Ffile%2Fe3TyAOZKfLg9cA01Iy1Mgm%2FKaizen-Site-embed%3Fnode-id%3D205%253A13171" allowfullscreen></iframe>
-
 ### Examples
 
 <iframe style="border: none;" width="744" height="450" src="https://www.figma.com/embed?embed_host=share&url=https%3A%2F%2Fwww.figma.com%2Ffile%2Fe3TyAOZKfLg9cA01Iy1Mgm%2FKaizen-Site-embed%3Fnode-id%3D1412%253A373" allowfullscreen></iframe>
@@ -32,9 +28,8 @@ import WhenNotToUse from "docs-components/WhenNotToUse"
 
 ## Options
 
-*   Variant:
-    *   Single-select.
-    *   Multi-select.
+*   Single-select or multi-select.
+*   Default or secondary select.
 *   Search:
     *   With search. See also: [Search Field](/components/search-field).
     *   Without search.
@@ -54,7 +49,7 @@ A single-select lets the user choose one option from 4 or more items. A multi-se
     *   If there's more than 10 options, provide another method of accessing the options such as an autocomplete search or using smart defaults by surfacing recommended options.
     *   If there's more than 5 options, consider showing options in alphabetical order or other predictable ordering for easy scanning.
 *   Style option:
-    *   We have alternative style for the input part of the single-select that is less prominent, currently called “Select (Text)” in the UI Kit
+    *   Use a secondary select for less prominence and where there's limited space.
 *   Search:
     *   There’s an option to turn on or off search in the input part.
 *   Good defaults:


### PR DESCRIPTION
This removes excess Figma embeds so that secondary selects are shown on
the main frames as the default selects.