### PR TITLE
fix: Fix subtitle and tag bug in Title Block

### DIFF
--- a/draft-packages/stories/TitleBlockZen.stories.tsx
+++ b/draft-packages/stories/TitleBlockZen.stories.tsx
@@ -310,6 +310,8 @@ Engagement.story = {
 export const Performance = () => (
   <TitleBlockZen
     title="Blanca Wheeler"
+    subtitle="Director of Stuff and Things"
+    avatar={<img alt="avatar image" src={assetUrl("site/empty-state.png")} />}
     primaryAction={{
       href: "#",
       label: "Request feedback",
@@ -347,7 +349,6 @@ export const Performance = () => (
         alert("breadcrumb clicked!")
       },
     }}
-    subtitle="Director of Stuff and Things"
     navigationTabs={[
       <NavigationTab text="Feedback" href="#" active />,
       <NavigationTab

--- a/draft-packages/stories/TitleBlockZen.stories.tsx
+++ b/draft-packages/stories/TitleBlockZen.stories.tsx
@@ -309,7 +309,7 @@ Engagement.story = {
 
 export const Performance = () => (
   <TitleBlockZen
-    title="Blanca Wheeler Wheeler Wheeler Wheeler Wheeler Wheeler"
+    title="Blanca Wheeler"
     primaryAction={{
       href: "#",
       label: "Request feedback",
@@ -347,7 +347,6 @@ export const Performance = () => (
         alert("breadcrumb clicked!")
       },
     }}
-    avatar={<img alt="avatar image" src={assetUrl("site/empty-state.png")} />}
     subtitle="Director of Stuff and Things"
     navigationTabs={[
       <NavigationTab text="Feedback" href="#" active />,
@@ -372,6 +371,7 @@ Performance.story = {
 export const LongLabels = () => (
   <TitleBlockZen
     title="Wolfeschlegelsteino Hausenbergerdorffsch Hausenbergerdorffsch"
+    surveyStatus={{ text: "Live", status: "live" }}
     primaryAction={{
       label: "Feedback anfordern",
       reversed: true,

--- a/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/TitleBlockZen.scss
+++ b/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/TitleBlockZen.scss
@@ -101,7 +101,7 @@ $tab-container-height-small: $ca-grid * 2.5;
       max-width: 520px;
     }
 
-    @include title-block-medium-and-small {
+    @include title-block-under-1366 {
       max-width: 50vw;
     }
 
@@ -168,8 +168,8 @@ $tab-container-height-small: $ca-grid * 2.5;
     @include title-block-medium-and-small {
       transform: translateY($ca-grid / 2);
     }
-    }
   }
+}
 
 .titleTextOverride.titleTextOverride {
   white-space: nowrap;
@@ -497,6 +497,9 @@ $tab-container-height-small: $ca-grid * 2.5;
   display: flex;
   align-items: center;
   justify-content: flex-end;
+  flex-basis: 480px;
+  flex-grow: 1;
+  flex-shrink: 1;
 
   @include ca-margin($start: $ca-grid / 2);
 

--- a/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/TitleBlockZen.scss
+++ b/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/TitleBlockZen.scss
@@ -499,6 +499,8 @@ $tab-container-height-small: $ca-grid * 2.5;
 .mainActionsContainer {
   display: flex;
   align-items: center;
+  justify-content: flex-end;
+
   @include ca-margin($start: $ca-grid / 2);
 
   @include title-block-small {
@@ -509,9 +511,9 @@ $tab-container-height-small: $ca-grid * 2.5;
 .secondaryActionsContainer {
   display: flex;
   align-items: flex-start;
+  justify-content: flex-end;
   padding: ($ca-grid / 2) 0;
   @include ca-margin($start: $ca-grid * 1.5);
-  flex-shrink: 0;
 
   // To be removed eventually – the Dropdown does not
   // currently set its own color, and we want it

--- a/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/TitleBlockZen.scss
+++ b/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/TitleBlockZen.scss
@@ -399,6 +399,9 @@ $tab-container-height-small: $ca-grid * 2.5;
       transform: translateY(4px);
 
       .hasSubtitle & {
+        transform: translateY(-10px);
+      }
+      .hasSubtitle.hasLongTitle & {
         transform: translateY(-4px);
       }
     }

--- a/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/TitleBlockZen.scss
+++ b/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/TitleBlockZen.scss
@@ -227,16 +227,14 @@ $tab-container-height-small: $ca-grid * 2.5;
     max-width: 100%;
   }
 
-  @include title-block-under-1366 {
+  @media (min-width: $kz-layout-breakpoints-large) {
     display: block;
   }
 
-  @include title-block-medium-and-small {
-    display: none;
-  }
-
-  .hasSubtitle & {
-    transform: translateY(10px);
+  .hasSubtitle.hasAvatar & {
+    @include title-block-under-1366 {
+      transform: translateY(10px);
+    }
   }
 
   .hasLongTitle & {
@@ -389,16 +387,49 @@ $tab-container-height-small: $ca-grid * 2.5;
   .breadcrumb:focus + & {
     opacity: 0;
 
+    /* Unfortunately since the avatar, subtitle and length of the
+     * subtitle can all affect the height of the content area here,
+     * we have some fragile hacks to cover each combination.
+     * The subtitle needs to wrap if long, and is vertically centred
+     * instead of positioned along the same baseline as the title,
+     * which is what it does when short. This all adds to the complexity
+     * and we made a call to meet the design requirements under a
+     * deadline instead of exploring a less fragile solution.
+     * (A better solution might involve behaviour where this element that
+     * fades out retains its visual space à la `visibility: hidden`.)
+     */
     @include title-block-under-1645 {
       left: $breadcrumb-circle-width + 12px;
-      transform: translateY(2px);
       position: absolute;
+      transform: translateY(2px);
+
+      .hasAvatar & {
+        transform: translateY(0);
+      }
+
+      .hasSubtitle & {
+        transform: translateY(2px);
+      }
+
+      .hasAvatar.hasSubtitle & {
+        transform: translateY(0);
+      }
+
+      .hasSubtitle.hasLongTitle & {
+        transform: translateY(2px);
+      }
     }
 
     @include title-block-under-1366 {
       transform: translateY(4px);
 
+      .hasAvatar & {
+        transform: translateY(0);
+      }
       .hasSubtitle & {
+        transform: translateY(-10px);
+      }
+      .hasAvatar.hasSubtitle & {
         transform: translateY(-10px);
       }
       .hasSubtitle.hasLongTitle & {

--- a/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/TitleBlockZen.scss
+++ b/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/TitleBlockZen.scss
@@ -284,7 +284,7 @@ $tab-container-height-small: $ca-grid * 2.5;
   font-size: $kz-typography-paragraph-small-font-size;
   line-height: $kz-typography-paragraph-small-line-height;
   letter-spacing: $kz-typography-paragraph-small-letter-spacing;
-  width: 230px;
+  max-width: 230px;
 
   @include ca-margin($start: $ca-grid / 2);
 
@@ -292,7 +292,7 @@ $tab-container-height-small: $ca-grid * 2.5;
     white-space: nowrap;
     text-overflow: ellipsis;
     overflow: hidden;
-    width: auto;
+    max-width: none;
     margin: ($ca-grid / 5) 0;
   }
 }

--- a/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/TitleBlockZen.scss
+++ b/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/TitleBlockZen.scss
@@ -159,7 +159,6 @@ $tab-container-height-small: $ca-grid * 2.5;
       flex-direction: column;
       justify-content: space-between;
       transform: translateY($ca-grid / 3);
-      // max-width: 42vw;
 
       .hasLongTitle.hasLongSubtitle & {
         align-items: baseline;
@@ -167,15 +166,10 @@ $tab-container-height-small: $ca-grid * 2.5;
     }
 
     @include title-block-medium-and-small {
-      // max-width: 42vw;
       transform: translateY($ca-grid / 2);
     }
-
-    @include title-block-small {
-      // max-width: 88vw;
     }
   }
-}
 
 .titleTextOverride.titleTextOverride {
   white-space: nowrap;

--- a/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/TitleBlockZen.tsx
+++ b/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/TitleBlockZen.tsx
@@ -373,8 +373,8 @@ const TitleBlockZen = ({
           [styles.hasSubtitle]: Boolean(subtitle),
           [styles.educationVariant]: variant === "education",
           [styles.adminVariant]: variant === "admin",
-          [styles.hasLongTitle]: title.length >= 30,
-          [styles.hasLongSubtitle]: subtitle && subtitle.length >= 34,
+          [styles.hasLongTitle]: title && title.length >= 30,
+          [styles.hasLongSubtitle]: subtitle && subtitle.length >= 18,
           [styles.hasNavigationTabs]:
             navigationTabs && navigationTabs.length > 0,
         })}

--- a/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/TitleBlockZen.tsx
+++ b/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/TitleBlockZen.tsx
@@ -373,6 +373,7 @@ const TitleBlockZen = ({
           [styles.hasSubtitle]: Boolean(subtitle),
           [styles.educationVariant]: variant === "education",
           [styles.adminVariant]: variant === "admin",
+          [styles.hasAvatar]: Boolean(avatar),
           [styles.hasLongTitle]: title && title.length >= 30,
           [styles.hasLongSubtitle]: subtitle && subtitle.length >= 18,
           [styles.hasNavigationTabs]:


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/6406263/86764700-94f08800-c08b-11ea-8482-18b99f514904.png)

This PR resolves the issue where there is too much space between the subtitle and tag when both are used simultaneously.

It also makes some minor adjustments to the stories for the component.