### PR TITLE
fix: Add basic tests for TitleBlockZen

### DIFF
--- a/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/MainActions.tsx
+++ b/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/MainActions.tsx
@@ -34,12 +34,23 @@ const MainActions = ({
     const menuContent = (
       <MenuContent>
         {primaryAction.menuItems.map((item, idx) => (
-          <MenuItem {...item} key={`main-action-primary-${idx}`} />
+          <MenuItem
+            {...item}
+            key={`main-action-primary-menu-item-${idx}`}
+            automationId={`main-action-primary-menu-item-${idx}`}
+          />
         ))}
       </MenuContent>
     )
     items = [
-      ...(defaultAction ? [<Button {...defaultAction} />] : []),
+      ...(defaultAction
+        ? [
+            <Button
+              {...defaultAction}
+              automationId="title-block-default-action-button"
+            />,
+          ]
+        : []),
       ...(primaryAction
         ? [
             <Menu
@@ -51,6 +62,7 @@ const MainActions = ({
                   reversed={reversed}
                   icon={chevronDownIcon}
                   iconPosition="end"
+                  automationId="title-block-primary-action-button"
                 />
               }
             >
@@ -61,8 +73,22 @@ const MainActions = ({
     ]
   } else {
     items = [
-      ...(defaultAction ? [<Button {...defaultAction} />] : []),
-      ...(primaryAction ? [<Button {...primaryAction} />] : []),
+      ...(defaultAction
+        ? [
+            <Button
+              {...defaultAction}
+              automationId="title-block-default-action-button"
+            />,
+          ]
+        : []),
+      ...(primaryAction
+        ? [
+            <Button
+              {...primaryAction}
+              automationId="title-block-primary-action-button"
+            />,
+          ]
+        : []),
     ]
   }
 
@@ -76,7 +102,10 @@ const MainActions = ({
       >
         <MenuContent>
           {overflowMenuItems.map((menuItem, idx) => (
-            <MenuItem {...menuItem} key={`main-action-overflow-item-${idx}`} />
+            <MenuItem
+              {...menuItem}
+              key={`main-action-overflow-item-menu-item-${idx}`}
+            />
           ))}
         </MenuContent>
       </Menu>,

--- a/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/MobileActions.tsx
+++ b/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/MobileActions.tsx
@@ -344,6 +344,31 @@ const DrawerHandle = ({
       )
     }
   }
+  // if there are default/secondary actions but no primary action
+  if (defaultAction || secondaryActions || secondaryOverflowMenuItems) {
+    return (
+      <div
+        className={styles.mobileActionsTopRow}
+        data-testid="title-block-mobile-actions-drawer-handle"
+      >
+        <button
+          className={classnames(
+            styles.mobileActionsExpandButtonFullWidth,
+            styles.mobileActionsPrimaryLabel
+          )}
+          onClick={toggleDisplay}
+        >
+          {renderDrawerHandleLabel("Other actions")}
+          <div className={styles.mobileActionsChevronSquare}>
+            <Icon
+              icon={isOpen ? chevronDownIcon : chevronUpIcon}
+              role="presentation"
+            />
+          </div>
+        </button>
+      </div>
+    )
+  }
   return null
 }
 

--- a/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/MobileActions.tsx
+++ b/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/MobileActions.tsx
@@ -392,7 +392,9 @@ export default class MobileActions extends React.Component<MobileActionsProps> {
           toggleDisplay={this.toggleDisplay}
           isOpen={this.state.isOpen}
         />
-        {(defaultAction || secondaryActions) && (
+        {(defaultAction ||
+          secondaryActions ||
+          (primaryAction && isMenuGroupNotButton(primaryAction))) && (
           <div className={styles.mobileActionsMenuContainer}>
             <MenuContent>
               <DrawerMenuContent

--- a/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/MobileActions.tsx
+++ b/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/MobileActions.tsx
@@ -185,7 +185,12 @@ const renderDrawerHandleLabel = (
   if (drawerHandleLabelIconPosition === "end") {
     return (
       <>
-        <span className={styles.drawerHandleLabelText}>{label}</span>
+        <span
+          className={styles.drawerHandleLabelText}
+          data-testid="drawer-handle-lable-text"
+        >
+          {label}
+        </span>
         <>
           {icon && (
             <span className={styles.drawerHandleIcon}>
@@ -205,7 +210,12 @@ const renderDrawerHandleLabel = (
             </span>
           )}
         </>
-        <span className={styles.drawerHandleLabelText}>{label}</span>
+        <span
+          className={styles.drawerHandleLabelText}
+          data-testid="drawer-handle-lable-text"
+        >
+          {label}
+        </span>
       </>
     )
   }

--- a/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/MobileActions.tsx
+++ b/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/MobileActions.tsx
@@ -191,7 +191,7 @@ const renderDrawerHandleLabel = (
       <>
         <span
           className={styles.drawerHandleLabelText}
-          data-testid="drawer-handle-lable-text"
+          data-automation-id="drawer-handle-lable-text"
         >
           {label}
         </span>
@@ -216,7 +216,7 @@ const renderDrawerHandleLabel = (
         </>
         <span
           className={styles.drawerHandleLabelText}
-          data-testid="drawer-handle-lable-text"
+          data-automation-id="drawer-handle-lable-text"
         >
           {label}
         </span>
@@ -239,7 +239,7 @@ const ButtonOrLink = ({ action, children }: ButtonOrLinkProps) => {
           styles.mobileActionsPrimaryLabel,
           styles.mobileActionsPrimaryButton
         )}
-        data-testid="title-block-mobile-actions-primary-button"
+        data-automation-id="title-block-mobile-actions-primary-button"
       >
         {children}
       </button>
@@ -253,7 +253,7 @@ const ButtonOrLink = ({ action, children }: ButtonOrLinkProps) => {
           styles.mobileActionsPrimaryLabel,
           styles.mobileActionsPrimaryButton
         )}
-        data-testid="title-block-mobile-actions-primary-button"
+        data-automation-id="title-block-mobile-actions-primary-button"
       >
         {children}
       </a>
@@ -266,7 +266,7 @@ const ButtonOrLink = ({ action, children }: ButtonOrLinkProps) => {
         styles.mobileActionsPrimaryLabel,
         styles.mobileActionsPrimaryButton
       )}
-      data-testid="title-block-mobile-actions-primary-button"
+      data-automation-id="title-block-mobile-actions-primary-button"
     >
       {children}
     </button>
@@ -309,7 +309,7 @@ const DrawerHandle = ({
       return (
         <div
           className={styles.mobileActionsTopRow}
-          data-testid="title-block-mobile-actions-drawer-handle"
+          data-automation-id="title-block-mobile-actions-drawer-handle"
         >
           <button
             className={classnames(
@@ -333,7 +333,7 @@ const DrawerHandle = ({
       return (
         <div
           className={styles.mobileActionsTopRow}
-          data-testid="title-block-mobile-actions-drawer-handle"
+          data-automation-id="title-block-mobile-actions-drawer-handle"
         >
           {
             <ButtonOrLink action={getAction(primaryAction)}>
@@ -368,7 +368,7 @@ const DrawerHandle = ({
     return (
       <div
         className={styles.mobileActionsTopRow}
-        data-testid="title-block-mobile-actions-drawer-handle"
+        data-automation-id="title-block-mobile-actions-drawer-handle"
       >
         <button
           className={classnames(

--- a/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/MobileActions.tsx
+++ b/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/MobileActions.tsx
@@ -33,7 +33,8 @@ const renderPrimaryLinks = (primaryAction: PrimaryActionProps) => {
           action={item.action}
           label={item.label}
           icon={item.hasOwnProperty("icon") ? item.icon : undefined}
-          key={`primary-link-${idx}`}
+          key={`title-block-mobile-actions-primary-link-${idx}`}
+          automationId={`title-block-mobile-actions-primary-link-${idx}`}
         />
       ))
   }
@@ -45,7 +46,7 @@ const renderPrimaryActions = (primaryAction: PrimaryActionProps) => {
     primaryAction.menuItems.length > 0
   ) {
     return [
-      <MenuSeparator />,
+      <MenuSeparator key="title-block-mobile-actions-primary-menu-separator" />,
       primaryAction.menuItems
         .filter(item => typeof item.action !== "string")
         .map((item, idx) => (
@@ -53,7 +54,8 @@ const renderPrimaryActions = (primaryAction: PrimaryActionProps) => {
             action={item.action}
             label={item.label}
             icon={item.hasOwnProperty("icon") ? item.icon : undefined}
-            key={`primary-action-${idx}`}
+            key={`title-block-mobile-actions-primary-action-${idx}`}
+            automationId={`title-block-mobile-actions-primary-action-${idx}`}
           />
         )),
     ]
@@ -67,6 +69,7 @@ const renderDefaultLink = defaultAction => {
         action={defaultAction.href}
         label={defaultAction.label}
         icon={defaultAction.icon}
+        automationId="title-block-mobile-actions-default-link"
       />
     )
   }
@@ -78,6 +81,7 @@ const renderDefaultAction = defaultAction => {
         action={defaultAction.onClick}
         label={defaultAction.label}
         icon={defaultAction.icon}
+        automationId="title-block-mobile-actions-default-action"
       />
     )
   }
@@ -99,7 +103,8 @@ const renderSecondaryActions = secondaryActions => {
       action={item.action}
       label={item.label}
       icon={item.icon}
-      key={`secondary-action-${idx}`}
+      key={`title-block-mobile-actions-secondary-action-${idx}`}
+      automationId={`title-block-mobile-actions-secondary-action-${idx}`}
     />
   ))
 }
@@ -112,13 +117,13 @@ const rendersecondaryOverflowMenuItems = (
       action={item.action}
       label={item.label}
       icon={item.icon}
-      key={`overflow-menu-item-${idx}`}
+      key={`title-block-mobile-actions-overflow-menu-item-${idx}`}
+      automationId={`title-block-mobile-actions-overflow-menu-item-${idx}`}
     />
   ))
 }
 
 type DrawerMenuContentProps = {
-  primaryMenuActions?: any[]
   primaryAction?: PrimaryActionProps
   defaultAction?: ButtonWithOnClickOrHref
   secondaryActions?: SecondaryActionsProps
@@ -152,7 +157,6 @@ const ConditionalOtherActionsHeading = ({
 }
 
 const DrawerMenuContent = ({
-  primaryMenuActions,
   primaryAction,
   defaultAction,
   secondaryActions,
@@ -194,7 +198,7 @@ const renderDrawerHandleLabel = (
         <>
           {icon && (
             <span className={styles.drawerHandleIcon}>
-              <Icon icon={icon} />
+              <Icon icon={icon} role="presentation" />
             </span>
           )}
         </>
@@ -206,7 +210,7 @@ const renderDrawerHandleLabel = (
         <>
           {icon && (
             <span className={styles.drawerHandleIcon}>
-              <Icon icon={icon} />
+              <Icon icon={icon} role="presentation" />
             </span>
           )}
         </>
@@ -235,6 +239,7 @@ const ButtonOrLink = ({ action, children }: ButtonOrLinkProps) => {
           styles.mobileActionsPrimaryLabel,
           styles.mobileActionsPrimaryButton
         )}
+        data-testid="title-block-mobile-actions-primary-button"
       >
         {children}
       </button>
@@ -248,6 +253,7 @@ const ButtonOrLink = ({ action, children }: ButtonOrLinkProps) => {
           styles.mobileActionsPrimaryLabel,
           styles.mobileActionsPrimaryButton
         )}
+        data-testid="title-block-mobile-actions-primary-button"
       >
         {children}
       </a>
@@ -260,6 +266,7 @@ const ButtonOrLink = ({ action, children }: ButtonOrLinkProps) => {
         styles.mobileActionsPrimaryLabel,
         styles.mobileActionsPrimaryButton
       )}
+      data-testid="title-block-mobile-actions-primary-button"
     >
       {children}
     </button>
@@ -300,7 +307,10 @@ const DrawerHandle = ({
     // If the primary action is a menu
     if (isMenuGroupNotButton(primaryAction)) {
       return (
-        <div className={styles.mobileActionsTopRow}>
+        <div
+          className={styles.mobileActionsTopRow}
+          data-testid="title-block-mobile-actions-drawer-handle"
+        >
           <button
             className={classnames(
               styles.mobileActionsExpandButtonFullWidth,
@@ -310,7 +320,10 @@ const DrawerHandle = ({
           >
             {primaryAction.label}
             <div className={styles.mobileActionsChevronSquare}>
-              <Icon icon={isOpen ? chevronDownIcon : chevronUpIcon} />
+              <Icon
+                icon={isOpen ? chevronDownIcon : chevronUpIcon}
+                role="presentation"
+              />
             </div>
           </button>
         </div>
@@ -318,7 +331,10 @@ const DrawerHandle = ({
     } else {
       // If the primary action is a button, or has no onClick/href/action
       return (
-        <div className={styles.mobileActionsTopRow}>
+        <div
+          className={styles.mobileActionsTopRow}
+          data-testid="title-block-mobile-actions-drawer-handle"
+        >
           {
             <ButtonOrLink action={getAction(primaryAction)}>
               {renderDrawerHandleLabel(
@@ -337,7 +353,10 @@ const DrawerHandle = ({
               className={styles.mobileActionsExpandButton}
               onClick={toggleDisplay}
             >
-              <Icon icon={isOpen ? chevronDownIcon : chevronUpIcon} />
+              <Icon
+                icon={isOpen ? chevronDownIcon : chevronUpIcon}
+                role="presentation"
+              />
             </button>
           )}
         </div>

--- a/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/TitleBlockZen.spec.tsx
+++ b/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/TitleBlockZen.spec.tsx
@@ -1,0 +1,47 @@
+import "./matchMedia.mock"
+
+import { cleanup, render } from "@testing-library/react"
+import * as React from "react"
+import { NavigationTab, TitleBlockZen } from "./index"
+
+afterEach(() => cleanup())
+
+describe("<TitleBlockZen />", () => {
+  describe("when the primary action is a button", () => {
+    const primaryActionAsButton = {
+      label: "primaryActionAsButton",
+      href: "#",
+      primary: true,
+    }
+
+    it("renders the primary action button label", () => {
+      const { queryByTestId } = render(
+        <TitleBlockZen title="Test Title" primaryAction={primaryActionAsButton}>
+          Example
+        </TitleBlockZen>
+      )
+      expect(queryByTestId("title-block-main-actions-toolbar")).toBeTruthy()
+    })
+
+    it("renders the primary action label as the label of the mobile action drawer", () => {
+      const { getByTestId } = render(
+        <TitleBlockZen title="Test Title" primaryAction={primaryActionAsButton}>
+          Example
+        </TitleBlockZen>
+      )
+      expect(
+        getByTestId("title-block-main-actions-toolbar").textContent
+      ).toEqual("primaryActionAsButton")
+    })
+
+    // it("blah", () => {
+    //   const ShallowWrapper = render(
+    //     <TitleBlockZen title="Test Title" primaryAction={primaryActionAsButton}>
+    //       Example
+    //     </TitleBlockZen>
+    //   )
+    //   expect(
+    //     ShallowWrapper.find()
+    // })
+  })
+})

--- a/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/TitleBlockZen.spec.tsx
+++ b/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/TitleBlockZen.spec.tsx
@@ -1,13 +1,13 @@
 import "./matchMedia.mock"
 
-import {
-  cleanup,
-  fireEvent,
-  queryByAttribute,
-  render,
-} from "@testing-library/react"
+import { configure } from "@testing-library/dom"
+import { cleanup, fireEvent, render } from "@testing-library/react"
 import * as React from "react"
 import { NavigationTab, TitleBlockZen } from "./index"
+
+configure({
+  testIdAttribute: "data-automation-id",
+})
 
 afterEach(() => cleanup())
 
@@ -20,16 +20,14 @@ describe("<TitleBlockZen />", () => {
     }
 
     it("renders the primary action button label and href", () => {
-      const { container } = render(
+      const { getByTestId } = render(
         <TitleBlockZen title="Test Title" primaryAction={primaryActionAsLink}>
           Example
         </TitleBlockZen>
       )
-      const btn = container.querySelector(
-        "[data-automation-id=title-block-primary-action-button]"
-      )
-      expect(btn!.textContent).toEqual("primaryActionLabel")
-      expect(btn!.getAttribute("href")).toEqual("primaryActionHref")
+      const btn = getByTestId("title-block-primary-action-button")
+      expect(btn.textContent).toEqual("primaryActionLabel")
+      expect(btn.getAttribute("href")).toEqual("primaryActionHref")
     })
 
     it("passes the href to the mobile action drawer button", () => {
@@ -52,16 +50,14 @@ describe("<TitleBlockZen />", () => {
     }
 
     it("renders the primary action button label and onClick", () => {
-      const { container } = render(
+      const { getByTestId } = render(
         <TitleBlockZen title="Test Title" primaryAction={primaryActionAsButton}>
           Example
         </TitleBlockZen>
       )
-      const btn = container.querySelector(
-        "[data-automation-id=title-block-primary-action-button]"
-      )
-      expect(btn!.textContent).toEqual("primaryActionLabel")
-      fireEvent.click(btn!)
+      const btn = getByTestId("title-block-primary-action-button")
+      expect(btn.textContent).toEqual("primaryActionLabel")
+      fireEvent.click(btn)
       expect(testOnClickFn).toHaveBeenCalled()
     })
 
@@ -95,32 +91,28 @@ describe("<TitleBlockZen />", () => {
     }
 
     it("renders the primary action menu button with label and menu items", () => {
-      const { container } = render(
+      const { getByTestId, getAllByTestId } = render(
         <TitleBlockZen title="Test Title" primaryAction={primaryActionAsMenu}>
           Example
         </TitleBlockZen>
       )
-      const btn = container.querySelector(
-        "[data-automation-id=title-block-primary-action-button]"
-      )
-      expect(btn!.textContent).toEqual("primaryActionLabel")
-      fireEvent.click(btn!)
-      const menuItems = container.querySelectorAll(
-        "[data-automation-id^=main-action-primary-menu-item-]"
-      )
-      expect(menuItems!.length).toEqual(2)
+      const btn = getByTestId("title-block-primary-action-button")
+      expect(btn.textContent).toEqual("primaryActionLabel")
+      fireEvent.click(btn)
+      const menuItems = getAllByTestId(/^main-action-primary-menu-item-/)
+      expect(menuItems.length).toEqual(2)
     })
 
     it("passes the primary menu items to the mobile actions drawer", () => {
-      const { container } = render(
+      const { getByTestId, getAllByTestId } = render(
         <TitleBlockZen title="Test Title" primaryAction={primaryActionAsMenu}>
           Example
         </TitleBlockZen>
       )
-      const menuItems = container.querySelectorAll(
-        "[data-automation-id^=title-block-mobile-actions-primary-link-]"
+      const menuItems = getAllByTestId(
+        /^title-block-mobile-actions-primary-link-/
       )
-      expect(menuItems!.length).toEqual(2)
+      expect(menuItems.length).toEqual(2)
     })
   })
 
@@ -131,30 +123,38 @@ describe("<TitleBlockZen />", () => {
     }
 
     it("renders the default action button label and href", () => {
-      const { container } = render(
+      const { getByTestId } = render(
         <TitleBlockZen title="Test Title" defaultAction={defaultActionAsLink}>
           Example
         </TitleBlockZen>
       )
-      const btn = container.querySelector(
-        "[data-automation-id=title-block-default-action-button]"
-      )
-      expect(btn!.textContent).toEqual("defaultActionLabel")
-      expect(btn!.getAttribute("href")).toEqual("defaultActionHref")
+      const btn = getByTestId("title-block-default-action-button")
+      expect(btn.textContent).toEqual("defaultActionLabel")
+      expect(btn.getAttribute("href")).toEqual("defaultActionHref")
     })
 
     it("creates a mobile actions default action menu item", () => {
-      const { container } = render(
+      const { getByTestId } = render(
         <TitleBlockZen title="Test Title" defaultAction={defaultActionAsLink}>
           Example
         </TitleBlockZen>
       )
 
-      const menuItem = container.querySelector(
-        "[data-automation-id=title-block-mobile-actions-default-link]"
+      const menuItem = getByTestId("title-block-mobile-actions-default-link")
+      expect(menuItem.getAttribute("href")).toEqual("defaultActionHref")
+      expect(menuItem.textContent).toEqual("defaultActionLabel")
+    })
+
+    it("renders the mobile actions menu drawer handle even with no primary action", () => {
+      const { getByTestId } = render(
+        <TitleBlockZen title="Test Title" defaultAction={defaultActionAsLink}>
+          Example
+        </TitleBlockZen>
       )
-      expect(menuItem!.getAttribute("href")).toEqual("defaultActionHref")
-      expect(menuItem!.textContent).toEqual("defaultActionLabel")
+
+      expect(
+        getByTestId("title-block-mobile-actions-drawer-handle")
+      ).toBeTruthy()
     })
   })
 
@@ -166,31 +166,27 @@ describe("<TitleBlockZen />", () => {
     }
 
     it("renders the default action button label and onClick", () => {
-      const { container } = render(
+      const { getByTestId } = render(
         <TitleBlockZen title="Test Title" defaultAction={defaultActionAsButton}>
           Example
         </TitleBlockZen>
       )
-      const btn = container.querySelector(
-        "[data-automation-id=title-block-default-action-button]"
-      )
-      expect(btn!.textContent).toEqual("defaultActionLabel")
-      fireEvent.click(btn!)
+      const btn = getByTestId("title-block-default-action-button")
+      expect(btn.textContent).toEqual("defaultActionLabel")
+      fireEvent.click(btn)
       expect(testOnClickFn).toHaveBeenCalled()
     })
 
     it("creates a mobile actions default action menu item", () => {
-      const { container } = render(
+      const { getByTestId } = render(
         <TitleBlockZen title="Test Title" defaultAction={defaultActionAsButton}>
           Example
         </TitleBlockZen>
       )
 
-      const menuItem = container.querySelector(
-        "[data-automation-id=title-block-mobile-actions-default-action]"
-      )
-      expect(menuItem!.textContent).toEqual("defaultActionLabel")
-      fireEvent.click(menuItem!)
+      const menuItem = getByTestId("title-block-mobile-actions-default-action")
+      expect(menuItem.textContent).toEqual("defaultActionLabel")
+      fireEvent.click(menuItem)
       expect(testOnClickFn).toHaveBeenCalled()
     })
 

--- a/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/TitleBlockZen.spec.tsx
+++ b/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/TitleBlockZen.spec.tsx
@@ -1,47 +1,209 @@
 import "./matchMedia.mock"
 
-import { cleanup, render } from "@testing-library/react"
+import {
+  cleanup,
+  fireEvent,
+  queryByAttribute,
+  render,
+} from "@testing-library/react"
 import * as React from "react"
 import { NavigationTab, TitleBlockZen } from "./index"
 
 afterEach(() => cleanup())
 
 describe("<TitleBlockZen />", () => {
-  describe("when the primary action is a button", () => {
-    const primaryActionAsButton = {
-      label: "primaryActionAsButton",
-      href: "#",
+  describe("when the primary action is a button with an href", () => {
+    const primaryActionAsLink = {
+      label: "primaryActionLabel",
+      href: "primaryActionHref",
       primary: true,
     }
 
-    it("renders the primary action button label", () => {
-      const { queryByTestId } = render(
+    it("renders the primary action button label and href", () => {
+      const { container } = render(
+        <TitleBlockZen title="Test Title" primaryAction={primaryActionAsLink}>
+          Example
+        </TitleBlockZen>
+      )
+      const btn = container.querySelector(
+        "[data-automation-id=title-block-primary-action-button]"
+      )
+      expect(btn!.textContent).toEqual("primaryActionLabel")
+      expect(btn!.getAttribute("href")).toEqual("primaryActionHref")
+    })
+
+    it("passes the href to the mobile action drawer button", () => {
+      const { getByTestId } = render(
+        <TitleBlockZen title="Test Title" primaryAction={primaryActionAsLink}>
+          Example
+        </TitleBlockZen>
+      )
+      const btn = getByTestId("title-block-mobile-actions-primary-button")
+      expect(btn.getAttribute("href")).toEqual("primaryActionHref")
+    })
+  })
+
+  describe("when the primary action is a button with an onClick", () => {
+    const testOnClickFn = jest.fn()
+    const primaryActionAsButton = {
+      label: "primaryActionLabel",
+      onClick: testOnClickFn,
+      primary: true,
+    }
+
+    it("renders the primary action button label and onClick", () => {
+      const { container } = render(
         <TitleBlockZen title="Test Title" primaryAction={primaryActionAsButton}>
           Example
         </TitleBlockZen>
       )
-      expect(queryByTestId("title-block-main-actions-toolbar")).toBeTruthy()
+      const btn = container.querySelector(
+        "[data-automation-id=title-block-primary-action-button]"
+      )
+      expect(btn!.textContent).toEqual("primaryActionLabel")
+      fireEvent.click(btn!)
+      expect(testOnClickFn).toHaveBeenCalled()
     })
 
-    it("renders the primary action label as the label of the mobile action drawer", () => {
+    it("creates a mobile actions primary button", () => {
       const { getByTestId } = render(
         <TitleBlockZen title="Test Title" primaryAction={primaryActionAsButton}>
           Example
         </TitleBlockZen>
       )
-      expect(
-        getByTestId("title-block-main-actions-toolbar").textContent
-      ).toEqual("primaryActionAsButton")
+
+      const btn = getByTestId("title-block-mobile-actions-primary-button")
+      expect(btn.textContent).toEqual("primaryActionLabel")
+      fireEvent.click(btn)
+      expect(testOnClickFn).toHaveBeenCalled()
+    })
+  })
+
+  describe("when the primary action is a menu", () => {
+    const primaryActionAsMenu = {
+      label: "primaryActionLabel",
+      menuItems: [
+        {
+          label: "Menu item 1",
+          action: "#",
+        },
+        {
+          label: "Menu item 1",
+          action: "#",
+        },
+      ],
+    }
+
+    it("renders the primary action menu button with label and menu items", () => {
+      const { container } = render(
+        <TitleBlockZen title="Test Title" primaryAction={primaryActionAsMenu}>
+          Example
+        </TitleBlockZen>
+      )
+      const btn = container.querySelector(
+        "[data-automation-id=title-block-primary-action-button]"
+      )
+      expect(btn!.textContent).toEqual("primaryActionLabel")
+      fireEvent.click(btn!)
+      const menuItems = container.querySelectorAll(
+        "[data-automation-id^=main-action-primary-menu-item-]"
+      )
+      expect(menuItems!.length).toEqual(2)
     })
 
-    // it("blah", () => {
-    //   const ShallowWrapper = render(
-    //     <TitleBlockZen title="Test Title" primaryAction={primaryActionAsButton}>
-    //       Example
-    //     </TitleBlockZen>
-    //   )
-    //   expect(
-    //     ShallowWrapper.find()
-    // })
+    it("passes the primary menu items to the mobile actions drawer", () => {
+      const { container } = render(
+        <TitleBlockZen title="Test Title" primaryAction={primaryActionAsMenu}>
+          Example
+        </TitleBlockZen>
+      )
+      const menuItems = container.querySelectorAll(
+        "[data-automation-id^=title-block-mobile-actions-primary-link-]"
+      )
+      expect(menuItems!.length).toEqual(2)
+    })
+  })
+
+  describe("when the default action is a button with an href", () => {
+    const defaultActionAsLink = {
+      label: "defaultActionLabel",
+      href: "defaultActionHref",
+    }
+
+    it("renders the default action button label and href", () => {
+      const { container } = render(
+        <TitleBlockZen title="Test Title" defaultAction={defaultActionAsLink}>
+          Example
+        </TitleBlockZen>
+      )
+      const btn = container.querySelector(
+        "[data-automation-id=title-block-default-action-button]"
+      )
+      expect(btn!.textContent).toEqual("defaultActionLabel")
+      expect(btn!.getAttribute("href")).toEqual("defaultActionHref")
+    })
+
+    it("creates a mobile actions default action menu item", () => {
+      const { container } = render(
+        <TitleBlockZen title="Test Title" defaultAction={defaultActionAsLink}>
+          Example
+        </TitleBlockZen>
+      )
+
+      const menuItem = container.querySelector(
+        "[data-automation-id=title-block-mobile-actions-default-link]"
+      )
+      expect(menuItem!.getAttribute("href")).toEqual("defaultActionHref")
+      expect(menuItem!.textContent).toEqual("defaultActionLabel")
+    })
+  })
+
+  describe("when the default action is a button with an onClick", () => {
+    const testOnClickFn = jest.fn()
+    const defaultActionAsButton = {
+      label: "defaultActionLabel",
+      onClick: testOnClickFn,
+    }
+
+    it("renders the default action button label and onClick", () => {
+      const { container } = render(
+        <TitleBlockZen title="Test Title" defaultAction={defaultActionAsButton}>
+          Example
+        </TitleBlockZen>
+      )
+      const btn = container.querySelector(
+        "[data-automation-id=title-block-default-action-button]"
+      )
+      expect(btn!.textContent).toEqual("defaultActionLabel")
+      fireEvent.click(btn!)
+      expect(testOnClickFn).toHaveBeenCalled()
+    })
+
+    it("creates a mobile actions default action menu item", () => {
+      const { container } = render(
+        <TitleBlockZen title="Test Title" defaultAction={defaultActionAsButton}>
+          Example
+        </TitleBlockZen>
+      )
+
+      const menuItem = container.querySelector(
+        "[data-automation-id=title-block-mobile-actions-default-action]"
+      )
+      expect(menuItem!.textContent).toEqual("defaultActionLabel")
+      fireEvent.click(menuItem!)
+      expect(testOnClickFn).toHaveBeenCalled()
+    })
+
+    it("renders the mobile actions menu drawer handle even with no primary action", () => {
+      const { getByTestId } = render(
+        <TitleBlockZen title="Test Title" defaultAction={defaultActionAsButton}>
+          Example
+        </TitleBlockZen>
+      )
+
+      expect(
+        getByTestId("title-block-mobile-actions-drawer-handle")
+      ).toBeTruthy()
+    })
   })
 })

--- a/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/TitleBlockZen.tsx
+++ b/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/TitleBlockZen.tsx
@@ -373,7 +373,7 @@ const TitleBlockZen = ({
           [styles.hasSubtitle]: Boolean(subtitle),
           [styles.educationVariant]: variant === "education",
           [styles.adminVariant]: variant === "admin",
-          [styles.hasLongTitle]: title.length >= 30,
+          [styles.hasLongTitle]: title && title.length >= 30,
           [styles.hasLongSubtitle]: subtitle && subtitle.length >= 34,
           [styles.hasNavigationTabs]:
             navigationTabs && navigationTabs.length > 0,

--- a/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/Toolbar.tsx
+++ b/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/Toolbar.tsx
@@ -15,7 +15,10 @@ type ToolbarProps = {
 
 const Toolbar = ({ items, noGap = false }: ToolbarProps) => {
   return (
-    <div className={styles.toolbar}>
+    <div
+      className={styles.toolbar}
+      data-testid="title-block-main-actions-toolbar"
+    >
       {items?.map((item, i) => (
         <div
           className={classNames(styles.toolbarItem, {

--- a/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/Toolbar.tsx
+++ b/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/Toolbar.tsx
@@ -17,7 +17,7 @@ const Toolbar = ({ items, noGap = false }: ToolbarProps) => {
   return (
     <div
       className={styles.toolbar}
-      data-testid="title-block-main-actions-toolbar"
+      data-automation-id="title-block-main-actions-toolbar"
     >
       {items?.map((item, i) => (
         <div

--- a/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/matchMedia.mock
+++ b/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/matchMedia.mock
@@ -1,0 +1,15 @@
+// Must be imported before the tested file
+
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: jest.fn().mockImplementation(query => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: jest.fn(), // deprecated
+    removeListener: jest.fn(), // deprecated
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+    dispatchEvent: jest.fn(),
+  })),
+});


### PR DESCRIPTION
## Changes

- Adds basic tests for primary and default actions (secondary still to come).
- Fixes two bugs relating to:
1. the mobile actions drawer handle not rendering when a default action but no primary action is passed in
2. a missing check for the presence of `title` before checking its length (previously relied on TS to enforce this)