### PR TITLE
feat: add language illustration

### DIFF
--- a/draft-packages/illustration/KaizenDraft/Illustration/Scene.tsx
+++ b/draft-packages/illustration/KaizenDraft/Illustration/Scene.tsx
@@ -194,6 +194,14 @@ export const KaizenSiteBrand = (props: SceneProps) => (
   <Base {...props} name="illustrations/scene/kaizen-site-brand.svg" />
 )
 
+export const KaizenSiteLanguageAlt = (props: SceneProps) => (
+  <Base {...props} name="illustrations/scene/kaizen-site-language-alt.svg" />
+)
+
+export const KaizenSiteLanguage = (props: SceneProps) => (
+  <Base {...props} name="illustrations/scene/kaizen-site-language.svg" />
+)
+
 export const KaizenSitePrinciples = (props: SceneProps) => (
   <Base {...props} name="illustrations/scene/kaizen-site-principles.svg" />
 )

--- a/draft-packages/stories/IllustrationScene.stories.tsx
+++ b/draft-packages/stories/IllustrationScene.stories.tsx
@@ -19,6 +19,8 @@ import {
   IntroductionsPerformance,
   KaizenSiteBrand,
   KaizenSiteBrandAlt,
+  KaizenSiteLanguage,
+  KaizenSiteLanguageAlt,
   KaizenSitePrinciples,
   KaizenSitePrinciplesAlt,
   KaizenSiteProduct,
@@ -357,6 +359,20 @@ export const KaizenSiteBrandStory = () => (
   </div>
 )
 KaizenSiteBrandStory.story = { name: "Kaizen Site: Brand" }
+
+export const KaizenSiteLanguageAltStory = () => (
+  <div style={{ width: "500px" }}>
+    <KaizenSiteLanguageAlt alt="" />
+  </div>
+)
+KaizenSiteLanguageAltStory.story = { name: "Kaizen Site: Language Alt" }
+
+export const KaizenSiteLanguageStory = () => (
+  <div style={{ width: "500px" }}>
+    <KaizenSiteLanguage alt="" />
+  </div>
+)
+KaizenSiteLanguageStory.story = { name: "Kaizen Site: Language" }
 
 export const KaizenSitePrinciplesStory = () => (
   <div style={{ width: "500px" }}>

--- a/site/docs/components/illustration.mdx
+++ b/site/docs/components/illustration.mdx
@@ -14,6 +14,9 @@ import WhenToUseAndWhenNotToUse from "docs-components/WhenToUseAndWhenNotToUse"
 import WhenToUse from "docs-components/WhenToUse"
 import WhenNotToUse from "docs-components/WhenNotToUse"
 
+## Adding new illustrations
+
+To add a new illustration to the Kaizen UI Kit, to export an illustration from the UI Kit, or to add an illustration to the Kaizen Component Library, Culture Amp employees can see an [internal link for the illustrations process on our wiki](https://cultureamp.atlassian.net/wiki/spaces/Prod/pages/1429995856/How+to+add+new+illustrations+to+Kaizen).
 
 ## Visuals
 

--- a/site/src/components/ContentOnly.scss
+++ b/site/src/components/ContentOnly.scss
@@ -20,7 +20,7 @@
   border-radius: 7px;
   box-shadow: var(--card-box-shadow);
   padding: 0;
-  margin-top: calc(-2 * var(--content-card-top-offset));
+  margin-top: calc(-1 * var(--content-card-top-offset));
   max-width: var(--page-content-width);
   width: 100%;
 

--- a/site/src/components/Footer.tsx
+++ b/site/src/components/Footer.tsx
@@ -32,7 +32,7 @@ const Footer: React.SFC<FooterProps> = ({
           <a href="https://cultureamp.com" className={styles.logoLink}>
             <Icon
               icon={companyLogo}
-              title="Culture Amp"
+              title="Culture Amp site"
               desc="Link to Culture Amp site"
               role="img"
             />

--- a/site/src/components/Head.tsx
+++ b/site/src/components/Head.tsx
@@ -25,6 +25,7 @@ const Head: React.SFC<HeadProps> = ({ pageTitle = "" }) => {
     <Helmet>
       {/* Load Culture Amp brand fonts:
       https://cultureamp.atlassian.net/wiki/spaces/Prod/pages/700482798/CA+Font+Service */}
+      <html lang="en" />
       <link
         rel="stylesheet"
         type="text/css"

--- a/site/src/components/Layout.tsx
+++ b/site/src/components/Layout.tsx
@@ -39,19 +39,21 @@ const Layout: React.SFC<LayoutProps> = ({
           [styles.noPageHeader]: !pageHeader,
         })}
       >
-        {pageHeader}
-        {fullWidthContent ? (
-          children
-        ) : (
-          <div
-            className={classnames({
-              [styles.contentContainer]: true,
-              [styles.trimBottomOfCardToContent]: trimBottomOfCardToContent,
-            })}
-          >
-            <div className={styles.content}>{children}</div>
-          </div>
-        )}
+        <main>
+          {pageHeader}
+          {fullWidthContent ? (
+            children
+          ) : (
+            <div
+              className={classnames({
+                [styles.contentContainer]: true,
+                [styles.trimBottomOfCardToContent]: trimBottomOfCardToContent,
+              })}
+            >
+              <div className={styles.content}>{children}</div>
+            </div>
+          )}
+        </main>
       </div>
       <div className={styles.footerContainer}>{footer}</div>
     </div>

--- a/site/src/components/Layout.tsx
+++ b/site/src/components/Layout.tsx
@@ -55,7 +55,9 @@ const Layout: React.SFC<LayoutProps> = ({
           )}
         </main>
       </div>
-      <div className={styles.footerContainer}>{footer}</div>
+      <footer>
+        <div className={styles.footerContainer}>{footer}</div>
+      </footer>
     </div>
   </>
 )

--- a/site/src/components/PageHeader.scss
+++ b/site/src/components/PageHeader.scss
@@ -110,7 +110,7 @@
 }
 
 .summaryParagraph {
-  font-size: 1.625rem;
+  font-size: 1.5rem;
   line-height: 1.4;
   font-weight: 400;
   margin-bottom: var(--content-card-top-offset);

--- a/site/src/components/PageHeader.tsx
+++ b/site/src/components/PageHeader.tsx
@@ -101,7 +101,7 @@ const PageHeader: React.SFC<PageHeaderProps> = ({
                 </Heading>
               </div>
               {summaryParagraph && (
-                <h3 className={styles.summaryParagraph}>{summaryParagraph}</h3>
+                <h2 className={styles.summaryParagraph}>{summaryParagraph}</h2>
               )}
               {children}
             </div>

--- a/site/src/pages/404.tsx
+++ b/site/src/pages/404.tsx
@@ -42,16 +42,25 @@ export default props => (
     <ContentOnly>
       <Content>
         <ContentMarkdownSection>
-          <md.h3>Try one of these instead:</md.h3>
+          <md.h2>Try one of these instead</md.h2>
           <md.ul>
             <md.li>
               <Link to="/guidelines/color">Color</Link>
             </md.li>
             <md.li>
-              <Link to="/guidelines/overview">Guidelines overview</Link>
+              <Link to="/components/button">Button</Link>
             </md.li>
             <md.li>
-              <Link to="/components/button">Components</Link>
+              <Link to="/language/grammar">Style and punctuation</Link>
+            </md.li>
+            <md.li>
+              <Link to="/guidelines/overview">Guidelines</Link>
+            </md.li>
+            <md.li>
+              <Link to="/components/overview">Components</Link>
+            </md.li>
+            <md.li>
+              <Link to="/language/overview">Language</Link>
             </md.li>
             <md.li>
               <Link to="/storybook">Storybook</Link>

--- a/site/src/pages/index.scss
+++ b/site/src/pages/index.scss
@@ -4,8 +4,8 @@
 .content {
   display: grid;
   grid-template-areas:
-    "guidelines-image components-image"
-    "guidelines-text components-text";
+    "guidelines-image language-image components-image"
+    "guidelines-text language-text components-text";
   justify-content: space-evenly;
   align-content: center;
   padding: calc(var(--ca-grid) * 6) 0;
@@ -15,17 +15,20 @@
       "guidelines-image"
       "guidelines-text"
       "."
+      "language-image"
+      "language-text"
+      "."
       "components-image"
       "components-text";
     padding: calc(var(--ca-grid) * 4) 0 0 0;
-    grid-template-rows: auto auto 3rem auto auto;
+    grid-template-rows: auto auto 3rem auto auto 3rem;
   }
 }
 
 %imageContainer {
   background: #fff;
-  width: 300px;
-  height: 300px;
+  width: 240px;
+  height: 240px;
   transition: transform $ca-duration-fast, box-shadow $ca-duration-fast;
 
   &:hover {
@@ -44,18 +47,28 @@
   grid-area: guidelines-image;
 }
 
+.languageImageContainer {
+  @extend %imageContainer;
+  grid-area: language-image;
+}
+
 .componentsImageContainer {
   @extend %imageContainer;
   grid-area: components-image;
 }
 
 %textContainer {
-  width: 300px;
+  width: 240px;
 }
 
 .guidelinesTextContainer {
   @extend %textContainer;
   grid-area: guidelines-text;
+}
+
+.languageTextContainer {
+  @extend %textContainer;
+  grid-area: language-text;
 }
 
 .componentsTextContainer {

--- a/site/src/pages/index.scss
+++ b/site/src/pages/index.scss
@@ -8,7 +8,7 @@
     "guidelines-text language-text components-text";
   justify-content: space-evenly;
   align-content: center;
-  padding: calc(var(--ca-grid) * 6) 0;
+  padding: calc(var(--ca-grid) * 4.5) 0;
 
   @include ca-media-mobile() {
     grid-template-areas:

--- a/site/src/pages/index.tsx
+++ b/site/src/pages/index.tsx
@@ -79,7 +79,7 @@ export default ({ location }) => {
             <div className={styles.guidelinesImageContainer}>
               <a href={withPrefix("/guidelines/overview")}>
                 <img
-                  src="https://kaizen-assets.s3-us-west-2.amazonaws.com/site/guidelines.png"
+                  src={assetUrl("illustrations/scene/kaizen-site-product.svg")}
                   alt="Guidelines"
                 />
               </a>
@@ -95,7 +95,9 @@ export default ({ location }) => {
             <div className={styles.componentsImageContainer}>
               <a href={withPrefix("/components/overview")}>
                 <img
-                  src="https://kaizen-assets.s3-us-west-2.amazonaws.com/site/components.png"
+                  src={assetUrl(
+                    "illustrations/scene/kaizen-site-resources.svg"
+                  )}
                   alt="Components"
                 />
               </a>

--- a/site/src/pages/index.tsx
+++ b/site/src/pages/index.tsx
@@ -13,8 +13,8 @@ const styles = require("./index.scss")
 const HomePageHeader = (
   <PageHeader
     headingText="Kaizen"
-    summaryParagraph={`Kaizen is Culture Amp’s design system. It’s the single source of truth\n
-      for our UX guidelines, design assets, and front-end code to help\nCulture Amp’s teams rapidly 
+    summaryParagraph={`Kaizen is Culture Amp’s design system. It’s the single source of truth 
+      for our UX guidelines, design assets, and front-end code to help Culture Amp’s teams rapidly 
       create a world-class experience.`}
     headingOnly
   />

--- a/site/src/pages/index.tsx
+++ b/site/src/pages/index.tsx
@@ -1,5 +1,6 @@
 import { Button } from "@kaizen/component-library"
 import { Heading } from "@kaizen/component-library/components/Heading"
+import { assetUrl } from "@kaizen/hosted-assets"
 import { graphql, useStaticQuery, withPrefix } from "gatsby"
 import * as React from "react"
 import { Content, ContentOnly } from "../components/ContentOnly"
@@ -77,12 +78,26 @@ export default ({ location }) => {
           <div className={styles.content}>
             <div className={styles.guidelinesImageContainer}>
               <a href={withPrefix("/guidelines/overview")}>
-                <img src="https://kaizen-assets.s3-us-west-2.amazonaws.com/site/guidelines.png" />
+                <img
+                  src="https://kaizen-assets.s3-us-west-2.amazonaws.com/site/guidelines.png"
+                  alt="Guidelines"
+                />
+              </a>
+            </div>
+            <div className={styles.languageImageContainer}>
+              <a href={withPrefix("/language/overview")}>
+                <img
+                  src={assetUrl("illustrations/scene/kaizen-site-language.svg")}
+                  alt="Language"
+                />
               </a>
             </div>
             <div className={styles.componentsImageContainer}>
               <a href={withPrefix("/components/overview")}>
-                <img src="https://kaizen-assets.s3-us-west-2.amazonaws.com/site/components.png" />
+                <img
+                  src="https://kaizen-assets.s3-us-west-2.amazonaws.com/site/components.png"
+                  alt="Components"
+                />
               </a>
             </div>
             <div className={styles.guidelinesTextContainer}>
@@ -94,6 +109,17 @@ export default ({ location }) => {
               <div className={styles.body}>
                 Learn how to design and build cohesive and predictable products
                 for Culture Amp.
+              </div>
+            </div>
+            <div className={styles.languageTextContainer}>
+              <div className={styles.headingContainer}>
+                <Heading tag="div" variant="heading-2">
+                  <a href={withPrefix("/language/overview")}>Language</a>
+                </Heading>
+              </div>
+              <div className={styles.body}>
+                Use the product language guide to answer all your nitty gritty
+                questions.
               </div>
             </div>
             <div className={styles.componentsTextContainer}>


### PR DESCRIPTION
This PR:

- adds the Kaizen Site Language illustrations
- uses the main Kaizen Site Language illustration on the homepage
- adds link to illustration process
- improves accessibility
- updates 404 page links

![image](https://user-images.githubusercontent.com/2476974/87014127-0147c480-c20f-11ea-9ffb-61f2fb4137e1.png)
![image](https://user-images.githubusercontent.com/2476974/87014351-5e437a80-c20f-11ea-9a6d-6a9a96b0b88d.png)

![image](https://user-images.githubusercontent.com/2476974/87014164-0efd4a00-c20f-11ea-96f0-42d26b421585.png)

![image](https://user-images.githubusercontent.com/2476974/87014200-1fadc000-c20f-11ea-9f25-30fa22fbd0ec.png)
![image](https://user-images.githubusercontent.com/2476974/87014211-26d4ce00-c20f-11ea-80f8-594044e36ce3.png)
