### PR TITLE
feat: Add Manager Lab signup illustrations

### DIFF
--- a/draft-packages/illustration/KaizenDraft/Illustration/Scene.tsx
+++ b/draft-packages/illustration/KaizenDraft/Illustration/Scene.tsx
@@ -145,6 +145,14 @@ export const PerformanceCompanySettings = (props: SceneProps) => (
   />
 )
 
+export const ManagerLabFourWeekCycle = (props: SceneProps) => (
+  <Base {...props} name="illustrations/scene/manager-lab-4-week-cycle.svg" />
+)
+
+export const ManagerLabScheduling = (props: SceneProps) => (
+  <Base {...props} name="illustrations/scene/manager-lab-scheduling.svg" />
+)
+
 export const ManagerLearningManagerHub = (props: SceneProps) => (
   <Base
     {...props}

--- a/draft-packages/stories/IllustrationScene.stories.tsx
+++ b/draft-packages/stories/IllustrationScene.stories.tsx
@@ -25,6 +25,8 @@ import {
   KaizenSiteProductAlt,
   KaizenSiteResources,
   KaizenSiteResourcesAlt,
+  ManagerLabFourWeekCycle,
+  ManagerLabScheduling,
   ManagerLearningCoaching,
   ManagerLearningFeedback,
   ManagerLearningManagerHub,
@@ -281,6 +283,20 @@ export const PerformanceCompanySettingsStory = () => (
 PerformanceCompanySettingsStory.story = {
   name: "Performance: Company Settings",
 }
+
+export const ManagerLabFourWeekCycleStory = () => (
+  <div style={{ width: "500px" }}>
+    <ManagerLabFourWeekCycle alt="" />
+  </div>
+)
+ManagerLabFourWeekCycleStory.story = { name: "Manager Lab: 4 week cycle" }
+
+export const ManagerLabSchedulingStory = () => (
+  <div style={{ width: "500px" }}>
+    <ManagerLabScheduling alt="" />
+  </div>
+)
+ManagerLabSchedulingStory.story = { name: "Manager Lab: Scheduling" }
 
 export const ManagerLearningManagerHubStory = () => (
   <div style={{ width: "500px" }}>


### PR DESCRIPTION
Makes these Manager Lab signup illustrations available:
<img width="398" alt="Screen Shot 2020-07-10 at 8 51 27 am" src="https://user-images.githubusercontent.com/7019081/87098422-98059700-c28a-11ea-94ce-4b7d96bdb62e.png">
<img width="346" alt="Screen Shot 2020-07-10 at 8 51 39 am" src="https://user-images.githubusercontent.com/7019081/87098436-9fc53b80-c28a-11ea-8d09-b274dbf94423.png">
