### PR TITLE
docs: update Kaizen Site heading only text layout

### DIFF
--- a/site/src/components/PageHeader.scss
+++ b/site/src/components/PageHeader.scss
@@ -116,8 +116,8 @@
   margin-bottom: var(--content-card-top-offset);
 
   .headingOnly & {
+    max-width: 60rem;
     text-align: center;
-    white-space: pre-wrap;
 
     @media (max-width: 1080px) {
       white-space: normal;


### PR DESCRIPTION
Instead of depending on pre-wrap for a single text layout, which results
in awkward line breaks at different font sizes and screen sizes, we'll
let it wrap normally, and add a max width.

Fixes:

![image](https://user-images.githubusercontent.com/2476974/87112894-63a4d180-c2b0-11ea-9bd9-726e10d152bb.png)

Like this:

![image](https://user-images.githubusercontent.com/2476974/87112951-86cf8100-c2b0-11ea-8492-82820c01e809.png)
