### PR TITLE
docs: update repo docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,8 +46,8 @@ Once it's approved, click "Squash and merge" to publish your changes. Share the 
 Every contribution must be **design reviewed** and **communicated**.
 
 - **Kaizen Site** changes use `docs: ` at the start of the first commit message and PR title.
-- **Major** component changes use `feat: ` at the start of PR titles. For 1 commit, use `feat: ` in the commit message too.
-- **Minor** component changes use `fix: ` at the start of PR titles. For 1 commit, use `fix: ` in the commit message too.
+- **New features** in components use `feat: ` at the start of PR titles. For 1 commit, use `feat: ` in the commit message too.
+- **Fixes** in components use `fix: ` at the start of PR titles. For 1 commit, use `fix: ` in the commit message too.
 - **Breaking changes** that are not backwards compatible use feat or fix as above and include `BREAKING CHANGE: ` in the body of a commit message.
 - **Design token** changes… let's talk about that.
 
@@ -64,9 +64,9 @@ Every code contribution **should strive to** have:
 - Basic level of unit tests
 - New or updated Storybook stories
 
-To update a component:
+To update a component in code:
 
-- Ask for a review from a design systems advocate (an "advocado"), Design Systems team, or someone in your team who is experienced with Kaizen*
+- Ask for a code review from a design systems advocate (an "advocado"), Design Systems team, or someone in your team who is experienced with Kaizen*
 - Notify the front-end engineering practice (#pract_front_end_eng) of any possible breaking changes
 - Notify the QA practice of any possible breaking changes
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,13 +41,23 @@ Once it's approved, click "Squash and merge" to publish your changes. Share the 
 
 ## Contributing code
 
+### Need to know
+
+Every contribution must be **design reviewed** and **communicated**.
+
+- **Kaizen Site** changes use `docs: ` at the start of the first commit message and PR title.
+- **Major** component changes use `feat: ` at the start of PR titles. For 1 commit, use `feat: ` in the commit message too.
+- **Minor** component changes use `fix: ` at the start of PR titles. For 1 commit, use `fix: ` in the commit message too.
+- **Breaking changes** that are not backwards compatible use feat or fix as above and include `BREAKING CHANGE: ` in the body of a commit message.
+- **Design token** changes… let's talk about that.
+
 ### Quality and reviews
 
 Every code contribution **must** have:
 
-- A design review from a designer
-- A PR summary that describes the changes and anything others should be aware of
-- Communications: share your new component or changes on Slack or at the Front End Practice meeting
+1. A design review from a designer
+2. Semantic versioning and conventional commit PR titles: see [Releasing packages](#releasing-packages)
+3. Communications: share your new component or changes on Slack and at relevant Front End Practice meetings
 
 Every code contribution **should strive to** have:
 
@@ -56,11 +66,19 @@ Every code contribution **should strive to** have:
 
 To update a component:
 
-- Ask for a review from a design systems advocate (an "advocado"), Design Systems Team, or someone in your team who is experienced with Kaizen*
+- Ask for a review from a design systems advocate (an "advocado"), Design Systems team, or someone in your team who is experienced with Kaizen*
 - Notify the front-end engineering practice (#pract_front_end_eng) of any possible breaking changes
 - Notify the QA practice of any possible breaking changes
 
-\* **If you're new to Kaizen, please ask the Design Systems Team (#team_design_systems) to set up an onboarding session to get you up to speed.** If you have an urgent PR to merge before that happens, it is safest to ask Design Systems Team to review it to catch any issues.
+\* **If you're new to Kaizen, please ask the Design Systems team to set up an onboarding session to get you up to speed.** If you have an urgent PR to merge before that happens, it is safest to ask Design Systems team to review it to catch any issues.
+
+### Design tokens
+
+See the [design tokens](https://github.com/cultureamp/kaizen-design-system/tree/master/packages/generator) package.
+
+### Building a new draft component
+
+See the [draft package generator](https://github.com/cultureamp/kaizen-design-system/tree/master/packages/generator) package.
 
 ### Browser and device support
 
@@ -70,7 +88,7 @@ To learn more about what browsers and devices we support in Kaizen Component Lib
 
 To strengthen the Kaizen Design System, we encourage engineers to take a component-first development approach. By concentrating on developing Kaizen components in Storybook, we are likely to improve the API design and achieve good separation of concerns, avoiding components tightly coupled to specific applications. If, however, you want to test a component in the context of another front-end codebase, you can [yarn link](https://yarnpkg.com/lang/en/docs/cli/link/) your local version of `@kaizen/component-library` with your other front-end codebase.
 
-#### For non-draft components
+#### For core, non-draft components
 
 **Step 1**: Make your local copy of `@kaizen/component-library` available.
 
@@ -168,7 +186,7 @@ Automated releases to the npm public registry are triggered for all pull request
 
 ### Release workflow
 
-To release a new version of a package, create a pull request which...
+To release a new version of a package, create a pull request that:
 
 - Modifies only the package(s) you wish to release ([see below](#updating-multiple-packages))
 - Has a conventional pull request title ([see below](#conventional-commit))

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This document serves to orient you within the repository — to get you set up a
 
 ## Quick links
 
+- [Kaizen Design Tokens README](./packages/design-tokens/README.md)
 - [Kaizen Component Library README](./packages/component-library/README.md)
 - [Kaizen Site README](./site/README.md) (and <https://cultureamp.design>)
 - [Contributing guidelines](./CONTRIBUTING.md)
@@ -48,7 +49,8 @@ To run Storybook locally, run the following from the repository root:
 ```
 yarn storybook
 ```
-(Having trouble running Storybook? Try running `yarn clean` and `yarn install --force`!)
+
+(Having trouble running Storybook? Try running `yarn reset`, which includes `yarn clean` and `yarn install --force`!)
 
 To develop the site locally, please refer to the documentation in [the site package](./site/README.md).
 
@@ -75,10 +77,6 @@ Command | Summary
 
 Please open a new [GitHub Issue](https://github.com/cultureamp/kaizen-design-system/issues/new) to report bugs or suggest changes.
 
-## Maintainers
-
-The design system is maintained by Culture Amp's [Design Systems Team](https://github.com/orgs/cultureamp/teams/design-systems), with tooling and operations support from [Delivery Engineering](https://github.com/orgs/cultureamp/teams/delivery-engineering). :rocket:
-
 ## Learn more
 
-Culture Amp employees can reach out to the Design Systems Team on Slack in the `#team_design_systems` channel.
+Culture Amp employees can reach out to the Design Systems crew on Slack.

--- a/packages/component-library/README.md
+++ b/packages/component-library/README.md
@@ -5,14 +5,13 @@ Kaizen components live in two places:
 1. The core Kaizen component library (`@kaizen/component-library`)
 2. Individual draft component packages
 
-To live in the core component library, a component must satisfy a number of quality checks including tests and accessibility standards. Design Systems Team is responsible for moving draft components from their own individual packages into the library when they're ready.
+To live in the core component library, a component must satisfy a number of quality checks including tests and accessibility standards.
 
 All components that do not yet meet these standards live in their own individual draft component packages.
 
-You can find documentation on where to find a particular component in [Storybook](https://cultureamp.design/storybook/). If you click on the blue `Show Info` button at the bottom of a story for a component, you will
-find the name of the npm package for that component.
+To find component usage docs in [Storybook](https://cultureamp.design/storybook/), click on the blue `Show Info` button at the bottom of a story for a component, revealing the name of the npm package for that component.
 
-## Add to a project
+## Add to a new project
 
 Kaizen Component Library is already included in our main product repositories. If it's needed in a new repo, add `@kaizen/component-library` to your `package.json` file:
 
@@ -75,4 +74,8 @@ You can also import Kaizen styles into SCSS files:
 ```
 @import '~@kaizen/component-library/styles/type';
 ```
+
+## Contributing
+
+To contribute to the component library, see the [Contributing guidelines](../../CONTRIBUTING.md).
 

--- a/packages/design-tokens/README.md
+++ b/packages/design-tokens/README.md
@@ -1,45 +1,60 @@
 # Kaizen Tokens
+
 Design tokens for all platforms.
 
 ## About
-Design Tokens are the heart of every Design System. The tokens represented here are platform-agnostic (JSON), as this will help us contribute to & facilitate the maintenance of living style guides. This package defines all the option tokens in Kaizen.
+
+Design tokens are named and stored visual design traits, including colors, typography, and animation timings. Design Tokens are the heart of every Design System.
+
+The tokens represented here are platform-agnostic (JSON), as this will help us contribute to & facilitate the maintenance of living style guides. This package defines all the option tokens in Kaizen.
+
+- **Option tokens** offer options. For example, `$kz-color-wisteria-500: #898ba9;` is one color option available.
+- **Decision tokens** communicate decisions about when to apply an option token to a context. For example, the color used for text is a decision.
 
 In its current state this package supports Sass and Less variables, generated from a JSON tokens file.
 
 **Please note** that the helpers in this package are specifically for accessing and using these design tokens. Component-specific helpers are best suited for kaizen-component-library.
 
 ## Installation
+
 ```
 yarn add @kaizen/design-tokens
 ```
 
 ## Usage
+
 ### Sass
+
 ```
 ## Note helper functions are provided
 @import "~@kaizen/design-tokens/sass/[color/depth/layout/spacing/typography/helpers]";
 ```
 
 ### Less
+
 ```
 ## Note helper functions are provided
 @import "~@kaizen/design-tokens/less/[color/depth/layout/spacing/typography/helpers]";
 ```
 
-### Javascript
+### JavaScript
+
 ```
 import * as tokens from @kaizen/design-tokens/tokens/[color/depth/layout/spacing/typography]
 ```
 
 ## Where possible, we keep things unitless.
+
 When adding support for another target the transformation should add the appropriate unit to the artefact. For example, converting typography sizes to Sass/Less should add REM.
 
 ### Web
+
 All values in tokens are represented as rem, em or px.
 
-    * Use REMs for sizes and spacing (grid).
-    * Use EMs for media queries.
-    * Use px for borders.
+* Use REMs for sizes and spacing (grid).
+* Use EMs for media queries.
+* Use px for borders.
 
 ## Contributing
+
 See [CONRTIBUTING.md](https://github.com/cultureamp/kaizen-design-system/blob/master/packages/design-tokens/CONTRIBUTING.md)

--- a/site/README.md
+++ b/site/README.md
@@ -1,8 +1,28 @@
 # Kaizen Site
 
+## Getting started
+
 `yarn gatsby develop`
 
 Visit: <http://localhost:8000>.
 
 Kaizen Site documentation is written using [Markdown syntax](https://daringfireball.net/projects/markdown/syntax).
+
+Because pages contain "user-generated content" in Markdown, pay attention to styling across pages with different content. For example, broad CSS selectors might have unintended consequences on, for example, bold text in nested bullets or code examples.
+
+To see storybook locally, you need to run that separately. See the main repo [README](../README.md). Storybook demos won't show on component pages.
+
+## Managing plugins
+
+To install [Gatsby plugins](https://www.gatsbyjs.org/plugins/):
+
+```
+yarn add -W <package>
+```
+
+## Troubleshooting
+
+If Gatsby gets confused about Kaizen Site, try removing the `site/.cache`.
+
+For storybook issues, see the main repo [README](../README.md).
 


### PR DESCRIPTION
Key changes:

- Link to design tokens package
- Link to new draft package generator
- Includes a TLDR for contributing
- Defines design tokens
- Adds Kaizen Site dev info
