### PR TITLE
docs: adds a pull_request_template.md for github

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,6 +1,6 @@
 ## Kaizen Contributor Checklist
 
-- [ ] This impacts experience and I got a design review ([details](https://github.com/cultureamp/kaizen-design-system/blob/master/CONTRIBUTING.md#quality-and-reviews))
+- [ ] This impacts experience and I got a design review
 - [ ] I've considered likely risks of these changes and got someone else to QA as appropriate
 - [ ] I have or will communicate these changes to the front end practice
 

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,0 +1,7 @@
+## Kaizen Contributor Checklist
+
+- [ ] I have gotten a design review from a designer if this introduces user facing changes
+- [ ] I have gotten someone else to QA this if the changes are significant
+- [ ] I or someone else has QA'ed this in IE11 if it feels worth it
+
+View the [Contributing docs](https://github.com/cultureamp/kaizen-design-system/blob/master/CONTRIBUTING.md) for more details.

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,7 +1,7 @@
 ## Kaizen Contributor Checklist
 
-- [ ] I have gotten a design review from a designer if this introduces user facing changes
-- [ ] I have gotten someone else to QA this if the changes are significant
-- [ ] I or someone else has QA'ed this in IE11 if it feels worth it
+- [ ] This impacts experience and I got a design review ([details](https://github.com/cultureamp/kaizen-design-system/blob/master/CONTRIBUTING.md#quality-and-reviews))
+- [ ] I've considered likely risks of these changes and got someone else to QA as appropriate
+- [ ] I have or will communicate these changes to the front end practice
 
 View the [Contributing docs](https://github.com/cultureamp/kaizen-design-system/blob/master/CONTRIBUTING.md) for more details.


### PR DESCRIPTION
This PR adds a pull request template. This is intended to work in conjunction with https://github.com/mbylstra/kaizen-contributor-checklist/pull/3 (currently hosted on my personal account, but it's intended be cloned to the cultureamp account when it's ready). You can play around with the checkboxes on that PR to see what happens.

For this PR it just adds a checklists, but when the Kaizen Contributor Checklist Github Action is added as a build step, then the build won't pass unless all the Kaizen checkboxes are ticked.

They are worded in a way that the items don't necessarily have to have been done (no need to get a design review if there are no user facing changes), but the automated check is meant to at least make you think about doing it.

The actual content of the checklist items is completely up for discussion.

If we decide to go ahead with this, then there'll be a follow up PR that adds the Github Action to the repo (this is a simple process)