### PR TITLE
fix: Adds overflow:visible to buttons to fix IE11 clipping issue

### DIFF
--- a/draft-packages/button/KaizenDraft/Button/styles.scss
+++ b/draft-packages/button/KaizenDraft/Button/styles.scss
@@ -53,6 +53,7 @@ $caButton-verticalPaddingForm: calc(
   text-align: center;
   cursor: pointer;
   text-align: center;
+  overflow: visible; // Required for the focus ring on IE11
 
   // looking for padding? See %caButtonContent
 


### PR DESCRIPTION
Turns out that in IE11, pseudo elements on buttons are constrained visually to the dimensions of the button, unless you explicitly add `overflow:visible`. The focus ring styles we have rely on the pseudo element being a bit bigger than the button, so it wasn't able to be seen at all.