### PR TITLE
fix: remove minimist from package.json resolutions

### DIFF
--- a/package.json
+++ b/package.json
@@ -126,9 +126,6 @@
     "lint-staged": "^10.2.2",
     "storybook-chromatic": "^3.4.1"
   },
-  "resolutions": {
-    "**/**/minimist": "^1.2.3"
-  },
   "lint-staged": {
     "*": [
       "prettier --write"

--- a/yarn.lock
+++ b/yarn.lock
@@ -15737,7 +15737,12 @@ minimist-options@^4.0.2:
     is-plain-obj "^1.1.0"
     kind-of "^6.0.3"
 
-minimist@^0.2.0, minimist@^1.1.0, minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0, minimist@^1.2.3, minimist@^1.2.5:
+minimist@^0.2.0:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.2.1.tgz#827ba4e7593464e7c221e8c5bed930904ee2c455"
+  integrity sha512-GY8fANSrTMfBVfInqJAY41QkOM+upUTytK1jZ0c8+3HdHrJxBJ3rF5i9moClXTE8uUSnUo8cAsCoxDXvSY4DHg==
+
+minimist@^1.1.0, minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0, minimist@^1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
   integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==


### PR DESCRIPTION
This was required in the past because a dependency had a transitive dependency on a version of minimist that had a security issue. This is no longer necessary.