### PR TITLE
fix: Make TitleBlockZen title extend full width when no buttons

### DIFF
--- a/draft-packages/stories/TitleBlockZen.stories.tsx
+++ b/draft-packages/stories/TitleBlockZen.stories.tsx
@@ -659,3 +659,24 @@ export const DefaultOnlyPrimary = () => (
 DefaultOnlyPrimary.story = {
   name: "Default (only primary action)",
 }
+
+export const DefaultOnlyLongTitle = () => (
+  <TitleBlockZen
+    title='Page title that is over the "long title" character threshold and goes way longer than usual'
+    subtitle="Subtitle goes here"
+    handleHamburgerClick={() => {
+      alert("Hamburger clicked")
+    }}
+    breadcrumb={{
+      path: "#",
+      text: "Back to home",
+      handleClick: event => {
+        alert("breadcrumb clicked!")
+      },
+    }}
+  />
+)
+
+DefaultOnlyLongTitle.story = {
+  name: "Default (only long title)",
+}

--- a/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/TitleBlockZen.scss
+++ b/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/TitleBlockZen.scss
@@ -97,36 +97,6 @@ $tab-container-height-small: $ca-grid * 2.5;
   align-items: center;
   min-width: 0; // this is an important trick to prevent flexbox items from overflowing
   width: 100%;
-
-  .hasLongTitle.hasLongSubtitle & {
-    @include title-block-under-1645 {
-      max-width: 520px;
-    }
-
-    @include title-block-under-1366 {
-      max-width: 50vw;
-    }
-
-    @media (max-width: 899px) {
-      max-width: 44vw;
-    }
-
-    @include title-block-small {
-      max-width: 83vw;
-    }
-  }
-
-  @include title-block-under-1645 {
-    max-width: 44vw;
-  }
-
-  @include title-block-under-1366 {
-    max-width: 42vw;
-  }
-
-  @include title-block-small {
-    max-width: 83vw;
-  }
 }
 
 .titleAndSubtitle {
@@ -146,6 +116,7 @@ $tab-container-height-small: $ca-grid * 2.5;
   display: flex;
   min-width: 0; // this is an important trick to prevent flexbox items from overflowing
 
+  // TODO: removing .hasLongTitle here fixes the alignment on Performance story, but we should be able to not wrap subtitle.
   .hasSubtitle.hasLongTitle.hasLongSubtitle & {
     align-items: center;
 

--- a/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/TitleBlockZen.scss
+++ b/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/TitleBlockZen.scss
@@ -125,6 +125,10 @@ $tab-container-height-small: $ca-grid * 2.5;
   @include title-block-small {
     max-width: 83vw;
   }
+
+  .hasLongTitle.hasNoPrimaryOrDefaultAction & {
+    max-width: 99%;
+  }
 }
 
 .titleAndSubtitle {

--- a/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/TitleBlockZen.scss
+++ b/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/TitleBlockZen.scss
@@ -54,6 +54,7 @@ $tab-container-height-small: $ca-grid * 2.5;
   display: flex;
   flex-direction: column;
   width: 100%;
+  min-width: 0; // this is an important trick to prevent flexbox items from overflowing
 
   @include title-block-medium-and-small {
     margin: 0 $title-block-margin-width-on-medium-and-small;

--- a/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/TitleBlockZen.scss
+++ b/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/TitleBlockZen.scss
@@ -94,7 +94,8 @@ $tab-container-height-small: $ca-grid * 2.5;
 .title {
   display: flex;
   align-items: center;
-  max-width: 724px;
+  min-width: 0; // this is an important trick to prevent flexbox items from overflowing
+  width: 100%;
 
   .hasLongTitle.hasLongSubtitle & {
     @include title-block-under-1645 {
@@ -125,15 +126,12 @@ $tab-container-height-small: $ca-grid * 2.5;
   @include title-block-small {
     max-width: 83vw;
   }
-
-  .hasLongTitle.hasNoPrimaryOrDefaultAction & {
-    max-width: 99%;
-  }
 }
 
 .titleAndSubtitle {
   display: flex;
   align-items: center;
+  min-width: 0; // this is an important trick to prevent flexbox items from overflowing
 
   .hasSubtitle & {
     @include title-block-under-1366 {
@@ -145,6 +143,7 @@ $tab-container-height-small: $ca-grid * 2.5;
 
 .titleAndSubtitleInner {
   display: flex;
+  min-width: 0; // this is an important trick to prevent flexbox items from overflowing
 
   .hasSubtitle.hasLongTitle.hasLongSubtitle & {
     align-items: center;
@@ -381,11 +380,13 @@ $tab-container-height-small: $ca-grid * 2.5;
 
 .titleAndAdjacent {
   display: flex;
+  min-width: 0; // this is an important trick to prevent flexbox items from overflowing
 }
 
 .titleAndAdjacentNotBreadcrumb {
   display: flex;
   transition: opacity 0.3s ease;
+  min-width: 0; // this is an important trick to prevent flexbox items from overflowing
 
   .breadcrumb:hover + &,
   .breadcrumb:focus + & {
@@ -532,9 +533,8 @@ $tab-container-height-small: $ca-grid * 2.5;
   display: flex;
   align-items: center;
   justify-content: flex-end;
-  flex-basis: 480px;
   flex-grow: 1;
-  flex-shrink: 1;
+  flex-shrink: 0;
 
   @include ca-margin($start: $ca-grid / 2);
 

--- a/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/TitleBlockZen.scss
+++ b/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/TitleBlockZen.scss
@@ -96,7 +96,12 @@ $tab-container-height-small: $ca-grid * 2.5;
   display: flex;
   align-items: center;
   min-width: 0; // this is an important trick to prevent flexbox items from overflowing
-  width: 100%;
+
+  // Applying width 100% when the title is *not* long and is followed by a subtitle
+  // causes misalignment of both.
+  @include title-block-under-1366 {
+    width: 100%;
+  }
 }
 
 .titleAndSubtitle {

--- a/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/TitleBlockZen.tsx
+++ b/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/TitleBlockZen.tsx
@@ -404,8 +404,6 @@ const TitleBlockZen = ({
           [styles.hasAvatar]: Boolean(avatar),
           [styles.hasLongTitle]: title && title.length >= 30,
           [styles.hasLongSubtitle]: subtitle && subtitle.length >= 18,
-          [styles.hasNoPrimaryOrDefaultAction]:
-            !primaryAction && !defaultAction,
           [styles.hasNavigationTabs]:
             navigationTabs && navigationTabs.length > 0,
         })}

--- a/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/TitleBlockZen.tsx
+++ b/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/TitleBlockZen.tsx
@@ -404,6 +404,8 @@ const TitleBlockZen = ({
           [styles.hasAvatar]: Boolean(avatar),
           [styles.hasLongTitle]: title && title.length >= 30,
           [styles.hasLongSubtitle]: subtitle && subtitle.length >= 18,
+          [styles.hasNoPrimaryOrDefaultAction]:
+            !primaryAction && !defaultAction,
           [styles.hasNavigationTabs]:
             navigationTabs && navigationTabs.length > 0,
         })}


### PR DESCRIPTION
## Changes

- Fixes a bug where the title was not extending to its full width even when there was space available.

Other small changes relating to horizontal positioning are also piggybacking on this PR:

- Fixes a title truncation issue where at smaller "desktop" widths the title was not getting an ellipsis but just being cut off abruptly.
- Adds a story for the case where there is only a long title plus a subtitle – not buttons.
- Fixes the bug where the top row of the Title Block was exceeding its max-width at the smallest "desktop" width when the content is cramped. This was fixed by setting `min-width: 0` on various elements to allow `flex-shrink` to work as intended.
- Puts `flex-shrink: 0` on the Main Actions (the 1 or 2 buttons in the top right corner). This is a trade-off that offers less glitchy behaviour at more cramped viewports at the cost of having less real estate for the other content.