### PR TITLE
feat: Add focus support to the Button components

### DIFF
--- a/draft-packages/button/KaizenDraft/Button/Button.tsx
+++ b/draft-packages/button/KaizenDraft/Button/Button.tsx
@@ -4,9 +4,11 @@ import GenericButton, {
   ButtonFunctions,
 } from "./components/GenericButton"
 
-const Button = forwardRef((props: ButtonProps, ref: Ref<ButtonFunctions>) => (
-  <GenericButton {...props} ref={ref} />
-))
+const Button = forwardRef(
+  (props: ButtonProps, ref: Ref<ButtonFunctions | undefined>) => (
+    <GenericButton {...props} ref={ref} />
+  )
+)
 
 Button.defaultProps = {
   fullWidth: false,

--- a/draft-packages/button/KaizenDraft/Button/Button.tsx
+++ b/draft-packages/button/KaizenDraft/Button/Button.tsx
@@ -1,9 +1,13 @@
 import * as React from "react"
-import GenericButton, { ButtonProps } from "./components/GenericButton"
+import GenericButton, {
+  ButtonProps,
+  ButtonFunctions,
+} from "./components/GenericButton"
+import { forwardRef, Ref } from "react"
 
-const Button: React.FunctionComponent<ButtonProps> = props => (
-  <GenericButton {...props} />
-)
+const Button = forwardRef((props: ButtonProps, ref: Ref<ButtonFunctions>) => (
+  <GenericButton {...props} ref={ref} />
+))
 
 Button.defaultProps = {
   fullWidth: false,

--- a/draft-packages/button/KaizenDraft/Button/Button.tsx
+++ b/draft-packages/button/KaizenDraft/Button/Button.tsx
@@ -1,11 +1,11 @@
 import React, { forwardRef, Ref } from "react"
 import GenericButton, {
   ButtonProps,
-  ButtonFunctions,
+  ButtonRef,
 } from "./components/GenericButton"
 
 const Button = forwardRef(
-  (props: ButtonProps, ref: Ref<ButtonFunctions | undefined>) => (
+  (props: ButtonProps, ref: Ref<ButtonRef | undefined>) => (
     <GenericButton {...props} ref={ref} />
   )
 )

--- a/draft-packages/button/KaizenDraft/Button/Button.tsx
+++ b/draft-packages/button/KaizenDraft/Button/Button.tsx
@@ -1,9 +1,8 @@
-import * as React from "react"
+import React, { forwardRef, Ref } from "react"
 import GenericButton, {
   ButtonProps,
   ButtonFunctions,
 } from "./components/GenericButton"
-import { forwardRef, Ref } from "react"
 
 const Button = forwardRef((props: ButtonProps, ref: Ref<ButtonFunctions>) => (
   <GenericButton {...props} ref={ref} />

--- a/draft-packages/button/KaizenDraft/Button/components/GenericButton.tsx
+++ b/draft-packages/button/KaizenDraft/Button/components/GenericButton.tsx
@@ -53,8 +53,10 @@ type Props = ButtonProps & {
 
 export type ButtonFunctions = { focus: () => void }
 
-const getAriaProps = (props: object) => {
-  const keys = Object.keys(props).filter(k => k.startsWith("aria-"))
+// We're treating custom props as anything that is kebab cased.
+// This is so we can support properties like aria-* or data-*
+const getCustomProps = (props: object) => {
+  const keys = Object.keys(props).filter(k => k.indexOf("-") !== -1)
   return keys.reduce((acc, val) => {
     acc[val] = props[val]
     return acc
@@ -108,7 +110,7 @@ const renderButton = (props: Props, ref: Ref<HTMLButtonElement>) => {
     ...rest
   } = props
   const label = props.icon && props.iconButton ? props.label : undefined
-  const ariaProps = getAriaProps(rest)
+  const customProps = getCustomProps(rest)
 
   return (
     <button
@@ -141,7 +143,7 @@ const renderButton = (props: Props, ref: Ref<HTMLButtonElement>) => {
         props.analytics && JSON.stringify(props.analytics.properties)
       }
       ref={ref}
-      {...ariaProps}
+      {...customProps}
     >
       {renderContent(props)}
     </button>
@@ -158,7 +160,7 @@ const renderLink = (props: Props, ref: Ref<HTMLAnchorElement>) => {
     onBlur,
     ...rest
   } = props
-  const ariaProps = getAriaProps(rest)
+  const customProps = getCustomProps(rest)
 
   return (
     <a
@@ -182,7 +184,7 @@ const renderLink = (props: Props, ref: Ref<HTMLAnchorElement>) => {
         props.analytics && JSON.stringify(props.analytics.properties)
       }
       ref={ref}
-      {...ariaProps}
+      {...customProps}
     >
       {renderContent(props)}
     </a>

--- a/draft-packages/button/KaizenDraft/Button/components/GenericButton.tsx
+++ b/draft-packages/button/KaizenDraft/Button/components/GenericButton.tsx
@@ -1,7 +1,6 @@
 import { Icon } from "@kaizen/component-library"
 import classNames from "classnames"
-import * as React from "react"
-import { forwardRef, Ref, useImperativeHandle, useRef } from "react"
+import React, { forwardRef, Ref, useImperativeHandle, useRef } from "react"
 
 const styles = require("./GenericButton.module.scss")
 

--- a/draft-packages/button/KaizenDraft/Button/components/GenericButton.tsx
+++ b/draft-packages/button/KaizenDraft/Button/components/GenericButton.tsx
@@ -53,6 +53,14 @@ type Props = ButtonProps & {
 
 export type ButtonFunctions = { focus: () => void }
 
+const getAriaProps = (props: object) => {
+  const keys = Object.keys(props).filter(k => k.startsWith("aria-"))
+  return keys.reduce((acc, val) => {
+    acc[val] = props[val]
+    return acc
+  }, {})
+}
+
 const GenericButton = forwardRef((props: Props, ref: Ref<ButtonFunctions>) => {
   const buttonRef = useRef<HTMLButtonElement | HTMLLinkElement>()
   useImperativeHandle(ref, () => ({
@@ -97,8 +105,10 @@ const renderButton = (props: Props, ref: Ref<HTMLButtonElement>) => {
     disableTabFocusAndIUnderstandTheAccessibilityImplications,
     onFocus,
     onBlur,
+    ...rest
   } = props
   const label = props.icon && props.iconButton ? props.label : undefined
+  const ariaProps = getAriaProps(rest)
 
   return (
     <button
@@ -131,6 +141,7 @@ const renderButton = (props: Props, ref: Ref<HTMLButtonElement>) => {
         props.analytics && JSON.stringify(props.analytics.properties)
       }
       ref={ref}
+      {...ariaProps}
     >
       {renderContent(props)}
     </button>
@@ -145,7 +156,9 @@ const renderLink = (props: Props, ref: Ref<HTMLAnchorElement>) => {
     newTabAndIUnderstandTheAccessibilityImplications,
     onFocus,
     onBlur,
+    ...rest
   } = props
+  const ariaProps = getAriaProps(rest)
 
   return (
     <a
@@ -169,6 +182,7 @@ const renderLink = (props: Props, ref: Ref<HTMLAnchorElement>) => {
         props.analytics && JSON.stringify(props.analytics.properties)
       }
       ref={ref}
+      {...ariaProps}
     >
       {renderContent(props)}
     </a>

--- a/draft-packages/button/KaizenDraft/Button/components/GenericButton.tsx
+++ b/draft-packages/button/KaizenDraft/Button/components/GenericButton.tsx
@@ -63,26 +63,28 @@ const getCustomProps = (props: object) => {
   }, {})
 }
 
-const GenericButton = forwardRef((props: Props, ref: Ref<ButtonFunctions>) => {
-  const buttonRef = useRef<HTMLButtonElement | HTMLLinkElement>()
-  useImperativeHandle(ref, () => ({
-    focus: () => {
-      buttonRef.current?.focus()
-    },
-  }))
+const GenericButton = forwardRef(
+  (props: Props, ref: Ref<ButtonFunctions | undefined>) => {
+    const buttonRef = useRef<HTMLButtonElement | HTMLAnchorElement>()
+    useImperativeHandle(ref, () => ({
+      focus: () => {
+        buttonRef.current?.focus()
+      },
+    }))
 
-  return (
-    <span
-      className={classNames(styles.container, {
-        [styles.fullWidth]: props.fullWidth,
-      })}
-    >
-      {props.href && !props.disabled
-        ? renderLink(props, buttonRef)
-        : renderButton(props, buttonRef)}
-    </span>
-  )
-})
+    return (
+      <span
+        className={classNames(styles.container, {
+          [styles.fullWidth]: props.fullWidth,
+        })}
+      >
+        {props.href && !props.disabled
+          ? renderLink(props, buttonRef as Ref<HTMLAnchorElement>)
+          : renderButton(props, buttonRef as Ref<HTMLButtonElement>)}
+      </span>
+    )
+  }
+)
 
 GenericButton.defaultProps = {
   iconPosition: "start",

--- a/draft-packages/button/KaizenDraft/Button/components/GenericButton.tsx
+++ b/draft-packages/button/KaizenDraft/Button/components/GenericButton.tsx
@@ -1,6 +1,7 @@
 import { Icon } from "@kaizen/component-library"
 import classNames from "classnames"
 import * as React from "react"
+import { forwardRef, Ref, useImperativeHandle, useRef } from "react"
 
 const styles = require("./GenericButton.module.scss")
 
@@ -51,15 +52,28 @@ type Props = ButtonProps & {
   iconButton?: boolean
 } & AdditionalContentProps
 
-const GenericButton: React.FunctionComponent<Props> = props => (
-  <span
-    className={classNames(styles.container, {
-      [styles.fullWidth]: props.fullWidth,
-    })}
-  >
-    {props.href && !props.disabled ? renderLink(props) : renderButton(props)}
-  </span>
-)
+export type ButtonFunctions = { focus: () => void }
+
+const GenericButton = forwardRef((props: Props, ref: Ref<ButtonFunctions>) => {
+  const buttonRef = useRef<HTMLButtonElement | HTMLLinkElement>()
+  useImperativeHandle(ref, () => ({
+    focus: () => {
+      buttonRef.current?.focus()
+    },
+  }))
+
+  return (
+    <span
+      className={classNames(styles.container, {
+        [styles.fullWidth]: props.fullWidth,
+      })}
+    >
+      {props.href && !props.disabled
+        ? renderLink(props, buttonRef)
+        : renderButton(props, buttonRef)}
+    </span>
+  )
+})
 
 GenericButton.defaultProps = {
   iconPosition: "start",
@@ -71,7 +85,7 @@ GenericButton.defaultProps = {
   type: "button",
 }
 
-const renderButton: React.FunctionComponent<Props> = props => {
+const renderButton = (props: Props, ref: Ref<HTMLButtonElement>) => {
   const {
     id,
     disabled,
@@ -117,13 +131,14 @@ const renderButton: React.FunctionComponent<Props> = props => {
       data-analytics-properties={
         props.analytics && JSON.stringify(props.analytics.properties)
       }
+      ref={ref}
     >
       {renderContent(props)}
     </button>
   )
 }
 
-const renderLink: React.FunctionComponent<Props> = props => {
+const renderLink = (props: Props, ref: Ref<HTMLAnchorElement>) => {
   const {
     id,
     href,
@@ -154,6 +169,7 @@ const renderLink: React.FunctionComponent<Props> = props => {
       data-analytics-properties={
         props.analytics && JSON.stringify(props.analytics.properties)
       }
+      ref={ref}
     >
       {renderContent(props)}
     </a>

--- a/draft-packages/button/KaizenDraft/Button/components/GenericButton.tsx
+++ b/draft-packages/button/KaizenDraft/Button/components/GenericButton.tsx
@@ -51,7 +51,7 @@ type Props = ButtonProps & {
   iconButton?: boolean
 } & AdditionalContentProps
 
-export type ButtonFunctions = { focus: () => void }
+export type ButtonRef = { focus: () => void }
 
 // We're treating custom props as anything that is kebab cased.
 // This is so we can support properties like aria-* or data-*
@@ -64,7 +64,7 @@ const getCustomProps = (props: object) => {
 }
 
 const GenericButton = forwardRef(
-  (props: Props, ref: Ref<ButtonFunctions | undefined>) => {
+  (props: Props, ref: Ref<ButtonRef | undefined>) => {
     const buttonRef = useRef<HTMLButtonElement | HTMLAnchorElement>()
     useImperativeHandle(ref, () => ({
       focus: () => {

--- a/draft-packages/button/index.ts
+++ b/draft-packages/button/index.ts
@@ -3,5 +3,5 @@ export { default as IconButton } from "./KaizenDraft/Button/IconButton"
 export { ButtonProps } from "./KaizenDraft/Button/components/GenericButton"
 export {
   IconButtonProps,
-  ButtonFunctions,
+  ButtonRef,
 } from "./KaizenDraft/Button/components/GenericButton"

--- a/draft-packages/button/index.ts
+++ b/draft-packages/button/index.ts
@@ -1,4 +1,7 @@
 export { default as Button } from "./KaizenDraft/Button/Button"
 export { default as IconButton } from "./KaizenDraft/Button/IconButton"
 export { ButtonProps } from "./KaizenDraft/Button/components/GenericButton"
-export { IconButtonProps } from "./KaizenDraft/Button/components/GenericButton"
+export {
+  IconButtonProps,
+  ButtonFunctions,
+} from "./KaizenDraft/Button/components/GenericButton"

--- a/draft-packages/stories/Button.stories.tsx
+++ b/draft-packages/stories/Button.stories.tsx
@@ -3,7 +3,8 @@ import { Button } from "../button"
 const configureIcon = require("@kaizen/component-library/icons/configure.icon.svg")
   .default
 import { action } from "@storybook/addon-actions"
-import React from "react"
+import React, { useCallback, useLayoutEffect, useRef } from "react"
+import { ButtonFunctions } from "@kaizen/draft-button/KaizenDraft/Button/components/GenericButton"
 
 export default {
   title: "Button (Zen) (React)",
@@ -299,6 +300,26 @@ export const OverflowingTextFormTestCase = () => (
     />
   </div>
 )
+
+export const FocusExample = () => {
+  const ref = useRef<ButtonFunctions>()
+  const handleClick = useCallback(() => {
+    ref.current?.focus()
+  }, [])
+  return (
+    <>
+      <Button label="Label" ref={ref} />
+      <hr />
+      <p>
+        This story is to test the ability to imperatively call the `focus`
+        function.
+      </p>
+      <button onClick={handleClick}>
+        Click here to focus the button above
+      </button>
+    </>
+  )
+}
 
 OverflowingTextFormTestCase.story = {
   name: "Overflowing text, Form (test case)",

--- a/draft-packages/stories/Button.stories.tsx
+++ b/draft-packages/stories/Button.stories.tsx
@@ -4,7 +4,7 @@ const configureIcon = require("@kaizen/component-library/icons/configure.icon.sv
   .default
 import { action } from "@storybook/addon-actions"
 import React, { useCallback, useLayoutEffect, useRef } from "react"
-import { ButtonFunctions } from "@kaizen/draft-button/KaizenDraft/Button/components/GenericButton"
+import { ButtonFunctions } from "@kaizen/draft-button"
 
 export default {
   title: "Button (Zen) (React)",

--- a/draft-packages/stories/Button.stories.tsx
+++ b/draft-packages/stories/Button.stories.tsx
@@ -4,7 +4,7 @@ const configureIcon = require("@kaizen/component-library/icons/configure.icon.sv
   .default
 import { action } from "@storybook/addon-actions"
 import React, { useCallback, useLayoutEffect, useRef } from "react"
-import { ButtonFunctions } from "@kaizen/draft-button"
+import { ButtonRef } from "@kaizen/draft-button"
 
 export default {
   title: "Button (Zen) (React)",
@@ -302,7 +302,7 @@ export const OverflowingTextFormTestCase = () => (
 )
 
 export const FocusExample = () => {
-  const ref = useRef<ButtonFunctions>()
+  const ref = useRef<ButtonRef>()
   const handleClick = useCallback(() => {
     ref.current?.focus()
   }, [])

--- a/packages/component-library/components/Button/Button.tsx
+++ b/packages/component-library/components/Button/Button.tsx
@@ -4,9 +4,11 @@ import GenericButton, {
   ButtonFunctions,
 } from "./components/GenericButton"
 
-const Button = forwardRef((props: ButtonProps, ref: Ref<ButtonFunctions>) => (
-  <GenericButton {...props} ref={ref} />
-))
+const Button = forwardRef(
+  (props: ButtonProps, ref: Ref<ButtonFunctions | undefined>) => (
+    <GenericButton {...props} ref={ref} />
+  )
+)
 
 Button.defaultProps = {
   fullWidth: false,

--- a/packages/component-library/components/Button/Button.tsx
+++ b/packages/component-library/components/Button/Button.tsx
@@ -1,9 +1,13 @@
 import * as React from "react"
-import GenericButton, { ButtonProps } from "./components/GenericButton"
+import GenericButton, {
+  ButtonProps,
+  ButtonFunctions,
+} from "./components/GenericButton"
+import { forwardRef, Ref } from "react"
 
-const Button: React.FunctionComponent<ButtonProps> = props => (
-  <GenericButton {...props} />
-)
+const Button = forwardRef((props: ButtonProps, ref: Ref<ButtonFunctions>) => (
+  <GenericButton {...props} ref={ref} />
+))
 
 Button.defaultProps = {
   fullWidth: false,

--- a/packages/component-library/components/Button/Button.tsx
+++ b/packages/component-library/components/Button/Button.tsx
@@ -1,11 +1,11 @@
 import React, { forwardRef, Ref } from "react"
 import GenericButton, {
   ButtonProps,
-  ButtonFunctions,
+  ButtonRef,
 } from "./components/GenericButton"
 
 const Button = forwardRef(
-  (props: ButtonProps, ref: Ref<ButtonFunctions | undefined>) => (
+  (props: ButtonProps, ref: Ref<ButtonRef | undefined>) => (
     <GenericButton {...props} ref={ref} />
   )
 )

--- a/packages/component-library/components/Button/Button.tsx
+++ b/packages/component-library/components/Button/Button.tsx
@@ -1,9 +1,8 @@
-import * as React from "react"
+import React, { forwardRef, Ref } from "react"
 import GenericButton, {
   ButtonProps,
   ButtonFunctions,
 } from "./components/GenericButton"
-import { forwardRef, Ref } from "react"
 
 const Button = forwardRef((props: ButtonProps, ref: Ref<ButtonFunctions>) => (
   <GenericButton {...props} ref={ref} />

--- a/packages/component-library/components/Button/components/GenericButton.tsx
+++ b/packages/component-library/components/Button/components/GenericButton.tsx
@@ -1,6 +1,7 @@
 import classNames from "classnames"
 import * as React from "react"
 import Icon from "../../Icon/Icon"
+import { forwardRef, Ref, useImperativeHandle, useRef } from "react"
 
 const styles = require("./GenericButton.module.scss")
 
@@ -43,15 +44,28 @@ type Props = ButtonProps & {
   iconButton?: boolean
 }
 
-const GenericButton: React.FunctionComponent<Props> = props => (
-  <span
-    className={classNames(styles.container, {
-      [styles.fullWidth]: props.fullWidth,
-    })}
-  >
-    {props.href ? renderLink(props) : renderButton(props)}
-  </span>
-)
+export type ButtonFunctions = { focus: () => void }
+
+const GenericButton = forwardRef((props: Props, ref: Ref<ButtonFunctions>) => {
+  const buttonRef = useRef<HTMLButtonElement | HTMLAnchorElement>()
+  useImperativeHandle(ref, () => ({
+    focus: () => {
+      buttonRef.current?.focus()
+    },
+  }))
+
+  return (
+    <span
+      className={classNames(styles.container, {
+        [styles.fullWidth]: props.fullWidth,
+      })}
+    >
+      {props.href
+        ? renderLink(props, buttonRef)
+        : renderButton(props, buttonRef)}
+    </span>
+  )
+})
 
 GenericButton.defaultProps = {
   iconPosition: "start",
@@ -63,7 +77,7 @@ GenericButton.defaultProps = {
   type: "button",
 }
 
-const renderButton: React.FunctionComponent<Props> = props => {
+const renderButton = (props: Props, ref: Ref<HTMLButtonElement>) => {
   const {
     id,
     disabled,
@@ -101,13 +115,14 @@ const renderButton: React.FunctionComponent<Props> = props => {
       data-analytics-properties={
         props.analytics && JSON.stringify(props.analytics.properties)
       }
+      ref={ref}
     >
       {renderContent(props)}
     </button>
   )
 }
 
-const renderLink: React.FunctionComponent<Props> = props => {
+const renderLink = (props: Props, ref: Ref<HTMLAnchorElement>) => {
   const {
     id,
     href,
@@ -138,6 +153,7 @@ const renderLink: React.FunctionComponent<Props> = props => {
       data-analytics-properties={
         props.analytics && JSON.stringify(props.analytics.properties)
       }
+      ref={ref}
     >
       {renderContent(props)}
     </a>

--- a/packages/component-library/components/Button/components/GenericButton.tsx
+++ b/packages/component-library/components/Button/components/GenericButton.tsx
@@ -55,26 +55,28 @@ const getCustomProps = (props: object) => {
   }, {})
 }
 
-const GenericButton = forwardRef((props: Props, ref: Ref<ButtonFunctions>) => {
-  const buttonRef = useRef<HTMLButtonElement | HTMLAnchorElement>()
-  useImperativeHandle(ref, () => ({
-    focus: () => {
-      buttonRef.current?.focus()
-    },
-  }))
+const GenericButton = forwardRef(
+  (props: Props, ref: Ref<ButtonFunctions | undefined>) => {
+    const buttonRef = useRef<HTMLButtonElement | HTMLAnchorElement>()
+    useImperativeHandle(ref, () => ({
+      focus: () => {
+        buttonRef.current?.focus()
+      },
+    }))
 
-  return (
-    <span
-      className={classNames(styles.container, {
-        [styles.fullWidth]: props.fullWidth,
-      })}
-    >
-      {props.href
-        ? renderLink(props, buttonRef)
-        : renderButton(props, buttonRef)}
-    </span>
-  )
-})
+    return (
+      <span
+        className={classNames(styles.container, {
+          [styles.fullWidth]: props.fullWidth,
+        })}
+      >
+        {props.href
+          ? renderLink(props, buttonRef as Ref<HTMLAnchorElement>)
+          : renderButton(props, buttonRef as Ref<HTMLButtonElement>)}
+      </span>
+    )
+  }
+)
 
 GenericButton.defaultProps = {
   iconPosition: "start",

--- a/packages/component-library/components/Button/components/GenericButton.tsx
+++ b/packages/component-library/components/Button/components/GenericButton.tsx
@@ -45,8 +45,10 @@ type Props = ButtonProps & {
 
 export type ButtonFunctions = { focus: () => void }
 
-const getAriaProps = (props: object) => {
-  const keys = Object.keys(props).filter(k => k.startsWith("aria-"))
+// We're treating custom props as anything that is kebab cased.
+// This is so we can support properties like aria-* or data-*
+const getCustomProps = (props: object) => {
+  const keys = Object.keys(props).filter(k => k.indexOf("-") !== -1)
   return keys.reduce((acc, val) => {
     acc[val] = props[val]
     return acc
@@ -96,7 +98,7 @@ const renderButton = (props: Props, ref: Ref<HTMLButtonElement>) => {
     ...rest
   } = props
   const label = props.icon && props.iconButton ? props.label : undefined
-  const ariaProps = getAriaProps(rest)
+  const customProps = getCustomProps(rest)
 
   return (
     <button
@@ -125,7 +127,7 @@ const renderButton = (props: Props, ref: Ref<HTMLButtonElement>) => {
         props.analytics && JSON.stringify(props.analytics.properties)
       }
       ref={ref}
-      {...ariaProps}
+      {...customProps}
     >
       {renderContent(props)}
     </button>
@@ -142,7 +144,7 @@ const renderLink = (props: Props, ref: Ref<HTMLAnchorElement>) => {
     onBlur,
     ...rest
   } = props
-  const ariaProps = getAriaProps(rest)
+  const customProps = getCustomProps(rest)
 
   return (
     <a
@@ -166,7 +168,7 @@ const renderLink = (props: Props, ref: Ref<HTMLAnchorElement>) => {
         props.analytics && JSON.stringify(props.analytics.properties)
       }
       ref={ref}
-      {...ariaProps}
+      {...customProps}
     >
       {renderContent(props)}
     </a>

--- a/packages/component-library/components/Button/components/GenericButton.tsx
+++ b/packages/component-library/components/Button/components/GenericButton.tsx
@@ -45,6 +45,14 @@ type Props = ButtonProps & {
 
 export type ButtonFunctions = { focus: () => void }
 
+const getAriaProps = (props: object) => {
+  const keys = Object.keys(props).filter(k => k.startsWith("aria-"))
+  return keys.reduce((acc, val) => {
+    acc[val] = props[val]
+    return acc
+  }, {})
+}
+
 const GenericButton = forwardRef((props: Props, ref: Ref<ButtonFunctions>) => {
   const buttonRef = useRef<HTMLButtonElement | HTMLAnchorElement>()
   useImperativeHandle(ref, () => ({
@@ -85,8 +93,10 @@ const renderButton = (props: Props, ref: Ref<HTMLButtonElement>) => {
     disableTabFocusAndIUnderstandTheAccessibilityImplications,
     onFocus,
     onBlur,
+    ...rest
   } = props
   const label = props.icon && props.iconButton ? props.label : undefined
+  const ariaProps = getAriaProps(rest)
 
   return (
     <button
@@ -115,6 +125,7 @@ const renderButton = (props: Props, ref: Ref<HTMLButtonElement>) => {
         props.analytics && JSON.stringify(props.analytics.properties)
       }
       ref={ref}
+      {...ariaProps}
     >
       {renderContent(props)}
     </button>
@@ -129,7 +140,9 @@ const renderLink = (props: Props, ref: Ref<HTMLAnchorElement>) => {
     newTabAndIUnderstandTheAccessibilityImplications,
     onFocus,
     onBlur,
+    ...rest
   } = props
+  const ariaProps = getAriaProps(rest)
 
   return (
     <a
@@ -153,6 +166,7 @@ const renderLink = (props: Props, ref: Ref<HTMLAnchorElement>) => {
         props.analytics && JSON.stringify(props.analytics.properties)
       }
       ref={ref}
+      {...ariaProps}
     >
       {renderContent(props)}
     </a>

--- a/packages/component-library/components/Button/components/GenericButton.tsx
+++ b/packages/component-library/components/Button/components/GenericButton.tsx
@@ -1,7 +1,6 @@
 import classNames from "classnames"
-import * as React from "react"
+import React, { forwardRef, Ref, useImperativeHandle, useRef } from "react"
 import Icon from "../../Icon/Icon"
-import { forwardRef, Ref, useImperativeHandle, useRef } from "react"
 
 const styles = require("./GenericButton.module.scss")
 

--- a/packages/component-library/components/Button/components/GenericButton.tsx
+++ b/packages/component-library/components/Button/components/GenericButton.tsx
@@ -43,7 +43,7 @@ type Props = ButtonProps & {
   iconButton?: boolean
 }
 
-export type ButtonFunctions = { focus: () => void }
+export type ButtonRef = { focus: () => void }
 
 // We're treating custom props as anything that is kebab cased.
 // This is so we can support properties like aria-* or data-*
@@ -56,7 +56,7 @@ const getCustomProps = (props: object) => {
 }
 
 const GenericButton = forwardRef(
-  (props: Props, ref: Ref<ButtonFunctions | undefined>) => {
+  (props: Props, ref: Ref<ButtonRef | undefined>) => {
     const buttonRef = useRef<HTMLButtonElement | HTMLAnchorElement>()
     useImperativeHandle(ref, () => ({
       focus: () => {

--- a/packages/component-library/components/Button/index.ts
+++ b/packages/component-library/components/Button/index.ts
@@ -1,3 +1,3 @@
 export { default as Button } from "./Button"
 export { default as IconButton } from "./IconButton"
-export { ButtonProps } from "./components/GenericButton"
+export { ButtonProps, ButtonFunctions } from "./components/GenericButton"

--- a/packages/component-library/components/Button/index.ts
+++ b/packages/component-library/components/Button/index.ts
@@ -1,3 +1,3 @@
 export { default as Button } from "./Button"
 export { default as IconButton } from "./IconButton"
-export { ButtonProps, ButtonFunctions } from "./components/GenericButton"
+export { ButtonProps, ButtonRef } from "./components/GenericButton"

--- a/packages/component-library/stories/Button.stories.tsx
+++ b/packages/component-library/stories/Button.stories.tsx
@@ -3,7 +3,7 @@ const configureIcon = require("@kaizen/component-library/icons/configure.icon.sv
   .default
 import { action } from "@storybook/addon-actions"
 import React, { useCallback, useRef } from "react"
-import { ButtonFunctions } from "../components/Button/components/GenericButton"
+import { ButtonFunctions } from "../components/Button"
 
 export default {
   title: "Button (deprecated) (React)",

--- a/packages/component-library/stories/Button.stories.tsx
+++ b/packages/component-library/stories/Button.stories.tsx
@@ -3,7 +3,7 @@ const configureIcon = require("@kaizen/component-library/icons/configure.icon.sv
   .default
 import { action } from "@storybook/addon-actions"
 import React, { useCallback, useRef } from "react"
-import { ButtonFunctions } from "../components/Button"
+import { ButtonRef } from "../components/Button"
 
 export default {
   title: "Button (deprecated) (React)",
@@ -436,7 +436,7 @@ export const MultipleButtons = () => (
 )
 
 export const FocusExample = () => {
-  const ref = useRef<ButtonFunctions>()
+  const ref = useRef<ButtonRef>()
   const handleClick = useCallback(() => {
     ref.current?.focus()
   }, [])

--- a/packages/component-library/stories/Button.stories.tsx
+++ b/packages/component-library/stories/Button.stories.tsx
@@ -3,6 +3,8 @@ const configureIcon = require("@kaizen/component-library/icons/configure.icon.sv
   .default
 import { action } from "@storybook/addon-actions"
 import * as React from "react"
+import { useCallback, useRef } from "react"
+import { ButtonFunctions } from "../components/Button/components/GenericButton"
 
 export default {
   title: "Button (deprecated) (React)",
@@ -433,3 +435,23 @@ export const MultipleButtons = () => (
     <Button label="Exit" automationId="demo-button-2" />
   </div>
 )
+
+export const FocusExample = () => {
+  const ref = useRef<ButtonFunctions>()
+  const handleClick = useCallback(() => {
+    ref.current?.focus()
+  }, [])
+  return (
+    <>
+      <Button label="Label" ref={ref} />
+      <hr />
+      <p>
+        This story is to test the ability to imperatively call the `focus`
+        function.
+      </p>
+      <button onClick={handleClick}>
+        Click here to focus the button above
+      </button>
+    </>
+  )
+}

--- a/packages/component-library/stories/Button.stories.tsx
+++ b/packages/component-library/stories/Button.stories.tsx
@@ -2,8 +2,7 @@ import { Button } from "@kaizen/component-library"
 const configureIcon = require("@kaizen/component-library/icons/configure.icon.svg")
   .default
 import { action } from "@storybook/addon-actions"
-import * as React from "react"
-import { useCallback, useRef } from "react"
+import React, { useCallback, useRef } from "react"
 import { ButtonFunctions } from "../components/Button/components/GenericButton"
 
 export default {


### PR DESCRIPTION
* Give the ability to imperatively call `focus` the two `Button` components.

![image](https://user-images.githubusercontent.com/4495057/87897327-53e67380-ca8e-11ea-9764-9ca1a815a898.png)

* Forward down any `aria-*` props down to the two `Button` components. Edit: support has been updated to allow for all kebab cased props.

### Motivation

I'm going through perf-ui at the moment, and making some a11y improvements. One of those improvements is for a dropdown menu, which uses this kaizen button. When the user presses escape, and we've closed the dropdown menu, we need to place the focus back on the original button.

The menu in perform, under "Goals":

![image](https://user-images.githubusercontent.com/4495057/87897513-f7378880-ca8e-11ea-872e-f12bb5a647d4.png)

I realised after the fact, that we already have a button dropdown in kaizen, and I should have just replaced the perform-ui code. But, I think the updates will still be handy at some point.