### PR TITLE
fix: Vertical tabs are bold in both active and inactive states

### DIFF
--- a/draft-packages/stories/ExampleLayout.module.scss
+++ b/draft-packages/stories/ExampleLayout.module.scss
@@ -3,6 +3,7 @@
 
 .container {
   margin-top: 20px;
+  padding: 1rem;
   display: flex;
   max-width: $kz-layout-content-max-width;
   margin: 0 auto;

--- a/draft-packages/stories/Tabs.stories.tsx
+++ b/draft-packages/stories/Tabs.stories.tsx
@@ -4,6 +4,7 @@ import { Tabs } from "@kaizen/draft-tabs"
 import classnames from "classnames"
 import * as React from "react"
 import { ExampleLayout } from "./ExampleLayout"
+import { Divider } from "@kaizen/draft-divider"
 
 export default {
   title: "Tabs (React)",
@@ -249,7 +250,7 @@ export const WithCustomTabRenderer = () => {
 }
 
 WithCustomTabRenderer.story = {
-  name: "With custom tab renderer (Horizontal)",
+  name: "(Example) With custom tab renderer (Horizontal)",
 }
 
 export const WithCustomTabRendererVertical = () => {
@@ -293,7 +294,7 @@ export const WithCustomTabRendererVertical = () => {
 }
 
 WithCustomTabRendererVertical.story = {
-  name: "With custom tab renderer (Vertical)",
+  name: "(Example) With custom tab renderer (Vertical)",
 }
 
 export const WithLayoutVerticalLTR = () => {
@@ -320,7 +321,7 @@ export const WithLayoutVerticalLTR = () => {
 }
 
 WithLayoutVerticalLTR.story = {
-  name: "Layout LTR (Vertical)",
+  name: "(Example) Layout LTR (Vertical)",
   parameters: {
     backgrounds: [
       {
@@ -356,7 +357,51 @@ export const WithLayoutVerticalRTL = () => {
 }
 
 WithLayoutVerticalRTL.story = {
-  name: "Layout RTL (Vertical)",
+  name: "(Example) Layout RTL (Vertical)",
+  parameters: {
+    backgrounds: [
+      {
+        name: "Stone",
+        value: colorTokens.kz.color.stone,
+        default: true,
+      },
+    ],
+  },
+}
+
+export const WithHeading = () => {
+  const tabs = [
+    {
+      label: "One (href here)",
+      href: "//www.example.com",
+      active: true,
+    },
+    { label: "Two", href: "https://www.cultureamp.design/storybook" },
+    { label: "Three", href: "https://www.cultureamp.design/storybook" },
+    { label: "Four", href: "https://www.cultureamp.design/storybook" },
+  ]
+  return (
+    <ExampleLayout>
+      <ExampleLayout.Sidebar>
+        <Box pr={1}>
+          <Heading variant="heading-6">Some Heading</Heading>
+          <Tabs orientation="vertical" tabs={tabs} textDirection="ltr" />
+          <Box py={1}>
+            <Divider variant="content" />
+          </Box>
+          <Heading variant="heading-6">Another Heading</Heading>
+          <Tabs orientation="vertical" tabs={tabs} textDirection="ltr" />
+        </Box>
+      </ExampleLayout.Sidebar>
+      <ExampleLayout.Content>
+        <Box p={2}>Example layout</Box>
+      </ExampleLayout.Content>
+    </ExampleLayout>
+  )
+}
+
+WithHeading.story = {
+  name: "(Example) Layout With heading",
   parameters: {
     backgrounds: [
       {

--- a/draft-packages/stories/Tabs.stories.tsx
+++ b/draft-packages/stories/Tabs.stories.tsx
@@ -371,7 +371,7 @@ WithLayoutVerticalRTL.story = {
 }
 
 export const WithHeading = () => {
-  const tabs = [
+  const firstTabs = [
     {
       label: "One (href here)",
       href: "//www.example.com",
@@ -381,17 +381,24 @@ export const WithHeading = () => {
     { label: "Three", href: "https://www.cultureamp.design/storybook" },
     { label: "Four", href: "https://www.cultureamp.design/storybook" },
   ]
+  const secondTabs = [
+    {
+      label: "Five",
+      href: "//www.example.com",
+    },
+    { label: "Six", href: "https://www.cultureamp.design/storybook" },
+  ]
   return (
     <ExampleLayout>
       <ExampleLayout.Sidebar>
         <Box pr={1}>
           <Heading variant="heading-6">Some Heading</Heading>
-          <Tabs orientation="vertical" tabs={tabs} textDirection="ltr" />
+          <Tabs orientation="vertical" tabs={firstTabs} textDirection="ltr" />
           <Box py={1}>
             <Divider variant="content" />
           </Box>
           <Heading variant="heading-6">Another Heading</Heading>
-          <Tabs orientation="vertical" tabs={tabs} textDirection="ltr" />
+          <Tabs orientation="vertical" tabs={secondTabs} textDirection="ltr" />
         </Box>
       </ExampleLayout.Sidebar>
       <ExampleLayout.Content>

--- a/draft-packages/stories/Tabs.stories.tsx
+++ b/draft-packages/stories/Tabs.stories.tsx
@@ -1,10 +1,11 @@
 import { Box, Heading, Paragraph } from "@kaizen/component-library"
-import * as colorTokens from "@kaizen/design-tokens/tokens/color.json"
+import { Card } from "@kaizen/draft-card"
 import { Tabs } from "@kaizen/draft-tabs"
+import { Divider } from "@kaizen/draft-divider"
+import * as colorTokens from "@kaizen/design-tokens/tokens/color.json"
 import classnames from "classnames"
 import * as React from "react"
 import { ExampleLayout } from "./ExampleLayout"
-import { Divider } from "@kaizen/draft-divider"
 
 export default {
   title: "Tabs (React)",
@@ -250,7 +251,7 @@ export const WithCustomTabRenderer = () => {
 }
 
 WithCustomTabRenderer.story = {
-  name: "(Example) With custom tab renderer (Horizontal)",
+  name: "With custom tab renderer (Horizontal)",
 }
 
 export const WithCustomTabRendererVertical = () => {
@@ -294,7 +295,7 @@ export const WithCustomTabRendererVertical = () => {
 }
 
 WithCustomTabRendererVertical.story = {
-  name: "(Example) With custom tab renderer (Vertical)",
+  name: "With custom tab renderer (Vertical)",
 }
 
 export const WithLayoutVerticalLTR = () => {
@@ -402,6 +403,47 @@ export const WithHeading = () => {
 
 WithHeading.story = {
   name: "(Example) Layout With heading",
+  parameters: {
+    backgrounds: [
+      {
+        name: "Stone",
+        value: colorTokens.kz.color.stone,
+        default: true,
+      },
+    ],
+  },
+}
+
+export const ExampleContentTab = () => {
+  const tabs = [
+    {
+      label: "One (href here)",
+      href: "//www.example.com",
+    },
+    {
+      label: "Two",
+      href: "https://www.cultureamp.design/storybook",
+      active: true,
+    },
+    { label: "Three", href: "https://www.cultureamp.design/storybook" },
+    { label: "Four", href: "https://www.cultureamp.design/storybook" },
+  ]
+  return (
+    <ExampleLayout>
+      <ExampleLayout.Content>
+        <Card>
+          <Box pb={2}>
+            <Tabs orientation="horizontal" tabs={tabs} textDirection="ltr" />
+            <Divider variant="content" />
+          </Box>
+        </Card>
+      </ExampleLayout.Content>
+    </ExampleLayout>
+  )
+}
+
+ExampleContentTab.story = {
+  name: "(Example) Content Tab in Content Area",
   parameters: {
     backgrounds: [
       {

--- a/draft-packages/stories/Tabs.stories.tsx
+++ b/draft-packages/stories/Tabs.stories.tsx
@@ -312,7 +312,9 @@ export const WithLayoutVerticalLTR = () => {
   return (
     <ExampleLayout>
       <ExampleLayout.Sidebar>
-        <Tabs orientation="vertical" tabs={tabs} />
+        <Box pr={1}>
+          <Tabs orientation="vertical" tabs={tabs} />
+        </Box>
       </ExampleLayout.Sidebar>
       <ExampleLayout.Content>
         <Box p={2}>Example layout</Box>
@@ -348,7 +350,9 @@ export const WithLayoutVerticalRTL = () => {
   return (
     <ExampleLayout rtl>
       <ExampleLayout.Sidebar>
-        <Tabs orientation="vertical" tabs={tabs} textDirection="rtl" />
+        <Box pl={1}>
+          <Tabs orientation="vertical" tabs={tabs} textDirection="rtl" />
+        </Box>
       </ExampleLayout.Sidebar>
       <ExampleLayout.Content>
         <Box p={2}>Example layout</Box>
@@ -392,12 +396,12 @@ export const WithHeading = () => {
     <ExampleLayout>
       <ExampleLayout.Sidebar>
         <Box pr={1}>
-          <Heading variant="heading-6">Some Heading</Heading>
+          <Heading variant="heading-6">Some heading</Heading>
           <Tabs orientation="vertical" tabs={firstTabs} textDirection="ltr" />
           <Box py={1}>
-            <Divider variant="content" />
+            <Divider variant="canvas" />
           </Box>
-          <Heading variant="heading-6">Another Heading</Heading>
+          <Heading variant="heading-6">Another heading</Heading>
           <Tabs orientation="vertical" tabs={secondTabs} textDirection="ltr" />
         </Box>
       </ExampleLayout.Sidebar>

--- a/draft-packages/tabs/KaizenDraft/Tabs/styles.scss
+++ b/draft-packages/tabs/KaizenDraft/Tabs/styles.scss
@@ -119,7 +119,6 @@
   &:hover:not(.horizontalTabActive) {
     color: $kz-color-wisteria-800;
     background-color: transparent;
-    font-weight: normal;
   }
 }
 
@@ -169,6 +168,5 @@
   &:hover:not(.verticalTabActive) {
     color: $kz-color-wisteria-800;
     background-color: transparent;
-    font-weight: normal;
   }
 }

--- a/draft-packages/tabs/KaizenDraft/Tabs/styles.scss
+++ b/draft-packages/tabs/KaizenDraft/Tabs/styles.scss
@@ -8,7 +8,6 @@
 @import "~@kaizen/deprecated-component-library-helpers/styles/type";
 
 .container {
-  @include ca-margin($bottom: $ca-grid);
   display: flex;
 }
 

--- a/draft-packages/tabs/KaizenDraft/Tabs/styles.scss
+++ b/draft-packages/tabs/KaizenDraft/Tabs/styles.scss
@@ -136,6 +136,7 @@
   justify-content: flex-start;
   padding-left: $kz-spacing-sm;
   border-radius: $kz-border-solid-border-radius;
+  font-weight: $kz-typography-heading-4-font-weight;
 
   :global(.js-focus-visible) &:global(.focus-visible):after {
     border-radius: $kz-border-borderless-border-radius;
@@ -146,7 +147,6 @@
 .verticalTabActive {
   composes: tab;
   composes: verticalTab;
-  font-weight: $kz-typography-heading-4-font-weight;
   color: $kz-color-cluny-500;
 }
 

--- a/draft-packages/tabs/KaizenDraft/Tabs/styles.scss
+++ b/draft-packages/tabs/KaizenDraft/Tabs/styles.scss
@@ -134,9 +134,16 @@
   display: flex;
   align-items: center;
   justify-content: flex-start;
-  padding-left: $kz-spacing-sm;
   border-radius: $kz-border-solid-border-radius;
   font-weight: $kz-typography-heading-4-font-weight;
+
+  [dir="rtl"] & {
+    padding-right: $kz-spacing-sm;
+  }
+
+  [dir="ltr"] & {
+    padding-left: $kz-spacing-sm;
+  }
 
   :global(.js-focus-visible) &:global(.focus-visible):after {
     border-radius: $kz-border-borderless-border-radius;


### PR DESCRIPTION
Updated to reflect the design in Figma. 

Stories: 
https://dev.cultureamp.design/ally/update-tabs/storybook/?path=/story/tabs-react--with-layout-vertical-ltr
https://dev.cultureamp.design/ally/update-tabs/storybook/?path=/story/tabs-react--with-heading


Checklist: 

- [ ] Design review