### PR TITLE
feat: allow arbitrary Html in TextField description fields (Elm & React)

### DIFF
--- a/draft-packages/form/KaizenDraft/Form/Primitives/FieldMessage/FieldMessage.elm
+++ b/draft-packages/form/KaizenDraft/Form/Primitives/FieldMessage/FieldMessage.elm
@@ -33,7 +33,7 @@ type alias ConfigValue msg =
     , automationId : Maybe String
     , reversed : Bool
     , message : String
-    , messageHtml : Maybe (Html msg)
+    , messageHtml : Maybe (List (Html msg))
     , status : FieldMessageStatus
     }
 
@@ -82,7 +82,7 @@ message value (Config config) =
     Config { config | message = value }
 
 
-messageHtml : Maybe (Html msg) -> Config msg -> Config msg
+messageHtml : Maybe (List (Html msg)) -> Config msg -> Config msg
 messageHtml value (Config config) =
     Config { config | messageHtml = value }
 
@@ -125,7 +125,7 @@ view (Config config) =
                     ]
                ]
         )
-        [ case ( config.message, config.messageHtml ) of
+        (case ( config.message, config.messageHtml ) of
             ( _, Just html ) ->
                 -- ideally we'd only allow either a string or html, not both, but
                 -- we wanted to avoid a breaking change, so we need to deal with
@@ -134,5 +134,5 @@ view (Config config) =
                 html
 
             ( messageString, Nothing ) ->
-                text messageString
-        ]
+                [ text messageString ]
+        )

--- a/draft-packages/form/KaizenDraft/Form/Primitives/FieldMessage/FieldMessage.elm
+++ b/draft-packages/form/KaizenDraft/Form/Primitives/FieldMessage/FieldMessage.elm
@@ -1,4 +1,4 @@
-module KaizenDraft.Form.Primitives.FieldMessage.FieldMessage exposing (FieldMessageStatus(..), automationId, default, id, message, reversed, status, view)
+module KaizenDraft.Form.Primitives.FieldMessage.FieldMessage exposing (FieldMessageStatus(..), automationId, default, id, message, messageHtml, reversed, status, view)
 
 import CssModules exposing (css)
 import Html exposing (..)
@@ -24,25 +24,27 @@ type FieldMessageStatus
 -- CONFIG
 
 
-type Config
-    = Config ConfigValue
+type Config msg
+    = Config (ConfigValue msg)
 
 
-type alias ConfigValue =
+type alias ConfigValue msg =
     { id : Maybe String
     , automationId : Maybe String
     , reversed : Bool
     , message : String
+    , messageHtml : Maybe (Html msg)
     , status : FieldMessageStatus
     }
 
 
-defaults : ConfigValue
+defaults : ConfigValue msg
 defaults =
     { id = Nothing
     , automationId = Nothing
     , reversed = False
     , message = ""
+    , messageHtml = Nothing
     , status = Default
     }
 
@@ -51,7 +53,7 @@ defaults =
 -- VARIANTS
 
 
-default : Config
+default : Config msg
 default =
     Config defaults
 
@@ -60,32 +62,37 @@ default =
 -- MODIFIERS
 
 
-id : String -> Config -> Config
+id : String -> Config msg -> Config msg
 id value (Config config) =
     Config { config | id = Just value }
 
 
-automationId : String -> Config -> Config
+automationId : String -> Config msg -> Config msg
 automationId value (Config config) =
     Config { config | automationId = Just value }
 
 
-reversed : Bool -> Config -> Config
+reversed : Bool -> Config msg -> Config msg
 reversed value (Config config) =
     Config { config | reversed = value }
 
 
-message : String -> Config -> Config
+message : String -> Config msg -> Config msg
 message value (Config config) =
     Config { config | message = value }
 
 
-status : FieldMessageStatus -> Config -> Config
+messageHtml : Maybe (Html msg) -> Config msg -> Config msg
+messageHtml value (Config config) =
+    Config { config | messageHtml = value }
+
+
+status : FieldMessageStatus -> Config msg -> Config msg
 status value (Config config) =
     Config { config | status = value }
 
 
-view : Config -> Html msg
+view : Config msg -> Html msg
 view (Config config) =
     let
         idAttr =
@@ -118,4 +125,14 @@ view (Config config) =
                     ]
                ]
         )
-        [ text config.message ]
+        [ case ( config.message, config.messageHtml ) of
+            ( _, Just html ) ->
+                -- ideally we'd only allow either a string or html, not both, but
+                -- we wanted to avoid a breaking change, so we need to deal with
+                -- nonsensical state where both are provided, so the html
+                -- aribitrarily wins out if both are supplied
+                html
+
+            ( messageString, Nothing ) ->
+                text messageString
+        ]

--- a/draft-packages/form/KaizenDraft/Form/Primitives/FieldMessage/FieldMessage.tsx
+++ b/draft-packages/form/KaizenDraft/Form/Primitives/FieldMessage/FieldMessage.tsx
@@ -7,7 +7,7 @@ export type FieldMessageStatus = "default" | "success" | "error"
 export type FieldMessageProps = {
   id?: string
   automationId?: string
-  message?: string
+  message?: React.ReactNode
   status?: FieldMessageStatus
   reversed?: boolean
 }

--- a/draft-packages/form/KaizenDraft/Form/TextAreaField/TextAreaField.tsx
+++ b/draft-packages/form/KaizenDraft/Form/TextAreaField/TextAreaField.tsx
@@ -19,7 +19,7 @@ type Props = {
   defaultValue?: string
   validationMessage?: string
   status?: InputStatus
-  description?: string
+  description?: React.ReactNode
   textAreaRef?: React.RefObject<HTMLTextAreaElement>
   onChange?: (event: React.ChangeEvent<HTMLTextAreaElement>) => any
   onBlur?: (event: React.FocusEvent<HTMLTextAreaElement>) => any

--- a/draft-packages/form/KaizenDraft/Form/TextField/TextField.elm
+++ b/draft-packages/form/KaizenDraft/Form/TextField/TextField.elm
@@ -6,6 +6,7 @@ module KaizenDraft.Form.TextField.TextField exposing
     , controlled
     , default
     , description
+    , descriptionHtml
     , disabled
     , icon
     , id
@@ -77,7 +78,7 @@ type alias ConfigValue msg =
     , placeholder : String
     , validationMessage : Maybe String
     , description : Maybe String
-    , descriptionHtml : Maybe (Html msg)
+    , descriptionHtml : Maybe (List (Html msg))
     , disabled : Bool
     , inputValue : String
     , controlled : Bool
@@ -163,6 +164,11 @@ validationMessage value (Config config) =
 description : String -> Config msg -> Config msg
 description value (Config config) =
     Config { config | description = Just value }
+
+
+descriptionHtml : List (Html msg) -> Config msg -> Config msg
+descriptionHtml value (Config config) =
+    Config { config | descriptionHtml = Just value }
 
 
 disabled : Bool -> Config msg -> Config msg

--- a/draft-packages/form/KaizenDraft/Form/TextField/TextField.elm
+++ b/draft-packages/form/KaizenDraft/Form/TextField/TextField.elm
@@ -77,6 +77,7 @@ type alias ConfigValue msg =
     , placeholder : String
     , validationMessage : Maybe String
     , description : Maybe String
+    , descriptionHtml : Maybe (Html msg)
     , disabled : Bool
     , inputValue : String
     , controlled : Bool
@@ -100,6 +101,7 @@ defaults =
     , placeholder = ""
     , validationMessage = Nothing
     , description = Nothing
+    , descriptionHtml = Nothing
     , disabled = False
     , inputValue = ""
     , controlled = True
@@ -357,8 +359,11 @@ view (Config config) =
                     FieldMessage.Default
 
         fieldDescriptionHtml =
-            case config.description of
-                Just descriptionString ->
+            case ( config.description, config.descriptionHtml ) of
+                ( Nothing, Nothing ) ->
+                    text ""
+
+                _ ->
                     div
                         [ styles.classList
                             [ ( .description, True )
@@ -368,14 +373,13 @@ view (Config config) =
                             (FieldMessage.default
                                 |> FieldMessage.id (idProp ++ "-field-description")
                                 |> FieldMessage.automationId (idProp ++ "-field-description")
-                                |> FieldMessage.message descriptionString
+                                |> FieldMessage.message
+                                    (config.description |> Maybe.withDefault "")
+                                |> FieldMessage.messageHtml config.descriptionHtml
                                 |> FieldMessage.status FieldMessage.Default
                                 |> FieldMessage.reversed config.reversed
                             )
                         ]
-
-                Nothing ->
-                    text ""
 
         fieldValidationMessageHtml =
             case config.validationMessage of

--- a/draft-packages/form/KaizenDraft/Form/TextField/TextField.tsx
+++ b/draft-packages/form/KaizenDraft/Form/TextField/TextField.tsx
@@ -31,7 +31,7 @@ type TextField = React.FunctionComponent<{
   icon?: React.SVGAttributes<SVGSymbolElement>
   status?: InputStatus
   validationMessage?: string
-  description?: string
+  description?: React.ReactNode
   onChange?: (event: React.ChangeEvent<HTMLInputElement>) => any
   onBlur?: (event: React.FocusEvent<HTMLInputElement>) => any
   onFocus?: (event: React.FocusEvent<HTMLInputElement>) => any

--- a/draft-packages/stories/ElmTextField.stories.tsx
+++ b/draft-packages/stories/ElmTextField.stories.tsx
@@ -3,4 +3,6 @@ import { loadElmStories } from "@cultureamp/elm-storybook"
 loadElmStories("TextField (Elm)", module, require("./TextFieldStories.elm"), [
   "Default",
   "Default /w icon",
+  "Default /w string description",
+  "Default /w html description",
 ])

--- a/draft-packages/stories/TextField.stories.tsx
+++ b/draft-packages/stories/TextField.stories.tsx
@@ -1,6 +1,7 @@
 import colorTokens from "@kaizen/design-tokens/tokens/color.json"
 import { action } from "@storybook/addon-actions"
 import React, { useCallback, useRef } from "react"
+import { Tooltip } from "@kaizen/draft-tooltip"
 
 import { TextField } from "@kaizen/draft-form"
 const lockIcon = require("@kaizen/component-library/icons/lock.icon.svg")
@@ -582,4 +583,37 @@ export const DefaultUncontrolled = () => {
 
 DefaultUncontrolled.story = {
   name: "Default, Uncontrolled",
+}
+
+export const DefaultWithHtmlDescription = () => {
+  const description = (
+    <>
+      The description may contain a link to further details - we recommended
+      opening the link in a new tab with an
+      <span style={{ position: "relative" }}>
+        <Tooltip position="above" text="opens in new tab">
+          <a
+            href="https://cultureamp.design/guidelines/link-vs-button/#opens-in-new-tab-tooltip"
+            target="_blank"
+          >
+            "opens in new tab" tooltip{" "}
+          </a>
+        </Tooltip>
+      </span>
+    </>
+  )
+
+  return (
+    <ExampleContainer>
+      <TextField
+        id="default-with-html-description"
+        labelText="This a text field with a HTML description"
+        description={description}
+      />
+    </ExampleContainer>
+  )
+}
+
+DefaultWithHtmlDescription.story = {
+  name: "Default w HTML description",
 }

--- a/draft-packages/stories/TextFieldStories.elm
+++ b/draft-packages/stories/TextFieldStories.elm
@@ -2,10 +2,13 @@ module Main exposing (TextFieldModel)
 
 import Browser.Dom exposing (blur)
 import ElmStorybook exposing (storyOf, storybook)
+import Html exposing (a, div, span, text)
+import Html.Attributes exposing (href, style, target)
 import Html.Extra exposing (static)
 import Icon.Icon as Icon
 import Icon.SvgAsset exposing (svgAsset)
 import KaizenDraft.Form.TextField.TextField as TextField
+import KaizenDraft.Tooltip.Tooltip as Tooltip
 import Task
 
 
@@ -77,4 +80,35 @@ main =
                         |> TextField.onEnter TextFieldEnter
                         |> TextField.icon icon
                     )
+        , storyOf "Default /w string description" config <|
+            \m ->
+                maxWidthContainer <|
+                    TextField.view
+                        (TextField.default
+                            |> TextField.labelText "Default TextField with string description"
+                            |> TextField.description "Helper text placed below the field can include further instructions or information on how to fill out the text field."
+                        )
+        , storyOf "Default /w html description" config <|
+            \m ->
+                maxWidthContainer <|
+                    TextField.view
+                        (TextField.default
+                            |> TextField.labelText "Default TextField with HTML description"
+                            |> TextField.descriptionHtml
+                                [ text "The description may contain a link to further details - we recommended opening the link in a new tab with an "
+                                , span [ style "position" "relative" ]
+                                    [ Tooltip.view
+                                        (Tooltip.default "opens in a new tab"
+                                            |> Tooltip.position Tooltip.Above
+                                        )
+                                        (a [ href "https://cultureamp.design/guidelines/link-vs-button/#opens-in-new-tab-tooltip", target "_blank", style "position" "relative" ]
+                                            [ text "\"opens in a new tab\" tooltip" ]
+                                        )
+                                    ]
+                                ]
+                        )
         ]
+
+
+maxWidthContainer content =
+    span [ style "max-width" "30rem" ] [ content ]


### PR DESCRIPTION
This allows arbitrary Html to be optionally used for description/message fields in relevant form fields. Currently
it is restricted to just strings. The use case was being able to put a link in the description to a page with more details.

The following components have been updated:
`FieldMessage` (named `message`, React and Elm, used by TextField and TextAreaField)
`TextField` (React and Elm)
`TextAreaField` (React only, Elm TextAreaField does not exist yet)

We wanted to avoid a breaking change. For React, we just needed to loosen the type of the `description`/`message` fields. In Elm a change from `string` to `Html msg` would be a breaking change, so instead we have introduced new fields `descriptionHtml` and `messageHtml` respectively. We also considered using the type system to restrict the allowed elements (ideally we'd only allow links and strong/em tags), but we felt this would overcomplicate things, particularly as we are currently exploring sharing code with Stencil/web components, so it didn't seem worth going too far down this path at this point in time.

Stories have been provided that show intended use cases. Although the React and Elm type systems allow anything to be put in, we hope that Kaizen users follow the guides in cultlureamp.design and use stories as examples of what is permitted.

**Storybook story demonstrating a link in description (React)**
https://dev.cultureamp.design/ted/loosen-text-field-description-restrictions/storybook/?path=/story/textfield-react--default-with-html-description

**Storybook story demonstrating a link in description (Elm)**
https://dev.cultureamp.design/ted/loosen-text-field-description-restrictions/storybook/?path=/story/textfield-elm--default-w-html-description

## TODO
- [x] Elm TextField
- [x] Elm story demonstrating a link inside the description (with an "open in new tab" tooltip as recommended by
      the design system guidelines)
- [x] React TextField
- [x] React story demonstrating a link inside the description (with an "open in new tab" tooltip as recommended by
      the design system guidelines)
- [x] All other components using FieldMessage? (the remainder was TextAreaField, no other components use FieldMessage)
