### PR TITLE
fix: title block explicitly sets color of breadcrumb text

### DIFF
--- a/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/TitleBlockZen.scss
+++ b/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/TitleBlockZen.scss
@@ -560,6 +560,7 @@ $tab-container-height-small: $ca-grid * 2.5;
 }
 
 .breadcrumb {
+  cursor: pointer;
   display: flex;
   position: absolute;
   z-index: $ca-z-index-sticky;

--- a/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/TitleBlockZen.scss
+++ b/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/TitleBlockZen.scss
@@ -570,12 +570,6 @@ $tab-container-height-small: $ca-grid * 2.5;
     $start: calc(-#{$breadcrumb-circle-width} - #{$ca-grid})
   );
   align-self: normal;
-  color: $kz-color-white;
-
-  .educationVariant &,
-  .adminVariant & {
-    color: $kz-color-wisteria-800;
-  }
 
   &:hover {
     text-decoration: none;
@@ -617,6 +611,15 @@ $tab-container-height-small: $ca-grid * 2.5;
 
   &:hover {
     text-decoration: underline;
+  }
+}
+
+.breadcrumb,
+.breadcrumbText {
+  color: $kz-color-white;
+  .educationVariant &,
+  .adminVariant & {
+    color: $kz-color-wisteria-800;
   }
 }
 


### PR DESCRIPTION
Issue only present in murmur.

<img width="220" alt="Screen Shot 2020-07-29 at 12 54 26 pm" src="https://user-images.githubusercontent.com/13988803/88744153-a9abd180-d19a-11ea-8996-3e9229ec5dec.png">

Becomes:

<img width="232" alt="Screen Shot 2020-07-29 at 12 54 58 pm" src="https://user-images.githubusercontent.com/13988803/88744177-b7f9ed80-d19a-11ea-9959-42e6fd755a5b.png">


Additionally I've explicitly set the cursor to pointer
