### PR TITLE
fix: Update react select version to fix scroll bug

### DIFF
--- a/draft-packages/select/package.json
+++ b/draft-packages/select/package.json
@@ -36,7 +36,7 @@
     "@kaizen/draft-form": "^2.3.0",
     "@types/classnames": "^2.2.10",
     "classnames": "^2.2.6",
-    "react-select": "3.0.8"
+    "react-select": "^3.1.0"
   },
   "devDependencies": {
     "@cultureamp/elm-storybook": "cultureamp/elm-storybook#0.2.1",

--- a/packages/component-library/package.json
+++ b/packages/component-library/package.json
@@ -43,7 +43,7 @@
     "react-animate-height": "^2.0.15",
     "react-focus-lock": "^1.19.1",
     "react-media": "^1.9.2",
-    "react-select": "^3.0.8",
+    "react-select": "^3.1.0",
     "react-tooltip": "^4.2.6",
     "react-transition-group": "^2.9.0",
     "uuid": "^3.3.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -19100,21 +19100,7 @@ react-remove-scroll@^2.3.0:
     use-callback-ref "^1.2.3"
     use-sidecar "^1.0.1"
 
-react-select@3.0.8:
-  version "3.0.8"
-  resolved "https://registry.yarnpkg.com/react-select/-/react-select-3.0.8.tgz#06ff764e29db843bcec439ef13e196865242e0c1"
-  integrity sha512-v9LpOhckLlRmXN5A6/mGGEft4FMrfaBFTGAnuPHcUgVId7Je42kTq9y0Z+Ye5z8/j0XDT3zUqza8gaRaI1PZIg==
-  dependencies:
-    "@babel/runtime" "^7.4.4"
-    "@emotion/cache" "^10.0.9"
-    "@emotion/core" "^10.0.9"
-    "@emotion/css" "^10.0.9"
-    memoize-one "^5.0.0"
-    prop-types "^15.6.0"
-    react-input-autosize "^2.2.2"
-    react-transition-group "^2.2.1"
-
-react-select@^3.0.8:
+react-select@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/react-select/-/react-select-3.1.0.tgz#ab098720b2e9fe275047c993f0d0caf5ded17c27"
   integrity sha512-wBFVblBH1iuCBprtpyGtd1dGMadsG36W5/t2Aj8OE6WbByDg5jIFyT7X5gT+l0qmT5TqWhxX+VsKJvCEl2uL9g==
@@ -19186,7 +19172,7 @@ react-tooltip@^4.2.6:
     prop-types "^15.7.2"
     uuid "^7.0.3"
 
-react-transition-group@^2.2.1, react-transition-group@^2.9.0:
+react-transition-group@^2.9.0:
   version "2.9.0"
   resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-2.9.0.tgz#df9cdb025796211151a436c69a8f3b97b5b07c8d"
   integrity sha512-+HzNTCHpeQyl4MJ/bdE0u6XRMe9+XG/+aL4mCxVN4DnPBQ0/5bfHWPDuOZUzYdMj94daZaZdCCc1Dzt9R/xSSg==


### PR DESCRIPTION
This fixes a bug where the dropdown doesnt scroll to the selected option

Updated it in a couple of places. Only a minor update that fixes a few
bugs and adds a new feature. Should be backwards compatible.

## Before
![before](https://user-images.githubusercontent.com/21532/88902248-4a7eb780-d295-11ea-9dc1-098944217e76.gif)

.. see how when you re-open it's at the top?

## After
![after](https://user-images.githubusercontent.com/21532/88902240-4783c700-d295-11ea-80c9-168771089dba.gif)

.. now when you open the select, the current selection is visible.
