### PR TITLE
fix: Extend TableHeaderRowCell to have automationId options

### DIFF
--- a/draft-packages/table/KaizenDraft/Table/Table.tsx
+++ b/draft-packages/table/KaizenDraft/Table/Table.tsx
@@ -52,7 +52,6 @@ const ratioToPercent = (width?: number) =>
 type TableHeaderRowCell = React.FunctionComponent<{
   labelText: string
   automationId?: string
-  checkboxAutomationId?: string
   onClick?: (e: React.MouseEvent<HTMLButtonElement>) => any
   width?: number
   flex?: string
@@ -73,7 +72,6 @@ export const TableHeaderRowCell: TableHeaderRowCell = ({
   onCheck,
   active,
   automationId,
-  checkboxAutomationId,
   ...otherProps
 }) => {
   const label = icon ? (
@@ -85,7 +83,7 @@ export const TableHeaderRowCell: TableHeaderRowCell = ({
       {checkable && (
         <div className={styles.headerRowCellCheckbox}>
           <Checkbox
-            automationId={checkboxAutomationId}
+            automationId={`${automationId}-checkbox`}
             checkedStatus={checkedStatus}
             onCheck={onCheck}
           />

--- a/draft-packages/table/KaizenDraft/Table/Table.tsx
+++ b/draft-packages/table/KaizenDraft/Table/Table.tsx
@@ -51,6 +51,8 @@ const ratioToPercent = (width?: number) =>
  */
 type TableHeaderRowCell = React.FunctionComponent<{
   labelText: string
+  automationId?: string
+  checkboxAutomationId?: string
   onClick?: (e: React.MouseEvent<HTMLButtonElement>) => any
   width?: number
   flex?: string
@@ -70,6 +72,8 @@ export const TableHeaderRowCell: TableHeaderRowCell = ({
   checkedStatus,
   onCheck,
   active,
+  automationId,
+  checkboxAutomationId,
   ...otherProps
 }) => {
   const label = icon ? (
@@ -80,7 +84,11 @@ export const TableHeaderRowCell: TableHeaderRowCell = ({
     <div className={styles.headerRowCellCheckboxContainer}>
       {checkable && (
         <div className={styles.headerRowCellCheckbox}>
-          <Checkbox checkedStatus={checkedStatus} onCheck={onCheck} />
+          <Checkbox
+            automationId={checkboxAutomationId}
+            checkedStatus={checkedStatus}
+            onCheck={onCheck}
+          />
         </div>
       )}
       <Heading tag="div" variant="heading-6">
@@ -95,6 +103,7 @@ export const TableHeaderRowCell: TableHeaderRowCell = ({
   }
   return onClick ? (
     <button
+      data-automation-id={automationId}
       style={style}
       className={classNames(styles.headerRowCell, { [styles.active]: active })}
       onClick={onClick}
@@ -106,6 +115,7 @@ export const TableHeaderRowCell: TableHeaderRowCell = ({
     </button>
   ) : (
     <div
+      data-automation-id={automationId}
       style={style}
       className={styles.headerRowCell}
       role="columnheader"


### PR DESCRIPTION
## Objective

Enable ability to add an automation ID for the button + checkbox. 

I decided to let that same automation ID apply to the `div`.

## Notes

This is part of my e2e test generate for Performance. Every one of these will be a blocker, so any help to merge as I go would be delightful.