### PR TITLE
feat: add divider for Elm

### DIFF
--- a/draft-packages/divider/KaizenDraft/Divider/Divider.elm
+++ b/draft-packages/divider/KaizenDraft/Divider/Divider.elm
@@ -1,0 +1,77 @@
+module KaizenDraft.Divider.Divider exposing (Variant(..), default, reversed, variant, view)
+
+import CssModules exposing (css)
+import Html exposing (Html, hr)
+
+
+type Config msg
+    = Config Configuration
+
+
+type alias Configuration =
+    { variant : Variant
+    , reversed : Bool
+    }
+
+
+defaults : Configuration
+defaults =
+    { variant = Canvas, reversed = False }
+
+
+
+-- VARIANTS
+
+
+type Variant
+    = Content
+    | Canvas
+
+
+default : Config msg
+default =
+    Config defaults
+
+
+variant : Variant -> Config msg
+variant variantType =
+    Config { defaults | variant = variantType }
+
+
+
+-- MODIFIERS
+
+
+reversed : Bool -> Config msg -> Config msg
+reversed isReversed (Config config) =
+    Config { config | reversed = isReversed }
+
+
+view : Config msg -> Html msg
+view (Config config) =
+    let
+        variantClass =
+            case config.variant of
+                Content ->
+                    .content
+
+                Canvas ->
+                    .canvas
+    in
+    hr
+        [ styles.classList
+            [ ( .wrapper, True )
+            , ( .reversed, config.reversed == True )
+            , ( variantClass, True )
+            ]
+        ]
+        []
+
+
+styles =
+    css "@kaizen/draft-divider/KaizenDraft/Divider/styles.module.scss"
+        { wrapper = "wrapper"
+        , content = "content"
+        , canvas = "canvas"
+        , reversed = "reversed"
+        }

--- a/draft-packages/stories/Divider.stories.elm
+++ b/draft-packages/stories/Divider.stories.elm
@@ -1,22 +1,21 @@
 module Main exposing (main)
 
+import CssModules exposing (css)
 import ElmStorybook exposing (statelessStoryOf, storybook)
 import Html exposing (Html, div)
 import Html.Attributes exposing (style)
 import KaizenDraft.Divider.Divider as Divider exposing (..)
 
 
-wisteria700 =
-    "#6B6E94"
-
-
-storyContainer : List (Html msg) -> Maybe String -> Html msg
-storyContainer children background =
+storyContainer : List (Html msg) -> Bool -> Html msg
+storyContainer children reversed =
     div
         [ style "width" "600px"
         , style "margin" "0 auto"
         , style "padding" "90px"
-        , style "background-color" (Maybe.withDefault "#fff" background)
+        , styles.classList
+            [ ( .reversedBackground, reversed )
+            ]
         ]
         children
 
@@ -24,13 +23,19 @@ storyContainer children background =
 main =
     storybook
         [ statelessStoryOf "Default" <|
-            storyContainer [ Divider.view Divider.default ] Nothing
+            storyContainer [ Divider.view Divider.default ] False
         , statelessStoryOf "Canvas" <|
-            storyContainer [ Divider.view (Divider.variant Divider.Canvas) ] Nothing
+            storyContainer [ Divider.view (Divider.variant Divider.Canvas) ] False
         , statelessStoryOf "Canvas (Reversed)" <|
-            storyContainer [ Divider.view (Divider.variant Divider.Canvas |> Divider.reversed True) ] (Just wisteria700)
+            storyContainer [ Divider.view (Divider.variant Divider.Canvas |> Divider.reversed True) ] True
         , statelessStoryOf "Content" <|
-            storyContainer [ Divider.view (Divider.variant Divider.Content) ] Nothing
+            storyContainer [ Divider.view (Divider.variant Divider.Content) ] False
         , statelessStoryOf "Content (Reversed)" <|
-            storyContainer [ Divider.view (Divider.variant Divider.Content |> Divider.reversed True) ] (Just wisteria700)
+            storyContainer [ Divider.view (Divider.variant Divider.Content |> Divider.reversed True) ] True
         ]
+
+
+styles =
+    css "./ElmDivider.stories.scss"
+        { reversedBackground = "reversedBackground"
+        }

--- a/draft-packages/stories/Divider.stories.elm
+++ b/draft-packages/stories/Divider.stories.elm
@@ -1,0 +1,36 @@
+module Main exposing (main)
+
+import ElmStorybook exposing (statelessStoryOf, storybook)
+import Html exposing (Html, div)
+import Html.Attributes exposing (style)
+import KaizenDraft.Divider.Divider as Divider exposing (..)
+
+
+wisteria700 =
+    "#6B6E94"
+
+
+storyContainer : List (Html msg) -> Maybe String -> Html msg
+storyContainer children background =
+    div
+        [ style "width" "600px"
+        , style "margin" "0 auto"
+        , style "padding" "90px"
+        , style "background-color" (Maybe.withDefault "#fff" background)
+        ]
+        children
+
+
+main =
+    storybook
+        [ statelessStoryOf "Default" <|
+            storyContainer [ Divider.view Divider.default ] Nothing
+        , statelessStoryOf "Canvas" <|
+            storyContainer [ Divider.view (Divider.variant Divider.Canvas) ] Nothing
+        , statelessStoryOf "Canvas (Reversed)" <|
+            storyContainer [ Divider.view (Divider.variant Divider.Canvas |> Divider.reversed True) ] (Just wisteria700)
+        , statelessStoryOf "Content" <|
+            storyContainer [ Divider.view (Divider.variant Divider.Content) ] Nothing
+        , statelessStoryOf "Content (Reversed)" <|
+            storyContainer [ Divider.view (Divider.variant Divider.Content |> Divider.reversed True) ] (Just wisteria700)
+        ]

--- a/draft-packages/stories/ElmDivider.stories.scss
+++ b/draft-packages/stories/ElmDivider.stories.scss
@@ -1,0 +1,5 @@
+@import "~@kaizen/design-tokens/sass/color";
+
+.reversedBackground {
+  background-color: $kz-color-wisteria-700;
+}

--- a/draft-packages/stories/ElmDivider.stories.tsx
+++ b/draft-packages/stories/ElmDivider.stories.tsx
@@ -1,0 +1,9 @@
+import { loadElmStories } from "@cultureamp/elm-storybook"
+
+loadElmStories("Divider (Elm)", module, require("./Divider.stories.elm"), [
+  "Default",
+  "Canvas",
+  "Canvas (Reversed)",
+  "Content",
+  "Content (Reversed)",
+])

--- a/elm.json
+++ b/elm.json
@@ -8,6 +8,7 @@
         "./draft-packages/checkbox-group",
         "./draft-packages/collapsible",
         "./draft-packages/dropdown",
+        "./draft-packages/divider",
         "./draft-packages/empty-state",
         "./draft-packages/events",
         "./draft-packages/form",


### PR DESCRIPTION
## Overview

<img width="714" alt="Screen Shot 2020-08-04 at 3 51 32 pm" src="https://user-images.githubusercontent.com/2108002/89257895-6655d500-d66a-11ea-9abb-dcc1a1d5820d.png">

Adds Elm divider for draft-divider package

