### PR TITLE
fix: Extend TitleBlockZen API so NavigationTabs can take an automation ID

### DIFF
--- a/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/NavigationTabs.tsx
+++ b/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/NavigationTabs.tsx
@@ -4,17 +4,14 @@ import { NON_REVERSED_VARIANTS, Variant } from "./TitleBlockZen"
 
 const styles = require("./NavigationTabs.scss")
 
-export type NavigationTabsProps = {
-  id?: string
-  automationId?: string
-}
-
 export type NavigationTabProps = {
   text: string
   href: string
   active?: boolean
   handleClick?: (event: React.MouseEvent) => void
   variant?: Variant
+  id?: string
+  automationId?: string
 }
 
 const isLight = (variant: Variant | undefined): boolean =>
@@ -27,6 +24,8 @@ const NavigationTab = (props: NavigationTabProps) => (
     })}
     href={props.href}
     onClick={props.handleClick}
+    id={props.id}
+    data-automation-id={props.automationId}
   >
     <div
       className={classnames(styles.linkLabel, {


### PR DESCRIPTION
## Objective

See title

## Notes

I did see that the `div` was within the `a` tag but decided not to look into it.