### PR TITLE
docs: add slider page

### DIFF
--- a/site/docs/components/slider.mdx
+++ b/site/docs/components/slider.mdx
@@ -21,16 +21,20 @@ import WhenNotToUse from "docs-components/WhenNotToUse"
 
 Sliders are helpful for choosing subjective values.
 
-- Always show the current, selected value.
+- Always indicate the current, selected value. Ideally with visible text associated with the handle, but at a minimum provide a text alternative for screen readers.
 - Provide a visible label describing what the slider changes, such as "Brightness".
 - Show the minimum value on the left and maximum value on the right, where these are reversed in Right-To-Left (RTL) languages.
+- We generally use sliders with no fill. You might use a fill when it's useful to give the impression of building towards the maximum value.
 - We only use horizontal sliders. We're yet to need a vertical slider.
-- We only use sliders with no fill so far.
 - We only use sliders with a single handle. We're unlikely to need a slider with more than one handle.
 
 ### Style
 
-- There's rarely a need to apply labels to every tick mark. Consider only showing a label for min, max, and middle ticks, such as 0%, 100%, and 50%.
+- Tick marks:
+    - For a fine-grained range, you might consider hiding tick marks to minimize visual clutter. For example, a range of 0%–100% with 1% steps would have too many ticks and be incredibly crowded.
+    - For a coarse range, where the slider may snap to widely spaced intervals, you might show a tick mark for every step so it is clear where the slider will snap to.
+- Tick labels:
+    - There's rarely a need to apply labels to every tick mark. Consider only showing a label for min, max, and middle ticks, such as 0%, 100%, and maybe 50%.
 
 ### Behavior
 

--- a/site/docs/components/slider.mdx
+++ b/site/docs/components/slider.mdx
@@ -1,0 +1,91 @@
+---
+title: Slider
+navTitle: Slider (not built)
+summaryParagraph: A slider lets people imprecisely select a value from a subjective range by moving a handle horizontally.
+tags: ["Range", "Range input", "Range slider"]
+needToKnow:
+- Avoid sliders when choosing a precise value is important.
+---
+
+import WhenToUseAndWhenNotToUse from "docs-components/WhenToUseAndWhenNotToUse"
+import WhenToUse from "docs-components/WhenToUse"
+import WhenNotToUse from "docs-components/WhenNotToUse"
+
+## Visuals
+
+### Examples
+
+<iframe style="border: none;" width="744" height="450" src="https://www.figma.com/embed?embed_host=share&url=https%3A%2F%2Fwww.figma.com%2Ffile%2Fe3TyAOZKfLg9cA01Iy1Mgm%2FKaizen-Site-embed%3Fnode-id%3D47508%253A35978&chrome=DOCUMENTATION" allowfullscreen></iframe>
+
+## To keep in mind
+
+Sliders are helpful for choosing subjective values.
+
+- Always show the current, selected value.
+- Provide a visible label describing what the slider changes, such as "Brightness".
+- Show the minimum value on the left and maximum value on the right, where these are reversed in Right-To-Left (RTL) languages.
+- We only use horizontal sliders. We're yet to need a vertical slider.
+- We only use sliders with no fill so far.
+- We only use sliders with a single handle. We're unlikely to need a slider with more than one handle.
+
+### Style
+
+- There's rarely a need to apply labels to every tick mark. Consider only showing a label for min, max, and middle ticks, such as 0%, 100%, and 50%.
+
+### Behavior
+
+- Use a `step` number to set the granularity that the slider values snap to. A good default step is 1 to stick to whole numbers.
+- Consider pairing the slider with a [Text Field](/components/text-field) as an alternative input control.
+
+### Accessibility
+
+For a custom slider:
+
+- Use the `slider` `role` to show that the element displays selects a value from within a given range.
+- Use the `aria-valuenow`, `aria-valuemin`, and `aria-valuemax` attributes to indicate progress completion.
+- Use the `aria-valuetext` attribute to show a text label associated with a given value.
+- Ensure a large touch target for selecting the handle.
+
+### Keyboard
+
+- The slider must be keyboard focusable and operable, and RTL languages reverse the direction of arrows. Usually:
+    - Right and Up arrows increase the selected value
+    - Left and Down arrows decrease the selected value
+
+## When to use and when not to use
+
+<WhenToUseAndWhenNotToUse>
+<WhenToUse>
+
+- Use a slider when an imprecise selection makes sense. For example, you might use a slider to ask someone to rate how they're feeling or adjust settings, such as brightness or volume.
+- Use a slider when changing the value has an immediate effect. If applying the setting requires pressing a confirmation button, consider using a [Radio Group](/components/radio-group) instead.
+
+</WhenToUse>
+<WhenNotToUse>
+
+- For selecting precise values, consider using a [Text Field](/components/text-field), [Radio Group](/components/radio-group), or [Select](/components/select) instead.
+- For large ranges e.g. 0–1000, use a [Text Field](/components/text-field) instead.
+- For small ranges e.g. 1–3, use a [Radio Group](/components/radio-group) or [Select](/components/select) instead.
+
+</WhenNotToUse>
+</WhenToUseAndWhenNotToUse>
+
+## See also
+
+- [Text Field](/components/text-field)
+- [Radio Group](/components/radio-group)
+- [Select](/components/select)
+
+## External Links
+
+- [MDN: input range](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/range)
+- [MDN: Using the slider role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_slider_role)
+- [WAI-ARIA: Slider authoring practices](https://www.w3.org/TR/wai-aria-practices-1.1/#slider)
+- [Spectrum: Slider](https://spectrum.adobe.com/page/slider/)
+- [Carbon: slider](https://www.carbondesignsystem.com/components/slider/usage/)
+- [Material: Sliders](https://material.io/components/sliders#usage)
+- [Ant Design: Slider](https://ant.design/components/slider/)
+- [Fluent UI: Slider](https://developer.microsoft.com/en-us/fluentui#/controls/web/slider)
+- [Lightning: Slider](https://www.lightningdesignsystem.com/components/slider/#site-main-content)
+- [Hubspot: UISlider](https://canvas.hubspot.com/show/UIComponents/input/UISlider)
+

--- a/site/docs/guidelines/forms.mdx
+++ b/site/docs/guidelines/forms.mdx
@@ -49,19 +49,21 @@ Where possible use client side validation where the user is presented feedback b
 </WhenToUseAndWhenNotToUse>
 
 ## See also
-- [Link vs button](/guidelines/link-vs-button)
+
+- [Autocomplete](/components/autocomplete)
 - [Button](/components/button)
 - [Checkbox Field](/components/checkbox-field)
 - [Checkbox Group](/components/checkbox-group)
 - [Date Picker](/components/date-picker)
-- [Icon Button](/components/icon-button)
-- [Icon](/components/icon)
-- [Radio Group](/components/radio-group)
-- [Text Field](/components/text-field)
-- [Autocomplete](/components/autocomplete)
 - [Divider](/components/divider)
 - [Dropdown](/components/dropdown)
+- [Icon Button](/components/icon-button)
+- [Icon](/components/icon)
+- [Link vs button](/guidelines/link-vs-button)
+- [Radio Group](/components/radio-group)
 - [Select](/components/select)
+- [Slider](/components/slider)
+- [Text Field](/components/text-field)
 
 ## External links
 


### PR DESCRIPTION
This PR adds documentation for a Slider component and examples of visuals.

Branch preview:

- https://dev.cultureamp.design/di/add-slider-page/components/slider/

Closes: https://github.com/cultureamp/kaizen-design-system/issues/248