### PR TITLE
feat: Add data-automation-class to generic notification

### DIFF
--- a/packages/component-library/components/Notification/__snapshots__/GlobalNotification.spec.tsx.snap
+++ b/packages/component-library/components/Notification/__snapshots__/GlobalNotification.spec.tsx.snap
@@ -3,6 +3,7 @@
 exports[`The basic notification renders correctly 1`] = `
 <div
   class="notification affirmative global hidden"
+  data-automation-class="generic-notification affirmative global"
   style="margin-top: 0px;"
 >
   <div
@@ -62,6 +63,7 @@ exports[`The basic notification renders correctly 1`] = `
 exports[`You can change the type 1`] = `
 <div
   class="notification informative global hidden"
+  data-automation-class="generic-notification informative global"
   style="margin-top: 0px;"
 >
   <div

--- a/packages/component-library/components/Notification/__snapshots__/InlineNotification.spec.tsx.snap
+++ b/packages/component-library/components/Notification/__snapshots__/InlineNotification.spec.tsx.snap
@@ -3,6 +3,7 @@
 exports[`Persistent versions of the notifications work 1`] = `
 <div
   class="notification negative inline hidden"
+  data-automation-class="generic-notification negative inline"
   style="margin-top: 0px;"
 >
   <div
@@ -41,6 +42,7 @@ exports[`Persistent versions of the notifications work 1`] = `
 exports[`The basic notification renders correctly 1`] = `
 <div
   class="notification cautionary inline hidden"
+  data-automation-class="generic-notification cautionary inline"
   style="margin-top: 0px;"
 >
   <div

--- a/packages/component-library/components/Notification/__snapshots__/ToastNotification.spec.tsx.snap
+++ b/packages/component-library/components/Notification/__snapshots__/ToastNotification.spec.tsx.snap
@@ -3,6 +3,7 @@
 exports[`The basic notification renders correctly 1`] = `
 <div
   class="notification affirmative toast hidden"
+  data-automation-class="generic-notification affirmative toast"
   style="margin-top: 0px;"
 >
   <div

--- a/packages/component-library/components/Notification/components/GenericNotification.tsx
+++ b/packages/component-library/components/Notification/components/GenericNotification.tsx
@@ -84,6 +84,7 @@ class GenericNotification extends React.Component<Props, State> {
         ref={this.containerRef}
         onTransitionEnd={this.onTransitionEnd}
         data-automation-id={this.props.automationId}
+        data-automation-class={`${this.props.type} ${this.props.style}`}
       >
         <div className={styles.icon}>
           <Icon icon={this.iconType()} role="presentation" inheritSize />

--- a/packages/component-library/components/Notification/components/GenericNotification.tsx
+++ b/packages/component-library/components/Notification/components/GenericNotification.tsx
@@ -84,7 +84,7 @@ class GenericNotification extends React.Component<Props, State> {
         ref={this.containerRef}
         onTransitionEnd={this.onTransitionEnd}
         data-automation-id={this.props.automationId}
-        data-automation-class={`${this.props.type} ${this.props.style}`}
+        data-automation-class={classnames(this.props.type, this.props.style)}
       >
         <div className={styles.icon}>
           <Icon icon={this.iconType()} role="presentation" inheritSize />

--- a/packages/component-library/components/Notification/components/GenericNotification.tsx
+++ b/packages/component-library/components/Notification/components/GenericNotification.tsx
@@ -84,7 +84,11 @@ class GenericNotification extends React.Component<Props, State> {
         ref={this.containerRef}
         onTransitionEnd={this.onTransitionEnd}
         data-automation-id={this.props.automationId}
-        data-automation-class={classnames(this.props.type, this.props.style)}
+        data-automation-class={classnames(
+          "generic-notification",
+          this.props.type,
+          this.props.style
+        )}
       >
         <div className={styles.icon}>
           <Icon icon={this.iconType()} role="presentation" inheritSize />


### PR DESCRIPTION
This will add a ` data-automation-class` to each notification with their `type` and `style` to find a generic match as opposed to specific notification matches. 

Reference conversation: https://cultureamp.slack.com/archives/C2ZNME08P/p1597132217066600

![Screen Shot 2020-08-12 at 10 52 23 am](https://user-images.githubusercontent.com/4946487/89963215-5b163100-dc8a-11ea-90ba-43659e4baa2d.png)
