### PR TITLE
feat: add basic automation-ids to Select

### DIFF
--- a/draft-packages/select/KaizenDraft/Select/Select.elm
+++ b/draft-packages/select/KaizenDraft/Select/Select.elm
@@ -22,7 +22,7 @@ module KaizenDraft.Select.Select exposing
 import Browser.Dom as Dom
 import CssModules exposing (css)
 import Html exposing (Html, div, input, span, text)
-import Html.Attributes exposing (id, readonly, style, tabindex, value)
+import Html.Attributes exposing (attribute, id, readonly, style, tabindex, value)
 import Html.Attributes.Aria exposing (role)
 import Html.Events exposing (on, onBlur, onFocus, preventDefaultOn)
 import Html.Extra exposing (viewIf)
@@ -733,6 +733,7 @@ view (Config config) selectId =
                 , ( .cautionary, config.selectType == Cautionary && state_.controlFocused == False )
                 , ( .error, config.selectType == Error && state_.controlFocused == False )
                 ]
+            , attribute "data-automation-id" "Select__Control"
             , preventDefaultOn "mousedown" <|
                 Decode.map
                     (\msg ->
@@ -847,6 +848,7 @@ viewMenuItem viewMenuItemData =
                     , ( .isTarget, data.menuItemIsTarget )
                     , ( .preventPointer, data.menuNavigation == Keyboard )
                     ]
+                 , attribute "data-automation-id" "Select__Option"
                  ]
                     ++ resolveMouseLeave
                     ++ resolveMouseUp

--- a/draft-packages/select/KaizenDraft/Select/Select.tsx
+++ b/draft-packages/select/KaizenDraft/Select/Select.tsx
@@ -116,13 +116,15 @@ export const AsyncSelect = (props: AsyncProps) => (
 )
 
 const Control: typeof components.Control = props => (
-  <components.Control
-    {...props}
-    className={classNames(styles.control, {
-      [styles.focusedControl]: props.isFocused,
-      [styles.disabled]: props.isDisabled,
-    })}
-  />
+  <div data-automation-id="Select__Control">
+    <components.Control
+      {...props}
+      className={classNames(styles.control, {
+        [styles.focusedControl]: props.isFocused,
+        [styles.disabled]: props.isDisabled,
+      })}
+    />
+  </div>
 )
 
 const Placeholder: typeof components.Placeholder = props => (
@@ -145,13 +147,15 @@ const Menu: typeof components.Menu = props => (
 
 // TODO - needsclick class disables fastclick on this element. Remove when fastclick is removed from consuming repos
 const Option: typeof components.Option = props => (
-  <components.Option
-    {...props}
-    className={classNames("needsclick", styles.option, {
-      [styles.focusedOption]: props.isFocused,
-      [styles.selectedOption]: props.isSelected,
-    })}
-  />
+  <div data-automation-id="Select__Option">
+    <components.Option
+      {...props}
+      className={classNames("needsclick", styles.option, {
+        [styles.focusedOption]: props.isFocused,
+        [styles.selectedOption]: props.isSelected,
+      })}
+    />
+  </div>
 )
 
 const NoOptionsMessage: typeof components.NoOptionsMessage = props => (


### PR DESCRIPTION
Currently, [system-tests](https://github.com/cultureamp/system-tests/blob/6b55526ad039906499f9c3880536ccbdf1cfb16f/lib/qa_tests/pages/comments_page.rb) have trouble interacting with the Kaizen Select. This change adds automation-ids for the Select control and its options to solve that. The naming convention follows that of newer components like the [TitleBlock](https://github.com/cultureamp/kaizen-design-system/blob/cb1dc2aead68e591cc21c665fb25c1817633c4d7/draft-packages/title-block/KaizenDraft/TitleBlock/TitleBlock.tsx#L139).