### PR TITLE
fix: Fix dismiss button overflow

### DIFF
--- a/draft-packages/modal/KaizenDraft/Modal/Primitives/ModalHeader.scss
+++ b/draft-packages/modal/KaizenDraft/Modal/Primitives/ModalHeader.scss
@@ -3,7 +3,7 @@
 @import "~@kaizen/deprecated-component-library-helpers/styles/type";
 
 .dismissButton {
-  @include ca-position($end: 0, $top: -$ca-grid * 0.25);
+  @include ca-position($end: 0, $top: 0);
   position: absolute;
   z-index: $ca-z-index-popover;
 }


### PR DESCRIPTION
The previous top position value was pushing the button above the modal.
This would become clear when hovering over the button, as the div fills
in and overflows the modal.