### PR TITLE
feat: Elm Box component

### DIFF
--- a/packages/component-library/components/Box/Box.elm
+++ b/packages/component-library/components/Box/Box.elm
@@ -1,0 +1,156 @@
+module Box.Box exposing (box, classNameAndIHaveSpokenToDST, margin, marginBottom, marginLeft, marginRight, marginTop, marginX, marginY, padding, paddingBottom, paddingLeft, paddingRight, paddingTop, paddingX, paddingY)
+
+import CssModules exposing (css)
+import Dict exposing (Dict)
+import Html exposing (Attribute, Html, div, span, text)
+import Html.Attributes exposing (attribute)
+import Spacing.Spacing as Spacing exposing (GridFraction)
+
+
+
+-- public
+
+
+box : List Property -> List (Html msg) -> Html msg
+box properties children =
+    let
+        config : Config
+        config =
+            toConfig properties
+
+        attributes : List (Attribute msg)
+        attributes =
+            Spacing.inlineStyles config.spacing
+                |> addOptionalAttribute "class"
+                    config.classNameAndIHaveSpokenToDST
+    in
+    div attributes children
+
+
+padding : Spacing.GridFraction -> Property
+padding n =
+    Spacing <| Spacing.padding n
+
+
+paddingTop : Spacing.GridFraction -> Property
+paddingTop n =
+    Spacing <| Spacing.paddingTop n
+
+
+paddingRight : Spacing.GridFraction -> Property
+paddingRight n =
+    Spacing <| Spacing.paddingRight n
+
+
+paddingBottom : Spacing.GridFraction -> Property
+paddingBottom n =
+    Spacing <| Spacing.paddingBottom n
+
+
+paddingLeft : Spacing.GridFraction -> Property
+paddingLeft n =
+    Spacing <| Spacing.paddingLeft n
+
+
+paddingX : Spacing.GridFraction -> Property
+paddingX n =
+    Spacing <| Spacing.paddingX n
+
+
+paddingY : Spacing.GridFraction -> Property
+paddingY n =
+    Spacing <| Spacing.paddingY n
+
+
+margin : Spacing.GridFraction -> Property
+margin n =
+    Spacing <| Spacing.margin n
+
+
+marginTop : Spacing.GridFraction -> Property
+marginTop n =
+    Spacing <| Spacing.marginTop n
+
+
+marginRight : Spacing.GridFraction -> Property
+marginRight n =
+    Spacing <| Spacing.marginRight n
+
+
+marginBottom : Spacing.GridFraction -> Property
+marginBottom n =
+    Spacing <| Spacing.marginBottom n
+
+
+marginLeft : Spacing.GridFraction -> Property
+marginLeft n =
+    Spacing <| Spacing.marginLeft n
+
+
+marginX : Spacing.GridFraction -> Property
+marginX n =
+    Spacing <| Spacing.marginX n
+
+
+marginY : Spacing.GridFraction -> Property
+marginY n =
+    Spacing <| Spacing.marginY n
+
+
+classNameAndIHaveSpokenToDST : String -> Property
+classNameAndIHaveSpokenToDST s =
+    ClassNameAndIHaveSpokenToDST s
+
+
+
+-- private
+
+
+type Property
+    = Spacing Spacing.Property
+    | ClassNameAndIHaveSpokenToDST String
+
+
+type alias Config =
+    { classNameAndIHaveSpokenToDST : Maybe String
+    , spacing : Spacing.Config
+    }
+
+
+defaultConfig : Config
+defaultConfig =
+    { spacing = Spacing.empty
+    , classNameAndIHaveSpokenToDST = Nothing
+    }
+
+
+toConfig : List Property -> Config
+toConfig =
+    List.foldl setProperty defaultConfig
+
+
+setProperty : Property -> Config -> Config
+setProperty param config =
+    case param of
+        Spacing spacing ->
+            { config | spacing = config.spacing |> Spacing.setProperty spacing }
+
+        ClassNameAndIHaveSpokenToDST s ->
+            { config | classNameAndIHaveSpokenToDST = Just s }
+
+
+
+-- helpers
+
+
+addOptionalAttribute :
+    String
+    -> Maybe String
+    -> List (Attribute msg)
+    -> List (Attribute msg)
+addOptionalAttribute key maybeValue attributes =
+    attributes
+        ++ (maybeValue
+                |> Maybe.map (List.singleton << attribute key)
+                |> Maybe.withDefault []
+           )

--- a/packages/component-library/components/Spacing/Spacing.elm
+++ b/packages/component-library/components/Spacing/Spacing.elm
@@ -1,0 +1,249 @@
+module Spacing.Spacing exposing (Config, GridFraction, Property, empty, inlineStyles, margin, marginBottom, marginLeft, marginRight, marginTop, marginX, marginY, padding, paddingBottom, paddingLeft, paddingRight, paddingTop, paddingX, paddingY, setProperty)
+
+import Dict exposing (Dict)
+import Html exposing (Attribute)
+import Html.Attributes exposing (style)
+
+
+type alias GridFraction =
+    Float
+
+
+gridInRem =
+    -- TODO: get this from @kaizen/design-tokens when it eventually supports Elm
+    1.5
+
+
+
+-- config
+
+
+type alias Config =
+    Dict String GridFraction
+
+
+empty =
+    Dict.empty
+
+
+padding : GridFraction -> Property
+padding n =
+    Padding n
+
+
+paddingTop : GridFraction -> Property
+paddingTop n =
+    PaddingTop n
+
+
+paddingRight : GridFraction -> Property
+paddingRight n =
+    PaddingRight n
+
+
+paddingBottom : GridFraction -> Property
+paddingBottom n =
+    PaddingBottom n
+
+
+paddingLeft : GridFraction -> Property
+paddingLeft n =
+    PaddingLeft n
+
+
+paddingX : GridFraction -> Property
+paddingX n =
+    PaddingX n
+
+
+paddingY : GridFraction -> Property
+paddingY n =
+    PaddingY n
+
+
+margin : GridFraction -> Property
+margin n =
+    Margin n
+
+
+marginTop : GridFraction -> Property
+marginTop n =
+    MarginTop n
+
+
+marginRight : GridFraction -> Property
+marginRight n =
+    MarginRight n
+
+
+marginBottom : GridFraction -> Property
+marginBottom n =
+    MarginBottom n
+
+
+marginLeft : GridFraction -> Property
+marginLeft n =
+    MarginLeft n
+
+
+marginX : GridFraction -> Property
+marginX n =
+    MarginX n
+
+
+marginY : GridFraction -> Property
+marginY n =
+    MarginY n
+
+
+setProperty : Property -> Config -> Config
+setProperty param config =
+    case param of
+        Padding n ->
+            config |> setSpacing "padding" n
+
+        PaddingTop n ->
+            config |> setSpacing "padding-top" n
+
+        PaddingRight n ->
+            config |> setSpacing "padding-right" n
+
+        PaddingBottom n ->
+            config |> setSpacing "padding-bottom" n
+
+        PaddingLeft n ->
+            config |> setSpacing "padding-left" n
+
+        PaddingX n ->
+            config |> setSpacing "padding-x" n
+
+        PaddingY n ->
+            config |> setSpacing "padding-y" n
+
+        Margin n ->
+            config |> setSpacing "margin" n
+
+        MarginTop n ->
+            config |> setSpacing "margin-top" n
+
+        MarginRight n ->
+            config |> setSpacing "margin-right" n
+
+        MarginBottom n ->
+            config |> setSpacing "margin-bottom" n
+
+        MarginLeft n ->
+            config |> setSpacing "margin-left" n
+
+        MarginX n ->
+            config |> setSpacing "margin-x" n
+
+        MarginY n ->
+            config |> setSpacing "margin-y" n
+
+
+type Property
+    = Padding GridFraction
+    | PaddingTop GridFraction
+    | PaddingRight GridFraction
+    | PaddingBottom GridFraction
+    | PaddingLeft GridFraction
+    | PaddingX GridFraction
+    | PaddingY GridFraction
+    | Margin GridFraction
+    | MarginTop GridFraction
+    | MarginRight GridFraction
+    | MarginBottom GridFraction
+    | MarginLeft GridFraction
+    | MarginX GridFraction
+    | MarginY GridFraction
+
+
+setSpacing : String -> GridFraction -> Config -> Config
+setSpacing cssProperty value config =
+    config |> Dict.insert cssProperty value
+
+
+
+-- view
+
+
+inlineStyles : Config -> List (Attribute msg)
+inlineStyles config =
+    config
+        |> Dict.toList
+        |> sortSpacingProperties
+        |> List.map
+            (\( property, value ) ->
+                let
+                    cssValue =
+                        gridFractionToCssValue value
+                in
+                if not (isCssProperty property) then
+                    case property of
+                        "margin-x" ->
+                            [ style "margin-left" cssValue
+                            , style "margin-right" cssValue
+                            ]
+
+                        "margin-y" ->
+                            [ style "margin-top" cssValue
+                            , style "margin-bottom" cssValue
+                            ]
+
+                        "padding-x" ->
+                            [ style "padding-left" cssValue
+                            , style "padding-right" cssValue
+                            ]
+
+                        "padding-y" ->
+                            [ style "padding-top" cssValue
+                            , style "padding-bottom" cssValue
+                            ]
+
+                        _ ->
+                            []
+
+                else
+                    [ style property cssValue ]
+            )
+        |> List.concat
+
+
+isCssProperty : String -> Bool
+isCssProperty property =
+    not <|
+        List.member property
+            [ "margin-x", "margin-y", "padding-x", "padding-y" ]
+
+
+sortSpacingProperties : List ( String, GridFraction ) -> List ( String, GridFraction )
+sortSpacingProperties properties =
+    -- the made up non css properties such as "padding-x" get converted to
+    -- real css properties "padding-left" and "padding-right" - they need
+    -- to be ordered before real css properties so that they can be
+    -- overridden. The order of the real css properties doesn't matter.
+    properties
+        |> List.sortWith
+            (\( propertyA, _ ) ( propertyB, _ ) ->
+                let
+                    propertyAIsCss =
+                        isCssProperty propertyA
+
+                    propertyBIsCss =
+                        isCssProperty propertyB
+                in
+                if not propertyAIsCss && propertyBIsCss then
+                    LT
+
+                else if propertyAIsCss && not propertyBIsCss then
+                    GT
+
+                else
+                    EQ
+            )
+
+
+gridFractionToCssValue : GridFraction -> String
+gridFractionToCssValue gridFraction =
+    String.fromFloat (gridFraction * gridInRem) ++ "rem"

--- a/packages/component-library/stories/Box.stories.elm
+++ b/packages/component-library/stories/Box.stories.elm
@@ -1,0 +1,22 @@
+module Main exposing (main)
+
+import Box.Box as Box exposing (..)
+import ElmStorybook exposing (statelessStoryOf, storybook)
+import Html exposing (text)
+
+
+main =
+    storybook
+        [ statelessStoryOf "Box Default" <|
+            box []
+                [ text "A box with no props has a default margin and padding of 0. The children of box are also unstyled" ]
+        , statelessStoryOf "Box With Margin" <|
+            box [ marginLeft 1, marginRight 0.25, marginTop 0.5, marginBottom 0.5 ]
+                [ text "This is an example Box with margin left, right, and top explicitly defined" ]
+        , statelessStoryOf "Box With Padding" <|
+            box [ padding 4 ]
+                [ text "Box with 4 units of padding X, 1 unit of padding right" ]
+        , statelessStoryOf "Box With X And Y Padding" <|
+            box [ paddingX 4, paddingRight 1 ]
+                [ text "Box with 4 units of padding X, 1 unit of padding right" ]
+        ]

--- a/packages/component-library/stories/ElmBox.stories.tsx
+++ b/packages/component-library/stories/ElmBox.stories.tsx
@@ -1,0 +1,8 @@
+import { loadElmStories } from "@cultureamp/elm-storybook"
+
+loadElmStories("Box (Elm)", module, require("./Box.stories.elm"), [
+  "Box Default",
+  "Box With Margin",
+  "Box With Padding",
+  "Box With X And Y Padding",
+])


### PR DESCRIPTION
This is a the Elm version of the React Box component.

Example: heading with 1 grid unit margin bottom:

```elm
box [ marginBottom 1 ]
    [ Heading.view
        (Heading.h1 |> Heading.variant Display0)
        [ Html.text "Display0" ]
    ]
```

Storybook: https://dev.cultureamp.design/mab/elm-box-inline-styles/storybook/?path=/story/box-elm--box-default

_Notes:_

## It uses inline styles
Not even a CSS-in-JS or CSS-in-Elm framework, just good old fashioned inline styles! ☠️ ☠️ ☠️ 
I know!! But hear me out:
- We've decided to go with a "component only" approach for the Box (in TS and Elm), where you don't have to write a line of CSS. I think this is very good for decoupling the design system from the underlying technology (scss). But it has a problem:  css classes are finite, but we want to be able to create a near-infinite number of classes, one for each spacing property `padding-right`, `margin-left` times each possible value (0.25, 0.5...4.5, etc), so you get a huge number of classes that need to be manually mapped from class names to elm record fields. https://github.com/cultureamp/elm-css-modules-loader uses "records" for it's elm-css implementation, but in Elm there is no way to programmatically convert class names to record fields, like how it's done in the Typescript version (because objects in JS are more like `Dicts` than Elm records): In Elm you need a `Dict` for that. So, the amount of code required is huge. I started doing this in an earlier branch (https://github.com/cultureamp/kaizen-design-system/commit/71d2f1c5a3cadd4b1e95e231e4f12b4a17fc9b1f#diff-b13bd9f0979215a31560b234f1a77367R25), but it was a crazy amount of work and would be error prone and hard to maintain, and wonder if there's a better way we can do it in the future.

Although this is not perfect, I think it's better than _not_ having a Box component at all, and it's an implementation detail that can be changed without having to necessarily change the public API (much). Having to find scss and upgrade that to use a Box component instead is far harder - I really don't think it would be possible to automate that, but it'd be far more feasible to automatically upgrade pure Elm code.

## It uses a different style of API than the other components
Rather than "pipeline config" style:

```elm
Box.view 
    (Box.defaults |> marginTop 1 |> marginRight 0.5)
    [ text "content in the box" ]
```
it looks like this:
```elm
box 
    [ marginTop 1, marginRight 0.5] 
    [ text "content in the box" ]
``` 

I think the pipeline config style makes sense for more complex components, but this is far less verbose for simple components like box that should be quicker to use than having to write scss. It does requires very verbose implementation code, but I think we should optimise APIs for Kaizen consumers rather than Kaizen maintainers. The other place I've seen this pattern is https://github.com/rtfeldman/elm-css#elm-css (to be clear, this style of API has nothing to do witih css-in-Elm or inline styles, that's just a coincidence, you could use it for any API, but I think it works well as a DSL for html as it looks a lot like actual html)


## no ability to change the sizes responsively
- I think we should explore the potential of being able to use custom breakpoints using dynamic JS or Elm (could be dynamically generated `<style>` tags). Using classes limits us to a finite set of breakpoints. I didn't think it was worth doing this for this PR. You can always use scss instead of the Box component if you need responsive styles.

## No RTL support
- If RTL support is needed, let's open a ticket. I also think that use of `"[dir=rtl]"` css selectors is a better approach than having to prop drill a rtl/direction prop. Again, I thin it's something we could explore with CSS-in-Elm/JS solutions.
