### PR TITLE
ci: Added a gtm plugin to manage analytics

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,6 +104,7 @@
     "react": "^16.9.0",
     "react-docgen-typescript-loader": "^3.7.1",
     "react-dom": "^16.9.0",
+    "react-gtm-module": "^2.0.10",
     "sass-loader": "^8.0.0",
     "style-loader": "^1.0.0",
     "stylelint": "^13.6.0",
@@ -122,13 +123,13 @@
     "@storybook/codemod": "^5.3.9",
     "@storybook/csf": "^0.0.1",
     "@storybook/node-logger": "^5.3.9",
+    "glob": "^7.1.1",
     "husky": "^4.2.5",
     "jscodeshift": "^0.7.0",
     "lint-staged": "^10.2.2",
-    "storybook-chromatic": "^3.4.1",
-    "glob": "^7.1.1",
     "loader-utils": "^1.0.2",
     "node-elm-compiler": "^5.0.0",
+    "storybook-chromatic": "^3.4.1",
     "yargs": "^6.5.0"
   },
   "lint-staged": {

--- a/storybook/gtm-addon/.babelrc
+++ b/storybook/gtm-addon/.babelrc
@@ -1,0 +1,13 @@
+{
+  "presets": [
+    [
+      "@babel/preset-env",
+      {
+        "targets": {
+          "node": "current"
+        }
+      }
+    ],
+    "@babel/preset-react"
+  ]
+}

--- a/storybook/gtm-addon/register.js
+++ b/storybook/gtm-addon/register.js
@@ -1,0 +1,12 @@
+import { addons } from "@storybook/addons"
+import TagManager from "react-gtm-module"
+
+/**
+ * This is inspired by the GA addon, but replacing GA for GTM and dropping custom events
+ * https://github.com/storybookjs/storybook/blob/next/addons/google-analytics/src/register.ts
+ */
+addons.register("my/design-addon", () => {
+  TagManager.initialize({
+    gtmId: "GTM-KS4VWLT",
+  })
+})

--- a/storybook/gtm-addon/register.js
+++ b/storybook/gtm-addon/register.js
@@ -1,12 +1,18 @@
 import { addons } from "@storybook/addons"
 import TagManager from "react-gtm-module"
+import { isEmpty } from "lodash"
 
 /**
  * This is inspired by the GA addon, but replacing GA for GTM and dropping custom events
  * https://github.com/storybookjs/storybook/blob/next/addons/google-analytics/src/register.ts
  */
-addons.register("my/design-addon", () => {
-  TagManager.initialize({
-    gtmId: "GTM-KS4VWLT",
-  })
+addons.register("kaizen/gtm-addon", () => {
+  const { analyticsGTM = {} } = addons.getConfig()
+
+  if (isEmpty(analyticsGTM)) {
+    console.warn("kaizen/gtm-addon - Analytics not set. Check manager.js")
+    return
+  }
+
+  TagManager.initialize(analyticsGTM)
 })

--- a/storybook/header-preset/index.tsx
+++ b/storybook/header-preset/index.tsx
@@ -3,13 +3,6 @@ import { render } from "react-dom"
 import Footer from "../../site/src/components/Footer"
 import SiteHeader from "./header"
 
-const analytics = document.createElement("noscript")
-analytics.innerHTML = `<!-- Google Tag Manager (noscript) -->
-<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-KS4VWLT"
-height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-<!-- End Google Tag Manager (noscript) -->`
-document.body.insertAdjacentElement("afterbegin", analytics)
-
 /**
  * Inject the nav header before the root node that storybook
  * uses to mount

--- a/storybook/main.ts
+++ b/storybook/main.ts
@@ -12,4 +12,5 @@ module.exports = {
     "../legacy-packages/**/*.stories.tsx",
   ],
   presets: [path.resolve("./storybook/header-preset/preset")],
+  addons: ["./storybook/gtm-addon/register.js"],
 }

--- a/storybook/manager.ts
+++ b/storybook/manager.ts
@@ -10,3 +10,11 @@ import "@storybook/addon-actions/register"
 // The following do not use the addons panel:
 import "@storybook/addon-backgrounds/register"
 import "@storybook/addon-viewport/register"
+
+import { addons } from "@storybook/addons"
+
+addons.setConfig({
+  analyticsGTM: {
+    gtmId: "GTM-KS4VWLT",
+  },
+})

--- a/storybook/preview-head.html
+++ b/storybook/preview-head.html
@@ -1,9 +1,1 @@
 <link rel="stylesheet" type="text/css" href="https://d1vmr11cgrgrrj.cloudfront.net/7834392/css/fonts.css">
-
-<!-- Google Tag Manager -->
-<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-  })(window,document,'script','dataLayer','GTM-KS4VWLT');</script>
-<!-- End Google Tag Manager -->

--- a/yarn.lock
+++ b/yarn.lock
@@ -18929,6 +18929,11 @@ react-focus-lock@^2.1.0, react-focus-lock@^2.3.1:
     use-callback-ref "^1.2.1"
     use-sidecar "^1.0.1"
 
+react-gtm-module@^2.0.10:
+  version "2.0.10"
+  resolved "https://registry.yarnpkg.com/react-gtm-module/-/react-gtm-module-2.0.10.tgz#462296c3d622b82413d0917d430bec557a586237"
+  integrity sha512-7fRxphVxbJVCNWDQyegugZOrOw97vqwzbTSZlHM2n+otg2iBQvKa0SzFxwcLi9monXADjWGX6xQER6IOl75FPw==
+
 react-helmet-async@^1.0.2:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/react-helmet-async/-/react-helmet-async-1.0.6.tgz#11c15c74e79b3f66670c73779bef3e0e352b1d4e"


### PR DESCRIPTION
## About 
This PR creates a GTM plugin for Storybook. 

Previously GTM tags were injected into the iframe that loads the story. The intention of analytics in Storybook is to give us an idea about how developers use our dev documentation - such as what stories are highly trafficked. This does not give us adequate tracking as we miss listening to `history.pushState`/`history.popState`. 

The changes correctly configure GTM so it's added into the head of the document, not the head of the story. 

### Resources
https://github.com/storybookjs/storybook/pull/11336
https://github.com/storybookjs/storybook/pull/11340