### PR TITLE
feat: Hierarchical menu and hierarchical select improvements [PHRI-32]

### DIFF
--- a/draft-packages/hierarchical-menu/KaizenDraft/HierarchicalMenu/HierarchicalMenu.tsx
+++ b/draft-packages/hierarchical-menu/KaizenDraft/HierarchicalMenu/HierarchicalMenu.tsx
@@ -275,9 +275,14 @@ const Menu = (props: MenuProps) => {
             </button>
           </div>
           <div className={styles.current}>
-            <Text style="body-bold" tag="p" inheritBaseline>
-              {hierarchy.current.label}
-            </Text>
+            <button
+              className={styles.currentButton}
+              onClick={() => onSelect(hierarchy, hierarchy.current)}
+            >
+              <Text style="body-bold" tag="p" inheritBaseline>
+                {hierarchy.current.label}
+              </Text>
+            </button>
             <Text style="small" tag="p" inheritBaseline>
               Level {hierarchy.current.level}
             </Text>

--- a/draft-packages/hierarchical-menu/KaizenDraft/HierarchicalMenu/HierarchicalMenu.tsx
+++ b/draft-packages/hierarchical-menu/KaizenDraft/HierarchicalMenu/HierarchicalMenu.tsx
@@ -313,10 +313,9 @@ const Menu = (props: MenuProps) => {
                       <button
                         className={styles.childLabelButton}
                         onClick={() => onSelect(hierarchy, c)}
+                        title={c.label}
                       >
-                        <Text style="body" tag="p" inheritBaseline>
-                          {c.label}
-                        </Text>
+                        <div className={styles.childLabelText}>{c.label}</div>
                       </button>
                       {c.numberOfChildren > 0 && (
                         <button

--- a/draft-packages/hierarchical-menu/KaizenDraft/HierarchicalMenu/HierarchicalMenu.tsx
+++ b/draft-packages/hierarchical-menu/KaizenDraft/HierarchicalMenu/HierarchicalMenu.tsx
@@ -22,7 +22,7 @@ export type HierarchyNode = {
   value: string
   label: string
   level: number
-  numberOfChildren: number
+  numberOfChildren: number | null
 }
 
 export type Hierarchy = {
@@ -114,13 +114,13 @@ export const HierarchicalMenu = (props: HierarchicalMenuProps) => {
 
   const navigateToParent = (toNode: HierarchyNode) => {
     setIsNavigating("toParent")
-    setIncomingNumberOfOptions(toNode.numberOfChildren)
+    setIncomingNumberOfOptions(toNode.numberOfChildren || 1)
     onNavigateToParent(hierarchy, toNode)
   }
 
   const navigateToChild = (toNode: HierarchyNode) => {
     setIsNavigating("toChild")
-    setIncomingNumberOfOptions(toNode.numberOfChildren)
+    setIncomingNumberOfOptions(toNode.numberOfChildren || 1)
     onNavigateToChild(hierarchy, toNode)
   }
 
@@ -317,19 +317,20 @@ const Menu = (props: MenuProps) => {
                       >
                         <div className={styles.childLabelText}>{c.label}</div>
                       </button>
-                      {c.numberOfChildren > 0 && (
+                      {c.numberOfChildren == null && (
+                        <button
+                          className={styles.disabledChildDrilldownButton}
+                          disabled
+                        >
+                          <DrilldownChevron label={c.label} dir={dir} />
+                        </button>
+                      )}
+                      {c.numberOfChildren != null && c.numberOfChildren > 0 && (
                         <button
                           className={styles.childDrilldownButton}
                           onClick={() => onNavigateToChild(c)}
                         >
-                          <div className={styles.childDrilldownButtonIcon}>
-                            <Icon
-                              icon={dir === "ltr" ? chevronRight : chevronLeft}
-                              role="img"
-                              title={`Drill down on ${c.label}`}
-                              inheritSize
-                            />
-                          </div>
+                          <DrilldownChevron label={c.label} dir={dir} />
                         </button>
                       )}
                     </div>
@@ -343,6 +344,23 @@ const Menu = (props: MenuProps) => {
     </div>
   )
 }
+
+const DrilldownChevron = ({
+  label,
+  dir,
+}: {
+  label: string
+  dir: MenuDirection
+}) => (
+  <div className={styles.childDrilldownButtonIcon}>
+    <Icon
+      icon={dir === "ltr" ? chevronRight : chevronLeft}
+      role="img"
+      title={`Drill down on ${label}`}
+      inheritSize
+    />
+  </div>
+)
 
 interface LoadingMenuProps {
   transitionLevel: "parent" | "child" | null

--- a/draft-packages/hierarchical-menu/KaizenDraft/HierarchicalMenu/KeyboardNavigableList.tsx
+++ b/draft-packages/hierarchical-menu/KaizenDraft/HierarchicalMenu/KeyboardNavigableList.tsx
@@ -2,10 +2,15 @@ import { useCallback, useEffect, useState } from "react"
 
 enum Keys {
   ARROW_DOWN = "ArrowDown",
+  ARROW_DOWN_IE = "Down", // IE/Edge specific value
   ARROW_UP = "ArrowUp",
+  ARROW_UP_IE = "Up", // IE/Edge specific value
   ARROW_RIGHT = "ArrowRight",
+  ARROW_RIGHT_IE = "Right", // IE/Edge specific value
   ARROW_LEFT = "ArrowLeft",
+  ARROW_LEFT_IE = "Left", // IE/Edge specific value
   SPACE = " ",
+  SPACE_IE = "Spacebar", // IE/Edge specific value
   ENTER = "Enter",
 }
 
@@ -86,7 +91,10 @@ export const KeyboardNavigableList = (props: Props) => {
     evt => {
       // don't interfere with keyboard SPACE and ENTER events on native
       // interactive elements like <a>, <button>
-      if (evt.target !== document.body) {
+      if (
+        evt.target !== document.body &&
+        evt.target !== document.documentElement // IE/Edge specific value
+      ) {
         return
       }
 
@@ -100,14 +108,23 @@ export const KeyboardNavigableList = (props: Props) => {
     (evt: KeyboardEvent) => {
       switch (evt.key) {
         case Keys.ARROW_UP:
+        case Keys.ARROW_UP_IE:
           return up(evt)
+
         case Keys.ARROW_DOWN:
+        case Keys.ARROW_DOWN_IE:
           return down(evt)
+
         case Keys.ARROW_LEFT:
+        case Keys.ARROW_LEFT_IE:
           return dir === "ltr" ? back(evt) : forward(evt)
+
         case Keys.ARROW_RIGHT:
+        case Keys.ARROW_RIGHT_IE:
           return dir === "ltr" ? forward(evt) : back(evt)
+
         case Keys.SPACE:
+        case Keys.SPACE_IE:
         case Keys.ENTER:
           return select(evt)
         default:

--- a/draft-packages/hierarchical-menu/KaizenDraft/HierarchicalMenu/styles.module.scss
+++ b/draft-packages/hierarchical-menu/KaizenDraft/HierarchicalMenu/styles.module.scss
@@ -95,6 +95,25 @@ $delay-before-showing-loading-placeholders: 500ms;
   justify-content: space-between;
 }
 
+.currentButton {
+  @include button-reset;
+  @include ca-type-align-start;
+  @include ca-margin($end: $kz-spacing-md);
+  color: inherit;
+  flex: 1;
+
+  :global(.js-focus-visible) & {
+    &:focus {
+      outline: none;
+    }
+
+    &:global(.focus-visible) {
+      outline: $kz-border-focus-ring-border-width
+        $kz-border-focus-ring-border-style $kz-color-cluny-300;
+    }
+  }
+}
+
 .body {
   @include ca-margin($end: 4px);
   background-color: $kz-color-white;

--- a/draft-packages/hierarchical-menu/KaizenDraft/HierarchicalMenu/styles.module.scss
+++ b/draft-packages/hierarchical-menu/KaizenDraft/HierarchicalMenu/styles.module.scss
@@ -163,6 +163,11 @@ $delay-before-showing-loading-placeholders: 500ms;
   }
 }
 
+.disabledChildDrilldownButton {
+  composes: childDrilldownButton;
+  opacity: 0.3;
+}
+
 .keyboardHighlightedChild {
   composes: child;
   background-color: $kz-color-wisteria-100;

--- a/draft-packages/hierarchical-menu/KaizenDraft/HierarchicalMenu/styles.module.scss
+++ b/draft-packages/hierarchical-menu/KaizenDraft/HierarchicalMenu/styles.module.scss
@@ -46,8 +46,11 @@ $delay-before-showing-loading-placeholders: 500ms;
 }
 
 .parent {
-  margin: 0 $kz-spacing-md;
-  border-bottom: 1px $kz-border-solid-border-style $kz-color-wisteria-500;
+  margin: 0 $kz-spacing-sm;
+  border: $kz-border-borderless-border-width $kz-border-borderless-border-style
+    $kz-border-borderless-border-color;
+  border-bottom-width: 1px;
+  border-bottom-color: $kz-color-wisteria-500;
   height: $option-height;
   display: flex;
   align-items: center;
@@ -89,7 +92,9 @@ $delay-before-showing-loading-placeholders: 500ms;
 }
 
 .current {
-  margin: 0 $kz-spacing-md;
+  margin: 0 $kz-spacing-sm;
+  border: $kz-border-borderless-border-width $kz-border-borderless-border-style
+    $kz-border-borderless-border-color;
   height: $option-height;
   display: flex;
   align-items: center;
@@ -136,7 +141,7 @@ $delay-before-showing-loading-placeholders: 500ms;
   color: inherit;
   flex: 1 0;
   height: $option-height;
-  padding: 0 $kz-spacing-md;
+  padding: 0 $kz-spacing-sm;
   border: $kz-border-focus-ring-border-width $kz-border-focus-ring-border-style
     $kz-border-borderless-border-color;
   cursor: default;
@@ -168,7 +173,7 @@ $delay-before-showing-loading-placeholders: 500ms;
   @include button-reset;
   color: inherit;
   height: $option-height;
-  padding: 0 $kz-spacing-md;
+  padding: 0 $kz-spacing-sm;
   display: flex;
   align-items: center;
   border: $kz-border-focus-ring-border-width $kz-border-focus-ring-border-style

--- a/draft-packages/hierarchical-menu/KaizenDraft/HierarchicalMenu/styles.module.scss
+++ b/draft-packages/hierarchical-menu/KaizenDraft/HierarchicalMenu/styles.module.scss
@@ -119,6 +119,10 @@ $delay-before-showing-loading-placeholders: 500ms;
   border: $kz-border-focus-ring-border-width $kz-border-focus-ring-border-style
     $kz-border-borderless-border-color;
 
+  // allows the .childLabelText to be truncated with white-space: nowrap
+  // and not break the flexbox layout
+  min-width: 0;
+
   :global(.js-focus-visible) & {
     &:focus {
       outline: none;
@@ -128,6 +132,14 @@ $delay-before-showing-loading-placeholders: 500ms;
       border-color: $kz-color-cluny-500;
     }
   }
+}
+
+.childLabelText {
+  @include kz-typography-paragraph-body;
+  @include ca-inherit-baseline;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .childDrilldownButton {

--- a/draft-packages/hierarchical-menu/KaizenDraft/HierarchicalMenu/styles.module.scss
+++ b/draft-packages/hierarchical-menu/KaizenDraft/HierarchicalMenu/styles.module.scss
@@ -59,6 +59,17 @@ $delay-before-showing-loading-placeholders: 500ms;
   display: flex;
   align-items: center;
   width: 100%;
+
+  :global(.js-focus-visible) & {
+    &:focus {
+      outline: none;
+    }
+
+    &:global(.focus-visible) {
+      outline: $kz-border-focus-ring-border-width
+        $kz-border-focus-ring-border-style $kz-color-cluny-300;
+    }
+  }
 }
 
 .disabledParentButton {
@@ -85,6 +96,7 @@ $delay-before-showing-loading-placeholders: 500ms;
 }
 
 .body {
+  @include ca-margin($end: 4px);
   background-color: $kz-color-white;
   color: $kz-color-wisteria-800;
   max-height: $option-height * $max-visible-options;
@@ -104,6 +116,18 @@ $delay-before-showing-loading-placeholders: 500ms;
   flex: 1 0;
   height: $option-height;
   padding: 0 $kz-spacing-md;
+  border: $kz-border-focus-ring-border-width $kz-border-focus-ring-border-style
+    $kz-border-borderless-border-color;
+
+  :global(.js-focus-visible) & {
+    &:focus {
+      outline: none;
+    }
+
+    &:global(.focus-visible) {
+      border-color: $kz-color-cluny-500;
+    }
+  }
 }
 
 .childDrilldownButton {
@@ -113,6 +137,18 @@ $delay-before-showing-loading-placeholders: 500ms;
   padding: 0 $kz-spacing-md;
   display: flex;
   align-items: center;
+  border: $kz-border-focus-ring-border-width $kz-border-focus-ring-border-style
+    $kz-border-borderless-border-color;
+
+  :global(.js-focus-visible) & {
+    &:focus {
+      outline: none;
+    }
+
+    &:global(.focus-visible) {
+      border-color: $kz-color-cluny-500;
+    }
+  }
 }
 
 .keyboardHighlightedChild {

--- a/draft-packages/hierarchical-menu/KaizenDraft/HierarchicalMenu/styles.module.scss
+++ b/draft-packages/hierarchical-menu/KaizenDraft/HierarchicalMenu/styles.module.scss
@@ -59,6 +59,7 @@ $delay-before-showing-loading-placeholders: 500ms;
   display: flex;
   align-items: center;
   width: 100%;
+  cursor: default;
 
   :global(.js-focus-visible) & {
     &:focus {
@@ -101,6 +102,7 @@ $delay-before-showing-loading-placeholders: 500ms;
   @include ca-margin($end: $kz-spacing-md);
   color: inherit;
   flex: 1;
+  cursor: default;
 
   :global(.js-focus-visible) & {
     &:focus {
@@ -137,6 +139,7 @@ $delay-before-showing-loading-placeholders: 500ms;
   padding: 0 $kz-spacing-md;
   border: $kz-border-focus-ring-border-width $kz-border-focus-ring-border-style
     $kz-border-borderless-border-color;
+  cursor: default;
 
   // allows the .childLabelText to be truncated with white-space: nowrap
   // and not break the flexbox layout
@@ -170,6 +173,7 @@ $delay-before-showing-loading-placeholders: 500ms;
   align-items: center;
   border: $kz-border-focus-ring-border-width $kz-border-focus-ring-border-style
     $kz-border-borderless-border-color;
+  cursor: default;
 
   :global(.js-focus-visible) & {
     &:focus {

--- a/draft-packages/hierarchical-menu/package.json
+++ b/draft-packages/hierarchical-menu/package.json
@@ -39,7 +39,7 @@
     "react-transition-group": "^4.4.1"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^1.6.0",
-    "react": "^16.9.0"
+    "@kaizen/design-tokens": "^2.1.1",
+    "react": "^16.13.1"
   }
 }

--- a/draft-packages/hierarchical-select/KaizenDraft/HierarchicalSelect/HierarchicalSelect.tsx
+++ b/draft-packages/hierarchical-select/KaizenDraft/HierarchicalSelect/HierarchicalSelect.tsx
@@ -105,9 +105,8 @@ export const HierarchicalSelect = (props: HierarchicalSelectProps) => {
               <div
                 className={styles.clear}
                 // since we can't nest buttons in buttons, make this an aria
-                // accessible button with onClick, role="button" and tabindex
+                // accessible button with onClick and role="button"
                 role="button"
-                tabIndex={0}
                 onClick={evt => {
                   onClear()
                   evt.stopPropagation()

--- a/draft-packages/hierarchical-select/KaizenDraft/HierarchicalSelect/HierarchicalSelect.tsx
+++ b/draft-packages/hierarchical-select/KaizenDraft/HierarchicalSelect/HierarchicalSelect.tsx
@@ -12,6 +12,7 @@ const chevronUp = require("@kaizen/component-library/icons/chevron-up.icon.svg")
   .default
 const chevronDown = require("@kaizen/component-library/icons/chevron-down.icon.svg")
   .default
+const clear = require("@kaizen/component-library/icons/clear.icon.svg").default
 const styles = require("./styles.module.scss")
 
 export { MenuWidth, MenuDirection, Hierarchy, HierarchyNode }
@@ -98,8 +99,28 @@ export const HierarchicalSelect = (props: HierarchicalSelectProps) => {
         ) : (
           <div className={styles.placeholder}>{placeholder}</div>
         )}
-        <div className={styles.chevron}>
-          <Icon icon={isOpen ? chevronUp : chevronDown} role="presentation" />
+        <div className={styles.indicators}>
+          {value && (
+            <>
+              <div
+                className={styles.clear}
+                // since we can't nest buttons in buttons, make this an aria
+                // accessible button with onClick, role="button" and tabindex
+                role="button"
+                tabIndex={0}
+                onClick={evt => {
+                  onClear()
+                  evt.stopPropagation()
+                }}
+              >
+                <Icon icon={clear} role="img" title="Clear value" />
+              </div>
+              <div className={styles.separator} />
+            </>
+          )}
+          <div className={styles.chevron}>
+            <Icon icon={isOpen ? chevronUp : chevronDown} role="presentation" />
+          </div>
         </div>
       </button>
       {isOpen && (

--- a/draft-packages/hierarchical-select/KaizenDraft/HierarchicalSelect/HierarchicalSelect.tsx
+++ b/draft-packages/hierarchical-select/KaizenDraft/HierarchicalSelect/HierarchicalSelect.tsx
@@ -69,6 +69,7 @@ export const HierarchicalSelect = (props: HierarchicalSelectProps) => {
         case "Backspace":
         case "Delete":
           if (hasOriginatedFromChildElement(evt)) {
+            evt.preventDefault()
             onClear()
             return
           }

--- a/draft-packages/hierarchical-select/KaizenDraft/HierarchicalSelect/HierarchicalSelect.tsx
+++ b/draft-packages/hierarchical-select/KaizenDraft/HierarchicalSelect/HierarchicalSelect.tsx
@@ -55,10 +55,21 @@ export const HierarchicalSelect = (props: HierarchicalSelectProps) => {
       }
     }
 
+    const handleDocumentEscape = (evt: KeyboardEvent) => {
+      if (
+        evt.key === "Escape" ||
+        evt.key === "Esc" // IE/Edge specific value
+      ) {
+        setIsOpen(false)
+      }
+    }
+
     document.addEventListener("click", handleDocumentClick)
+    document.addEventListener("keydown", handleDocumentEscape)
 
     return () => {
       document.removeEventListener("click", handleDocumentClick)
+      document.removeEventListener("keydown", handleDocumentEscape)
     }
   }, [])
 

--- a/draft-packages/hierarchical-select/KaizenDraft/HierarchicalSelect/HierarchicalSelect.tsx
+++ b/draft-packages/hierarchical-select/KaizenDraft/HierarchicalSelect/HierarchicalSelect.tsx
@@ -68,6 +68,7 @@ export const HierarchicalSelect = (props: HierarchicalSelectProps) => {
         className={styles.button}
         type="button"
         onClick={() => setIsOpen(!isOpen)}
+        title={value ? value.label : placeholder}
       >
         {value ? (
           <div className={styles.value}>{value.label}</div>

--- a/draft-packages/hierarchical-select/KaizenDraft/HierarchicalSelect/styles.module.scss
+++ b/draft-packages/hierarchical-select/KaizenDraft/HierarchicalSelect/styles.module.scss
@@ -27,7 +27,7 @@
   align-items: center;
   justify-content: space-between;
   width: 100%;
-  min-height: $input-height;
+  height: $input-height;
   border: $kz-border-solid-border-width $kz-border-solid-border-style
     $ca-border-color;
   border-radius: $kz-border-solid-border-radius;

--- a/draft-packages/hierarchical-select/KaizenDraft/HierarchicalSelect/styles.module.scss
+++ b/draft-packages/hierarchical-select/KaizenDraft/HierarchicalSelect/styles.module.scss
@@ -35,7 +35,7 @@
   &:hover,
   &:focus {
     .chevron {
-      color: $kz-color-wisteria-800;
+      color: $kz-color-wisteria-500;
     }
   }
 
@@ -64,10 +64,34 @@
   opacity: $input-placeholder-opacity;
 }
 
-.chevron {
+.indicators {
   color: $kz-color-wisteria-300;
+  display: flex;
 }
 
+.separator {
+  @include ca-margin($start: $kz-spacing-sm, $end: $kz-spacing-sm);
+  border-left: 1px solid currentColor;
+}
+
+.clear {
+  &:hover {
+    color: $kz-color-wisteria-500;
+  }
+
+  :global(.js-focus-visible) & {
+    &:focus {
+      outline: none;
+    }
+
+    &:global(.focus-visible) {
+      outline: $kz-border-focus-ring-border-width
+        $kz-border-focus-ring-border-style $kz-color-cluny-500;
+    }
+  }
+}
+
+.clear > svg,
 .chevron > svg {
   display: block;
 }

--- a/draft-packages/hierarchical-select/KaizenDraft/HierarchicalSelect/styles.module.scss
+++ b/draft-packages/hierarchical-select/KaizenDraft/HierarchicalSelect/styles.module.scss
@@ -52,7 +52,11 @@
 .value {
   @include kz-typography-paragraph-body;
   @include ca-inherit-baseline;
+  @include ca-margin($end: $kz-spacing-xs);
   pointer-events: none;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .placeholder {

--- a/draft-packages/hierarchical-select/package.json
+++ b/draft-packages/hierarchical-select/package.json
@@ -33,10 +33,11 @@
   "dependencies": {
     "@kaizen/component-library": "^7.27.0",
     "@kaizen/draft-button": "^1.13.3",
-    "@kaizen/draft-form": "^2.4.3"
+    "@kaizen/draft-form": "^2.4.3",
+    "@kaizen/draft-hierarchical-menu": "^1.1.0"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^1.6.0",
-    "react": "^16.9.0"
+    "@kaizen/design-tokens": "^2.1.1",
+    "react": "^16.13.1"
   }
 }

--- a/draft-packages/stories/HierarchicalSelect.stories.tsx
+++ b/draft-packages/stories/HierarchicalSelect.stories.tsx
@@ -14,7 +14,7 @@ interface StoryContainerRenderProps {
   hierarchy: Hierarchy | null
   setHierarchy: (hierarchy: Hierarchy) => void
   value: HierarchyNode | null
-  setValue: (value: HierarchyNode) => void
+  setValue: (value: HierarchyNode | null) => void
 }
 
 interface StoryContainerProps {
@@ -67,6 +67,7 @@ export const DefaultStory = () => (
             setHierarchy(currentHierarchy)
             setValue(toNode)
           }}
+          onClear={() => setValue(null)}
           placeholder="Select..."
           value={value}
         />
@@ -92,6 +93,7 @@ export const RtlStory = () => (
               setHierarchy(currentHierarchy)
               setValue(toNode)
             }}
+            onClear={() => setValue(null)}
             placeholder="Select RTL..."
             value={value}
             dir="rtl"

--- a/draft-packages/stories/hierarchicalStoriesHelpers.ts
+++ b/draft-packages/stories/hierarchicalStoriesHelpers.ts
@@ -1,4 +1,4 @@
-import { HierarchyNode, Hierarchy } from "@kaizen/draft-hierarchical-menu"
+import { Hierarchy } from "@kaizen/draft-hierarchical-menu"
 
 export enum ResponseTime {
   INSTANT = 0,
@@ -43,6 +43,18 @@ export const levelZero: Hierarchy = {
       numberOfChildren: 0,
     },
     { value: "id_jack", label: "Jack Van Wyk", level: 1, numberOfChildren: 0 },
+    {
+      value: "id_long_example_1",
+      label: "Example of a long name to show truncation with ellipses",
+      level: 1,
+      numberOfChildren: 0,
+    },
+    {
+      value: "id_long_example_2",
+      label: "Example of a long name to show truncation with ellipses",
+      level: 1,
+      numberOfChildren: null,
+    },
   ],
 }
 


### PR DESCRIPTION
Follow up to https://github.com/cultureamp/kaizen-design-system/pull/687. Fixes the known issues from that PR and some more.

**Screenshot:**

![Screen Shot 2020-08-19 at 11 46 46 am](https://user-images.githubusercontent.com/4900094/90582672-ae9bf800-e211-11ea-89ac-2342d5415637.png)

**Storybook:**
https://dev.cultureamp.design/lijuenc/hierarchical-menu-improvements/storybook/?path=/story/hierarchicalselect-react--default-story

**Menu and select:**
- Make focus styles consistent with other Kaizen inputs and buttons

**Menu:**
- Truncate long option names with ellipses (screenshot above)
- Support disabled state for drill down button (<kbd>></kbd> in last option in screenshot above)
- Make current hierarchy node clickable ("Didier Elzinga" in screenshot above) so that the current level can selected without having to go back to the parent
- IE11 compatibility for:
  - keyboard navigation (<kbd>↑</kbd>, <kbd>↓</kbd>, <kbd>←</kbd>, <kbd>→</kbd>, <kbd>Space</kbd>, <kbd>Enter</kbd>)
  - some styling and layout issues

**Select:**
- Close menu when <kbd>Escape</kbd> is pressed
- Clear select value when <kbd>Backspace</kbd> or <kbd>Delete</kbd> is pressed
- Clear select value when cross icon button is clicked (screenshot above)
- IE11 compatibility for:
  - keyboard navigation (<kbd>↑</kbd>, <kbd>↓</kbd>, <kbd>←</kbd>, <kbd>→</kbd>, <kbd>Space</kbd>, <kbd>Enter</kbd>, <kbd>Backspace</kbd>, <kbd>Delete</kbd>)
  - some styling and layout issues

**Known issues:**
- The cross icon button does not work in IE11 (but works fine in Chrome, Firefox, Safari, IE Edge). The workaround for this for now is to use the <kbd>Backspace</kbd> or <kbd>Delete</kbd> key to clear the select value