### PR TITLE
feat: Add automation IDs to Tabs

### DIFF
--- a/draft-packages/tabs/KaizenDraft/Tabs/Tabs.tsx
+++ b/draft-packages/tabs/KaizenDraft/Tabs/Tabs.tsx
@@ -4,12 +4,12 @@ import * as React from "react"
 const styles = require("./styles.scss")
 
 interface Tab {
-  readonly automationId: string
   readonly label: string
   readonly active?: boolean
   readonly disabled?: boolean
   readonly onClick?: (e: React.MouseEvent<HTMLAnchorElement>) => any
   readonly href?: string
+  readonly automationId?: string
 }
 
 interface Props {

--- a/draft-packages/tabs/KaizenDraft/Tabs/Tabs.tsx
+++ b/draft-packages/tabs/KaizenDraft/Tabs/Tabs.tsx
@@ -4,6 +4,7 @@ import * as React from "react"
 const styles = require("./styles.scss")
 
 interface Tab {
+  readonly automationId: string
   readonly label: string
   readonly active?: boolean
   readonly disabled?: boolean
@@ -60,6 +61,7 @@ const RowTab = ({ tabs, renderTab, textDirection }) => (
         })
       ) : (
         <a
+          data-automation-id={t.automationId}
           key={t.label}
           onClick={t.onClick}
           href={!t.disabled ? t.href : null}
@@ -88,6 +90,7 @@ const VerticalTab = ({ tabs, renderTab, textDirection }) => (
         })
       ) : (
         <a
+          data-automation-id={t.automationId}
           key={t.label}
           onClick={t.onClick}
           href={!t.disabled ? t.href : null}


### PR DESCRIPTION
Adds automation IDs to both vertical and horizontal tabs.

Usage example from performance:

```js
const modifiedTabs = filteredTabs.map((t: Tab) => {
    return {
      ...t,
      // add here 
      automationId: t.automationId,
      onClick: (e: React.MouseEvent<HTMLAnchorElement>) => {
        if (t.onClick) {
          t.onClick(e)
        }

        if (e.defaultPrevented) return

        if (t.href && isRegularMouseClick(e)) {
          e.preventDefault()
          router.replace(t.href as string)
        }

        if (isSticky) {
          scrollToTopOfTabContentIfNecessary(ref.current)
        }
      },
    }
  })

  return (
    // This first wrapper is needed as so we can calculate where the tabs should be,
    // when not in sticky mode.
    // The inner wrapper is needed to set the css styling for position: sticky,
    // only if isSticky is true.
    <span className={cx(isSticky && styles.rootSticky)} ref={ref}>
      <div className={cx(isSticky && styles.tabsSticky)}>
        <KaizenTabs tabs={modifiedTabs} {...rest} />
      </div>
    </span>
  )
```