### PR TITLE
feat: Add new badge to menu items

### DIFF
--- a/draft-packages/stories/ZenNavigationBar.stories.tsx
+++ b/draft-packages/stories/ZenNavigationBar.stories.tsx
@@ -419,6 +419,7 @@ export const WithFooterAndHeaderComponents = () => (
       secondary: [
         <Menu
           heading="Admin"
+          showIndicator
           items={[
             {
               label: "Skills",

--- a/draft-packages/stories/ZenNavigationBar.stories.tsx
+++ b/draft-packages/stories/ZenNavigationBar.stories.tsx
@@ -451,6 +451,10 @@ export const WithFooterAndHeaderComponents = () => (
                 {
                   label: "Feedback stats",
                   url: "/",
+                  badge: {
+                    kind: "new",
+                    text: "New",
+                  },
                 },
               ],
             },

--- a/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/components/Indicator.module.scss
+++ b/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/components/Indicator.module.scss
@@ -1,0 +1,9 @@
+@import "~@kaizen/design-tokens/sass/color";
+@import "~@kaizen/design-tokens/sass/spacing";
+@import "~@kaizen/component-library/styles/layout";
+
+.container {
+  @include ca-margin($end: 4px);
+  width: $kz-spacing-sm;
+  color: $kz-color-seedling-400;
+}

--- a/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/components/Indicator.tsx
+++ b/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/components/Indicator.tsx
@@ -1,0 +1,20 @@
+import React from "react"
+import { Icon } from "@kaizen/component-library"
+
+const styles = require("./Indicator.module.scss")
+
+const fullIcon = require("@kaizen/component-library/icons/full.icon.svg")
+  .default
+
+const Indicator = () => (
+  <span className={styles.container}>
+    <Icon
+      icon={fullIcon}
+      role="presentation"
+      title={"Menu indicator"}
+      inheritSize
+    />
+  </span>
+)
+
+export default Indicator

--- a/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/components/Link.tsx
+++ b/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/components/Link.tsx
@@ -5,6 +5,7 @@ import ReactTooltip from "react-tooltip"
 import uuid from "uuid/v4"
 import { NavBarContext } from "../context"
 import { LinkProps } from "../types"
+import Indicator from "./Indicator"
 
 const arrowForwardIcon = require("@kaizen/component-library/icons/arrow-forward.icon.svg")
   .default
@@ -21,6 +22,7 @@ export default class Link extends React.PureComponent<LinkProps> {
     new: false,
     content: false,
     target: "_self",
+    showIndicator: false,
   }
 
   render = () => {
@@ -41,6 +43,7 @@ export default class Link extends React.PureComponent<LinkProps> {
       menuOpen,
       colorScheme,
       tooltip,
+      showIndicator,
     } = this.props
 
     const toolId = uuid()
@@ -98,6 +101,7 @@ export default class Link extends React.PureComponent<LinkProps> {
                 />
               </span>
             )}
+            {showIndicator && !icon && <Indicator />}
             {text && !(icon && iconOnly) && (
               <span className={classNames(styles.linkText)}>
                 {text}

--- a/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/components/Menu.module.scss
+++ b/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/components/Menu.module.scss
@@ -62,9 +62,3 @@
     margin-left: 0;
   }
 }
-
-.indicatorIcon {
-  @include ca-margin($end: 4px);
-  width: $kz-spacing-sm;
-  color: $kz-color-seedling-400;
-}

--- a/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/components/Menu.module.scss
+++ b/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/components/Menu.module.scss
@@ -1,4 +1,5 @@
 @import "~@kaizen/design-tokens/sass/color";
+@import "~@kaizen/design-tokens/sass/spacing";
 @import "~@kaizen/component-library/styles/type";
 @import "~@kaizen/component-library/styles/layout";
 @import "../styles";
@@ -60,4 +61,10 @@
     width: auto;
     margin-left: 0;
   }
+}
+
+.indicatorIcon {
+  @include ca-margin($end: 4px);
+  width: $kz-spacing-sm;
+  color: $kz-color-seedling-400;
 }

--- a/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/components/Menu.tsx
+++ b/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/components/Menu.tsx
@@ -7,7 +7,7 @@ import { OffCanvasContext, ZenOffCanvas } from "@kaizen/draft-zen-off-canvas"
 import classNames from "classnames"
 import Media from "react-media"
 import { NavBarContext } from "../context"
-import { ColorScheme, MenuProps, NavigationItem } from "../types"
+import { MenuProps, NavigationItem } from "../types"
 import Dropdown from "./Dropdown"
 import Link from "./Link"
 import MenuGroup from "./MenuGroup"
@@ -15,6 +15,8 @@ import MenuGroup from "./MenuGroup"
 const arrowLeftIcon = require("@kaizen/component-library/icons/arrow-left.icon.svg")
   .default
 const chevronDownIcon = require("@kaizen/component-library/icons/chevron-down.icon.svg")
+  .default
+const fullIcon = require("@kaizen/component-library/icons/full.icon.svg")
   .default
 
 const styles = require("./Menu.module.scss")
@@ -32,6 +34,7 @@ export default class Menu extends React.Component<MenuProps, State> {
     mobileEnabled: true,
     small: false,
     opaque: false,
+    showIndicator: false,
   }
   rootRef = React.createRef<any>()
 
@@ -52,6 +55,7 @@ export default class Menu extends React.Component<MenuProps, State> {
       items,
       header,
       colorScheme,
+      showIndicator,
     } = this.props
 
     return (
@@ -103,6 +107,16 @@ export default class Menu extends React.Component<MenuProps, State> {
                           icon={icon}
                           role="presentation"
                           title={`${heading} icon`}
+                        />
+                      </span>
+                    )}
+                    {showIndicator && (
+                      <span className={styles.indicatorIcon}>
+                        <Icon
+                          icon={fullIcon}
+                          role="presentation"
+                          title={`${heading} indicator`}
+                          inheritSize
                         />
                       </span>
                     )}

--- a/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/components/Menu.tsx
+++ b/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/components/Menu.tsx
@@ -134,7 +134,7 @@ export default class Menu extends React.Component<MenuProps, State> {
   }
 
   renderOffCanvas() {
-    const { items, heading, badge } = this.props
+    const { items, heading } = this.props
     const links: Array<NavigationItem | undefined> = items.map(
       (item, index) => {
         if ("url" in item) {
@@ -143,7 +143,7 @@ export default class Menu extends React.Component<MenuProps, State> {
               key={`${item.url}-${uuid()}`}
               text={item.label}
               href={item.url}
-              badge={badge}
+              badge={item.badge}
             />
           )
         } else if ("title" in item) {

--- a/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/components/Menu.tsx
+++ b/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/components/Menu.tsx
@@ -11,12 +11,11 @@ import { MenuProps, NavigationItem } from "../types"
 import Dropdown from "./Dropdown"
 import Link from "./Link"
 import MenuGroup from "./MenuGroup"
+import Indicator from "./Indicator"
 
 const arrowLeftIcon = require("@kaizen/component-library/icons/arrow-left.icon.svg")
   .default
 const chevronDownIcon = require("@kaizen/component-library/icons/chevron-down.icon.svg")
-  .default
-const fullIcon = require("@kaizen/component-library/icons/full.icon.svg")
   .default
 
 const styles = require("./Menu.module.scss")
@@ -71,6 +70,7 @@ export default class Menu extends React.Component<MenuProps, State> {
                     href="#"
                     onClick={() => toggleVisibleMenu(heading)}
                     opaque={opaque}
+                    showIndicator={showIndicator}
                   />
                 )}
               </OffCanvasContext.Consumer>
@@ -110,16 +110,7 @@ export default class Menu extends React.Component<MenuProps, State> {
                         />
                       </span>
                     )}
-                    {showIndicator && (
-                      <span className={styles.indicatorIcon}>
-                        <Icon
-                          icon={fullIcon}
-                          role="presentation"
-                          title={`${heading} indicator`}
-                          inheritSize
-                        />
-                      </span>
-                    )}
+                    {showIndicator && !icon && <Indicator />}
                     <span className={styles.linkText}>{heading}</span>
                     <span className={styles.downIcon}>
                       <Icon icon={chevronDownIcon} role="presentation" />
@@ -143,7 +134,7 @@ export default class Menu extends React.Component<MenuProps, State> {
   }
 
   renderOffCanvas() {
-    const { items, heading } = this.props
+    const { items, heading, badge } = this.props
     const links: Array<NavigationItem | undefined> = items.map(
       (item, index) => {
         if ("url" in item) {
@@ -152,6 +143,7 @@ export default class Menu extends React.Component<MenuProps, State> {
               key={`${item.url}-${uuid()}`}
               text={item.label}
               href={item.url}
+              badge={badge}
             />
           )
         } else if ("title" in item) {

--- a/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/components/MenuGroup.tsx
+++ b/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/components/MenuGroup.tsx
@@ -14,7 +14,12 @@ const MenuGroup = ({
   offCanvas,
 }: MenuGroupProps) => {
   const renderOffCanvasMenuItem = (item: MenuItemProps) => (
-    <Link key={`${item.url}-${uuid()}`} text={item.label} href={item.url} />
+    <Link
+      key={`${item.url}-${uuid()}`}
+      text={item.label}
+      href={item.url}
+      badge={item.badge}
+    />
   )
 
   const renderOffCanvasMenuGroup = () => (

--- a/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/components/MenuItem.module.scss
+++ b/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/components/MenuItem.module.scss
@@ -3,9 +3,10 @@
 @import "~@kaizen/component-library/styles/type";
 @import "~@kaizen/component-library/styles/animation";
 @import "~@kaizen/design-tokens/sass/border";
+@import "~@kaizen/design-tokens/sass/spacing";
 @import "../styles";
 
-$menuItem__padding: $ca-grid / 2;
+$menuItem__padding: $kz-spacing-md / 2;
 $menuItem__margin: 4px;
 
 .buttonReset {
@@ -30,7 +31,7 @@ $menuItem__margin: 4px;
 }
 
 .arrowIcon {
-  @include ca-margin($start: $ca-grid / 2);
+  @include ca-margin($start: $kz-spacing-md / 2);
 
   display: flex;
   color: rgba($kz-color-wisteria-800, 0.5);
@@ -79,4 +80,36 @@ $menuItem__margin: 4px;
 
   composes: buttonReset;
   width: calc(100% - #{$menuItem__margin * 2});
+}
+
+.linkLabel {
+  display: flex;
+  align-items: center;
+}
+
+.badge {
+  @include ca-margin($start: $kz-spacing-md * 0.25);
+  min-height: $kz-spacing-md;
+  border-radius: $kz-spacing-md;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  &.badgeNew {
+    @include ca-padding(
+      $start: $kz-spacing-md * 0.5,
+      $end: $kz-spacing-md * 0.5
+    );
+    background-color: $kz-color-seedling-200;
+  }
+
+  &.badgeNotification {
+    @include ca-padding($start: $kz-spacing-md / 3, $end: $kz-spacing-md / 3);
+    background-color: $kz-color-wisteria-800;
+
+    @include navbar-mobile-only {
+      background-color: $kz-color-coral-500;
+      color: $kz-color-white;
+    }
+  }
 }

--- a/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/components/MenuItem.tsx
+++ b/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/components/MenuItem.tsx
@@ -1,8 +1,8 @@
-import { Icon } from "@kaizen/component-library"
+import { Icon, Paragraph } from "@kaizen/component-library"
 import classNames from "classnames"
 import React from "react"
 import { NavBarContext } from "../context"
-import { MenuItemProps } from "../types"
+import { Badge, MenuItemProps } from "../types"
 
 const arrowForwardIcon = require("@kaizen/component-library/icons/arrow-forward.icon.svg")
   .default
@@ -15,6 +15,7 @@ const MenuItem = ({
   onClick,
   showArrowIcon = false,
   active = false,
+  badge,
 }: MenuItemProps) => {
   const { handleNavigationChange } = React.useContext(NavBarContext)
 
@@ -29,6 +30,22 @@ const MenuItem = ({
     </span>
   )
 
+  const renderBadge = ({ kind, text }: Badge) => (
+    <div
+      className={classNames(styles.badge, {
+        [styles.badgeNotification]: kind === "notification",
+        [styles.badgeNew]: kind === "new",
+      })}
+    >
+      <Paragraph
+        variant="extra-small"
+        color={kind === "new" ? "dark" : "white"}
+      >
+        {text}
+      </Paragraph>
+    </div>
+  )
+
   const renderForm = () => (
     // HTML forms only accept POST. We use a hidden `_method` input as a convention for emulating other HTTP verbs.
     // This behaviour is the same as what is implemented by UJS and supported by Rails:
@@ -36,7 +53,10 @@ const MenuItem = ({
     <form method="post" action={url}>
       <input name="_method" value={method} type="hidden" />
       <button type="submit" className={styles.itemBtn}>
-        {label}
+        <div className={styles.linkLabel}>
+          {label}
+          {badge && renderBadge(badge)}
+        </div>
         {showArrowIcon && renderArrowIcon()}
       </button>
     </form>
@@ -49,7 +69,10 @@ const MenuItem = ({
       tabIndex={0}
       onClick={handleItemClick}
     >
-      {label}
+      <div className={styles.linkLabel}>
+        {label}
+        {badge && renderBadge(badge)}
+      </div>
       {showArrowIcon && renderArrowIcon()}
     </a>
   )

--- a/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/types.ts
+++ b/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/types.ts
@@ -48,6 +48,7 @@ export type MenuProps = {
   opaque?: boolean
   small?: boolean
   colorScheme?: ColorScheme
+  showIndicator?: boolean
 }
 
 export type MenuItemProps = {

--- a/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/types.ts
+++ b/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/types.ts
@@ -35,6 +35,7 @@ export type LinkProps = {
   small?: boolean
   colorScheme?: ColorScheme
   tooltip?: string
+  showIndicator?: boolean
 }
 
 export type MenuProps = {

--- a/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/types.ts
+++ b/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/types.ts
@@ -14,6 +14,11 @@ export type NavigationChange = (
 
 export type NavigationItem = ReactElement<LinkProps> | ReactElement<MenuProps>
 
+export type Badge = {
+  kind: "new" | "notification"
+  text: string
+}
+
 export type LinkProps = {
   icon?: React.SVGAttributes<SVGSymbolElement>
   text?: string
@@ -25,10 +30,7 @@ export type LinkProps = {
   hasMenu?: boolean
   onClick?: NavigationChange
   menuOpen?: boolean
-  badge?: {
-    kind: "new" | "notification"
-    text: string
-  }
+  badge?: Badge
   opaque?: boolean
   small?: boolean
   colorScheme?: ColorScheme
@@ -55,6 +57,7 @@ export type MenuItemProps = {
   showArrowIcon?: boolean
   active?: boolean
   onClick?: NavigationChange
+  badge?: Badge
 }
 
 export type MenuGroupProps = {

--- a/packages/component-library/components/NavigationBar/NavigationBar.tsx
+++ b/packages/component-library/components/NavigationBar/NavigationBar.tsx
@@ -26,7 +26,7 @@ type Props = {
   children?: Navigation
 }
 
-export default class NavigationBar extends React.Component<Props> {
+export default class NavigationBar extends React.Component<Props, {}> {
   static displayName = "NavigationBar"
   static Link = Link
   static Menu = Menu

--- a/packages/component-library/components/NavigationBar/components/Indicator.module.scss
+++ b/packages/component-library/components/NavigationBar/components/Indicator.module.scss
@@ -1,0 +1,9 @@
+@import "~@kaizen/design-tokens/sass/color";
+@import "~@kaizen/design-tokens/sass/spacing";
+@import "~@kaizen/component-library/styles/layout";
+
+.container {
+  @include ca-margin($end: 4px);
+  width: $kz-spacing-sm;
+  color: $kz-color-seedling-400;
+}

--- a/packages/component-library/components/NavigationBar/components/Indicator.tsx
+++ b/packages/component-library/components/NavigationBar/components/Indicator.tsx
@@ -1,0 +1,20 @@
+import React from "react"
+import { Icon } from "@kaizen/component-library"
+
+const styles = require("./Indicator.module.scss")
+
+const fullIcon = require("@kaizen/component-library/icons/full.icon.svg")
+  .default
+
+const Indicator = () => (
+  <span className={styles.container}>
+    <Icon
+      icon={fullIcon}
+      role="presentation"
+      title={"Menu indicator"}
+      inheritSize
+    />
+  </span>
+)
+
+export default Indicator

--- a/packages/component-library/components/NavigationBar/components/Link.tsx
+++ b/packages/component-library/components/NavigationBar/components/Link.tsx
@@ -6,6 +6,7 @@ import * as React from "react"
 
 const styles = require("./Link.module.scss")
 import { LinkProps } from "../types"
+import Indicator from "./Indicator"
 
 export default class Link extends React.PureComponent<LinkProps> {
   static displayName = "Link"
@@ -30,6 +31,7 @@ export default class Link extends React.PureComponent<LinkProps> {
       target,
       hasMenu,
       section,
+      showIndicator,
     } = this.props
 
     return (
@@ -53,6 +55,7 @@ export default class Link extends React.PureComponent<LinkProps> {
         )}
         {text && !(icon && iconOnly) && (
           <span className={styles.linkText}>
+            {showIndicator && hasMenu && <Indicator />}
             {text}
             {badge && (
               <span

--- a/packages/component-library/components/NavigationBar/components/Menu.module.scss
+++ b/packages/component-library/components/NavigationBar/components/Menu.module.scss
@@ -169,3 +169,21 @@ $menu__square-size: $ca-grid * 2;
   color: $kz-color-white;
   padding: ($ca-grid / 2) $ca-grid;
 }
+
+.badge {
+  @include ca-margin($start: $ca-grid * 0.25);
+  @include ca-type-inter-small-bold;
+  @include ca-inherit-baseline;
+
+  border-radius: $ca-grid;
+  &.badgeNew {
+    @include ca-padding($start: $ca-grid * 0.5, $end: $ca-grid * 0.5);
+    background-color: $kz-color-seedling-200;
+    color: $kz-color-wisteria-800;
+  }
+  &.badgeNotification {
+    @include ca-padding($start: $ca-grid / 3, $end: $ca-grid / 3);
+    background-color: $kz-color-coral-500;
+    color: $kz-color-white;
+  }
+}

--- a/packages/component-library/components/NavigationBar/components/Menu.tsx
+++ b/packages/component-library/components/NavigationBar/components/Menu.tsx
@@ -15,6 +15,7 @@ import Media from "react-media"
 import { MOBILE_QUERY } from "../constants"
 import { MenuGroup, MenuItem, MenuProps } from "../types"
 import Link from "./Link"
+import Indicator from "./Indicator"
 
 const styles = require("./Menu.module.scss")
 
@@ -41,6 +42,7 @@ export default class Menu extends React.Component<MenuProps, State> {
       heading,
       mobileEnabled,
       section,
+      showIndicator,
     } = this.props
 
     return (
@@ -56,6 +58,7 @@ export default class Menu extends React.Component<MenuProps, State> {
                     onClick={() => toggleVisibleMenu(heading)}
                     hasMenu
                     section={section}
+                    showIndicator={showIndicator}
                   />
                 )}
               </OffCanvasContext.Consumer>
@@ -78,6 +81,7 @@ export default class Menu extends React.Component<MenuProps, State> {
                   children
                 ) : (
                   <React.Fragment>
+                    {showIndicator && <Indicator />}
                     <span className={styles.linkText}>{heading}</span>
                     <Icon icon={chevronDownIcon} role="presentation" />
                   </React.Fragment>
@@ -160,9 +164,11 @@ export default class Menu extends React.Component<MenuProps, State> {
         text={item.label}
         href={item.url}
         onClick={onLinkClick}
+        badge={item.badge}
       />
     )
   }
+
   renderOffCanvasMenuGroup = (menuGroup: MenuGroup) => {
     const { title, items } = menuGroup
 
@@ -176,7 +182,7 @@ export default class Menu extends React.Component<MenuProps, State> {
 
   renderMenuItem = (item: MenuItem) => {
     const { onLinkClick } = this.props
-    const { label, url, method, active = false } = item
+    const { label, url, method, active = false, badge } = item
 
     if (method && method !== "get") {
       return (
@@ -192,6 +198,16 @@ export default class Menu extends React.Component<MenuProps, State> {
             })}
           >
             {label}
+            {badge && (
+              <span
+                className={classNames(styles.badge, {
+                  [styles.badgeNotification]: badge.kind === "notification",
+                  [styles.badgeNew]: badge.kind === "new",
+                })}
+              >
+                {badge.text}
+              </span>
+            )}
           </button>
         </form>
       )
@@ -207,6 +223,16 @@ export default class Menu extends React.Component<MenuProps, State> {
         onClick={onLinkClick}
       >
         {label}
+        {badge && (
+          <span
+            className={classNames(styles.badge, {
+              [styles.badgeNotification]: badge.kind === "notification",
+              [styles.badgeNew]: badge.kind === "new",
+            })}
+          >
+            {badge.text}
+          </span>
+        )}
       </a>
     )
   }

--- a/packages/component-library/components/NavigationBar/types.ts
+++ b/packages/component-library/components/NavigationBar/types.ts
@@ -10,6 +10,11 @@ export type NavigationItem = ReactElement<LinkProps> | ReactElement<MenuProps>
 
 export type LinkClick = (event: React.MouseEvent<HTMLAnchorElement>) => void
 
+type Badge = {
+  kind: "new" | "notification"
+  text: string
+}
+
 export type LinkProps = {
   icon?: React.SVGAttributes<SVGSymbolElement>
   text?: string
@@ -20,11 +25,9 @@ export type LinkProps = {
   onClick?: LinkClick
   target?: "_self" | "_blank"
   hasMenu?: boolean
-  badge?: {
-    kind: "new" | "notification"
-    text: string
-  }
+  badge?: Badge
   section?: string
+  showIndicator?: boolean
 }
 
 export type MenuProps = {
@@ -36,6 +39,8 @@ export type MenuProps = {
   mobileEnabled?: boolean
   section?: string
   onLinkClick?: LinkClick
+  showIndicator?: boolean
+  badge?: Badge
 }
 
 export type MenuItem = {
@@ -43,6 +48,7 @@ export type MenuItem = {
   url: string
   active?: boolean
   method?: "get" | "post" | "put" | "delete"
+  badge?: Badge
 }
 
 export type MenuGroup = {

--- a/packages/component-library/stories/NavigationBar.stories.tsx
+++ b/packages/component-library/stories/NavigationBar.stories.tsx
@@ -242,6 +242,7 @@ export const MenuGroup = () => (
         />,
         <Menu
           heading="Admin"
+          showIndicator
           items={[
             {
               label: "Skills",
@@ -274,6 +275,7 @@ export const MenuGroup = () => (
                 {
                   label: "Feedback stats",
                   url: "meh",
+                  badge: { kind: "new", text: "New" },
                 },
               ],
             },


### PR DESCRIPTION
This PR adds new badge to dropdown menu items in both the new and old navbar.
It also adds the option of adding an indicator on Menu link.

<img width="280" alt="Screen Shot 2020-08-26 at 10 47 57 am" src="https://user-images.githubusercontent.com/22196200/91242063-c2071000-e789-11ea-8b0f-d2ce3a87a4ba.png">