### PR TITLE
fix: title block secondary actions tablet view bugfix

### DIFF
--- a/draft-packages/stories/TitleBlockZen.stories.tsx
+++ b/draft-packages/stories/TitleBlockZen.stories.tsx
@@ -5,8 +5,6 @@ import {
   TitleBlockZen,
 } from "../title-block-zen/KaizenDraft/TitleBlockZen"
 const addIcon = require("@kaizen/component-library/icons/add.icon.svg").default
-const visibleIcon = require("@kaizen/component-library/icons/visible.icon.svg")
-  .default
 const commentIcon = require("@kaizen/component-library/icons/comment.icon.svg")
   .default
 const starIcon = require("@kaizen/component-library/icons/star-on.icon.svg")

--- a/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/TitleBlockZen.tsx
+++ b/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/TitleBlockZen.tsx
@@ -483,7 +483,10 @@ const TitleBlockZen = ({
                   )}
                 </div>
               </div>
-              {(primaryAction || defaultAction) && (
+              {(primaryAction ||
+                defaultAction ||
+                secondaryActions ||
+                secondaryOverflowMenuItems) && (
                 <MainActions
                   primaryAction={primaryAction}
                   defaultAction={defaultAction}


### PR DESCRIPTION
Previously there was a bug where the secondary actions did not show on a tablet view when the absence of either a primary or default action.

Image shows the secondary menu which was not shown when other 2 buttons were not present.

<img width="476" alt="Screen Shot 2020-08-25 at 5 36 20 pm" src="https://user-images.githubusercontent.com/13988803/91127086-9a686700-e6f9-11ea-8c1c-a5bad3ef0ca5.png">
