### PR TITLE
fix: consider icon position end when additional content is used on generic button

### DIFF
--- a/draft-packages/button/KaizenDraft/Button/components/GenericButton.module.scss
+++ b/draft-packages/button/KaizenDraft/Button/components/GenericButton.module.scss
@@ -77,6 +77,10 @@
   @extend %caButtonIconWrapper;
 }
 
+.additionalContentWrapper {
+  @extend %caButtonAdditionalContentWrapper;
+}
+
 .destructiveModifier.destructiveModifier {
   @extend %caButtonDestructiveModifier;
 }

--- a/draft-packages/button/KaizenDraft/Button/components/GenericButton.tsx
+++ b/draft-packages/button/KaizenDraft/Button/components/GenericButton.tsx
@@ -217,8 +217,12 @@ const renderContent: React.FunctionComponent<Props> = props => (
     {(!props.icon || !props.iconButton) && (
       <span className={styles.label}>{props.label}</span>
     )}
+    {props.additionalContent && (
+      <span className={styles.additionalContentWrapper}>
+        {props.additionalContent}
+      </span>
+    )}
     {props.icon && props.iconPosition === "end" && renderIcon(props.icon)}
-    {props.additionalContent}
   </span>
 )
 

--- a/draft-packages/button/KaizenDraft/Button/styles.scss
+++ b/draft-packages/button/KaizenDraft/Button/styles.scss
@@ -382,6 +382,12 @@ $caButton-verticalPaddingForm: calc(
   align-self: flex-start;
 }
 
+%caButtonAdditionalContentWrapper {
+  display: inherit;
+  &:not(:last-child) {
+    @include ca-margin($end: 0.5em, $start: null);
+  }
+}
 %caButtonIconButton {
   width: $caButton-height;
 


### PR DESCRIPTION
I have extended the functionality of the hidden `additionalContent` api, to position it before the icon when `iconPosition` is set to `end`. 
This considers the margin needed to space additional content and icon apart.

I have searched our major repos and there is currently no use case where `iconPosition` is set to `end` as well as `additionalContent` being provided. 

This produces a button where the additional content - in this case a badge - can live before the icon. And does not effect the filter drawer button.

<img width="384" alt="Screen Shot 2020-08-28 at 3 49 28 pm" src="https://user-images.githubusercontent.com/13988803/91519205-11923b00-e946-11ea-9d65-570cc2c8f275.png">
