### PR TITLE
fix: fixes margin when a status tag and page switcher are used together

### DIFF
--- a/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/TitleBlockZen.scss
+++ b/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/TitleBlockZen.scss
@@ -392,9 +392,14 @@ $tab-container-height-small: $ca-grid * 2.5;
   @include title-block-medium-and-small {
     display: none;
   }
+
+  + .pageSwitcherSelectNextToTitle {
+    @include ca-margin($start: 0);
+  }
 }
 
 .pageSwitcherSelectNextToTitle {
+  @include ca-margin($start: $ca-grid / 2);
   flex-shrink: 0;
   width: 10 * $ca-grid;
 }


### PR DESCRIPTION
Small bugfix where the margin was incorrect.

<img width="1058" alt="Screen Shot 2020-08-31 at 11 57 44 am" src="https://user-images.githubusercontent.com/13988803/91672325-04fa2680-eb82-11ea-80d5-47119bec864b.png">
