### PR TITLE
docs: update to include Prominent variant

### DIFF
--- a/draft-packages/form/KaizenDraft/Form/TextAreaField/README.mdx
+++ b/draft-packages/form/KaizenDraft/Form/TextAreaField/README.mdx
@@ -24,7 +24,7 @@ import Dont from "docs-components/Dont"
 
 ## To keep in mind
 * **Prominent Text Area variant**
-    * A Text Area Field variant that optimizes for context where the aim is collection of user feedback, over system settings information (such as providing performance feedback in performance).
+    * Text Area Field variant that optimizes for contexts where the aim is user feedback collection rather than system settings information (such as performance feedback).
     * Prominent Text Areas and Text Area Fields are generally not mixed in the same context. 
 
 * **Optional vs required:**
@@ -121,7 +121,7 @@ All text area copy should be in sentence case i.e. the first letter of the first
 <WhenToUse>
 
 * Use a Text Area Field to gather longer text input.
-* If the aim is to collect general user feedback over system settings consider using the Prominent Text Area variant. 
+* If the aim is to collect general user feedback rather than system settings information consider using the Prominent Text Area variant. 
 
 </WhenToUse>
 <WhenNotToUse>

--- a/draft-packages/form/KaizenDraft/Form/TextAreaField/README.mdx
+++ b/draft-packages/form/KaizenDraft/Form/TextAreaField/README.mdx
@@ -23,6 +23,9 @@ import Dont from "docs-components/Dont"
 <iframe style="border: none;" width="744" height="450" src="https://www.figma.com/embed?embed_host=share&url=https%3A%2F%2Fwww.figma.com%2Ffile%2Fe3TyAOZKfLg9cA01Iy1Mgm%2FKaizen-Site-embed%3Fnode-id%3D50186%253A40775&chrome=DOCUMENTATION" allowfullscreen></iframe>
 
 ## To keep in mind
+* **Prominent Text Area variant**
+    * A Text Area Field variant that optimizes for context where the aim is collection of user feedback, over system settings information (such as providing performance feedback in performance).
+    * Prominent Text Areas and Text Area Fields are generally not mixed in the same context. 
 
 * **Optional vs required:**
     * As a rule of thumb, generally use “ (optional)” to indicate optional fields instead of “`*`” to indicate required fields. See [Forms](/guidelines/forms) for details.
@@ -50,7 +53,9 @@ To be scannable and fully helpful, a text area must have an associated label. He
 
 ### Give it a clear, short label
 
-Make sure your text area has a short, descriptive label above it that describes what the user should type into the box below. Avoid phrasing your labels as questions that are unnecessarily wordy. Keep in mind that your label shouldn’t contain instructions. Reserve those for the helper text.
+Make sure your text area has a short, descriptive label above it that describes what the user should type into the box below. To facilitate keyword loading and scanning, avoid phrasing your labels as questions that are unnecessarily wordy. If you find that the application lends itself to question like labels consider consider using the Prominent Text Area variant.  
+
+Keep in mind that your label shouldn’t contain instructions. Reserve those for the helper text.
 
 <DoAndDontContainer>
 <Do>
@@ -116,6 +121,7 @@ All text area copy should be in sentence case i.e. the first letter of the first
 <WhenToUse>
 
 * Use a Text Area Field to gather longer text input.
+* If the aim is to collect general user feedback over system settings consider using the Prominent Text Area variant. 
 
 </WhenToUse>
 <WhenNotToUse>


### PR DESCRIPTION
This PR adds details of the Prominent Text Area to the Text Area Field including copy and usage guidelines.

Branch preview: https://dev.cultureamp.design/dlimiter-adds-prominent-text-area/components/text-area-field/