### PR TITLE
docs: add table of contents to site

### DIFF
--- a/site/docs/components/divider.mdx
+++ b/site/docs/components/divider.mdx
@@ -37,6 +37,8 @@ Dividers separate content into clear groups. This helps people navigate the info
 * We use full-bleed dividers in lists/menus and middle dividers to group or separate content.
 * They inherit the background color they sit on, hence the need for an opacity (alpha).
 
+## When to use and when not to use
+
 <WhenToUseAndWhenNotToUse>
 <WhenToUse>
 

--- a/site/docs/guidelines/filtering.mdx
+++ b/site/docs/guidelines/filtering.mdx
@@ -77,7 +77,7 @@ For [filtering that uses tags](#tags-in-filtering) to display selected values, c
 
 Consider providing a method for users to preserve or return to a combination of filter fields and values. For example, you might support "saving" a filter view. Alternatively, you might considering reusing the same filter settings across pages or browser sessions.
 
-### Filtering components
+## Filtering components
 
 We sometimes use the following components in filters:
 
@@ -96,7 +96,7 @@ We sometimes use the following components in filters:
 - We prefer search above content and right-aligned.
 - Use multi-select with tags outside the select input when it's important to keep the applied filter values visible. In contrast, if it's sufficient context to know only that a filter is applied but not the exact values, you might show the selected values as checkboxes in the select dropdown instead. Note: we currently use tags for selected values in our [Select component](/components/select).
 
-#### Select in filtering
+### Select in filtering
 
 A [select](/components/select/) lets you choose options from an option menu. A single-select lets you choose one option while a multi-select lets you choose multiple options.
 
@@ -123,7 +123,7 @@ The select filter:
     *   Other things that have natural ordering like age groups, performance rating (good, great, better), rating scales (strongly disagree to strongly agree)
 *   Can combine autocomplete search within the select input
 
-#### Section tabs in filtering
+### Section tabs in filtering
 
 Section tabs organize content by grouping similar information from the same dataset into containers that are shown and hidden into sections.
 
@@ -144,7 +144,7 @@ Section tabs are useful in filtering when:
 *   Understanding relationships between segments of data:
     *   Some tabs are parts of a whole (e.g. complete/incomplete)
 
-#### Checkbox group in filtering
+### Checkbox group in filtering
 
 A [checkbox group](/components/checkbox-group/) contains checkbox fields that let people select zero or more options from a set.
 
@@ -165,7 +165,7 @@ The checkbox group filter:
 *   Combine groups of checkboxes
 *   Works for 5+ checkboxes
 
-#### Radio group in filtering
+### Radio group in filtering
 
 [Radio groups](/components/radio-group/) include a set of radios that let people select exactly one option in a set.
 
@@ -185,7 +185,7 @@ A radio group filter:
 *   Radios are tabs
 *   Works for 5–20 radios whereas tabs might only work for &lt;5
 
-#### Search in filtering
+### Search in filtering
 
 [Search](/components/search-field) lets users quickly find relevant content. It allows a user to type a word or phrase to filter a large amount of data down to a known piece of content or to a narrower list of relevant content without navigation.
 
@@ -222,7 +222,7 @@ Here are some considerations for search in filtering:
     *   Filters can be separate from search and add the selected value Tag to the search input field
     *   Possible to combine specific tag results and keyword search in one search bar e.g. Gmail searching for `"Label: unread" covid-19|`
 
-#### Date picker in filtering
+### Date picker in filtering
 
 A [Date Picker](/components/date-picker) lets users select a date or range of dates. It uses a text field and a visual calendar in a popover.
 
@@ -243,7 +243,7 @@ In [data visualizations](/guidelines/data-visualization), such as a bar chart th
 
 *   Consider providing handles to filter and zoom in on a time period.
 
-#### Tags in filtering
+### Tags in filtering
 
 <iframe style="border: none;" width="744" height="450" src="https://www.figma.com/embed?embed_host=share&url=https%3A%2F%2Fwww.figma.com%2Ffile%2Fe3TyAOZKfLg9cA01Iy1Mgm%2FKaizen-Site-embed%3Fnode-id%3D26297%253A59&chrome=DOCUMENTATION" allowfullscreen></iframe>
 
@@ -251,7 +251,7 @@ A [Tag](/components/tag/) helps users quickly recognize important information ab
 
 Use dismissible tags with a [select](/component/select) to show selected filter values when there are multiple selected values you want to show while the select is closed.
 
-#### Logic and rules
+### Logic and rules
 
 <iframe style="border: none;" width="744" height="450" src="https://www.figma.com/embed?embed_host=share&url=https%3A%2F%2Fwww.figma.com%2Ffile%2Fe3TyAOZKfLg9cA01Iy1Mgm%2FKaizen-Site-embed%3Fnode-id%3D26297%253A0&chrome=DOCUMENTATION" allowfullscreen></iframe>
 
@@ -259,7 +259,7 @@ Use dismissible tags with a [select](/component/select) to show selected filter 
     - Use a `fieldset` for each row of form fields. Use a single `legend` to describe all elements in that row. Use an individual `label` for each form field in that form. To avoid visual repetition and noise, you might visibly hide redundant labels, providing them only to people using screen readers off screen.
     - Show how each row relates to the next. For example, for survey branching logic, you might show that each condition is combined together using the keyword "AND".
 
-#### Badges in filtering
+### Badges in filtering
 
 [Badges](/components/badge/) show the count of some adjacent data. A dot badge notifies the user that something is new or updated without showing a count.
 

--- a/site/docs/guidelines/localization.mdx
+++ b/site/docs/guidelines/localization.mdx
@@ -34,7 +34,7 @@ If you explicitly need to set the `text-align` property for your document or com
 
 <CATypeAlignExample />
 
-##### Available Mixins
+### Available Mixins
 
 | Name                | Description                                                   |
 | ------------------- | ------------------------------------------------------------- |
@@ -51,8 +51,6 @@ When using any `left` or `right`-specific CSS properties e.g. `margin-left`, `pa
 
 <CAMarginExample />
 
-##### Params
-
 Note: all params are optional.
 
 | Name      | Value                       |
@@ -65,8 +63,6 @@ Note: all params are optional.
 ### Padding
 
 <CAPaddingExample />
-
-##### Params
 
 Note: all params are optional.
 
@@ -82,8 +78,6 @@ Note: all params are optional.
 This mixin is relevant to `absolute` or `relative`-positioned elements.
 
 <CAPositionExample />
-
-##### Params
 
 Note: all params are optional.
 

--- a/site/docs/language/grammar.mdx
+++ b/site/docs/language/grammar.mdx
@@ -11,7 +11,7 @@ tags: ["grammar", "punctuation", "style"]
 ## General styles
 
 
-#### Active voice vs. passive voice
+### Active voice vs. passive voice
 
 There are two kinds of construction in English: active and passive. We use active voice at Culture Amp. Not only does it help to simplify sentences, it can also help you shorten your writing and make it less convoluted.
 
@@ -36,7 +36,7 @@ Words like “was” and “by” may indicate that you’re writing in passive 
 Distinguishing between active and passive can often be very confusing, so make sure you ask a content strategist if you’re in doubt.
 
 
-#### American spelling
+### American spelling
 
 We use American spelling across the Culture Amp platform including in transactional emails, Intercom messages and the Academy. There are a few exceptions, but those mostly apply to marketing communications in different regions and personal communications to customers/users. Here are some common misspellings that apply to our platform:
 
@@ -144,7 +144,7 @@ Capitalized
 Avoid unnecessary capitalization like using initial capitals on words you want to emphasize, or feel are important.
 
 
-#### Dates
+### Dates
 
 When writing dates, spell out the day of the week and abbreviate the month.
 
@@ -165,7 +165,7 @@ Do not use ordinal indicators (as seen in superscripts) like “th,” “nd,”
 For convenience dates, mention the number of days if it’s less than a week. For example, “Due in 5 days.” If it’s more than a week, round it down to a week. Alternatively, you can also mention the date, “Due on March 26, 2020.”
 
 
-#### e.g.
+### e.g.
 
 e.g. is an abbreviation of the latin phrase _exempli gratia_ meaning “for the sake of example.” We recommend against using it in the platform. Instead use “for example” or “like.” 
 
@@ -175,14 +175,14 @@ e.g. is an abbreviation of the latin phrase _exempli gratia_ meaning “for the 
 >Don’t: You can splice your results using demographics, e.g. age, gender, geography, etc.
 
 
-#### Gender
+### Gender
 
 Avoid using gendered language like “he” or “she.” Instead use words like “they,” “them,” “people,”  “the person,” “the employee,” or “HR leader.” 
 
 For more, see personal pronouns.
 
 
-#### Headings and titles
+### Headings and titles
 
 Remember to write all headings and titles in sentence case, that is the first word of the sentence should be capitalized leaving everything lower case (unless there’s a proper noun or brand name). You don’t have to place a period at the end of a title or heading. For example:
 
@@ -191,7 +191,7 @@ Remember to write all headings and titles in sentence case, that is the first wo
 >Don’t: The Culture Amp Language Style Guide
 
 
-#### Links
+### Links
 
 Links are used commonly across Culture Amp to connect the reader to the Academy, support and other features within the platform. When inserting a hyperlink, make sure the text that’s being linked communicates information related to the link. Don’t use ‘click here’ or ‘learn more’ as links or button labels. They’re ambiguous and create uncertainty about where those links lead. Plus, they’re not good for accessibility or scanning. Instead, use text that describes where they’ll go or what they’ll do and try to include the link at the end of your sentence after the objective.
 
@@ -205,7 +205,7 @@ Links are used commonly across Culture Amp to connect the reader to the Academy,
 >Don’t: “<span style="text-decoration:underline;">Click here</span> to contact Culture Amp support.”
 
 
-#### Lists
+### Lists
 
 Lists are a great way to break up huge chunks of text and make paragraphs more scannable. We recommend using them when you can, but make sure you standardize the grammatical structure.
 
@@ -230,7 +230,7 @@ For a list that begins with an introduction or a “stem” sentence, make sure 
 >*   delete multiple 360 surveys
 
 
-#### Numbers
+### Numbers
 
 There are various rules that apply to numbers in writing:
 
@@ -242,7 +242,7 @@ There are various rules that apply to numbers in writing:
 *   There are always exceptions to these rules, especially when it comes to readability. When in doubt, always ask!
 
 
-#### Personal pronouns
+### Personal pronouns
 
 Pronouns take the place of nouns in writing. We recommend the use of pronouns to make your writing more conversational and less robotic. Here are some commonly used pronouns and the rules that apply:
 
@@ -316,7 +316,7 @@ To save space and be concise, you can remove the pronoun from buttons and links.
 >Don’t: Create your goal
 
 
-#### Times
+### Times
 
 When writing out a time, use the user’s local time without a time zone in all cases when it’s unambiguous. Use a.m. or p.m. and not 24-hour time. Here are some other rules to keep in mind:
 
@@ -328,7 +328,7 @@ When writing out a time, use the user’s local time without a time zone in all 
 *   For time ranges in a sentence, use words to separate them: Automatically run sync between midnight and 3:00 a.m. (PDT)
 
 
-#### Two words or one?
+### Two words or one?
 
 If you’re worried about whether words like log in, log out, sign in to and sign into are two words or one, they’re both.
 
@@ -344,7 +344,7 @@ Every day is two words unless you’re using it as an adjective: an everyday act
 ## Punctuation
 
 
-#### Apostrophes
+### Apostrophes
 
 Apostrophes are used to make a word possessive. For a singular possessive the apostrophe comes before the s. For example:
 
@@ -375,7 +375,7 @@ Don’t use apostrophes to make numbers or acronyms into plurals. For example:
 >Don’t: Since the 1950’s
 
 
-#### Colons and semicolons
+### Colons and semicolons
 
 Colons are used to introduce a list. For example:
 
@@ -390,7 +390,7 @@ Colons also separate hours from minutes when we’re talking about time.
 Semicolons are usually used in long sentences. This can get complicated, so avoid them if you can. An easy way to get the same result is to break your sentences up into two lines, or use an en dash.
 
 
-#### Commas
+### Commas
 
 Commas are used to separate words and word groups. The most common way to use a comma is when you’re listing items in a sentence or introducing a list. For example:
 
@@ -411,7 +411,7 @@ As we follow the AP style guide, we recommend against using this type of comma.
 For other use cases, take a look at the AP style guidelines. 
 
 
-#### Dashes
+### Dashes
 
 Dashes are used to separate parts of sentences. Remember, these are different from a hyphen. There are broadly two types of dashes used in writing:
 
@@ -427,7 +427,7 @@ As the overuse of this type of dash can get clunky, we advise against using it. 
 
 
 
-#### Ellipses
+### Ellipses
 
 An ellipses is a special punctuation mark consisting of three dots (not just three fullstops). Its shortcut on a Mac is option + ; or ctrl + alt + . on a PC. The ellipses serves a number of different purposes:
 
@@ -439,17 +439,17 @@ An ellipses is a special punctuation mark consisting of three dots (not just thr
 Avoid using ellipses for purposes other than the above. They wear thin quickly.
 
 
-#### Exclamation marks
+### Exclamation marks
 
 Exclamation marks are used to add strong feelings, emphasis or a high volume of speaking. Use these sparingly and never use more than one as they can become annoying. If you’re unsure about whether to add an exclamation point or not, err on the side of no. Instead, use well-chosen words to convey excitement or emphasis. When in doubt, ask a content strategist.
 
 
-#### Oxford commas
+### Oxford commas
 
 See commas.
 
 
-#### Slashes
+### Slashes
 
 The slash is a versatile punctuation mark that’s often used as a stand-in for the words “per” or “or.” For every case, we advise against using the slash. When in doubt, use “per” or “or.” The only time slashes are acceptable are in URLs, for example:
 
@@ -458,7 +458,7 @@ The slash is a versatile punctuation mark that’s often used as a stand-in for 
 Make sure you don’t confuse the forward slash (/) with a backward slash (\).
 
 
-#### Stops or periods
+### Stops or periods
 
 Full stops or periods are widely used to conclude to a sentence. They’re also used between e.g., p.m., and a.m., and after contractions like Ms., vs. and etc. They’re not used for capitalized abbreviations like EST, PDT, or NA.
 

--- a/site/src/components/ContentOnly.scss
+++ b/site/src/components/ContentOnly.scss
@@ -15,7 +15,6 @@
 }
 
 .content {
-  background: blue;
   background-color: #fff;
   border-radius: 7px;
   box-shadow: var(--card-box-shadow);

--- a/site/src/components/Layout.scss
+++ b/site/src/components/Layout.scss
@@ -48,13 +48,15 @@
   &.trimBottomOfCardToContent {
     grid-template-rows: min-content;
   }
+
+  @media (min-width: 768px) and (max-width: 1439px) {
+    justify-items: left;
+  }
 }
 
 .content {
   display: grid;
   grid-column: content;
-  max-width: var(--content-max-width);
-  width: 100%;
   padding: 0 0 $ca-grid;
   box-sizing: border-box;
 }
@@ -62,3 +64,8 @@
 .footerContainer {
   grid-area: footer;
 }
+
+.fullWidthContent {
+  width: 100%;
+}
+

--- a/site/src/components/Layout.scss
+++ b/site/src/components/Layout.scss
@@ -68,4 +68,3 @@
 .fullWidthContent {
   width: 100%;
 }
-

--- a/site/src/components/Layout.tsx
+++ b/site/src/components/Layout.tsx
@@ -48,6 +48,7 @@ const Layout: React.SFC<LayoutProps> = ({
           ) : (
             <div
               className={classnames({
+                [styles.fullWidthContent]: true,
                 [styles.contentContainer]: true,
                 [styles.trimBottomOfCardToContent]: trimBottomOfCardToContent,
               })}

--- a/site/src/components/PageHeader.scss
+++ b/site/src/components/PageHeader.scss
@@ -37,7 +37,7 @@
 .sideSection {
   grid-area: side;
   display: grid;
-  grid-template-rows: ($ca-grid * 9.5) auto;
+  grid-template-rows: ($ca-grid * 7.5) auto;
   row-gap: $ca-grid;
 
   @include ca-media-mobile() {
@@ -69,6 +69,8 @@
 
 .tagsContainer {
   color: $kz-color-white;
+  margin-bottom: 2rem;
+  opacity: 0.8;
 }
 
 .tagsLabel {
@@ -76,20 +78,19 @@
   line-height: 1.5;
   text-transform: uppercase;
   font-weight: 500;
-  margin-left: $ca-grid / 2;
   margin-bottom: $ca-grid / 2;
 }
 
 .tags {
   display: flex;
   flex-wrap: wrap;
-  margin-left: -0.25em;
+  margin-left: -0.5em;
 }
 
 .mainSection {
   grid-area: main;
   padding: 0 $ca-grid * 3;
-  max-width: calc(780px - $ca-grid);
+  max-width: $ca-grid * 27;
 
   @include ca-media-mobile() {
     padding: 0;
@@ -114,7 +115,7 @@
   font-size: 1.25rem;
   line-height: 1.5;
   font-weight: 400;
-  margin-bottom: var(--content-card-top-offset);
+  margin-bottom: calc(var(--content-card-top-offset) * 0.75);
 
   .headingOnly & {
     max-width: 60rem;

--- a/site/src/components/PageHeader.scss
+++ b/site/src/components/PageHeader.scss
@@ -19,7 +19,11 @@
 .pageHeaderInner {
   display: grid;
   grid-template-columns: [side] (12 * $ca-grid) [main] 1fr;
-  width: var(--content-max-width);
+  width: calc(var(--content-max-width) - (#{$ca-grid} * 2));
+
+  @media (min-width: 768px) and (max-width: 1439px) {
+    width: 100%;
+  }
 
   @include ca-media-mobile() {
     grid-template-columns: 1fr;

--- a/site/src/components/PageHeader.scss
+++ b/site/src/components/PageHeader.scss
@@ -88,7 +88,8 @@
 
 .mainSection {
   grid-area: main;
-  padding: 0 $ca-grid * 6;
+  padding: 0 $ca-grid * 3;
+  max-width: calc(780px - $ca-grid);
 
   @include ca-media-mobile() {
     padding: 0;
@@ -110,8 +111,8 @@
 }
 
 .summaryParagraph {
-  font-size: 1.5rem;
-  line-height: 1.4;
+  font-size: 1.25rem;
+  line-height: 1.5;
   font-weight: 400;
   margin-bottom: var(--content-card-top-offset);
 

--- a/site/src/components/PageHeader.tsx
+++ b/site/src/components/PageHeader.tsx
@@ -76,18 +76,6 @@ const PageHeader: React.SFC<PageHeaderProps> = ({
                     alt=""
                   />
                 </div>
-                <div className={styles.tagsContainer}>
-                  {tags && (
-                    <>
-                      <div className={styles.tagsLabel}>Also known as:</div>
-                      <div className={styles.tags}>
-                        {tags.map((tagText, i) => (
-                          <Tag text={tagText} key={`tag-${i}`} />
-                        ))}
-                      </div>
-                    </>
-                  )}
-                </div>
               </div>
             )}
             <div className={styles.mainSection}>
@@ -103,6 +91,18 @@ const PageHeader: React.SFC<PageHeaderProps> = ({
               {summaryParagraph && (
                 <h2 className={styles.summaryParagraph}>{summaryParagraph}</h2>
               )}
+              <div className={styles.tagsContainer}>
+                {tags && (
+                  <>
+                    <div className={styles.tagsLabel}>Also known as:</div>
+                    <div className={styles.tags}>
+                      {tags.map((tagText, i) => (
+                        <Tag text={tagText} key={`tag-${i}`} />
+                      ))}
+                    </div>
+                  </>
+                )}
+              </div>
               {children}
             </div>
           </div>

--- a/site/src/components/SidebarAndContent.scss
+++ b/site/src/components/SidebarAndContent.scss
@@ -70,6 +70,7 @@ $tableOfContents-width: $ca-grid * 10;
 .sidebar {
   grid-area: sidebar;
   margin-top: $ca-grid * 1.5;
+  max-width: $sidebar-width;
 
   @media (min-width: 768px) and (max-width: 1439px) {
     grid-row-start: 2;
@@ -122,6 +123,7 @@ $tableOfContents-width: $ca-grid * 10;
   grid-area: tableOfContents;
   margin-top: $ca-grid * 1.5;
   margin-left: $ca-grid * 0.5;
+  max-width: $tableOfContents-width;
 }
 
 .tableOfContentsLabel {

--- a/site/src/components/SidebarAndContent.scss
+++ b/site/src/components/SidebarAndContent.scss
@@ -25,8 +25,7 @@ $tableOfContents-width: $ca-grid * 10;
     grid-template-areas:
       "tableOfContents"
       "content"
-      "sidebar"
-      ;
+      "sidebar";
     grid-template-columns: 1fr;
     grid-template-rows: 1fr auto;
   }

--- a/site/src/components/SidebarAndContent.scss
+++ b/site/src/components/SidebarAndContent.scss
@@ -111,6 +111,7 @@ $tableOfContents-width: $ca-grid * 10;
 .tableOfContentsLabel {
   font-size: $kz-typography-heading-5-font-size;
   font-weight: $kz-typography-paragraph-bold-font-weight;
+  margin: 0.5rem 0;
   opacity: 0.75;
 }
 
@@ -139,6 +140,6 @@ $tableOfContents-width: $ca-grid * 10;
   }
   ol {
     list-style-type: none;
-    padding-inline-start: 12px;
+    padding-inline-start: $ca-grid;
   }
 }

--- a/site/src/components/SidebarAndContent.scss
+++ b/site/src/components/SidebarAndContent.scss
@@ -11,9 +11,15 @@ $tableOfContents-width: $ca-grid * 10;
 .sidebarAndContent {
   display: grid;
   grid-template-areas: "sidebar content tableOfContents";
-  grid-template-columns: $sidebar-width 1fr $tableOfContents-width;
+  grid-template-columns: $sidebar-width minmax(840px, 936px) $tableOfContents-width;
   grid-template-rows: 1fr;
   grid-gap: var(--sidebar-content-gap);
+
+  @media (min-width: 768px) and (max-width: 1439px) {
+    grid-template-areas: "tableOfContents sidebar content";
+    grid-template-columns: max($tableOfContents-width, $sidebar-width) auto;
+    grid-template-rows: auto 1fr;
+  }
 
   @include ca-media-mobile() {
     grid-template-areas:
@@ -33,7 +39,13 @@ $tableOfContents-width: $ca-grid * 10;
   box-shadow: var(--card-box-shadow);
   padding: 0;
   margin-top: calc(-1 * var(--content-card-top-offset));
-  max-width: var(--page-content-width);
+  max-width: 1080px;
+
+  @media (min-width: 768px) and (max-width: 1439px) {
+    grid-row-start: 1;
+    grid-row-end: span 2;
+    max-width: 768px;
+  }
 
   @include ca-media-mobile() {
     border: 0;
@@ -59,6 +71,11 @@ $tableOfContents-width: $ca-grid * 10;
 .sidebar {
   grid-area: sidebar;
   margin-top: $ca-grid * 1.5;
+
+  @media (min-width: 768px) and (max-width: 1439px) {
+    grid-row-start: 2;
+    grid-column-start: 1;
+  }
 }
 
 .sidebarSectionTitle {
@@ -118,8 +135,11 @@ $tableOfContents-width: $ca-grid * 10;
 .tableOfContentsList {
   margin-left: -$ca-grid * 0.5;
   padding-left: 0;
-  width: 240px;
   margin-bottom: var(--content-card-top-offset);
+
+  @media (min-width: 768px) and (max-width: 1440px) {
+    margin-left: 0;
+  }
 
   li {
     list-style-type: none;
@@ -131,7 +151,6 @@ $tableOfContents-width: $ca-grid * 10;
     color: inherit;
     display: inline-block;
     padding: $ca-grid * 0.25 $ca-grid / 2;
-    width: 100%;
     text-decoration: none;
     border-radius: 7px;
   }

--- a/site/src/components/SidebarAndContent.scss
+++ b/site/src/components/SidebarAndContent.scss
@@ -1,22 +1,26 @@
 @import "~@kaizen/design-tokens/sass/color";
+@import "~@kaizen/design-tokens/sass/typography";
 @import "~@kaizen/component-library/styles/layout";
 @import "~@kaizen/component-library/styles/color";
 @import "~@kaizen/component-library/styles/type";
 @import "~@kaizen/component-library/styles/responsive";
 
 $sidebar-width: $ca-grid * 10;
+$tableOfContents-width: $ca-grid * 10;
 
 .sidebarAndContent {
   display: grid;
-  grid-template-areas: "sidebar content";
-  grid-template-columns: $sidebar-width 1fr;
+  grid-template-areas: "sidebar content tableOfContents";
+  grid-template-columns: $sidebar-width 1fr $tableOfContents-width;
   grid-template-rows: 1fr;
   grid-gap: var(--sidebar-content-gap);
 
   @include ca-media-mobile() {
     grid-template-areas:
+      "tableOfContents"
       "content"
-      "sidebar";
+      "sidebar"
+      ;
     grid-template-columns: 1fr;
     grid-template-rows: 1fr auto;
   }
@@ -72,14 +76,16 @@ $sidebar-width: $ca-grid * 10;
 }
 
 .tab {
+  border-radius: 7px;
   list-style: none;
   display: flex;
   align-items: center;
   box-sizing: border-box;
-  font-size: 18px;
+  font-size: 16px;
   line-height: 24px;
 
   a {
+    border-radius: 7px;
     padding: $ca-grid * 0.25 $ca-grid / 2;
     width: 100%;
     text-decoration: none;
@@ -93,5 +99,46 @@ $sidebar-width: $ca-grid * 10;
   &.active {
     background-color: $kz-color-ash;
     color: $kz-color-cluny-500;
+  }
+}
+
+.tableOfContents {
+  grid-area: tableOfContents;
+  margin-top: $ca-grid * 1.5;
+  margin-left: $ca-grid * 0.5;
+}
+
+.tableOfContentsLabel {
+  font-size: $kz-typography-heading-5-font-size;
+  font-weight: $kz-typography-paragraph-bold-font-weight;
+  opacity: 0.75;
+}
+
+.tableOfContentsList {
+  margin-left: -$ca-grid * 0.5;
+  padding-left: 0;
+  width: 240px;
+  margin-bottom: var(--content-card-top-offset);
+
+  li {
+    list-style-type: none;
+    box-sizing: border-box;
+    font-size: 16px;
+    line-height: 24px;
+  }
+  a {
+    color: inherit;
+    display: inline-block;
+    padding: $ca-grid * 0.25 $ca-grid / 2;
+    width: 100%;
+    text-decoration: none;
+    border-radius: 7px;
+  }
+  a:hover {
+    color: $kz-color-cluny-500;
+  }
+  ol {
+    list-style-type: none;
+    padding-inline-start: 12px;
   }
 }

--- a/site/src/components/SidebarAndContent.tsx
+++ b/site/src/components/SidebarAndContent.tsx
@@ -122,7 +122,7 @@ export const TableOfContents: React.SFC<TableOfContentsProps> = ({
   items,
 }) => (items ?
   <ol className={styles.tableOfContents}>
-    {TableOfContentsBody(items, 4)}
+    {TableOfContentsBody(items, 2)}
   </ol>
   :
     null

--- a/site/src/components/SidebarAndContent.tsx
+++ b/site/src/components/SidebarAndContent.tsx
@@ -108,9 +108,13 @@ const TableOfContentsBody = (items, depth) => {
   }
 
   return items.map(item => (
-    <li key={item.url}><a href={item.url}>{item.title}</a>
-      { item.items ? <ol>{TableOfContentsBody(item.items || [], depth - 1)}</ol> : null }
-    </li>)
+    item.url ?
+      <li key={item.url}><a href={item.url}>{item.title}</a>
+        { item.items ? <ol>{TableOfContentsBody(item.items || [], depth - 1)}</ol> : null }
+      </li>
+      :
+      TableOfContentsBody(item.items || [], depth - 1)
+    )
   )
 }
 

--- a/site/src/components/SidebarAndContent.tsx
+++ b/site/src/components/SidebarAndContent.tsx
@@ -116,8 +116,10 @@ const TableOfContentsBody = (items, depth) => {
 
 export const TableOfContents: React.SFC<TableOfContentsProps> = ({
   items,
-}) => (
+}) => (items ?
   <ol className={styles.tableOfContents}>
     {TableOfContentsBody(items, 4)}
   </ol>
+  :
+    null
 )

--- a/site/src/components/SidebarAndContent.tsx
+++ b/site/src/components/SidebarAndContent.tsx
@@ -27,12 +27,13 @@ type SidebarTabProps = {
   children: React.ReactNode
 }
 
+type ItemOrArray<T> = T | Array<ItemOrArray<T>>;
+type Item = {
+  title: string,
+  url: string
+}
 type TableOfContentsProps = {
-  items: Array<{
-    title: string,
-    url: string
-    items?: {}
-  }>
+  items: ItemOrArray<Item>
 }
 
 type ContentNeedToKnowProps = {

--- a/site/src/components/SidebarAndContent.tsx
+++ b/site/src/components/SidebarAndContent.tsx
@@ -27,9 +27,9 @@ type SidebarTabProps = {
   children: React.ReactNode
 }
 
-type ItemOrArray<T> = T | Array<ItemOrArray<T>>;
+type ItemOrArray<T> = T | Array<ItemOrArray<T>>
 type Item = {
-  title: string,
+  title: string
   url: string
 }
 type TableOfContentsProps = {
@@ -107,26 +107,32 @@ const TableOfContentsBody = (items, depth) => {
     return
   }
 
-  return items.map(item => (
-    item.url ?
-      <li key={item.url}><a href={item.url}>{item.title}</a>
-        { item.items ? <ol>{TableOfContentsBody(item.items || [], depth - 1)}</ol> : null }
+  return items.map(item =>
+    item.url ? (
+      <li key={item.url}>
+        <a href={item.url}>{item.title}</a>
+        {item.items ? (
+          <ol>{TableOfContentsBody(item.items || [], depth - 1)}</ol>
+        ) : null}
       </li>
-      :
+    ) : (
       TableOfContentsBody(item.items || [], depth - 1)
     )
   )
 }
 
-export const TableOfContents: React.SFC<TableOfContentsProps> = ({
-  items,
-}) => (items ?
-  <div className={styles.tableOfContents} role="navigation" aria-labelledby="table-of-contents-label">
-    <p id="table-of-contents-label" className={styles.tableOfContentsLabel}>On this page</p>
-    <ol className={styles.tableOfContentsList}>
-      {TableOfContentsBody(items, 2)}
-    </ol>
-  </div>
-  :
-    null
-)
+export const TableOfContents: React.SFC<TableOfContentsProps> = ({ items }) =>
+  items ? (
+    <div
+      className={styles.tableOfContents}
+      role="navigation"
+      aria-labelledby="table-of-contents-label"
+    >
+      <p id="table-of-contents-label" className={styles.tableOfContentsLabel}>
+        On this page
+      </p>
+      <ol className={styles.tableOfContentsList}>
+        {TableOfContentsBody(items, 2)}
+      </ol>
+    </div>
+  ) : null

--- a/site/src/components/SidebarAndContent.tsx
+++ b/site/src/components/SidebarAndContent.tsx
@@ -27,6 +27,14 @@ type SidebarTabProps = {
   children: React.ReactNode
 }
 
+type TableOfContentsProps = {
+  items: Array<{
+    title: string,
+    url: string
+    items?: {}
+  }>
+}
+
 type ContentNeedToKnowProps = {
   listOfTips: string[]
 }
@@ -92,3 +100,23 @@ export const ContentNeedToKnowSection: React.SFC<ContentNeedToKnowProps> = ({
 export const SidebarAndContent: React.SFC<SidebarAndContentProps> = ({
   children,
 }) => <div className={styles.sidebarAndContent}>{children}</div>
+
+const TableOfContentsBody = (items, depth) => {
+  if (depth === 0) {
+    return
+  }
+
+  return items.map(item => (
+    <li key={item.url}><a href={item.url}>{item.title}</a>
+      { item.items ? <ol>{TableOfContentsBody(item.items || [], depth - 1)}</ol> : null }
+    </li>)
+  )
+}
+
+export const TableOfContents: React.SFC<TableOfContentsProps> = ({
+  items,
+}) => (
+  <ol className={styles.tableOfContents}>
+    {TableOfContentsBody(items, 4)}
+  </ol>
+)

--- a/site/src/components/SidebarAndContent.tsx
+++ b/site/src/components/SidebarAndContent.tsx
@@ -121,9 +121,12 @@ const TableOfContentsBody = (items, depth) => {
 export const TableOfContents: React.SFC<TableOfContentsProps> = ({
   items,
 }) => (items ?
-  <ol className={styles.tableOfContents}>
-    {TableOfContentsBody(items, 2)}
-  </ol>
+  <div className={styles.tableOfContents} role="navigation" aria-labelledby="table-of-contents-label">
+    <p id="table-of-contents-label" className={styles.tableOfContentsLabel}>On this page</p>
+    <ol className={styles.tableOfContentsList}>
+      {TableOfContentsBody(items, 2)}
+    </ol>
+  </div>
   :
     null
 )

--- a/site/src/pages/404.tsx
+++ b/site/src/pages/404.tsx
@@ -38,6 +38,7 @@ export default props => (
     pageHeader={FourOhFourPageHeader}
     footer={<Footer />}
     trimBottomOfCardToContent
+    fullWidthContent={true}
   >
     <ContentOnly>
       <Content>

--- a/site/src/pages/index.tsx
+++ b/site/src/pages/index.tsx
@@ -72,6 +72,7 @@ export default ({ location }) => {
       currentPath={location.pathname}
       pageHeader={HomePageHeader}
       footer={<Footer reverseVariant extraContent={<FooterExtraContent />} />}
+      fullWidthContent={true}
     >
       <ContentOnly>
         <Content>

--- a/site/src/styles/global.scss
+++ b/site/src/styles/global.scss
@@ -6,9 +6,9 @@
 :root {
   --ca-grid: #{$ca-grid};
   --content-card-top-offset: calc(var(--ca-grid) * 3);
-  --sidebar-content-gap: calc(var(--ca-grid) * 2);
-  --content-top-and-bottom-margin: calc(var(--ca-grid) * 4);
-  --content-side-margin: calc(var(--ca-grid) * 6);
+  --sidebar-content-gap: calc(var(--ca-grid));
+  --content-top-and-bottom-margin: calc(var(--ca-grid) * 2);
+  --content-side-margin: calc(var(--ca-grid) * 4);
   --page-content-width: calc(var(--ca-grid) * 45);
   --card-box-shadow: 0px 3px 18px rgba(0, 0, 0, 0.19);
 }

--- a/site/src/styles/global.scss
+++ b/site/src/styles/global.scss
@@ -5,9 +5,9 @@
 
 :root {
   --ca-grid: #{$ca-grid};
-  --content-card-top-offset: calc(var(--ca-grid) * 3);
+  --content-card-top-offset: calc(var(--ca-grid) * 2);
   --sidebar-content-gap: calc(var(--ca-grid));
-  --content-top-and-bottom-margin: calc(var(--ca-grid) * 2);
+  --content-top-and-bottom-margin: calc(var(--ca-grid) * 3);
   --content-side-margin: calc(var(--ca-grid) * 4);
   --page-content-width: calc(var(--ca-grid) * 45);
   --card-box-shadow: 0px 3px 18px rgba(0, 0, 0, 0.19);

--- a/site/src/styles/markdown.scss
+++ b/site/src/styles/markdown.scss
@@ -18,11 +18,11 @@ $link-icon-margin: 12px;
 
   :global(.md-p),
   :global(.md-li) {
-    font-size: 1.0rem;
+    font-size: 1rem;
     line-height: 1.5;
   }
 
-  :global(.md-ol) ,
+  :global(.md-ol),
   :global(.md-ul) {
     padding-inline-start: 30px;
   }

--- a/site/src/styles/markdown.scss
+++ b/site/src/styles/markdown.scss
@@ -5,6 +5,7 @@
 @import "~@kaizen/component-library/styles/type";
 @import "~@kaizen/component-library/styles/color";
 @import "~@kaizen/component-library/styles/border";
+@import "~@kaizen/component-library/styles/responsive";
 @import "~@kaizen/component-library/components/NavigationBar/styles";
 @import "~@kaizen/component-library/components/Icon/styles";
 
@@ -90,18 +91,30 @@ $link-icon-margin: 12px;
     @include kz-typography-heading-2;
     margin-top: $ca-grid * 3.25;
     margin-bottom: 0;
+
+    @include ca-media-mobile() {
+      margin-top: $ca-grid * 2;
+    }
   }
 
   :global(.md-h2) + :global(.md-p),
   :global(.md-h2) + :global(.md-ul),
   :global(.md-h2) + :global(.md-ol) {
     margin-top: $ca-grid * 1.5;
+
+    @include ca-media-mobile() {
+      margin-top: $ca-grid;
+    }
   }
 
   :global(.md-h3) {
     @include kz-typography-heading-3;
     margin-top: $ca-grid * 2;
     margin-bottom: $ca-grid;
+
+    @include ca-media-mobile() {
+      margin-top: $ca-grid;
+    }
   }
 
   :global(.md-h2) + :global(.md-h3) {
@@ -112,6 +125,10 @@ $link-icon-margin: 12px;
     @include kz-typography-heading-4;
     margin-top: $ca-grid * 2;
     margin-bottom: $ca-grid;
+
+    @include ca-media-mobile() {
+      margin-top: $ca-grid;
+    }
   }
 
   :global(.md-h3) + :global(.md-h4) {

--- a/site/src/styles/markdown.scss
+++ b/site/src/styles/markdown.scss
@@ -22,6 +22,11 @@ $link-icon-margin: 12px;
     line-height: 1.5;
   }
 
+  :global(.md-ol) ,
+  :global(.md-ul) {
+    padding-inline-start: 30px;
+  }
+
   :global(.md-li) {
     margin: 0;
     margin-bottom: 0.5em;
@@ -83,14 +88,14 @@ $link-icon-margin: 12px;
 
   :global(.md-h2) {
     @include kz-typography-heading-2;
-    margin-top: $ca-grid * 3.5;
+    margin-top: $ca-grid * 3.25;
     margin-bottom: 0;
   }
 
   :global(.md-h2) + :global(.md-p),
   :global(.md-h2) + :global(.md-ul),
   :global(.md-h2) + :global(.md-ol) {
-    margin-top: $ca-grid * 2.5;
+    margin-top: $ca-grid * 1.5;
   }
 
   :global(.md-h3) {

--- a/site/src/styles/markdown.scss
+++ b/site/src/styles/markdown.scss
@@ -18,12 +18,13 @@ $link-icon-margin: 12px;
 
   :global(.md-p),
   :global(.md-li) {
-    font-size: 1.25rem;
-    line-height: 1.8;
+    font-size: 1.0rem;
+    line-height: 1.5;
   }
 
   :global(.md-li) {
     margin: 0;
+    margin-bottom: 0.5em;
     font-weight: $kz-typography-paragraph-body-font-weight;
 
     :global(.md-p) {
@@ -103,8 +104,7 @@ $link-icon-margin: 12px;
   }
 
   :global(.md-h4) {
-    font-size: 1.375rem;
-    line-height: 1.0909090909;
+    @include kz-typography-heading-4;
     margin-top: $ca-grid * 2;
     margin-bottom: $ca-grid;
   }
@@ -114,15 +114,13 @@ $link-icon-margin: 12px;
   }
 
   :global(.md-h5) {
-    font-size: 1rem;
-    line-height: 1.5;
-    font-weight: $ca-weight-medium;
+    @include kz-typography-heading-4;
   }
 
   :global(.md-em),
   :global(.md-i) {
     font-style: normal;
-    font-weight: $ca-weight-book;
+    font-weight: $kz-typography-paragraph-bold-font-weight;
   }
 
   :global(.md-strong) {

--- a/site/src/templates/componentPage.tsx
+++ b/site/src/templates/componentPage.tsx
@@ -83,7 +83,6 @@ export default ({ data, pageContext, location }) => {
           </SidebarSection>
         </Sidebar>
         <Content>
-          <TableOfContents items={md.tableOfContents.items} />
           <ContentNeedToKnowSection listOfTips={md.frontmatter.needToKnow} />
           {md.frontmatter.title !== "Overview" && renderStorybookIFrame()}
           <ContentMarkdownSection>
@@ -93,6 +92,7 @@ export default ({ data, pageContext, location }) => {
             <MDXRenderer>{data.mdx.body}</MDXRenderer>
           </ContentMarkdownSection>
         </Content>
+        <TableOfContents items={md.tableOfContents.items} />
       </SidebarAndContent>
     </Layout>
   )

--- a/site/src/templates/componentPage.tsx
+++ b/site/src/templates/componentPage.tsx
@@ -12,6 +12,7 @@ import {
   SidebarAndContent,
   SidebarSection,
   SidebarTab,
+  TableOfContents
 } from "../components/SidebarAndContent"
 import StorybookDemo from "../components/StorybookDemo"
 import { sortSidebarTabs, stripTrailingSlash } from "./util"
@@ -34,7 +35,6 @@ export default ({ data, pageContext, location }) => {
   const md = data.mdx
   const allPages = data.allMdx.edges
   const currentPath = location.pathname
-  const toc = data.mdx.tableOfContents.items // table of contents
 
   const overviewPage = allPages.filter(
     el => el.node.frontmatter.navTitle === "Overview"
@@ -68,18 +68,6 @@ export default ({ data, pageContext, location }) => {
     />
   )
 
-  const ToC = (items, depth) => {
-    if (depth === 0) {
-      return
-    }
-
-    return items.map(item => {
-      return <li key={item.url}><a href={item.url}>{item.title}</a>
-        { item.items ? <ol>{ToC(item.items || [], depth - 1)}</ol> : null }
-      </li>
-    })
-  }
-
   return (
     <Layout
       pageTitle={md.frontmatter.title}
@@ -95,9 +83,7 @@ export default ({ data, pageContext, location }) => {
           </SidebarSection>
         </Sidebar>
         <Content>
-          <ol>
-            {ToC(toc, 4)}
-          </ol>
+          <TableOfContents items={md.tableOfContents.items} />
           <ContentNeedToKnowSection listOfTips={md.frontmatter.needToKnow} />
           {md.frontmatter.title !== "Overview" && renderStorybookIFrame()}
           <ContentMarkdownSection>

--- a/site/src/templates/componentPage.tsx
+++ b/site/src/templates/componentPage.tsx
@@ -12,7 +12,7 @@ import {
   SidebarAndContent,
   SidebarSection,
   SidebarTab,
-  TableOfContents
+  TableOfContents,
 } from "../components/SidebarAndContent"
 import StorybookDemo from "../components/StorybookDemo"
 import { sortSidebarTabs, stripTrailingSlash } from "./util"

--- a/site/src/templates/componentPage.tsx
+++ b/site/src/templates/componentPage.tsx
@@ -34,6 +34,7 @@ export default ({ data, pageContext, location }) => {
   const md = data.mdx
   const allPages = data.allMdx.edges
   const currentPath = location.pathname
+  const toc = data.mdx.tableOfContents.items // table of contents
 
   const overviewPage = allPages.filter(
     el => el.node.frontmatter.navTitle === "Overview"
@@ -67,6 +68,18 @@ export default ({ data, pageContext, location }) => {
     />
   )
 
+  const ToC = (items, depth) => {
+    if (depth === 0) {
+      return
+    }
+
+    return items.map(item => {
+      return <li key={item.url}><a href={item.url}>{item.title}</a>
+        { item.items ? <ol>{ToC(item.items || [], depth - 1)}</ol> : null }
+      </li>
+    })
+  }
+
   return (
     <Layout
       pageTitle={md.frontmatter.title}
@@ -82,6 +95,9 @@ export default ({ data, pageContext, location }) => {
           </SidebarSection>
         </Sidebar>
         <Content>
+          <ol>
+            {ToC(toc, 4)}
+          </ol>
           <ContentNeedToKnowSection listOfTips={md.frontmatter.needToKnow} />
           {md.frontmatter.title !== "Overview" && renderStorybookIFrame()}
           <ContentMarkdownSection>
@@ -122,6 +138,7 @@ export const query = graphql`
         demoStoryId
         demoStoryHeight
       }
+      tableOfContents
     }
   }
 `

--- a/site/src/templates/guidelinePage.tsx
+++ b/site/src/templates/guidelinePage.tsx
@@ -12,6 +12,7 @@ import {
   SidebarAndContent,
   SidebarSection,
   SidebarTab,
+  TableOfContents
 } from "../components/SidebarAndContent"
 import { sortSidebarTabs, stripTrailingSlash } from "./util"
 
@@ -79,6 +80,7 @@ export default ({ data, pageContext, location }) => {
           </SidebarSection>
         </Sidebar>
         <Content>
+          <TableOfContents items={md.tableOfContents.items} />
           <ContentNeedToKnowSection listOfTips={md.frontmatter.needToKnow} />
           <ContentMarkdownSection>
             {/*
@@ -116,6 +118,7 @@ export const query = graphql`
         needToKnow
         headerImage
       }
+      tableOfContents
     }
   }
 `

--- a/site/src/templates/guidelinePage.tsx
+++ b/site/src/templates/guidelinePage.tsx
@@ -68,15 +68,15 @@ export default ({ data, pageContext, location }) => {
           <SidebarSection>
             {renderSidebarTabs(overviewPage, currentPath, "Overview")}
           </SidebarSection>
+          <SidebarSection title="Guidelines">
+            {renderSidebarTabs(guidelinePages, currentPath, "Guidelines")}
+          </SidebarSection>
           <SidebarSection title="Comparing components">
             {renderSidebarTabs(
               comparingPages,
               currentPath,
               "Comparing components"
             )}
-          </SidebarSection>
-          <SidebarSection title="Guidelines">
-            {renderSidebarTabs(guidelinePages, currentPath, "Guidelines")}
           </SidebarSection>
         </Sidebar>
         <Content>

--- a/site/src/templates/guidelinePage.tsx
+++ b/site/src/templates/guidelinePage.tsx
@@ -80,7 +80,6 @@ export default ({ data, pageContext, location }) => {
           </SidebarSection>
         </Sidebar>
         <Content>
-          <TableOfContents items={md.tableOfContents.items} />
           <ContentNeedToKnowSection listOfTips={md.frontmatter.needToKnow} />
           <ContentMarkdownSection>
             {/*
@@ -88,6 +87,7 @@ export default ({ data, pageContext, location }) => {
             <MDXRenderer>{data.mdx.body}</MDXRenderer>
           </ContentMarkdownSection>
         </Content>
+        <TableOfContents items={md.tableOfContents.items} />
       </SidebarAndContent>
     </Layout>
   )

--- a/site/src/templates/guidelinePage.tsx
+++ b/site/src/templates/guidelinePage.tsx
@@ -12,7 +12,7 @@ import {
   SidebarAndContent,
   SidebarSection,
   SidebarTab,
-  TableOfContents
+  TableOfContents,
 } from "../components/SidebarAndContent"
 import { sortSidebarTabs, stripTrailingSlash } from "./util"
 

--- a/site/src/templates/languagePage.tsx
+++ b/site/src/templates/languagePage.tsx
@@ -10,7 +10,7 @@ import {
   Sidebar,
   SidebarAndContent,
   SidebarTab,
-  TableOfContents
+  TableOfContents,
 } from "../components/SidebarAndContent"
 import { sortSidebarTabs, stripTrailingSlash } from "./util"
 

--- a/site/src/templates/languagePage.tsx
+++ b/site/src/templates/languagePage.tsx
@@ -10,6 +10,7 @@ import {
   Sidebar,
   SidebarAndContent,
   SidebarTab,
+  TableOfContents
 } from "../components/SidebarAndContent"
 import { sortSidebarTabs, stripTrailingSlash } from "./util"
 
@@ -60,6 +61,7 @@ export default ({ data, pageContext, location }) => {
           {renderSidebarTabs(pagesWithoutOverview, currentPath, "language")}
         </Sidebar>
         <Content>
+          <TableOfContents items={md.tableOfContents.items} />
           <ContentMarkdownSection>
             {/*
             // @ts-ignore */}
@@ -93,6 +95,7 @@ export const query = graphql`
         summaryParagraph
         tags
       }
+      tableOfContents
     }
   }
 `

--- a/site/src/templates/languagePage.tsx
+++ b/site/src/templates/languagePage.tsx
@@ -61,13 +61,13 @@ export default ({ data, pageContext, location }) => {
           {renderSidebarTabs(pagesWithoutOverview, currentPath, "language")}
         </Sidebar>
         <Content>
-          <TableOfContents items={md.tableOfContents.items} />
           <ContentMarkdownSection>
             {/*
             // @ts-ignore */}
             <MDXRenderer>{data.mdx.body}</MDXRenderer>
           </ContentMarkdownSection>
         </Content>
+        <TableOfContents items={md.tableOfContents.items} />
       </SidebarAndContent>
     </Layout>
   )


### PR DESCRIPTION
This PR:

- Adds a "table of contents" to each content page on the site
- Reduces type size in line with Zen style now that we are using Greycliff and Inter
- Adjusts layout to accommodate table of contents
- Makes content amendments to fix heading levels and missing headings
- Swaps "Guidelines" and "Comparing components" subsections in the sidebar in line with Google Analytics content usage

The table of contents specifically only shows heading levels 2 and 3 at this time to reduce level of indentation in the visual output and encourage people to avoid skipping heading levels because if they go from 2 to 4, level 4 won't show.

Branch previews:

- Storybook demo and Figma embed: https://dev.cultureamp.design/di/add-table-of-contents-to-site/components/modal/
- No TOC: https://dev.cultureamp.design/di/add-table-of-contents-to-site/language/check/
- 404: https://dev.cultureamp.design/di/add-table-of-contents-to-site/404/
- Home: https://dev.cultureamp.design/di/add-table-of-contents-to-site/
