### PR TITLE
fix: Bump design-tokens peer dependency to the latest version

### DIFF
--- a/draft-packages/avatar/package.json
+++ b/draft-packages/avatar/package.json
@@ -37,7 +37,7 @@
     "react-textfit": "^1.1.0"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^1.6.0",
+    "@kaizen/design-tokens": "^1.6.0 || ^2",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/button/package.json
+++ b/draft-packages/button/package.json
@@ -39,7 +39,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "1.6.0",
+    "@kaizen/design-tokens": "1.6.0 || ^2",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/card/package.json
+++ b/draft-packages/card/package.json
@@ -31,7 +31,7 @@
   "private": false,
   "license": "MIT",
   "peerDependencies": {
-    "@kaizen/design-tokens": "^1.6.0",
+    "@kaizen/design-tokens": "^1.6.0 || ^2",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/checkbox-group/package.json
+++ b/draft-packages/checkbox-group/package.json
@@ -41,7 +41,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^1.2.0",
+    "@kaizen/design-tokens": "^1.2.0 || ^2",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/collapsible/package.json
+++ b/draft-packages/collapsible/package.json
@@ -41,7 +41,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^1.2.0",
+    "@kaizen/design-tokens": "^1.2.0 || ^2",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/divider/package.json
+++ b/draft-packages/divider/package.json
@@ -34,7 +34,7 @@
     "classnames": "^2.2.6"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^1.6.0",
+    "@kaizen/design-tokens": "^1.6.0 || ^2",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/dropdown-menu/package.json
+++ b/draft-packages/dropdown-menu/package.json
@@ -40,7 +40,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^1.2.0",
+    "@kaizen/design-tokens": "^1.2.0 || ^2",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/dropdown/package.json
+++ b/draft-packages/dropdown/package.json
@@ -41,7 +41,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^1.2.0",
+    "@kaizen/design-tokens": "^1.2.0 || ^2",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/empty-state/package.json
+++ b/draft-packages/empty-state/package.json
@@ -40,7 +40,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^1.2.0",
+    "@kaizen/design-tokens": "^1.2.0 || ^2",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/events/package.json
+++ b/draft-packages/events/package.json
@@ -40,7 +40,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^1.2.0",
+    "@kaizen/design-tokens": "^1.2.0 || ^2",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/form/package.json
+++ b/draft-packages/form/package.json
@@ -41,7 +41,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^1.2.0",
+    "@kaizen/design-tokens": "^1.2.0 || ^2",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/guidance-block/package.json
+++ b/draft-packages/guidance-block/package.json
@@ -40,7 +40,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^1.2.0",
+    "@kaizen/design-tokens": "^1.2.0 || ^2",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/hero-card/package.json
+++ b/draft-packages/hero-card/package.json
@@ -41,7 +41,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^1.2.0",
+    "@kaizen/design-tokens": "^1.2.0 || ^2",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/hero-panel/package.json
+++ b/draft-packages/hero-panel/package.json
@@ -40,7 +40,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^1.2.0",
+    "@kaizen/design-tokens": "^1.2.0 || ^2",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/loading-placeholder/package.json
+++ b/draft-packages/loading-placeholder/package.json
@@ -40,7 +40,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^1.2.0",
+    "@kaizen/design-tokens": "^1.2.0 || ^2",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/loading-spinner/package.json
+++ b/draft-packages/loading-spinner/package.json
@@ -31,7 +31,7 @@
   "private": false,
   "license": "MIT",
   "peerDependencies": {
-    "@kaizen/design-tokens": "^1.6.0",
+    "@kaizen/design-tokens": "^1.6.0 || ^2",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/menu-list/package.json
+++ b/draft-packages/menu-list/package.json
@@ -41,7 +41,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^1.2.0",
+    "@kaizen/design-tokens": "^1.2.0 || ^2",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/menu/package.json
+++ b/draft-packages/menu/package.json
@@ -39,7 +39,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "1.6.0",
+    "@kaizen/design-tokens": "1.6.0 || ^2",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/modal/package.json
+++ b/draft-packages/modal/package.json
@@ -46,7 +46,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^1.2.0",
+    "@kaizen/design-tokens": "^1.2.0 || ^2",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/popover/package.json
+++ b/draft-packages/popover/package.json
@@ -41,7 +41,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^1.2.0",
+    "@kaizen/design-tokens": "^1.2.0 || ^2",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/radio-group/package.json
+++ b/draft-packages/radio-group/package.json
@@ -40,7 +40,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^1.2.0",
+    "@kaizen/design-tokens": "^1.2.0 || ^2",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/radio/package.json
+++ b/draft-packages/radio/package.json
@@ -41,7 +41,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^1.2.0",
+    "@kaizen/design-tokens": "^1.2.0 || ^2",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/select/package.json
+++ b/draft-packages/select/package.json
@@ -43,7 +43,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^1.2.0",
+    "@kaizen/design-tokens": "^1.2.0 || ^2",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/split-button/package.json
+++ b/draft-packages/split-button/package.json
@@ -41,7 +41,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^1.2.0",
+    "@kaizen/design-tokens": "^1.2.0 || ^2",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/table/package.json
+++ b/draft-packages/table/package.json
@@ -41,7 +41,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^1.2.0",
+    "@kaizen/design-tokens": "^1.2.0 || ^2",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/tabs/package.json
+++ b/draft-packages/tabs/package.json
@@ -41,7 +41,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^1.2.0",
+    "@kaizen/design-tokens": "^1.2.0 || ^2",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/tag/package.json
+++ b/draft-packages/tag/package.json
@@ -41,7 +41,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^1.2.0",
+    "@kaizen/design-tokens": "^1.2.0 || ^2",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/tile/package.json
+++ b/draft-packages/tile/package.json
@@ -31,7 +31,7 @@
   "private": false,
   "license": "MIT",
   "peerDependencies": {
-    "@kaizen/design-tokens": "^1.6.0",
+    "@kaizen/design-tokens": "^1.6.0 || ^2",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/title-block/package.json
+++ b/draft-packages/title-block/package.json
@@ -43,7 +43,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^1.2.0",
+    "@kaizen/design-tokens": "^1.2.0 || ^2",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/tooltip/package.json
+++ b/draft-packages/tooltip/package.json
@@ -41,7 +41,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^1.2.0",
+    "@kaizen/design-tokens": "^1.2.0 || ^2",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/user-interactions/package.json
+++ b/draft-packages/user-interactions/package.json
@@ -40,7 +40,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^1.2.0",
+    "@kaizen/design-tokens": "^1.2.0 || ^2",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/vertical-progress-step/package.json
+++ b/draft-packages/vertical-progress-step/package.json
@@ -40,7 +40,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^1.2.0",
+    "@kaizen/design-tokens": "^1.2.0 || ^2",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/well/package.json
+++ b/draft-packages/well/package.json
@@ -40,7 +40,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^1.2.0",
+    "@kaizen/design-tokens": "^1.2.0 || ^2",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/zen-navigation-bar/package.json
+++ b/draft-packages/zen-navigation-bar/package.json
@@ -44,7 +44,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^1.2.0",
+    "@kaizen/design-tokens": "^1.2.0 || ^2",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/zen-off-canvas/package.json
+++ b/draft-packages/zen-off-canvas/package.json
@@ -42,7 +42,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^1.2.0",
+    "@kaizen/design-tokens": "^1.2.0 || ^2",
     "react": "^16.9.0"
   }
 }

--- a/packages/component-library/package.json
+++ b/packages/component-library/package.json
@@ -26,7 +26,7 @@
   "private": false,
   "license": "MIT",
   "peerDependencies": {
-    "@kaizen/design-tokens": "^1.4.0",
+    "@kaizen/design-tokens": "^1.4.0 || ^2",
     "focus-visible": "4.x || 5.x",
     "react": "^16.9.0"
   },

--- a/packages/generator/generators/draft/templates/package.txt
+++ b/packages/generator/generators/draft/templates/package.txt
@@ -32,7 +32,7 @@
   "license": "MIT",
   "dependencies": {},
   "peerDependencies": {
-    "@kaizen/design-tokens": "^1.6.0",
+    "@kaizen/design-tokens": "^2",
     "react": "^16.9.0"
   }
 }


### PR DESCRIPTION
This updates all packages to use the same version of `design-tokens` as a peer dependency across Kaizen. I've added a new version range for now, with the view to drop the ~v1 peer dependency in a couple of weeks when all dependants are on ~v2.

To see the breaking changes from 1.15.0 -> 2.0.0, [see this PR](https://github.com/cultureamp/kaizen-design-system/pull/606/files).