### PR TITLE
docs: move copy guidelines

### DIFF
--- a/draft-packages/button/KaizenDraft/Button/README.mdx
+++ b/draft-packages/button/KaizenDraft/Button/README.mdx
@@ -24,6 +24,27 @@ import Dont from "docs-components/Dont"
 
 <iframe style="border: none;" width="744" height="450" src="https://www.figma.com/embed?embed_host=share&url=https%3A%2F%2Fwww.figma.com%2Ffile%2Fe3TyAOZKfLg9cA01Iy1Mgm%2FKaizen-Site-embed%3Fnode-id%3D205%253A12210" allowfullscreen></iframe>
 
+## To keep in mind
+
+*   All buttons use a button element (not a link element and no `role=”button”`)
+*   All buttons have a large click target of 48px to meet minimum touch target sizes
+*   Default action button:
+    *   Use this when there is more than 1 button or it is not the most important action on the page
+*   Primary action button:
+    *   Use only 1 primary action button per page
+*   Destructive action button:
+    *   Only use when the action will result in data loss, cannot be undone, or otherwise have significant consequences
+*   Secondary action button:
+    *   Secondary Action Buttons kind of look like links but have lots of padding, a large clickable area, and sit next to other buttons, such as a Primary button. That is, they perform actions and do not navigate.
+*   Icon + label (icon on the left):
+    *   RTL: flip the direction of arrow icons when the user is using a right-to-left language
+*   Label + icon (icon on the right):
+    *   RTL: flip the direction of arrow icons when the user is using a right-to-left language
+*   Disabled buttons:
+    *   See the [Interaction states guidelines for disabled elements](/guidelines/interaction-states#disabled-state).
+*   Supplementary information:
+    *   You might show additional, optional information on hover and focus using a [Tooltip](/components/tooltip) or [Popover](/components/popover).
+
 ## Copy guidelines
 
 All buttons across the platform should be clear, actionable and predictable. When a user clicks on a button, they should know what to expect. Therefore, it’s important to pay close attention to the labelling. Here are the most important rules to keep in mind:
@@ -164,27 +185,6 @@ Keep in mind that you shouldn’t use personal pronouns unless you’re asking t
 ### The button should match the body
 
 Make sure that the button uses the same verb and noun as what’s used in the body text above it. For example, if you say “Upload your most up-to-date employee data into Culture Amp.” in the body, the button should say “Upload data,” not “Import data.” There are also cases in which the action the user wants to perform is a common label button like “Next” or “Cancel.” Make sure that you’ve rewritten your body copy to make the action very clear. For example, if a user is trying to cancel sending a survey, but there’s also a cancel button to exit the modal they’re viewing, reword the copy of the body to say “don’t send survey.”
-
-## To keep in mind
-
-*   All buttons use a button element (not a link element and no `role=”button”`)
-*   All buttons have a large click target of 48px to meet minimum touch target sizes
-*   Default action button:
-    *   Use this when there is more than 1 button or it is not the most important action on the page
-*   Primary action button:
-    *   Use only 1 primary action button per page
-*   Destructive action button:
-    *   Only use when the action will result in data loss, cannot be undone, or otherwise have significant consequences
-*   Secondary action button:
-    *   Secondary Action Buttons kind of look like links but have lots of padding, a large clickable area, and sit next to other buttons, such as a Primary button. That is, they perform actions and do not navigate.
-*   Icon + label (icon on the left):
-    *   RTL: flip the direction of arrow icons when the user is using a right-to-left language
-*   Label + icon (icon on the right):
-    *   RTL: flip the direction of arrow icons when the user is using a right-to-left language
-*   Disabled buttons:
-    *   See the [Interaction states guidelines for disabled elements](/guidelines/interaction-states#disabled-state).
-*   Supplementary information:
-    *   You might show additional, optional information on hover and focus using a [Tooltip](/components/tooltip) or [Popover](/components/popover).
 
 ## When to use and when not to use
 

--- a/draft-packages/empty-state/KaizenDraft/EmptyState/README.mdx
+++ b/draft-packages/empty-state/KaizenDraft/EmptyState/README.mdx
@@ -40,6 +40,28 @@ import Dont from "docs-components/Dont"
     *   Dashed
     *   None
 
+## To keep in mind
+
+* There are different Empty States including:
+    * **Positive empty state**: nothing is here because everything is working/you’ve completed all tasks.
+    * **Informative empty state**: things are happening and there are things to be done but no direct action required.
+    * **Action empty state**: we need the user to do something right now.
+    * **Neutral empty state**: nothing has happened/we have nothing to show.
+    * **Negative empty state**: something didn’t load/we couldn’t find anything.
+
+* They also come in three different sizes for you to use (max, mid, min):
+    * For viewports or containers **larger than 1080px**: show an empty pattern that’s 1080px wide (e.g. using max-width: 1080px) using the “large” layout.
+    * For viewports or containers **smaller than 720px**: show a responsive, scaling empty pattern (e.g. using max-width: 100%).
+    * For viewports or containers **between 300px and 720px**: use the “medium” layout.
+    * For viewports or containers **smaller than 300px**: use the “small” layout.
+
+* Call To Actions (CTAs):
+    * We use Default Buttons unless it is the only action on the page, then we use Primary Action Buttons (label + icon).
+    * If no action is appropriate, don’t show a button. Instead, you might include hyperlinks in the body copy as needed.
+
+* Illustrations:
+    * Each type of empty state comes with a standard illustration. Do not mix and match.
+
 ## Copy guidelines
 
 Empty states are a great way to engage and educate users. It’s a chance for our brand voice to shine through, but make sure to always prioritize clarity and action over joyful language and humor. Here are some rules to keep in mind:
@@ -124,28 +146,6 @@ Based on the overall user flow and the nature of the empty state, make sure you 
 
 All empty state copy should be in sentence case i.e. the first letter of the first word is capitalized and everything else is in lower case unless it’s a proper noun or feature name. Always err on the side of minimal punctuation, so leave out full stops and commas where possible.
 
-
-## To keep in mind
-
-* There are different Empty States including:
-    * **Positive empty state**: nothing is here because everything is working/you’ve completed all tasks.
-    * **Informative empty state**: things are happening and there are things to be done but no direct action required.
-    * **Action empty state**: we need the user to do something right now.
-    * **Neutral empty state**: nothing has happened/we have nothing to show.
-    * **Negative empty state**: something didn’t load/we couldn’t find anything.
-
-* They also come in three different sizes for you to use (max, mid, min):
-    * For viewports or containers **larger than 1080px**: show an empty pattern that’s 1080px wide (e.g. using max-width: 1080px) using the “large” layout.
-    * For viewports or containers **smaller than 720px**: show a responsive, scaling empty pattern (e.g. using max-width: 100%).
-    * For viewports or containers **between 300px and 720px**: use the “medium” layout.
-    * For viewports or containers **smaller than 300px**: use the “small” layout.
-
-* Call To Actions (CTAs):
-    * We use Default Buttons unless it is the only action on the page, then we use Primary Action Buttons (label + icon).
-    * If no action is appropriate, don’t show a button. Instead, you might include hyperlinks in the body copy as needed.
-
-* Illustrations:
-    * Each type of empty state comes with a standard illustration. Do not mix and match.
 
 ## When to use and when not to use
 

--- a/draft-packages/form/KaizenDraft/Form/CheckboxField/README.mdx
+++ b/draft-packages/form/KaizenDraft/Form/CheckboxField/README.mdx
@@ -23,6 +23,10 @@ import Dont from "docs-components/Dont"
 
 <iframe style="border: none;" width="744" height="450" src="https://www.figma.com/embed?embed_host=share&url=https%3A%2F%2Fwww.figma.com%2Ffile%2Fe3TyAOZKfLg9cA01Iy1Mgm%2FKaizen-Site-embed%3Fnode-id%3D1292%253A688" allowfullscreen></iframe>
 
+## To keep in mind
+
+*   Ensure both label and input are clickable to select the checkbox field. That is, use `label` tags that wrap the `input` element or use a `for` attribute.
+
 ## Copy guidelines
 
 We use checkboxes across the platform to help users select specific settings, or to make declarations. To make checkbox fields as clear as possible, follow these rules:
@@ -69,10 +73,6 @@ If the checkbox field includes a declarative sentence, use first person pronouns
 
 All checkbox field text should be in sentence case i.e. the first letter of the first word is capitalized and everything else is in lower case unless it’s a proper noun or feature name. Always err on the side of minimal punctuation, so leave out full stops and commas where possible.
 
-
-## To keep in mind
-
-*   Ensure both label and input are clickable to select the checkbox field. That is, use `label` tags that wrap the `input` element or use a `for` attribute.
 
 ## When to use and when not to use
 

--- a/draft-packages/form/KaizenDraft/Form/TextAreaField/README.mdx
+++ b/draft-packages/form/KaizenDraft/Form/TextAreaField/README.mdx
@@ -23,6 +23,7 @@ import Dont from "docs-components/Dont"
 <iframe style="border: none;" width="744" height="450" src="https://www.figma.com/embed?embed_host=share&url=https%3A%2F%2Fwww.figma.com%2Ffile%2Fe3TyAOZKfLg9cA01Iy1Mgm%2FKaizen-Site-embed%3Fnode-id%3D50186%253A40775&chrome=DOCUMENTATION" allowfullscreen></iframe>
 
 ## To keep in mind
+
 * **Prominent Text Area variant**
     * Text Area Field variant that optimizes for contexts where the aim is user feedback collection rather than system settings information (such as performance feedback).
     * Prominent Text Areas and Text Area Fields are generally not mixed in the same context. 

--- a/draft-packages/form/KaizenDraft/Form/TextField/README.mdx
+++ b/draft-packages/form/KaizenDraft/Form/TextField/README.mdx
@@ -25,6 +25,16 @@ import Dont from "docs-components/Dont"
 
 <iframe style="border: none;" width="744" height="450" src="https://www.figma.com/embed?embed_host=share&url=https%3A%2F%2Fwww.figma.com%2Ffile%2Fe3TyAOZKfLg9cA01Iy1Mgm%2FKaizen-Site-embed%3Fnode-id%3D205%253A12677" allowfullscreen></iframe>
 
+## To keep in mind
+
+* Most of the time, we validate text fields on “blur” (when leaving the text fields) or on form submission as needed. We don’t validate on key strokes.
+* As a rule of thumb, generally use “ (optional)” to indicate optional fields instead of “`*`” to indicate required fields.
+* Consider if a more specific `type` is needed as an `email` type for email addresses.
+* When displaying a validation messages, such as an error, use a `aria-describedby` attribute to associate the text field with the element containing the validation message.
+* Pre-fill the Text Field input with good defaults wherever possible.
+* Disabled state:
+    * See [Interaction states guidelines for disabled elements](/guidelines/interaction-states#disabled-state).
+
 ## Copy guidelines
 
 To be scannable and fully helpful, a text field must have an associated label and must contain an example of the text you wish the user to input. Here’s what you should know:
@@ -106,16 +116,6 @@ Helper text placed below the field can include further instructions or informati
 ### Write in sentence case with minimal punctuation
 
 All text field copy should be in sentence case i.e. the first letter of the first word is capitalized and everything else is in lower case unless it’s a proper noun or feature name. Always err on the side of minimal punctuation, so leave out full stops and commas where possible.
-
-## To keep in mind
-
-* Most of the time, we validate text fields on “blur” (when leaving the text fields) or on form submission as needed. We don’t validate on key strokes.
-* As a rule of thumb, generally use “ (optional)” to indicate optional fields instead of “`*`” to indicate required fields.
-* Consider if a more specific `type` is needed as an `email` type for email addresses.
-* When displaying a validation messages, such as an error, use a `aria-describedby` attribute to associate the text field with the element containing the validation message.
-* Pre-fill the Text Field input with good defaults wherever possible.
-* Disabled state:
-    * See [Interaction states guidelines for disabled elements](/guidelines/interaction-states#disabled-state).
 
 ## When to use and when not to use
 

--- a/draft-packages/form/KaizenDraft/Form/ToggleSwitchField/README.mdx
+++ b/draft-packages/form/KaizenDraft/Form/ToggleSwitchField/README.mdx
@@ -23,6 +23,14 @@ import Dont from "docs-components/Dont"
 
 <iframe style="border: none;" width="744" height="450" src="https://www.figma.com/embed?embed_host=share&url=https%3A%2F%2Fwww.figma.com%2Ffile%2Fe3TyAOZKfLg9cA01Iy1Mgm%2FKaizen-Site-embed%3Fnode-id%3D1412%253A1819" allowfullscreen></iframe>
 
+## To keep in mind
+
+*   Toggles are made up of two states: On (green, always on the right) & Off (grey, always on the left)
+*   Labels can be positioned to the left or right of a toggle, depending on layout constraints. 
+*   The label should never be on both sides (e.g. On/Off).
+*   Toggle switches can be triggered by a drag gesture.
+*   In RTL documents, the toggle switch and label are both flipped
+
 ## Copy guidelines
 
 All toggle switches should begin with a verb and should be clear and concise. When a user clicks on a toggle switch, they expect the action to be immediate. Therefore, avoid ambiguous language and pay close attention to the following rules:
@@ -115,14 +123,6 @@ Never phrase your label as a question. Refer to the point above. Depending on th
 ### Write in sentence case with minimal punctuation
 
 All toggle switch copy should be in sentence case i.e. the first letter of the first word is capitalized and everything else is in lower case unless it’s a proper noun or feature name. Always err on the side of minimal punctuation, so leave out full stops and commas where possible.
-
-## To keep in mind
-
-*   Toggles are made up of two states: On (green, always on the right) & Off (grey, always on the left)
-*   Labels can be positioned to the left or right of a toggle, depending on layout constraints. 
-*   The label should never be on both sides (e.g. On/Off).
-*   Toggle switches can be triggered by a drag gesture.
-*   In RTL documents, the toggle switch and label are both flipped
 
 ## When to use and when not to use
 

--- a/draft-packages/guidance-block/KaizenDraft/GuidanceBlock/README.mdx
+++ b/draft-packages/guidance-block/KaizenDraft/GuidanceBlock/README.mdx
@@ -25,6 +25,28 @@ import Dont from "docs-components/Dont"
 
 To ensure the Guidance Block is distinct from other page content, you might use a different visual treatment for the card container.
 
+## To keep in mind
+
+The Guidance Block is a modular design element with a consistent structure and a clear call to action. It is commonly used to:
+
+* Prompt a user action (e.g. Select a focus area, create an action, redact comments, start onboarding).
+* Provide a summary view of longer form content contained on another page. This is similar to a content application of [tile](/components/tile) but with more prominence/hierarchy (e.g Manager learning).
+* Cross promote relevant content or functionality in a different part of the platform.
+* Avoid showing more than one Guidance Block at a time because they would compete for the user's attention instead of guiding the user. Instead, you might conditionally show only whichever Guidance Block is most important to the user at that moment.
+
+### Anatomy
+
+* **Card container:** The Guidance Block content appears inside a card.
+* **Spot illustration:** Provide an illustration that assist the user in the task the Guidance Block describes.
+* **Title and description:** Use the guidelines above to guide the user with appropriate copy.
+* **Action button:** Use a link styled as a primary action button (if there are no others on the page) or a default action button to navigate to the page with the action that the Guidance Block describes. For immediate actions, show a [confirmation modal](/components/modal) instead of navigating.
+* **Optional dismiss button:** If it's possible a user will never want to take this action, consider providing a secondary dismiss button to remove the Guidance Block.
+
+### Behavior
+
+* The Guidance Block may appear conditionally, depending on the state of the action we want the user to take. For example, if they've been through onboarding before, we might remove the Guidance Block from the page.
+* If the use case action is optional or not relevant to all users, the Guidance Block may also be made dismissible.
+
 ## Copy guidelines
 
 Guidance blocks are a chance to flex those marketing writing muscles. Grab the users attention but don’t go overboard into the ad world. Avoid superlatives, flowery or overly sales and marketing heavy language. Instead speak to the user’s objective, describe the action they need to take and highlight the benefit. Remain calm and clear. Don’t use urgent language in an attempt to drive engagement and clicks. It could lead to a negative and disappointing experience if the urgency is misplaced or unwarranted. If the guidance block has to perform an immediate action, consider showing a [confirmation modal](/components/modal).
@@ -89,28 +111,6 @@ Your CTA button should be short and clear. Give it a strong verb. A user should 
 ### Write in sentence case with minimal punctuation
 
 All guidance block copy should be in sentence case i.e. the first letter of the first word is capitalized and everything else is in lower case unless it’s a proper noun or feature name. Always err on the side of minimal punctuation, so leave out full stops and commas where possible.
-
-## To keep in mind
-
-The Guidance Block is a modular design element with a consistent structure and a clear call to action. It is commonly used to:
-
-* Prompt a user action (e.g. Select a focus area, create an action, redact comments, start onboarding).
-* Provide a summary view of longer form content contained on another page. This is similar to a content application of [tile](/components/tile) but with more prominence/hierarchy (e.g Manager learning).
-* Cross promote relevant content or functionality in a different part of the platform.
-* Avoid showing more than one Guidance Block at a time because they would compete for the user's attention instead of guiding the user. Instead, you might conditionally show only whichever Guidance Block is most important to the user at that moment.
-
-### Anatomy
-
-* **Card container:** The Guidance Block content appears inside a card.
-* **Spot illustration:** Provide an illustration that assist the user in the task the Guidance Block describes.
-* **Title and description:** Use the guidelines above to guide the user with appropriate copy.
-* **Action button:** Use a link styled as a primary action button (if there are no others on the page) or a default action button to navigate to the page with the action that the Guidance Block describes. For immediate actions, show a [confirmation modal](/components/modal) instead of navigating.
-* **Optional dismiss button:** If it's possible a user will never want to take this action, consider providing a secondary dismiss button to remove the Guidance Block.
-
-### Behavior
-
-* The Guidance Block may appear conditionally, depending on the state of the action we want the user to take. For example, if they've been through onboarding before, we might remove the Guidance Block from the page.
-* If the use case action is optional or not relevant to all users, the Guidance Block may also be made dismissible.
 
 ## When to use and when not to use
 

--- a/draft-packages/menu/KaizenDraft/Menu/README.mdx
+++ b/draft-packages/menu/KaizenDraft/Menu/README.mdx
@@ -51,7 +51,7 @@ A menu provides access to additional actions and navigation links on demand whil
 
 * Ensure people using keyboards can open and close the menu by pressing the button and access links and buttons within the menu list.
 
-### Copy guidelines
+## Copy guidelines
 
 * Use a noun for the menu button text to describe the links and actions contained within.
 

--- a/draft-packages/radio-group/KaizenDraft/RadioGroup/README.mdx
+++ b/draft-packages/radio-group/KaizenDraft/RadioGroup/README.mdx
@@ -27,6 +27,22 @@ import Dont from "docs-components/Dont"
 
 <iframe style="border: none;" width="744" height="450" src="https://www.figma.com/embed?embed_host=share&url=https%3A%2F%2Fwww.figma.com%2Ffile%2Fe3TyAOZKfLg9cA01Iy1Mgm%2FKaizen-Site-embed%3Fnode-id%3D1412%253A277" allowfullscreen></iframe>
 
+## To keep in mind
+
+*   There must always be more than one radio field used together in a group.
+*   Radio Group contains a set of Radios and a Radio Group Label.
+*   Show options in a sensible order, such as alphabetical, numeric.
+*   Avoid long lists. Chunk long lists and group related options together.
+*   The setting only applies when the user takes an action, such as clicking a save button.
+*   Prefer vertical (stacked) radios to easily scan and compare options.
+*   Use a fieldset to group related radio fields together in a set.
+*   Offer a default option.
+*   Prefer to use a default selected option.
+*   Avoid nesting.
+*   For Right-To-Left languages, add `dir=”rtl”` to a `div` wrapping the Radios
+*   Disabled state:
+    *   See [Interaction states guidelines for disabled elements](/guidelines/interaction-states#disabled-state).
+
 ## Copy guidelines
 
 Radios are helpful when presenting a set of mutually exclusive options out of which a user must make one selection. Keep these points in mind:
@@ -67,22 +83,6 @@ If your options are single sentences, words or fragments, don’t place a period
 
 ### Write in sentence case
 All radio copy should be in sentence case i.e. the first letter of the first word is capitalized and everything else is in lower case unless it’s a proper noun or feature name.
-
-## To keep in mind
-
-*   There must always be more than one radio field used together in a group.
-*   Radio Group contains a set of Radios and a Radio Group Label.
-*   Show options in a sensible order, such as alphabetical, numeric.
-*   Avoid long lists. Chunk long lists and group related options together.
-*   The setting only applies when the user takes an action, such as clicking a save button.
-*   Prefer vertical (stacked) radios to easily scan and compare options.
-*   Use a fieldset to group related radio fields together in a set.
-*   Offer a default option.
-*   Prefer to use a default selected option.
-*   Avoid nesting.
-*   For Right-To-Left languages, add `dir=”rtl”` to a `div` wrapping the Radios
-*   Disabled state:
-    *   See [Interaction states guidelines for disabled elements](/guidelines/interaction-states#disabled-state).
 
 ## When to use and when not to use
 

--- a/draft-packages/tooltip/KaizenDraft/Tooltip/README.mdx
+++ b/draft-packages/tooltip/KaizenDraft/Tooltip/README.mdx
@@ -23,24 +23,6 @@ import WhenNotToUse from "docs-components/WhenNotToUse"
 
 <iframe style="border: none;" width="744" height="450" src="https://www.figma.com/embed?embed_host=share&url=https%3A%2F%2Fwww.figma.com%2Ffile%2Fe3TyAOZKfLg9cA01Iy1Mgm%2FKaizen-Site-embed%3Fnode-id%3D205%253A12158" allowfullscreen></iframe>
 
-## Copy guidelines
-Tooltips are a useful way to highlight additional information for a feature or element in the platform. Use them sparingly and keep these rules in mind:
-
-### They shouldn’t be a barrier to task completion
-Tooltips should never stop a user (or be a gate) from completing a task or performing an action. They disappear so they should never contain critical information that a user would absolutely need to proceed, or information without which a user may cause errors. If the information is crucial for a user to proceed, consider using a [modal](/components/modal) or [inline notification](/guidelines/notifications) instead.
-
-### Don’t use tooltips to convey errors
-Never include any kind of error messages in a tooltip. As tooltips are hidden, a user may not be aware of an error if it exists in the tooltip text.
-
-### Keep it brief
-Good tooltips contain concise and helpful information. Keep it to one or two very short sentences. Don’t use it to duplicate information that already exists on the page. Instead, closely consider its placement and whether the disclosed copy will inform the action the user is about to perform.
-
-### Avoid links and buttons
-As tooltips only surface from a hover, never include links or buttons in the copy. If your tooltip requires either of these, considers putting your content in a [popover](/components/popover).
-
-### Write in sentence case with minimal punctuation
-All tooltips copy should be in sentence case i.e. the first letter of the first word is capitalized and everything else is in lower case unless it’s a proper noun or feature name. Always err on the side of minimal punctuation, so leave out full stops and commas where possible.
-
 ## To keep in mind
 
 *   Anatomy:
@@ -79,6 +61,30 @@ All tooltips copy should be in sentence case i.e. the first letter of the first 
     *   Tooltips contain limited content so we can use an ‘announcer’ to announce tooltip content to people using screen readers e.g. using an ARIA live region.
     *   In contrast, a user might interact with a Popover, requiring focus, so we need to move focus to the Popover when it’s triggered and support keyboard navigation to dismiss a dismissible Popover.
 *   Use sparingly. Tooltips innately hide information. Consider exposing it immediately without a tooltip or removing it completely.
+
+## Copy guidelines
+
+Tooltips are a useful way to highlight additional information for a feature or element in the platform. Use them sparingly and keep these rules in mind:
+
+### They shouldn’t be a barrier to task completion
+
+Tooltips should never stop a user (or be a gate) from completing a task or performing an action. They disappear so they should never contain critical information that a user would absolutely need to proceed, or information without which a user may cause errors. If the information is crucial for a user to proceed, consider using a [modal](/components/modal) or [inline notification](/guidelines/notifications) instead.
+
+### Don’t use tooltips to convey errors
+
+Never include any kind of error messages in a tooltip. As tooltips are hidden, a user may not be aware of an error if it exists in the tooltip text.
+
+### Keep it brief
+
+Good tooltips contain concise and helpful information. Keep it to one or two very short sentences. Don’t use it to duplicate information that already exists on the page. Instead, closely consider its placement and whether the disclosed copy will inform the action the user is about to perform.
+
+### Avoid links and buttons
+
+As tooltips only surface from a hover, never include links or buttons in the copy. If your tooltip requires either of these, considers putting your content in a [popover](/components/popover).
+
+### Write in sentence case with minimal punctuation
+
+All tooltips copy should be in sentence case i.e. the first letter of the first word is capitalized and everything else is in lower case unless it’s a proper noun or feature name. Always err on the side of minimal punctuation, so leave out full stops and commas where possible.
 
 ## When to use and when not to use
 

--- a/draft-packages/tooltip/KaizenDraft/Tooltip/README.mdx
+++ b/draft-packages/tooltip/KaizenDraft/Tooltip/README.mdx
@@ -25,42 +25,58 @@ import WhenNotToUse from "docs-components/WhenNotToUse"
 
 ## To keep in mind
 
-*   Anatomy:
-    *   The anatomy of a tooltip is made up of a **container**, **description** and **tip** (i.e. arrow).
-    *   A tooltip is connected to a **trigger** element, such as a button or icon, that shows the tooltip when the interactive trigger element is hovered, focused, or clicked. (More details below.)
-*   Visual details:
-    *   Text and tips within tooltips can be left, centered and right aligned, as appropriate within its environmental context.
-    *   Use strong signifiers for trigger elements to ensure the tooltip is discoverable.
-    *   The proximity of tooltips is always paired nearby the element with which they are associated.
-    *   Don’t crop tooltips e.g. at the edge of modals.
-*   Trigger:
-    *   Needs to be discoverable:
-        *   E.g. something like an icon to tell you there’s a tooltip
-        *   E.g. show the first tooltip/popover immediately on page load so people know they’re there
-        *   Avoid triggering tooltips from text without indicators that the text has behaviour
-    *   Needs to not be noisy (e.g. we don’t litter UI with icons all the time)
-    *   Only trigger tooltips from:
-        *   Interactive elements:
-            *   Buttons
-            *   Links
-            *   Icon buttons
-        *   Non-interactive elements (be mindful of keyboard accessibility):
-            *   Icons
-            *   Abbreviations (e.g. dashed underlined text for HRIS that shows a tooltip that says Human Resource Information System)
-            *   Truncated text
-    *   For interactive elements that trigger tooltips, only have optional information in the tooltip because it could be missed when the user clicks.
-*   Moods:
-    *   When combined with an icon, use the matching icon and mood (Positive, Informative, Cautionary, Negative). For example, when using a Lapis (blue) colored information icon, show an informative tooltip.
-    *   When used without an icon, use the Default tooltip (white).
-*   Animation details:
-    *   A Tooltip **lifts up** from the **trigger point**, by “slide fading” towards the top of the screen away from the trigger point. Related: Tooltip arrows always point down and “slide fade” upwards unless they're at a viewport edge, then the tooltip should move in the opposite (and most logical) direction.
-*   Amount:
-    *   Use sparingly. If you’re building something that requires a lot of tooltips, work on clarifying the design and the language in the experience.
-    *   Only show 1 tooltip at a time.
-*   Accessibility:
-    *   Tooltips contain limited content so we can use an ‘announcer’ to announce tooltip content to people using screen readers e.g. using an ARIA live region.
-    *   In contrast, a user might interact with a Popover, requiring focus, so we need to move focus to the Popover when it’s triggered and support keyboard navigation to dismiss a dismissible Popover.
-*   Use sparingly. Tooltips innately hide information. Consider exposing it immediately without a tooltip or removing it completely.
+Use sparingly. Tooltips innately hide information. Consider exposing the information immediately without a tooltip or removing it completely.
+
+### Anatomy
+
+*   The anatomy of a tooltip is made up of a **container**, **description** and **tip** (i.e. arrow).
+*   A tooltip is connected to a **trigger** element, such as a button or icon, that shows the tooltip when the interactive trigger element is hovered, focused, or clicked. (More details below.)
+
+### Visual details
+
+*   Text and tips within tooltips can be left, centered and right aligned, as appropriate within its environmental context.
+*   Use strong signifiers for trigger elements to ensure the tooltip is discoverable.
+*   The proximity of tooltips is always paired nearby the element with which they are associated.
+*   Don’t crop tooltips e.g. at the edge of modals.
+
+### Trigger
+
+*   Needs to be discoverable:
+    *   E.g. something like an icon to tell you there’s a tooltip
+    *   E.g. show the first tooltip/popover immediately on page load so people know they’re there
+    *   Avoid triggering tooltips from text without indicators that the text has behaviour
+*   Needs to not be noisy (e.g. we don’t litter UI with icons all the time)
+*   Only trigger tooltips from:
+    *   Interactive elements:
+        *   Buttons
+        *   Links
+        *   Icon buttons
+    *   Non-interactive elements (be mindful of keyboard accessibility):
+        *   Icons
+        *   Abbreviations (e.g. dashed underlined text for HRIS that shows a tooltip that says Human Resource Information System)
+        *   Truncated text
+*   For interactive elements that trigger tooltips, only have optional information in the tooltip because it could be missed when the user clicks.
+
+### Moods
+
+For context, see [Moods](/guidelines/moods).
+
+*   When combined with an icon, use the matching icon and mood (Positive, Informative, Cautionary, Negative). For example, when using a Cluny (blue) colored information icon, show an informative tooltip.
+*   When used without an icon, use the Default tooltip (white).
+
+### Animation details
+
+*   A Tooltip **lifts up** from the **trigger point**, by “slide fading” towards the top of the screen away from the trigger point. Related: Tooltip arrows always point down and “slide fade” upwards unless they're at a viewport edge, then the tooltip should move in the opposite (and most logical) direction.
+
+### Amount
+
+*   Use sparingly. If you’re building something that requires a lot of tooltips, work on clarifying the design and the language in the experience.
+*   Only show 1 tooltip at a time.
+
+### Accessibility
+
+*   Tooltips contain limited content so we can use an ‘announcer’ to announce tooltip content to people using screen readers e.g. using an ARIA live region.
+*   In contrast, a user might interact with a Popover, requiring focus, so we need to move focus to the Popover when it’s triggered and support keyboard navigation to dismiss a dismissible Popover.
 
 ## Copy guidelines
 

--- a/site/docs/components/inline-notification.mdx
+++ b/site/docs/components/inline-notification.mdx
@@ -52,6 +52,21 @@ E.g. **Meaning changed** We prevent significant changes to the meaning of questi
     *   Single-line: inline/adjacent heading and body
     *   Multi-line: stacked heading and body
 
+## To keep in mind
+
+*   Inline Notifications are used for contextual information, including positive feedback or confirmation about an action, warnings about possible issues or show-stopping errors.
+*   They are used to provide context in close **proximity** to a piece of content.
+*   They must always follow this **anatomy**:
+      * Title
+      * Body
+      * CTA link
+*   Inline notifications can be **system or user triggered**.
+*   Dismissible or persistent:
+    *   Use **Persistent** notifications when the information continues to be relevant after the message is shown, e.g. Defining the reporting size on an Insight report
+    *   Use **Dismissible** notifications when the information has been acknowledged and the message is no longer relevant, e.g. helpfully updating formatting for user input data.
+*   What’s an **autohide**?
+    *   TODO: add details
+
 ## Copy guidelines
 
 The key to a good inline notification is conciseness and clarity.  Here are some language rules:
@@ -112,21 +127,6 @@ Make sure you [adjust the tone](/language/voiceandtone/) of your writing to fit 
 ### Write in sentence case with minimal punctuation. 
 
 All inline notifications copy should be in sentence case i.e. the first letter of the first word is capitalized and everything else is in lower case unless it’s a proper noun or feature name. Always err on the side of minimal punctuation, so leave out full stops and commas where possible.
-
-## To keep in mind
-
-*   Inline Notifications are used for contextual information, including positive feedback or confirmation about an action, warnings about possible issues or show-stopping errors.
-*   They are used to provide context in close **proximity** to a piece of content.
-*   They must always follow this **anatomy**:
-      * Title
-      * Body
-      * CTA link
-*   Inline notifications can be **system or user triggered**.
-*   Dismissible or persistent:
-    *   Use **Persistent** notifications when the information continues to be relevant after the message is shown, e.g. Defining the reporting size on an Insight report
-    *   Use **Dismissible** notifications when the information has been acknowledged and the message is no longer relevant, e.g. helpfully updating formatting for user input data.
-*   What’s an **autohide**?
-    *   TODO: add details
 
 ## When to use and when not to use
 

--- a/site/docs/guidelines/moods.mdx
+++ b/site/docs/guidelines/moods.mdx
@@ -22,12 +22,12 @@ Our set of “Positive”, “Informative”, “Cautionary”, and “Negative�
 
 - Background color:
   - Positive mood uses a tint or shade of Seedling
-  - Informative mood uses a tint or shade of Lapis
+  - Informative mood uses a tint or shade of Cluny
   - Cautionary mood uses a tint or shade of Yuzu
   - Negative mood uses a tint or shade of Coral
 - Border color:
   - Positive mood uses Seedling
-  - Informative mood uses Lapis
+  - Informative mood uses Cluny
   - Cautionary mood uses Yuzu
   - Negative mood uses Coral
 - Icon:


### PR DESCRIPTION
Designers sometimes misunderstand copy guidelines because they appear before the introduction of key terms outlined in the Anatomy section. For consistency, we're moving all copy guidelines below the "To keep in mind" section.