### PR TITLE
feat: add animated badge component

### DIFF
--- a/draft-packages/badge/KaizenDraft/Badge/Badge.tsx
+++ b/draft-packages/badge/KaizenDraft/Badge/Badge.tsx
@@ -29,12 +29,12 @@ export const Badge = (props: BadgeProps) => {
 }
 
 export const BadgeAnimated: React.FunctionComponent<BadgeProps> = props => {
-  const [isFocussed, setIsFocussed] = useState(false)
+  const [isFocussed, setIsFocused] = useState(false)
 
   useLayoutEffect(() => {
-    setIsFocussed(true)
+    setIsFocused(true)
     setTimeout(() => {
-      setIsFocussed(false)
+      setIsFocused(false)
     }, 150)
   }, [props.children])
 

--- a/draft-packages/badge/KaizenDraft/Badge/Badge.tsx
+++ b/draft-packages/badge/KaizenDraft/Badge/Badge.tsx
@@ -29,7 +29,7 @@ export const Badge = (props: BadgeProps) => {
 }
 
 export const BadgeAnimated: React.FunctionComponent<BadgeProps> = props => {
-  const [isFocussed, setIsFocused] = useState(false)
+  const [isFocused, setIsFocused] = useState(false)
 
   useLayoutEffect(() => {
     setIsFocused(true)

--- a/draft-packages/badge/KaizenDraft/Badge/Badge.tsx
+++ b/draft-packages/badge/KaizenDraft/Badge/Badge.tsx
@@ -1,9 +1,9 @@
+import React, { useLayoutEffect, useState, useRef } from "react"
 import classNames from "classnames"
-import * as React from "react"
 
 const styles = require("./styles.module.scss")
 
-type Variant = "default" | "active"
+type Variant = "default" | "active" | "dark"
 
 export interface BadgeProps {
   readonly children: string
@@ -19,10 +19,32 @@ export const Badge = (props: BadgeProps) => {
       className={classNames(styles.badge, {
         [styles.default]: variant === "default",
         [styles.active]: variant === "active",
-        [styles.reversed]: reversed === true,
+        [styles.dark]: variant === "dark",
+        [styles.reversed]: reversed,
       })}
     >
       {children}
+    </span>
+  )
+}
+
+export const BadgeAnimated: React.FunctionComponent<BadgeProps> = props => {
+  const [isFocussed, setIsFocussed] = useState(false)
+
+  useLayoutEffect(() => {
+    setIsFocussed(true)
+    setTimeout(() => {
+      setIsFocussed(false)
+    }, 150)
+  }, [props.children])
+
+  return (
+    <span
+      className={classNames(styles.animation, {
+        [styles.animationOn]: isFocussed,
+      })}
+    >
+      <Badge {...props} />
     </span>
   )
 }

--- a/draft-packages/badge/KaizenDraft/Badge/Badge.tsx
+++ b/draft-packages/badge/KaizenDraft/Badge/Badge.tsx
@@ -41,7 +41,7 @@ export const BadgeAnimated: React.FunctionComponent<BadgeProps> = props => {
   return (
     <span
       className={classNames(styles.animation, {
-        [styles.animationOn]: isFocussed,
+        [styles.animationOn]: isFocused,
       })}
     >
       <Badge {...props} />

--- a/draft-packages/badge/KaizenDraft/Badge/styles.module.scss
+++ b/draft-packages/badge/KaizenDraft/Badge/styles.module.scss
@@ -38,13 +38,6 @@ $small: $ca-grid;
 .dark {
   background-color: rgba($kz-color-wisteria-700, 0.1);
   color: $kz-color-wisteria-800;
-  .animation & {
-    transition: background-color ($kz-animation-duration-slow / 2)
-      $kz-animation-easing-function-ease-in;
-    &.animationOn {
-      background-color: rgba($kz-color-wisteria-700, 0.2);
-    }
-  }
 }
 
 .reversed.dark {
@@ -57,14 +50,23 @@ $small: $ca-grid;
   color: $kz-color-white;
 }
 
+$badge-duration-timing: ($kz-animation-duration-slow / 2)
+  $kz-animation-easing-function-ease-in;
+
+$badge-transition: transform $badge-duration-timing,
+  background-color $badge-duration-timing;
+
 .animation {
+  display: inherit;
   .badge {
-    transition: transform ($kz-animation-duration-slow / 2)
-      $kz-animation-easing-function-ease-in;
+    transition: $badge-transition;
     transform-origin: center;
     transform: scale3d(1, 1, 1);
   }
   &.animationOn .badge {
     transform: scale3d(1.35, 1.35, 1.35);
+    &.dark {
+      background-color: rgba($kz-color-wisteria-700, 0.2);
+    }
   }
 }

--- a/draft-packages/badge/KaizenDraft/Badge/styles.module.scss
+++ b/draft-packages/badge/KaizenDraft/Badge/styles.module.scss
@@ -21,7 +21,6 @@ $small: $ca-grid;
   padding: 1px $kz-spacing-xs;
   min-width: 8px;
   text-align: center;
-  z-index: 2;
 }
 
 .default {

--- a/draft-packages/badge/KaizenDraft/Badge/styles.module.scss
+++ b/draft-packages/badge/KaizenDraft/Badge/styles.module.scss
@@ -2,6 +2,8 @@
 @import "~@kaizen/design-tokens/sass/typography";
 @import "~@kaizen/design-tokens/sass/spacing";
 @import "~@kaizen/component-library/styles/type";
+@import "~@kaizen/design-tokens/sass/animation";
+@import "~@kaizen/component-library/styles/animation";
 
 $small: $ca-grid;
 
@@ -10,6 +12,7 @@ $small: $ca-grid;
   border-radius: $kz-spacing-sm;
   color: $kz-color-wisteria-800;
   display: inline-block;
+  position: relative;
   font-family: $kz-typography-paragraph-extra-small-font-family;
   font-size: $kz-typography-paragraph-extra-small-font-size;
   font-weight: $kz-typography-paragraph-bold-font-weight;
@@ -18,6 +21,7 @@ $small: $ca-grid;
   padding: 1px $kz-spacing-xs;
   min-width: 8px;
   text-align: center;
+  z-index: 2;
 }
 
 .default {
@@ -31,7 +35,36 @@ $small: $ca-grid;
   color: $kz-color-white;
 }
 
-.reversed {
-  background-color: add-alpha($kz-color-white, 10%);
+.dark {
+  background-color: rgba($kz-color-wisteria-700, 0.1);
+  color: $kz-color-wisteria-800;
+  .animation & {
+    transition: background-color ($kz-animation-duration-slow / 2)
+      $kz-animation-easing-function-ease-in;
+    &.animationOn {
+      background-color: rgba($kz-color-wisteria-700, 0.2);
+    }
+  }
+}
+
+.reversed.dark {
+  background-color: $kz-color-wisteria-700;
   color: $kz-color-white;
+}
+
+.reversed {
+  background-color: rgba($kz-color-white, 0.1);
+  color: $kz-color-white;
+}
+
+.animation {
+  .badge {
+    transition: transform ($kz-animation-duration-slow / 2)
+      $kz-animation-easing-function-ease-in;
+    transform-origin: center;
+    transform: scale3d(1, 1, 1);
+  }
+  &.animationOn .badge {
+    transform: scale3d(1.35, 1.35, 1.35);
+  }
 }

--- a/draft-packages/stories/Badge.stories.tsx
+++ b/draft-packages/stories/Badge.stories.tsx
@@ -1,28 +1,105 @@
 import * as colorTokens from "@kaizen/design-tokens/tokens/color.json"
 import * as React from "react"
 
-import { Badge } from "@kaizen/draft-badge"
+import { Button } from "@kaizen/component-library"
+import { ToggleSwitchField, ToggledStatus } from "@kaizen/draft-form"
+import { Badge, BadgeAnimated } from "@kaizen/draft-badge"
 
 export default {
   title: "Badge (React)",
 }
 
-export const DefaultStory = () => <Badge variant="default">3</Badge>
+const BadgeStoryWrapper: React.FunctionComponent<{
+  children: (badgeCount: string, useAnimation: boolean) => void
+}> = ({ children }) => {
+  const [useAnimation, setUseAnimation] = React.useState(false)
+  const [badgeCount, setBadgeCount] = React.useState(1)
+
+  return (
+    <div style={{ padding: "20px" }}>
+      {children(String(badgeCount), useAnimation)}
+      <div style={{ height: "40px" }} />
+      <ToggleSwitchField
+        toggledStatus={useAnimation ? ToggledStatus.ON : ToggledStatus.OFF}
+        onToggle={() => {
+          setUseAnimation(s => !s)
+        }}
+        labelText="Use Animation"
+      />
+      {useAnimation && (
+        <Button
+          label="Add Badge Number"
+          onClick={() => {
+            setBadgeCount(s => s + 1)
+          }}
+        />
+      )}
+    </div>
+  )
+}
+
+export const DefaultStory = () => (
+  <BadgeStoryWrapper>
+    {(badgeCount, useAnimation) =>
+      useAnimation ? (
+        <BadgeAnimated variant="default">{badgeCount}</BadgeAnimated>
+      ) : (
+        <Badge variant="default">{badgeCount}</Badge>
+      )
+    }
+  </BadgeStoryWrapper>
+)
 
 DefaultStory.story = {
   name: "Default (Kaizen Site Demo)",
 }
 
-export const Active = () => <Badge variant="active">1</Badge>
+export const Active = () => (
+  <BadgeStoryWrapper>
+    {(badgeCount, useAnimation) =>
+      useAnimation ? (
+        <BadgeAnimated variant="active">{badgeCount}</BadgeAnimated>
+      ) : (
+        <Badge variant="active">{badgeCount}</Badge>
+      )
+    }
+  </BadgeStoryWrapper>
+)
 
 Active.story = {
   name: "Active",
 }
 
+export const Dark = () => (
+  <BadgeStoryWrapper>
+    {(badgeCount, useAnimation) =>
+      useAnimation ? (
+        <BadgeAnimated variant="dark">{badgeCount}</BadgeAnimated>
+      ) : (
+        <Badge variant="dark">{badgeCount}</Badge>
+      )
+    }
+  </BadgeStoryWrapper>
+)
+
+Dark.story = {
+  name: "Dark",
+}
+
 export const Reversed = () => (
-  <Badge variant="default" reversed>
-    3
-  </Badge>
+  <BadgeStoryWrapper>
+    {(badgeCount, useAnimation) =>
+      useAnimation ? (
+        <BadgeAnimated variant="default" reversed>
+          {badgeCount}
+        </BadgeAnimated>
+      ) : (
+        <Badge variant="default" reversed>
+          {badgeCount}
+        </Badge>
+      )
+    }
+  </BadgeStoryWrapper>
 )
 
 Reversed.story = {
@@ -39,9 +116,19 @@ Reversed.story = {
 }
 
 export const ReversedActive = () => (
-  <Badge variant="active" reversed>
-    3
-  </Badge>
+  <BadgeStoryWrapper>
+    {(badgeCount, useAnimation) =>
+      useAnimation ? (
+        <BadgeAnimated variant="active" reversed>
+          {badgeCount}
+        </BadgeAnimated>
+      ) : (
+        <Badge variant="active" reversed>
+          {badgeCount}
+        </Badge>
+      )
+    }
+  </BadgeStoryWrapper>
 )
 
 ReversedActive.story = {

--- a/draft-packages/stories/TitleBlockZen.stories.tsx
+++ b/draft-packages/stories/TitleBlockZen.stories.tsx
@@ -11,6 +11,8 @@ const starIcon = require("@kaizen/component-library/icons/star-on.icon.svg")
   .default
 const reportSharingIcon = require("@kaizen/component-library/icons/report-sharing.icon.svg")
   .default
+const arrowForwardIcon = require("@kaizen/component-library/icons/arrow-forward.icon.svg")
+  .default
 import { assetUrl } from "@kaizen/hosted-assets"
 
 const styles = require("./TitleBlockZen.stories.scss")
@@ -102,6 +104,46 @@ export const Default = () => (
 
 Default.story = {
   name: "Default",
+}
+
+export const WithBadge = () => {
+  const [badgeCount, setBadgeCount] = React.useState(1)
+  return (
+    <TitleBlockZen
+      title="Page title"
+      surveyStatus={{ text: "Live", status: "live" }}
+      primaryAction={{
+        label: "Click Me",
+        icon: arrowForwardIcon,
+        iconPosition: "end",
+        reversed: true,
+        primary: true,
+        href: "#",
+        onClick: () => setBadgeCount(b => b + 1),
+        badge: {
+          text: String(badgeCount),
+          animateChange: true,
+        },
+      }}
+      defaultAction={{
+        label: "Default link",
+        reversed: true,
+        onClick: () => setBadgeCount(b => b + 1),
+        href: "#",
+      }}
+      breadcrumb={{
+        path: "#",
+        text: "Back to home",
+        handleClick: event => {
+          alert("breadcrumb clicked!")
+        },
+      }}
+    />
+  )
+}
+
+WithBadge.story = {
+  name: "With Primary Action Badge",
 }
 
 export const DefaultWithMenuButton = () => (

--- a/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/MainActions.tsx
+++ b/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/MainActions.tsx
@@ -13,7 +13,7 @@ import {
   BadgeProps,
 } from "./TitleBlockZen"
 import Toolbar from "./Toolbar"
-import { Badge } from "@kaizen/draft-badge"
+import { Badge, BadgeAnimated } from "@kaizen/draft-badge"
 const chevronDownIcon = require("@kaizen/component-library/icons/chevron-down.icon.svg")
   .default
 const meatballsIcon = require("@kaizen/component-library/icons/meatballs.icon.svg")
@@ -29,12 +29,14 @@ type MainActionsProps = {
   showOverflowMenu?: boolean
 }
 
-const renderBadge = (badge?: BadgeProps) =>
-  badge ? (
-    <Badge variant="dark" animateChange={badge.animateChange}>
-      {badge.text}
-    </Badge>
-  ) : null
+const renderBadge = (badge?: BadgeProps) => {
+  if (!badge) return null
+  return badge.animateChange ? (
+    <BadgeAnimated variant="dark">{badge.text}</BadgeAnimated>
+  ) : (
+    <Badge variant="dark">{badge.text}</Badge>
+  )
+}
 
 const ButtonAllowingAdditionalContent = (
   props: GenericProps & LabelProps & AdditionalContentProps

--- a/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/MainActions.tsx
+++ b/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/MainActions.tsx
@@ -1,12 +1,19 @@
 import { Button, IconButton } from "@kaizen/draft-button"
+import GenericButton, {
+  AdditionalContentProps,
+  GenericProps,
+  LabelProps,
+} from "@kaizen/draft-button/KaizenDraft/Button/components/GenericButton"
 import { Menu, MenuContent, MenuItem, MenuItemProps } from "@kaizen/draft-menu"
 import * as React from "react"
 import {
   TitleBlockButtonProps,
   isMenuGroupNotButton,
   PrimaryActionProps,
+  BadgeProps,
 } from "./TitleBlockZen"
 import Toolbar from "./Toolbar"
+import { Badge } from "@kaizen/draft-badge"
 const chevronDownIcon = require("@kaizen/component-library/icons/chevron-down.icon.svg")
   .default
 const meatballsIcon = require("@kaizen/component-library/icons/meatballs.icon.svg")
@@ -21,6 +28,17 @@ type MainActionsProps = {
   overflowMenuItems?: MenuItemProps[]
   showOverflowMenu?: boolean
 }
+
+const renderBadge = (badge?: BadgeProps) =>
+  badge ? (
+    <Badge variant="dark" animateChange={badge.animateChange}>
+      {badge.text}
+    </Badge>
+  ) : null
+
+const ButtonAllowingAdditionalContent = (
+  props: GenericProps & LabelProps & AdditionalContentProps
+) => <GenericButton {...props} />
 
 const MainActions = ({
   primaryAction,
@@ -56,13 +74,14 @@ const MainActions = ({
             <Menu
               align="right"
               button={
-                <Button
+                <ButtonAllowingAdditionalContent
                   label={primaryAction.label}
                   primary
                   reversed={reversed}
                   icon={chevronDownIcon}
                   iconPosition="end"
                   automationId="title-block-primary-action-button"
+                  additionalContent={renderBadge(primaryAction.badge)}
                 />
               }
             >
@@ -83,9 +102,10 @@ const MainActions = ({
         : []),
       ...(primaryAction
         ? [
-            <Button
+            <ButtonAllowingAdditionalContent
               {...primaryAction}
               automationId="title-block-primary-action-button"
+              additionalContent={renderBadge(primaryAction.badge)}
             />,
           ]
         : []),

--- a/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/TitleBlockZen.tsx
+++ b/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/TitleBlockZen.tsx
@@ -51,6 +51,11 @@ export interface TitleBlockProps {
   surveyStatus?: SurveyStatus
 }
 
+export type BadgeProps = {
+  text: string
+  animateChange?: boolean
+}
+
 export type TitleBlockButtonProps = Omit<ButtonProps, "onClick"> & {
   onClick?: (e: any) => void
 }
@@ -89,8 +94,8 @@ export type SelectProps = React.ComponentProps<typeof Select>
  * in the dropdown menu when you click it. (`MenuItemProps` is a type imported from the `Menu` component.)
  */
 export type PrimaryActionProps =
-  | MenuGroup
-  | (TitleBlockButtonProps & { primary: boolean })
+  | (MenuGroup & { badge?: BadgeProps })
+  | (TitleBlockButtonProps & { primary: boolean; badge?: BadgeProps })
 
 /**
  * ### SecondaryActionsProps


### PR DESCRIPTION
What has happened?:

-We have added the `dark` variant for use case with the green kaizen button.
- We have created a new component that animated a badge change - see gif.
- We have allowed the title block to accept a badge for a primaryAction
- Stories updated!


![animation-gif](https://user-images.githubusercontent.com/13988803/92195183-79a1cd80-eec0-11ea-93e5-11aa36543a21.gif)

