### PR TITLE
fix: Add explicit rule for underline on nav tabs

### DIFF
--- a/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/NavigationTabs.scss
+++ b/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/NavigationTabs.scss
@@ -17,6 +17,7 @@
   padding: 0 ($ca-grid / 2);
   @include ca-margin($end: $ca-grid);
   color: rgba($kz-color-white, 0.7);
+  text-decoration: none;
 
   @include title-block-under-1440 {
     @include ca-margin($end: $ca-grid * 0.25);


### PR DESCRIPTION
## Changes

Navigation Tabs were previously relying on global styles in Storybook and consuming repos to remove the underline from links in their default non-hovered state.

This PR makes that rule explicit.
![image](https://user-images.githubusercontent.com/6406263/92429625-e3c6b500-f1d5-11ea-8b12-15121f75de6d.png)
