### PR TITLE
fix: admin theme subtitle fix

### DIFF
--- a/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/TitleBlockZen.scss
+++ b/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/TitleBlockZen.scss
@@ -274,6 +274,10 @@ $tab-container-height-small: $ca-grid * 2.5;
   letter-spacing: $kz-typography-paragraph-small-letter-spacing;
   max-width: 230px;
 
+  .adminVariant & {
+    color: $kz-color-wisteria-800;
+  }
+
   @include ca-margin($start: $ca-grid / 2);
 
   @include title-block-under-1366 {


### PR DESCRIPTION
Broken - invisible unless highlighted:
![Screen Shot 2020-09-08 at 4 40 52 pm](https://user-images.githubusercontent.com/13988803/92433791-2eeec100-f1f2-11ea-9384-76c571ff43f9.png)

Fixed:
![Screen Shot 2020-09-08 at 4 41 00 pm](https://user-images.githubusercontent.com/13988803/92433794-301fee00-f1f2-11ea-8c5b-00010645eee4.png)
