### PR TITLE
fix: expose public function in draft card

### DIFF
--- a/draft-packages/card/KaizenDraft/Card/Card.elm
+++ b/draft-packages/card/KaizenDraft/Card/Card.elm
@@ -1,4 +1,4 @@
-module KaizenDraft.Card.Card exposing (Tag, default, view)
+module KaizenDraft.Card.Card exposing (Tag(..), default, tag, view)
 
 import CssModules exposing (css)
 import Html exposing (Html, article, div, header, li, main_, section)


### PR DESCRIPTION
the draft card has a tag function to be piped when initialising a card
we only used the default configuration before
when creating a new card of type section I noticed that the tag function
and the Tag types were not exposed.

usage in murmur: https://github.com/cultureamp/murmur/pull/14416/files#diff-07e2d306a4bcf6ded329f8e77cc2cf1cR110
(search for Card.tag on the files)