### PR TITLE
feat: Allow any Button props to be sent to GuidanceBlock actions

### DIFF
--- a/draft-packages/guidance-block/KaizenDraft/GuidanceBlock/GuidanceBlock.tsx
+++ b/draft-packages/guidance-block/KaizenDraft/GuidanceBlock/GuidanceBlock.tsx
@@ -1,5 +1,5 @@
 import { Heading, Icon, Paragraph } from "@kaizen/component-library"
-import { Button } from "@kaizen/draft-button"
+import { Button, ButtonProps } from "@kaizen/draft-button"
 const configureIcon = require("@kaizen/component-library/icons/arrow-forward.icon.svg")
   .default
 
@@ -21,16 +21,8 @@ type Props = {
     description: string | React.ReactNode
   }
   actions: {
-    primary: {
-      label: string
-      onClick: () => void
-      disabled?: boolean
-    }
-    secondary?: {
-      label: string
-      onClick: () => void
-      disabled?: boolean
-    }
+    primary: ButtonProps
+    secondary?: ButtonProps
     dismiss?: {
       onClick: () => void
     }
@@ -114,21 +106,14 @@ class GuidanceBlock extends React.Component<Props, State> {
           })}
         >
           <Button
-            label={primary.label}
-            onClick={primary.onClick}
             icon={withActionButtonArrow ? configureIcon : null}
             iconPosition="end"
-            disabled={primary.disabled}
+            {...primary}
           />
 
           {secondary && (
             <div className={styles.secondaryAction}>
-              <Button
-                label={secondary.label}
-                onClick={secondary.onClick}
-                secondary
-                disabled={secondary.disabled}
-              />
+              <Button secondary {...secondary} />
             </div>
           )}
         </div>

--- a/draft-packages/guidance-block/KaizenDraft/GuidanceBlock/GuidanceBlock.tsx
+++ b/draft-packages/guidance-block/KaizenDraft/GuidanceBlock/GuidanceBlock.tsx
@@ -1,4 +1,5 @@
-import { Button, Heading, Icon, Paragraph } from "@kaizen/component-library"
+import { Heading, Icon, Paragraph } from "@kaizen/component-library"
+import { Button } from "@kaizen/draft-button"
 const configureIcon = require("@kaizen/component-library/icons/arrow-forward.icon.svg")
   .default
 

--- a/draft-packages/guidance-block/package.json
+++ b/draft-packages/guidance-block/package.json
@@ -32,6 +32,7 @@
   "license": "MIT",
   "dependencies": {
     "@kaizen/component-library": "^7.30.4",
+    "@kaizen/draft-button": "^2.0.0",
     "@types/classnames": "^2.2.10",
     "classnames": "^2.2.6"
   },

--- a/draft-packages/stories/GuidanceBlock.stories.tsx
+++ b/draft-packages/stories/GuidanceBlock.stories.tsx
@@ -96,7 +96,7 @@ const SecondaryAction = () => (
         },
         secondary: {
           label: "Secondary action",
-          onClick: () => alert("tada: 🎉"),
+          href: "#",
         },
       }}
       persistent


### PR DESCRIPTION
## Background

In a recent project using the GuidanceBlock component - I found that I needed to be able to use more than just the `label`, `onClick` and `disabled` props for the buttons. 

This PR allows you to send through any button props, rather than just the 3 that were specified previously. This also means that we won't need to adjust this package if the Button API changes.