### PR TITLE
fix: Change all require to import (icons and styles) 

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -15,7 +15,6 @@ module.exports = {
   extends: ["prettier", "prettier/@typescript-eslint"],
   parser: "@typescript-eslint/parser",
   parserOptions: {
-    project: "tsconfig.json",
     sourceType: "module",
   },
   plugins: [

--- a/draft-packages/avatar/KaizenDraft/Avatar/Avatar.tsx
+++ b/draft-packages/avatar/KaizenDraft/Avatar/Avatar.tsx
@@ -1,11 +1,8 @@
 import React, { useState } from "react"
 import cx from "classnames"
 import { Icon } from "@kaizen/component-library"
-// @ts-ignore
 import { Textfit } from "react-textfit"
-// @ts-ignore
 import userIcon from "@kaizen/component-library/icons/user.icon.svg"
-// @ts-ignore
 import styles from "./styles.module.scss"
 
 type AvatarSizes = "small" | "medium" | "large"

--- a/draft-packages/collapsible/KaizenDraft/Collapsible/Collapsible.tsx
+++ b/draft-packages/collapsible/KaizenDraft/Collapsible/Collapsible.tsx
@@ -6,10 +6,8 @@ import AnimateHeight from "react-animate-height"
 import { Sticky } from "./CollapsibleGroup"
 
 const styles = require("./styles.scss")
-const chevronUp = require("@kaizen/component-library/icons/chevron-up.icon.svg")
-  .default
-const chevronDown = require("@kaizen/component-library/icons/chevron-down.icon.svg")
-  .default
+import chevronUp from "@kaizen/component-library/icons/chevron-up.icon.svg"
+import chevronDown from "@kaizen/component-library/icons/chevron-down.icon.svg"
 
 export type Props = {
   id: string

--- a/draft-packages/filter-drawer/KaizenDraft/FilterDrawer/FilterDrawer.tsx
+++ b/draft-packages/filter-drawer/KaizenDraft/FilterDrawer/FilterDrawer.tsx
@@ -8,8 +8,8 @@ import * as React from "react"
  * this rule off.
  */
 // eslint-disable-next-line import/no-extraneous-dependencies
-const filterIcon = require("@kaizen/component-library/icons/filter.icon.svg")
-  .default
+import filterIcon from "@kaizen/component-library/icons/filter.icon.svg"
+
 const styles = require("./styles.module.scss")
 import { FilterDrawerButton } from "./FilterDrawerButton"
 

--- a/draft-packages/filter-drawer/KaizenDraft/FilterDrawer/FilterDrawer.tsx
+++ b/draft-packages/filter-drawer/KaizenDraft/FilterDrawer/FilterDrawer.tsx
@@ -2,12 +2,6 @@ import { MenuContent } from "@kaizen/draft-menu"
 import { StatelessMenu } from "@kaizen/draft-menu/KaizenDraft/Menu/StatelessMenu"
 import classnames from "classnames"
 import * as React from "react"
-/**
- * Eslint throws a false negative for modules that use require. Ensure you
- * are importing @kaizen/component-library into your package before turning
- * this rule off.
- */
-// eslint-disable-next-line import/no-extraneous-dependencies
 import filterIcon from "@kaizen/component-library/icons/filter.icon.svg"
 
 const styles = require("./styles.module.scss")

--- a/draft-packages/filter-drawer/KaizenDraft/FilterDrawer/FilterDrawerButton.tsx
+++ b/draft-packages/filter-drawer/KaizenDraft/FilterDrawer/FilterDrawerButton.tsx
@@ -6,8 +6,8 @@ import GenericButton, {
 } from "@kaizen/draft-button/KaizenDraft/Button/components/GenericButton"
 import classnames from "classnames"
 import * as React from "react"
-const filterIcon = require("@kaizen/component-library/icons/filter.icon.svg")
-  .default
+import filterIcon from "@kaizen/component-library/icons/filter.icon.svg"
+
 const styles = require("./FilterDrawerButton.module.scss")
 
 type FilterButtonProps = {

--- a/draft-packages/form/KaizenDraft/Form/Primitives/Checkbox/Checkbox.tsx
+++ b/draft-packages/form/KaizenDraft/Form/Primitives/Checkbox/Checkbox.tsx
@@ -1,8 +1,6 @@
 import { Icon } from "@kaizen/component-library"
-const checkIcon = require("@kaizen/component-library/icons/check.icon.svg")
-  .default
-const minusIcon = require("@kaizen/component-library/icons/minus.icon.svg")
-  .default
+import checkIcon from "@kaizen/component-library/icons/check.icon.svg"
+import minusIcon from "@kaizen/component-library/icons/minus.icon.svg"
 import classnames from "classnames"
 import * as React from "react"
 

--- a/draft-packages/form/KaizenDraft/Form/TextField/TextField.tsx
+++ b/draft-packages/form/KaizenDraft/Form/TextField/TextField.tsx
@@ -8,9 +8,7 @@ import {
   Label,
 } from "@kaizen/draft-form"
 import exclamationIcon from "@kaizen/component-library/icons/exclamation.icon.svg"
-
 import successIcon from "@kaizen/component-library/icons/success.icon.svg"
-
 import classnames from "classnames"
 import * as React from "react"
 

--- a/draft-packages/form/KaizenDraft/Form/TextField/TextField.tsx
+++ b/draft-packages/form/KaizenDraft/Form/TextField/TextField.tsx
@@ -7,10 +7,10 @@ import {
   InputType,
   Label,
 } from "@kaizen/draft-form"
-const exclamationIcon = require("@kaizen/component-library/icons/exclamation.icon.svg")
-  .default
-const successIcon = require("@kaizen/component-library/icons/success.icon.svg")
-  .default
+import exclamationIcon from "@kaizen/component-library/icons/exclamation.icon.svg"
+
+import successIcon from "@kaizen/component-library/icons/success.icon.svg"
+
 import classnames from "classnames"
 import * as React from "react"
 

--- a/draft-packages/guidance-block/KaizenDraft/GuidanceBlock/GuidanceBlock.tsx
+++ b/draft-packages/guidance-block/KaizenDraft/GuidanceBlock/GuidanceBlock.tsx
@@ -1,12 +1,11 @@
 import { Button, Heading, Icon, Paragraph } from "@kaizen/component-library"
 import configureIcon from "@kaizen/component-library/icons/arrow-forward.icon.svg"
+import closeIcon from "@kaizen/component-library/icons/close.icon.svg"
 
 import classnames from "classnames"
 import * as React from "react"
 
 const styles = require("./GuidanceBlock.scss")
-
-import closeIcon from "@kaizen/component-library/icons/close.icon.svg"
 
 type Props = {
   img: {

--- a/draft-packages/guidance-block/KaizenDraft/GuidanceBlock/GuidanceBlock.tsx
+++ b/draft-packages/guidance-block/KaizenDraft/GuidanceBlock/GuidanceBlock.tsx
@@ -1,14 +1,12 @@
 import { Button, Heading, Icon, Paragraph } from "@kaizen/component-library"
-const configureIcon = require("@kaizen/component-library/icons/arrow-forward.icon.svg")
-  .default
+import configureIcon from "@kaizen/component-library/icons/arrow-forward.icon.svg"
 
 import classnames from "classnames"
 import * as React from "react"
 
 const styles = require("./GuidanceBlock.scss")
 
-const closeIcon = require("@kaizen/component-library/icons/close.icon.svg")
-  .default
+import closeIcon from "@kaizen/component-library/icons/close.icon.svg"
 
 type Props = {
   img: {

--- a/draft-packages/hero-panel/KaizenDraft/HeroPanel/HeroPanel.tsx
+++ b/draft-packages/hero-panel/KaizenDraft/HeroPanel/HeroPanel.tsx
@@ -8,8 +8,7 @@ import {
   Text,
 } from "@kaizen/component-library"
 const styles = require("./HeroPanel.scss")
-const crossIcon = require("@kaizen/component-library/icons/close.icon.svg")
-  .default
+import crossIcon from "@kaizen/component-library/icons/close.icon.svg"
 
 interface Props {
   readonly id?: string

--- a/draft-packages/hierarchical-menu/KaizenDraft/HierarchicalMenu/HierarchicalMenu.tsx
+++ b/draft-packages/hierarchical-menu/KaizenDraft/HierarchicalMenu/HierarchicalMenu.tsx
@@ -10,7 +10,6 @@ import spacingTokens from "@kaizen/design-tokens/tokens/spacing.json"
 import { KeyboardNavigableList } from "./KeyboardNavigableList"
 
 import chevronLeft from "@kaizen/component-library/icons/chevron-left.icon.svg"
-
 import chevronRight from "@kaizen/component-library/icons/chevron-right.icon.svg"
 
 const styles = require("./styles.module.scss")

--- a/draft-packages/hierarchical-menu/KaizenDraft/HierarchicalMenu/HierarchicalMenu.tsx
+++ b/draft-packages/hierarchical-menu/KaizenDraft/HierarchicalMenu/HierarchicalMenu.tsx
@@ -9,10 +9,10 @@ import borderTokens from "@kaizen/design-tokens/tokens/border.json"
 import spacingTokens from "@kaizen/design-tokens/tokens/spacing.json"
 import { KeyboardNavigableList } from "./KeyboardNavigableList"
 
-const chevronLeft = require("@kaizen/component-library/icons/chevron-left.icon.svg")
-  .default
-const chevronRight = require("@kaizen/component-library/icons/chevron-right.icon.svg")
-  .default
+import chevronLeft from "@kaizen/component-library/icons/chevron-left.icon.svg"
+
+import chevronRight from "@kaizen/component-library/icons/chevron-right.icon.svg"
+
 const styles = require("./styles.module.scss")
 
 export type MenuWidth = "default" | "contain"

--- a/draft-packages/hierarchical-select/KaizenDraft/HierarchicalSelect/HierarchicalSelect.tsx
+++ b/draft-packages/hierarchical-select/KaizenDraft/HierarchicalSelect/HierarchicalSelect.tsx
@@ -8,11 +8,11 @@ import {
   HierarchicalMenu,
 } from "@kaizen/draft-hierarchical-menu"
 
-const chevronUp = require("@kaizen/component-library/icons/chevron-up.icon.svg")
-  .default
-const chevronDown = require("@kaizen/component-library/icons/chevron-down.icon.svg")
-  .default
-const clear = require("@kaizen/component-library/icons/clear.icon.svg").default
+import chevronUp from "@kaizen/component-library/icons/chevron-up.icon.svg"
+
+import chevronDown from "@kaizen/component-library/icons/chevron-down.icon.svg"
+
+import clear from "@kaizen/component-library/icons/clear.icon.svg"
 const styles = require("./styles.module.scss")
 
 export { MenuWidth, MenuDirection, Hierarchy, HierarchyNode }

--- a/draft-packages/hierarchical-select/KaizenDraft/HierarchicalSelect/HierarchicalSelect.tsx
+++ b/draft-packages/hierarchical-select/KaizenDraft/HierarchicalSelect/HierarchicalSelect.tsx
@@ -9,9 +9,7 @@ import {
 } from "@kaizen/draft-hierarchical-menu"
 
 import chevronUp from "@kaizen/component-library/icons/chevron-up.icon.svg"
-
 import chevronDown from "@kaizen/component-library/icons/chevron-down.icon.svg"
-
 import clear from "@kaizen/component-library/icons/clear.icon.svg"
 const styles = require("./styles.module.scss")
 

--- a/draft-packages/modal/KaizenDraft/Modal/Presets/ConfirmationModal.tsx
+++ b/draft-packages/modal/KaizenDraft/Modal/Presets/ConfirmationModal.tsx
@@ -2,12 +2,11 @@ import classnames from "classnames"
 import * as React from "react"
 
 import { Heading, Icon } from "@kaizen/component-library"
-const information = require("@kaizen/component-library/icons/information.icon.svg")
-  .default
-const success = require("@kaizen/component-library/icons/success.icon.svg")
-  .default
-const exclamation = require("@kaizen/component-library/icons/exclamation.icon.svg")
-  .default
+import information from "@kaizen/component-library/icons/information.icon.svg"
+
+import success from "@kaizen/component-library/icons/success.icon.svg"
+
+import exclamation from "@kaizen/component-library/icons/exclamation.icon.svg"
 
 import {
   GenericModal,

--- a/draft-packages/modal/KaizenDraft/Modal/Presets/ConfirmationModal.tsx
+++ b/draft-packages/modal/KaizenDraft/Modal/Presets/ConfirmationModal.tsx
@@ -3,9 +3,7 @@ import * as React from "react"
 
 import { Heading, Icon } from "@kaizen/component-library"
 import information from "@kaizen/component-library/icons/information.icon.svg"
-
 import success from "@kaizen/component-library/icons/success.icon.svg"
-
 import exclamation from "@kaizen/component-library/icons/exclamation.icon.svg"
 
 import {

--- a/draft-packages/modal/KaizenDraft/Modal/Primitives/ModalHeader.tsx
+++ b/draft-packages/modal/KaizenDraft/Modal/Primitives/ModalHeader.tsx
@@ -1,7 +1,7 @@
 import * as React from "react"
 
 import { IconButton } from "@kaizen/draft-button"
-const close = require("@kaizen/component-library/icons/close.icon.svg").default
+import close from "@kaizen/component-library/icons/close.icon.svg"
 import GenericModalSection from "./GenericModalSection"
 
 const styles = require("./ModalHeader.scss")

--- a/draft-packages/popover/KaizenDraft/Popover/Popover.tsx
+++ b/draft-packages/popover/KaizenDraft/Popover/Popover.tsx
@@ -1,12 +1,12 @@
 import { Icon } from "@kaizen/component-library"
-const closeIcon = require("@kaizen/component-library/icons/close.icon.svg")
-  .default
-const negativeIcon = require("@kaizen/component-library/icons/exclamation.icon.svg")
-  .default
-const informativeIcon = require("@kaizen/component-library/icons/information.icon.svg")
-  .default
-const positiveIcon = require("@kaizen/component-library/icons/success.icon.svg")
-  .default
+import closeIcon from "@kaizen/component-library/icons/close.icon.svg"
+
+import negativeIcon from "@kaizen/component-library/icons/exclamation.icon.svg"
+
+import informativeIcon from "@kaizen/component-library/icons/information.icon.svg"
+
+import positiveIcon from "@kaizen/component-library/icons/success.icon.svg"
+
 import classNames from "classnames"
 import * as React from "react"
 

--- a/draft-packages/popover/KaizenDraft/Popover/Popover.tsx
+++ b/draft-packages/popover/KaizenDraft/Popover/Popover.tsx
@@ -1,10 +1,7 @@
 import { Icon } from "@kaizen/component-library"
 import closeIcon from "@kaizen/component-library/icons/close.icon.svg"
-
 import negativeIcon from "@kaizen/component-library/icons/exclamation.icon.svg"
-
 import informativeIcon from "@kaizen/component-library/icons/information.icon.svg"
-
 import positiveIcon from "@kaizen/component-library/icons/success.icon.svg"
 
 import classNames from "classnames"

--- a/draft-packages/select/KaizenDraft/Select/Select.tsx
+++ b/draft-packages/select/KaizenDraft/Select/Select.tsx
@@ -7,10 +7,9 @@ import { Props as ReactSelectProps } from "react-select/src/Select"
 
 import { Icon } from "@kaizen/component-library"
 
-const chevronDownIcon = require("@kaizen/component-library/icons/chevron-down.icon.svg")
-  .default
-const clearIcon = require("@kaizen/component-library/icons/clear.icon.svg")
-  .default
+import chevronDownIcon from "@kaizen/component-library/icons/chevron-down.icon.svg"
+
+import clearIcon from "@kaizen/component-library/icons/clear.icon.svg"
 
 const styles = require("./styles.react.scss")
 

--- a/draft-packages/select/KaizenDraft/Select/Select.tsx
+++ b/draft-packages/select/KaizenDraft/Select/Select.tsx
@@ -6,9 +6,7 @@ import { AsyncProps as ReactAsyncSelectProps } from "react-select/src/Async"
 import { Props as ReactSelectProps } from "react-select/src/Select"
 
 import { Icon } from "@kaizen/component-library"
-
 import chevronDownIcon from "@kaizen/component-library/icons/chevron-down.icon.svg"
-
 import clearIcon from "@kaizen/component-library/icons/clear.icon.svg"
 
 const styles = require("./styles.react.scss")

--- a/draft-packages/split-button/KaizenDraft/SplitButton/Dropdown.tsx
+++ b/draft-packages/split-button/KaizenDraft/SplitButton/Dropdown.tsx
@@ -3,8 +3,8 @@ import classnames from "classnames"
 import * as React from "react"
 import { Dir } from "./types"
 
-const chevronDown = require("@kaizen/component-library/icons/chevron-down.icon.svg")
-  .default
+import chevronDown from "@kaizen/component-library/icons/chevron-down.icon.svg"
+
 const styles = require("./styles.scss")
 
 type Variant = "default" | "primary"

--- a/draft-packages/stories/Button.stories.tsx
+++ b/draft-packages/stories/Button.stories.tsx
@@ -1,7 +1,7 @@
 import * as colorTokens from "@kaizen/design-tokens/tokens/color.json"
 import { Button, CustomButtonProps, ButtonRef } from "../button"
-const configureIcon = require("@kaizen/component-library/icons/configure.icon.svg")
-  .default
+import configureIcon from "@kaizen/component-library/icons/configure.icon.svg"
+
 import { action } from "@storybook/addon-actions"
 import React, { useCallback, useRef } from "react"
 

--- a/draft-packages/stories/Collapsible.stories.tsx
+++ b/draft-packages/stories/Collapsible.stories.tsx
@@ -4,8 +4,7 @@ import { action } from "@storybook/addon-actions"
 import * as React from "react"
 
 const styles = require("./Collapsible.stories.scss")
-const translationIcon = require("@kaizen/component-library/icons/translation.icon.svg")
-  .default
+import translationIcon from "@kaizen/component-library/icons/translation.icon.svg"
 
 const ListItem = ({ children }: { children: JSX.Element }) => (
   <div className={styles.listItem}>{children}</div>

--- a/draft-packages/stories/Dropdown.stories.tsx
+++ b/draft-packages/stories/Dropdown.stories.tsx
@@ -1,9 +1,9 @@
-const caMonogramIcon = require("@kaizen/component-library/icons/ca-monogram.icon.svg")
-  .default
-const kebabIcon = require("@kaizen/component-library/icons/kebab.icon.svg")
-  .default
-const printIcon = require("@kaizen/component-library/icons/print.icon.svg")
-  .default
+import caMonogramIcon from "@kaizen/component-library/icons/ca-monogram.icon.svg"
+
+import kebabIcon from "@kaizen/component-library/icons/kebab.icon.svg"
+
+import printIcon from "@kaizen/component-library/icons/print.icon.svg"
+
 import { action } from "@storybook/addon-actions"
 import * as React from "react"
 

--- a/draft-packages/stories/Dropdown.stories.tsx
+++ b/draft-packages/stories/Dropdown.stories.tsx
@@ -1,7 +1,5 @@
 import caMonogramIcon from "@kaizen/component-library/icons/ca-monogram.icon.svg"
-
 import kebabIcon from "@kaizen/component-library/icons/kebab.icon.svg"
-
 import printIcon from "@kaizen/component-library/icons/print.icon.svg"
 
 import { action } from "@storybook/addon-actions"

--- a/draft-packages/stories/EmptyState.stories.tsx
+++ b/draft-packages/stories/EmptyState.stories.tsx
@@ -1,7 +1,7 @@
-const chevronLeft = require("@kaizen/component-library/icons/chevron-left.icon.svg")
-  .default
-const chevronRight = require("@kaizen/component-library/icons/chevron-right.icon.svg")
-  .default
+import chevronLeft from "@kaizen/component-library/icons/chevron-left.icon.svg"
+
+import chevronRight from "@kaizen/component-library/icons/chevron-right.icon.svg"
+
 import * as React from "react"
 
 import { Button } from "@kaizen/draft-button"

--- a/draft-packages/stories/IconButton.stories.tsx
+++ b/draft-packages/stories/IconButton.stories.tsx
@@ -1,7 +1,7 @@
 import * as colorTokens from "@kaizen/design-tokens/tokens/color.json"
 import { IconButton } from "../button"
-const configureIcon = require("@kaizen/component-library/icons/configure.icon.svg")
-  .default
+import configureIcon from "@kaizen/component-library/icons/configure.icon.svg"
+
 import { action } from "@storybook/addon-actions"
 import * as React from "react"
 

--- a/draft-packages/stories/Menu.stories.tsx
+++ b/draft-packages/stories/Menu.stories.tsx
@@ -2,17 +2,11 @@ import { Box, Paragraph } from "@kaizen/component-library"
 import * as colorTokens from "@kaizen/design-tokens/tokens/color.json"
 import { Button, IconButton } from "@kaizen/draft-button"
 import chevronDown from "@kaizen/component-library/icons/chevron-down.icon.svg"
-
 import chevronUp from "@kaizen/component-library/icons/chevron-up.icon.svg"
-
 import duplicateIcon from "@kaizen/component-library/icons/duplicate.icon.svg"
-
 import editIcon from "@kaizen/component-library/icons/edit.icon.svg"
-
 import trashIcon from "@kaizen/component-library/icons/trash.icon.svg"
-
 import kebabIcon from "@kaizen/component-library/icons/kebab.icon.svg"
-
 import meatballsIcon from "@kaizen/component-library/icons/meatballs.icon.svg"
 
 import { action } from "@storybook/addon-actions"

--- a/draft-packages/stories/Menu.stories.tsx
+++ b/draft-packages/stories/Menu.stories.tsx
@@ -1,20 +1,20 @@
 import { Box, Paragraph } from "@kaizen/component-library"
 import * as colorTokens from "@kaizen/design-tokens/tokens/color.json"
 import { Button, IconButton } from "@kaizen/draft-button"
-const chevronDown = require("@kaizen/component-library/icons/chevron-down.icon.svg")
-  .default
-const chevronUp = require("@kaizen/component-library/icons/chevron-up.icon.svg")
-  .default
-const duplicateIcon = require("@kaizen/component-library/icons/duplicate.icon.svg")
-  .default
-const editIcon = require("@kaizen/component-library/icons/edit.icon.svg")
-  .default
-const trashIcon = require("@kaizen/component-library/icons/trash.icon.svg")
-  .default
-const kebabIcon = require("@kaizen/component-library/icons/kebab.icon.svg")
-  .default
-const meatballsIcon = require("@kaizen/component-library/icons/meatballs.icon.svg")
-  .default
+import chevronDown from "@kaizen/component-library/icons/chevron-down.icon.svg"
+
+import chevronUp from "@kaizen/component-library/icons/chevron-up.icon.svg"
+
+import duplicateIcon from "@kaizen/component-library/icons/duplicate.icon.svg"
+
+import editIcon from "@kaizen/component-library/icons/edit.icon.svg"
+
+import trashIcon from "@kaizen/component-library/icons/trash.icon.svg"
+
+import kebabIcon from "@kaizen/component-library/icons/kebab.icon.svg"
+
+import meatballsIcon from "@kaizen/component-library/icons/meatballs.icon.svg"
+
 import { action } from "@storybook/addon-actions"
 import React, { useState } from "react"
 import {

--- a/draft-packages/stories/Modal.stories.tsx
+++ b/draft-packages/stories/Modal.stories.tsx
@@ -14,10 +14,9 @@ import {
 } from "@kaizen/draft-modal"
 import { action } from "@storybook/addon-actions"
 import * as React from "react"
-const lockIcon = require("@kaizen/component-library/icons/lock.icon.svg")
-  .default
-const userIcon = require("@kaizen/component-library/icons/user.icon.svg")
-  .default
+import lockIcon from "@kaizen/component-library/icons/lock.icon.svg"
+
+import userIcon from "@kaizen/component-library/icons/user.icon.svg"
 
 const styles = require("./Modal.stories.scss")
 

--- a/draft-packages/stories/Modal.stories.tsx
+++ b/draft-packages/stories/Modal.stories.tsx
@@ -15,7 +15,6 @@ import {
 import { action } from "@storybook/addon-actions"
 import * as React from "react"
 import lockIcon from "@kaizen/component-library/icons/lock.icon.svg"
-
 import userIcon from "@kaizen/component-library/icons/user.icon.svg"
 
 const styles = require("./Modal.stories.scss")

--- a/draft-packages/stories/SplitButton.stories.tsx
+++ b/draft-packages/stories/SplitButton.stories.tsx
@@ -4,7 +4,6 @@ import { action } from "@storybook/addon-actions"
 import * as React from "react"
 
 import duplicateIcon from "@kaizen/component-library/icons/duplicate.icon.svg"
-
 import editIcon from "@kaizen/component-library/icons/edit.icon.svg"
 
 export default {

--- a/draft-packages/stories/SplitButton.stories.tsx
+++ b/draft-packages/stories/SplitButton.stories.tsx
@@ -3,10 +3,9 @@ import { SplitButton } from "@kaizen/draft-split-button"
 import { action } from "@storybook/addon-actions"
 import * as React from "react"
 
-const duplicateIcon = require("@kaizen/component-library/icons/duplicate.icon.svg")
-  .default
-const editIcon = require("@kaizen/component-library/icons/edit.icon.svg")
-  .default
+import duplicateIcon from "@kaizen/component-library/icons/duplicate.icon.svg"
+
+import editIcon from "@kaizen/component-library/icons/edit.icon.svg"
 
 export default {
   title: "SplitButton (React)",

--- a/draft-packages/stories/Table.stories.tsx
+++ b/draft-packages/stories/Table.stories.tsx
@@ -13,12 +13,11 @@ import {
 } from "../table"
 const styles = require("./Table.stories.scss")
 
-const commentIcon = require("@kaizen/component-library/icons/comment.icon.svg")
-  .default
-const chevronDownIcon = require("@kaizen/component-library/icons/chevron-down.icon.svg")
-  .default
-const chevronUpIcon = require("@kaizen/component-library/icons/chevron-up.icon.svg")
-  .default
+import commentIcon from "@kaizen/component-library/icons/comment.icon.svg"
+
+import chevronDownIcon from "@kaizen/component-library/icons/chevron-down.icon.svg"
+
+import chevronUpIcon from "@kaizen/component-library/icons/chevron-up.icon.svg"
 
 const Container: React.FunctionComponent = ({ children }) => (
   <div style={{ margin: "1rem auto", width: "100%", maxWidth: "60rem" }}>

--- a/draft-packages/stories/Table.stories.tsx
+++ b/draft-packages/stories/Table.stories.tsx
@@ -14,9 +14,7 @@ import {
 const styles = require("./Table.stories.scss")
 
 import commentIcon from "@kaizen/component-library/icons/comment.icon.svg"
-
 import chevronDownIcon from "@kaizen/component-library/icons/chevron-down.icon.svg"
-
 import chevronUpIcon from "@kaizen/component-library/icons/chevron-up.icon.svg"
 
 const Container: React.FunctionComponent = ({ children }) => (

--- a/draft-packages/stories/TextField.stories.tsx
+++ b/draft-packages/stories/TextField.stories.tsx
@@ -5,7 +5,6 @@ import { Tooltip } from "@kaizen/draft-tooltip"
 
 import { TextField } from "@kaizen/draft-form"
 import lockIcon from "@kaizen/component-library/icons/lock.icon.svg"
-
 import userIcon from "@kaizen/component-library/icons/user.icon.svg"
 
 const ExampleContainer: React.FunctionComponent = ({ children }) => (

--- a/draft-packages/stories/TextField.stories.tsx
+++ b/draft-packages/stories/TextField.stories.tsx
@@ -4,10 +4,9 @@ import React, { useCallback, useRef } from "react"
 import { Tooltip } from "@kaizen/draft-tooltip"
 
 import { TextField } from "@kaizen/draft-form"
-const lockIcon = require("@kaizen/component-library/icons/lock.icon.svg")
-  .default
-const userIcon = require("@kaizen/component-library/icons/user.icon.svg")
-  .default
+import lockIcon from "@kaizen/component-library/icons/lock.icon.svg"
+
+import userIcon from "@kaizen/component-library/icons/user.icon.svg"
 
 const ExampleContainer: React.FunctionComponent = ({ children }) => (
   <div style={{ width: "98%", margin: "1%" }}>{children}</div>

--- a/draft-packages/stories/Tile.stories.tsx
+++ b/draft-packages/stories/Tile.stories.tsx
@@ -10,8 +10,7 @@ import {
 import { Coaching } from "@kaizen/draft-illustration"
 import { Tag } from "@kaizen/draft-tag"
 
-const bookmarkIcon = require("@kaizen/component-library/icons/bookmark-off.icon.svg")
-  .default
+import bookmarkIcon from "@kaizen/component-library/icons/bookmark-off.icon.svg"
 
 export default {
   title: "Tile (React)",

--- a/draft-packages/stories/TitleBlockZen.stories.tsx
+++ b/draft-packages/stories/TitleBlockZen.stories.tsx
@@ -4,15 +4,15 @@ import {
   NavigationTab,
   TitleBlockZen,
 } from "../title-block-zen/KaizenDraft/TitleBlockZen"
-const addIcon = require("@kaizen/component-library/icons/add.icon.svg").default
-const commentIcon = require("@kaizen/component-library/icons/comment.icon.svg")
-  .default
-const starIcon = require("@kaizen/component-library/icons/star-on.icon.svg")
-  .default
-const reportSharingIcon = require("@kaizen/component-library/icons/report-sharing.icon.svg")
-  .default
-const arrowForwardIcon = require("@kaizen/component-library/icons/arrow-forward.icon.svg")
-  .default
+import addIcon from "@kaizen/component-library/icons/add.icon.svg"
+import commentIcon from "@kaizen/component-library/icons/comment.icon.svg"
+
+import starIcon from "@kaizen/component-library/icons/star-on.icon.svg"
+
+import reportSharingIcon from "@kaizen/component-library/icons/report-sharing.icon.svg"
+
+import arrowForwardIcon from "@kaizen/component-library/icons/arrow-forward.icon.svg"
+
 import { assetUrl } from "@kaizen/hosted-assets"
 
 const styles = require("./TitleBlockZen.stories.scss")

--- a/draft-packages/stories/TitleBlockZen.stories.tsx
+++ b/draft-packages/stories/TitleBlockZen.stories.tsx
@@ -6,13 +6,9 @@ import {
 } from "../title-block-zen/KaizenDraft/TitleBlockZen"
 import addIcon from "@kaizen/component-library/icons/add.icon.svg"
 import commentIcon from "@kaizen/component-library/icons/comment.icon.svg"
-
 import starIcon from "@kaizen/component-library/icons/star-on.icon.svg"
-
 import reportSharingIcon from "@kaizen/component-library/icons/report-sharing.icon.svg"
-
 import arrowForwardIcon from "@kaizen/component-library/icons/arrow-forward.icon.svg"
-
 import { assetUrl } from "@kaizen/hosted-assets"
 
 const styles = require("./TitleBlockZen.stories.scss")

--- a/draft-packages/stories/ZenNavigationBar.stories.tsx
+++ b/draft-packages/stories/ZenNavigationBar.stories.tsx
@@ -3,15 +3,9 @@ import * as React from "react"
 import { Button, Icon } from "@kaizen/component-library"
 import { Link, Menu, ZenNavigationBar } from "@kaizen/draft-zen-navigation-bar"
 import { ColorScheme } from "@kaizen/draft-zen-navigation-bar/KaizenDraft/ZenNavigationBar/types"
-
-const caIcon = require("@kaizen/component-library/icons/ca-monogram.icon.svg")
-  .default
-const academyIcon = require("@kaizen/component-library/icons/academy.icon.svg")
-  .default
-const caMonogramIcon = require("@kaizen/component-library/icons/ca-monogram.icon.svg")
-  .default
-const supportIcon = require("@kaizen/component-library/icons/support.icon.svg")
-  .default
+import caIcon from "@kaizen/component-library/icons/ca-monogram.icon.svg"
+import academyIcon from "@kaizen/component-library/icons/academy.icon.svg"
+import supportIcon from "@kaizen/component-library/icons/support.icon.svg"
 
 export default {
   title: "ZenNavigationBar (React)",
@@ -31,7 +25,7 @@ const accountMenuBtn = (
       height: "100%",
     }}
   >
-    <Icon icon={caMonogramIcon} title="Culture Amp Logo" inheritSize />
+    <Icon icon={caIcon} title="Culture Amp Logo" inheritSize />
   </div>
 )
 

--- a/draft-packages/table/KaizenDraft/Table/Table.tsx
+++ b/draft-packages/table/KaizenDraft/Table/Table.tsx
@@ -4,8 +4,7 @@ import classNames from "classnames"
 import * as React from "react"
 
 const styles = require("./styles.scss")
-const sortDescendingIcon = require("@kaizen/component-library/icons/sort-descending.icon.svg")
-  .default
+import sortDescendingIcon from "@kaizen/component-library/icons/sort-descending.icon.svg"
 
 type TableContainer = React.FunctionComponent
 export const TableContainer: TableContainer = ({ children, ...otherProps }) => (

--- a/draft-packages/tag/KaizenDraft/Tag/Tag.tsx
+++ b/draft-packages/tag/KaizenDraft/Tag/Tag.tsx
@@ -2,11 +2,8 @@ import { Icon } from "@kaizen/component-library"
 import classNames from "classnames"
 import * as React from "react"
 import clearIcon from "@kaizen/component-library/icons/clear.icon.svg"
-
 import exclamationIcon from "@kaizen/component-library/icons/exclamation.icon.svg"
-
 import informationIcon from "@kaizen/component-library/icons/information.icon.svg"
-
 import successIcon from "@kaizen/component-library/icons/success.icon.svg"
 
 const styles = require("./Tag.scss")

--- a/draft-packages/tag/KaizenDraft/Tag/Tag.tsx
+++ b/draft-packages/tag/KaizenDraft/Tag/Tag.tsx
@@ -1,14 +1,14 @@
 import { Icon } from "@kaizen/component-library"
 import classNames from "classnames"
 import * as React from "react"
-const clearIcon = require("@kaizen/component-library/icons/clear.icon.svg")
-  .default
-const exclamationIcon = require("@kaizen/component-library/icons/exclamation.icon.svg")
-  .default
-const informationIcon = require("@kaizen/component-library/icons/information.icon.svg")
-  .default
-const successIcon = require("@kaizen/component-library/icons/success.icon.svg")
-  .default
+import clearIcon from "@kaizen/component-library/icons/clear.icon.svg"
+
+import exclamationIcon from "@kaizen/component-library/icons/exclamation.icon.svg"
+
+import informationIcon from "@kaizen/component-library/icons/information.icon.svg"
+
+import successIcon from "@kaizen/component-library/icons/success.icon.svg"
+
 const styles = require("./Tag.scss")
 
 type Variant =

--- a/draft-packages/tile/KaizenDraft/Tile/components/GenericTile.tsx
+++ b/draft-packages/tile/KaizenDraft/Tile/components/GenericTile.tsx
@@ -10,11 +10,11 @@ import classNames from "classnames"
  * this rule off.
  */
 // eslint-disable-next-line import/no-extraneous-dependencies
-const informationIcon = require("@kaizen/component-library/icons/information.icon.svg")
-  .default
+import informationIcon from "@kaizen/component-library/icons/information.icon.svg"
+
 // eslint-disable-next-line import/no-extraneous-dependencies
-const arrowBackwardIcon = require("@kaizen/component-library/icons/arrow-backward.icon.svg")
-  .default
+import arrowBackwardIcon from "@kaizen/component-library/icons/arrow-backward.icon.svg"
+
 const styles = require("./GenericTile.scss")
 
 export interface TileAction {

--- a/draft-packages/tile/KaizenDraft/Tile/components/GenericTile.tsx
+++ b/draft-packages/tile/KaizenDraft/Tile/components/GenericTile.tsx
@@ -4,15 +4,7 @@ import Action from "./Action"
 import { IconButton } from "@kaizen/draft-button"
 import classNames from "classnames"
 
-/**
- * Eslint throws a false negative for modules that use require. Ensure you
- * are importing @kaizen/component-library into your package before turning
- * this rule off.
- */
-// eslint-disable-next-line import/no-extraneous-dependencies
 import informationIcon from "@kaizen/component-library/icons/information.icon.svg"
-
-// eslint-disable-next-line import/no-extraneous-dependencies
 import arrowBackwardIcon from "@kaizen/component-library/icons/arrow-backward.icon.svg"
 
 const styles = require("./GenericTile.scss")

--- a/draft-packages/tile/package.json
+++ b/draft-packages/tile/package.json
@@ -35,6 +35,7 @@
     "react": "^16.9.0"
   },
   "dependencies": {
+    "@kaizen/component-library": "^7.30.4",
     "classnames": "^2.2.6"
   }
 }

--- a/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/MainActions.tsx
+++ b/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/MainActions.tsx
@@ -14,10 +14,9 @@ import {
 } from "./TitleBlockZen"
 import Toolbar from "./Toolbar"
 import { Badge, BadgeAnimated } from "@kaizen/draft-badge"
-const chevronDownIcon = require("@kaizen/component-library/icons/chevron-down.icon.svg")
-  .default
-const meatballsIcon = require("@kaizen/component-library/icons/meatballs.icon.svg")
-  .default
+import chevronDownIcon from "@kaizen/component-library/icons/chevron-down.icon.svg"
+
+import meatballsIcon from "@kaizen/component-library/icons/meatballs.icon.svg"
 
 const styles = require("./TitleBlockZen.scss")
 

--- a/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/MainActions.tsx
+++ b/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/MainActions.tsx
@@ -15,7 +15,6 @@ import {
 import Toolbar from "./Toolbar"
 import { Badge, BadgeAnimated } from "@kaizen/draft-badge"
 import chevronDownIcon from "@kaizen/component-library/icons/chevron-down.icon.svg"
-
 import meatballsIcon from "@kaizen/component-library/icons/meatballs.icon.svg"
 
 const styles = require("./TitleBlockZen.scss")

--- a/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/MobileActions.tsx
+++ b/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/MobileActions.tsx
@@ -17,10 +17,9 @@ import {
   TitleBlockMenuItemProps,
   convertSecondaryActionsToMenuItems,
 } from "./TitleBlockZen"
-const chevronDownIcon = require("@kaizen/component-library/icons/chevron-down.icon.svg")
-  .default
-const chevronUpIcon = require("@kaizen/component-library/icons/chevron-up.icon.svg")
-  .default
+import chevronDownIcon from "@kaizen/component-library/icons/chevron-down.icon.svg"
+
+import chevronUpIcon from "@kaizen/component-library/icons/chevron-up.icon.svg"
 
 const styles = require("./MobileActions.scss")
 

--- a/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/SecondaryActions.tsx
+++ b/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/SecondaryActions.tsx
@@ -3,10 +3,9 @@ import { Menu, MenuContent, MenuItem } from "@kaizen/draft-menu"
 import * as React from "react"
 import { SecondaryActionsProps, TitleBlockMenuItemProps } from "./TitleBlockZen"
 import Toolbar from "./Toolbar"
-const chevronDownIcon = require("@kaizen/component-library/icons/chevron-down.icon.svg")
-  .default
-const meatballsIcon = require("@kaizen/component-library/icons/meatballs.icon.svg")
-  .default
+import chevronDownIcon from "@kaizen/component-library/icons/chevron-down.icon.svg"
+
+import meatballsIcon from "@kaizen/component-library/icons/meatballs.icon.svg"
 
 const styles = require("./TitleBlockZen.scss")
 

--- a/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/SecondaryActions.tsx
+++ b/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/SecondaryActions.tsx
@@ -4,7 +4,6 @@ import * as React from "react"
 import { SecondaryActionsProps, TitleBlockMenuItemProps } from "./TitleBlockZen"
 import Toolbar from "./Toolbar"
 import chevronDownIcon from "@kaizen/component-library/icons/chevron-down.icon.svg"
-
 import meatballsIcon from "@kaizen/component-library/icons/meatballs.icon.svg"
 
 const styles = require("./TitleBlockZen.scss")

--- a/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/TitleBlockZen.tsx
+++ b/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/TitleBlockZen.tsx
@@ -12,12 +12,11 @@ import NavigationTab, { NavigationTabProps } from "./NavigationTabs"
 import SecondaryActions from "./SecondaryActions"
 
 const styles = require("./TitleBlockZen.scss")
-const leftArrow = require("@kaizen/component-library/icons/arrow-backward.icon.svg")
-  .default
-const rightArrow = require("@kaizen/component-library/icons/arrow-forward.icon.svg")
-  .default
-const hamburgerIcon = require("@kaizen/component-library/icons/hamburger.icon.svg")
-  .default
+import leftArrow from "@kaizen/component-library/icons/arrow-backward.icon.svg"
+
+import rightArrow from "@kaizen/component-library/icons/arrow-forward.icon.svg"
+
+import hamburgerIcon from "@kaizen/component-library/icons/hamburger.icon.svg"
 
 export const NON_REVERSED_VARIANTS = ["education", "admin"]
 

--- a/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/TitleBlockZen.tsx
+++ b/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/TitleBlockZen.tsx
@@ -13,9 +13,7 @@ import SecondaryActions from "./SecondaryActions"
 
 const styles = require("./TitleBlockZen.scss")
 import leftArrow from "@kaizen/component-library/icons/arrow-backward.icon.svg"
-
 import rightArrow from "@kaizen/component-library/icons/arrow-forward.icon.svg"
-
 import hamburgerIcon from "@kaizen/component-library/icons/hamburger.icon.svg"
 
 export const NON_REVERSED_VARIANTS = ["education", "admin"]

--- a/draft-packages/vertical-progress-step/KaizenDraft/VerticalProgressStep/VerticalProgressIndicator/VerticalProgressIndicator.tsx
+++ b/draft-packages/vertical-progress-step/KaizenDraft/VerticalProgressStep/VerticalProgressIndicator/VerticalProgressIndicator.tsx
@@ -1,11 +1,10 @@
 import * as React from "react"
 
-const emptyIcon = require("@kaizen/component-library/icons/empty.icon.svg")
-  .default
-const printIcon = require("@kaizen/component-library/icons/print.icon.svg")
-  .default
-const successIcon = require("@kaizen/component-library/icons/success.icon.svg")
-  .default
+import emptyIcon from "@kaizen/component-library/icons/empty.icon.svg"
+
+import printIcon from "@kaizen/component-library/icons/print.icon.svg"
+
+import successIcon from "@kaizen/component-library/icons/success.icon.svg"
 
 import { Icon } from "@kaizen/component-library"
 

--- a/draft-packages/vertical-progress-step/KaizenDraft/VerticalProgressStep/VerticalProgressIndicator/VerticalProgressIndicator.tsx
+++ b/draft-packages/vertical-progress-step/KaizenDraft/VerticalProgressStep/VerticalProgressIndicator/VerticalProgressIndicator.tsx
@@ -1,11 +1,8 @@
 import * as React from "react"
 
 import emptyIcon from "@kaizen/component-library/icons/empty.icon.svg"
-
 import printIcon from "@kaizen/component-library/icons/print.icon.svg"
-
 import successIcon from "@kaizen/component-library/icons/success.icon.svg"
-
 import { Icon } from "@kaizen/component-library"
 
 const styles = require("./VerticalProgressIndicator.module.scss")

--- a/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/components/Badge.tsx
+++ b/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/components/Badge.tsx
@@ -1,8 +1,7 @@
 import { Icon } from "@kaizen/component-library"
-const caMonogramIcon = require("@kaizen/component-library/icons/ca-monogram.icon.svg")
-  .default
-const spinnerIcon = require("@kaizen/component-library/icons/spinner.icon.svg")
-  .default
+import caMonogramIcon from "@kaizen/component-library/icons/ca-monogram.icon.svg"
+
+import spinnerIcon from "@kaizen/component-library/icons/spinner.icon.svg"
 
 import classNames from "classnames"
 import * as React from "react"

--- a/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/components/Badge.tsx
+++ b/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/components/Badge.tsx
@@ -1,6 +1,5 @@
 import { Icon } from "@kaizen/component-library"
 import caMonogramIcon from "@kaizen/component-library/icons/ca-monogram.icon.svg"
-
 import spinnerIcon from "@kaizen/component-library/icons/spinner.icon.svg"
 
 import classNames from "classnames"

--- a/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/components/Indicator.tsx
+++ b/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/components/Indicator.tsx
@@ -3,8 +3,7 @@ import { Icon } from "@kaizen/component-library"
 
 const styles = require("./Indicator.module.scss")
 
-const fullIcon = require("@kaizen/component-library/icons/full.icon.svg")
-  .default
+import fullIcon from "@kaizen/component-library/icons/full.icon.svg"
 
 const Indicator = () => (
   <span className={styles.container}>

--- a/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/components/Link.tsx
+++ b/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/components/Link.tsx
@@ -7,8 +7,8 @@ import { NavBarContext } from "../context"
 import { LinkProps } from "../types"
 import Indicator from "./Indicator"
 
-const arrowForwardIcon = require("@kaizen/component-library/icons/arrow-forward.icon.svg")
-  .default
+import arrowForwardIcon from "@kaizen/component-library/icons/arrow-forward.icon.svg"
+
 const styles = require("./Link.module.scss")
 
 export default class Link extends React.PureComponent<LinkProps> {

--- a/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/components/Menu.tsx
+++ b/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/components/Menu.tsx
@@ -14,7 +14,6 @@ import MenuGroup from "./MenuGroup"
 import Indicator from "./Indicator"
 
 import arrowLeftIcon from "@kaizen/component-library/icons/arrow-left.icon.svg"
-
 import chevronDownIcon from "@kaizen/component-library/icons/chevron-down.icon.svg"
 
 const styles = require("./Menu.module.scss")

--- a/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/components/Menu.tsx
+++ b/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/components/Menu.tsx
@@ -13,10 +13,9 @@ import Link from "./Link"
 import MenuGroup from "./MenuGroup"
 import Indicator from "./Indicator"
 
-const arrowLeftIcon = require("@kaizen/component-library/icons/arrow-left.icon.svg")
-  .default
-const chevronDownIcon = require("@kaizen/component-library/icons/chevron-down.icon.svg")
-  .default
+import arrowLeftIcon from "@kaizen/component-library/icons/arrow-left.icon.svg"
+
+import chevronDownIcon from "@kaizen/component-library/icons/chevron-down.icon.svg"
 
 const styles = require("./Menu.module.scss")
 

--- a/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/components/MenuItem.tsx
+++ b/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/components/MenuItem.tsx
@@ -4,8 +4,8 @@ import React from "react"
 import { NavBarContext } from "../context"
 import { Badge, MenuItemProps } from "../types"
 
-const arrowForwardIcon = require("@kaizen/component-library/icons/arrow-forward.icon.svg")
-  .default
+import arrowForwardIcon from "@kaizen/component-library/icons/arrow-forward.icon.svg"
+
 const styles = require("./MenuItem.module.scss")
 
 const MenuItem = ({

--- a/draft-packages/zen-off-canvas/KaizenDraft/ZenOffCanvas/components/Header.tsx
+++ b/draft-packages/zen-off-canvas/KaizenDraft/ZenOffCanvas/components/Header.tsx
@@ -2,8 +2,8 @@ import * as React from "react"
 
 import { ColorScheme } from "@kaizen/draft-zen-navigation-bar/KaizenDraft/ZenNavigationBar/types"
 import classNames from "classnames"
-const closeIcon = require("@kaizen/component-library/icons/close.icon.svg")
-  .default
+import closeIcon from "@kaizen/component-library/icons/close.icon.svg"
+
 import IconButton from "@kaizen/component-library/components/Button/IconButton"
 
 const styles = require("./Header.module.scss")

--- a/draft-packages/zen-off-canvas/KaizenDraft/ZenOffCanvas/components/Header.tsx
+++ b/draft-packages/zen-off-canvas/KaizenDraft/ZenOffCanvas/components/Header.tsx
@@ -3,7 +3,6 @@ import * as React from "react"
 import { ColorScheme } from "@kaizen/draft-zen-navigation-bar/KaizenDraft/ZenNavigationBar/types"
 import classNames from "classnames"
 import closeIcon from "@kaizen/component-library/icons/close.icon.svg"
-
 import IconButton from "@kaizen/component-library/components/Button/IconButton"
 
 const styles = require("./Header.module.scss")

--- a/legacy-packages/stories/MenuList.stories.tsx
+++ b/legacy-packages/stories/MenuList.stories.tsx
@@ -7,8 +7,7 @@ import {
   MenuList,
   MenuSeparator,
 } from "@kaizen/component-library"
-const caMonogramIcon = require("@kaizen/component-library/icons/ca-monogram.icon.svg")
-  .default
+import caMonogramIcon from "@kaizen/component-library/icons/ca-monogram.icon.svg"
 
 export default {
   title: "MenuList (React, deprecated)",

--- a/legacy-packages/title-block/KaizenDraft/TitleBlock/TitleBlock.tsx
+++ b/legacy-packages/title-block/KaizenDraft/TitleBlock/TitleBlock.tsx
@@ -6,10 +6,10 @@ import Media from "react-media"
 import Icon from "@kaizen/component-library/components/Icon/Icon"
 import { MOBILE_QUERY } from "@kaizen/component-library/components/NavigationBar/constants"
 import { Tag } from "@kaizen/draft-tag"
-const backIcon = require("@kaizen/component-library/icons/arrow-backward.icon.svg")
-  .default
-const forwardIcon = require("@kaizen/component-library/icons/arrow-forward.icon.svg")
-  .default
+import backIcon from "@kaizen/component-library/icons/arrow-backward.icon.svg"
+
+import forwardIcon from "@kaizen/component-library/icons/arrow-forward.icon.svg"
+
 import NavigationButtons, { NavigationButton } from "./NavigationButtons"
 
 const styles = require("./TitleBlock.scss")

--- a/package.json
+++ b/package.json
@@ -21,7 +21,9 @@
     "lint": "elm-format --validate packages && yarn eslint && yarn prettier && stylelint '**/*.scss'",
     "lint:fix": "elm-format --yes packages && yarn eslint --fix && yarn prettier --write",
     "clean:storybook": "rimraf 'storybook/public'",
-    "clean": "lerna run clean && yarn gatsby clean && yarn clean:storybook && rimraf 'elm-stuff'",
+    "clean:stories": "rimraf './packages/component-library/stories/*.d.ts' './packages/component-library/stories/*.js.map' './packages/component-library/stories/*.js'",
+    "clean:draft-stories": "rimraf './draft-packages/stories/*.d.ts' './draft-packages/stories/*.js.map' './draft-packages/stories/*.js'",
+    "clean": "lerna run clean && yarn gatsby clean && yarn clean:storybook && yarn clean:stories && yarn clean:draft-stories && rimraf 'elm-stuff'",
     "reset": "yarn clean && yarn install --force",
     "chromatic": "chromatic"
   },

--- a/packages/component-library/components/Dropdown/Dropdown.tsx
+++ b/packages/component-library/components/Dropdown/Dropdown.tsx
@@ -1,16 +1,6 @@
 import { Icon } from "@kaizen/component-library"
-
-/**
- * Eslint throws a false negative for modules that use require. Ensure you
- * are importing @kaizen/component-library into your package before turning
- * this rule off.
- */
-// eslint-disable-next-line import/no-extraneous-dependencies
-import chevronDownIcon from "@kaizen/component-library/icons/chevron-down.icon.svg"
-
-// eslint-disable-next-line import/no-extraneous-dependencies
-import ellipsisIcon from "@kaizen/component-library/icons/ellipsis.icon.svg"
-
+import chevronDownIcon from "../../icons/chevron-down.icon.svg"
+import ellipsisIcon from "../../icons/ellipsis.icon.svg"
 import classNames from "classnames"
 import * as React from "react"
 import DropdownMenu from "./DropdownMenu"

--- a/packages/component-library/components/Dropdown/Dropdown.tsx
+++ b/packages/component-library/components/Dropdown/Dropdown.tsx
@@ -6,11 +6,11 @@ import { Icon } from "@kaizen/component-library"
  * this rule off.
  */
 // eslint-disable-next-line import/no-extraneous-dependencies
-const chevronDownIcon = require("@kaizen/component-library/icons/chevron-down.icon.svg")
-  .default
+import chevronDownIcon from "@kaizen/component-library/icons/chevron-down.icon.svg"
+
 // eslint-disable-next-line import/no-extraneous-dependencies
-const ellipsisIcon = require("@kaizen/component-library/icons/ellipsis.icon.svg")
-  .default
+import ellipsisIcon from "@kaizen/component-library/icons/ellipsis.icon.svg"
+
 import classNames from "classnames"
 import * as React from "react"
 import DropdownMenu from "./DropdownMenu"

--- a/packages/component-library/components/Dropdown/Dropdown.tsx
+++ b/packages/component-library/components/Dropdown/Dropdown.tsx
@@ -1,4 +1,4 @@
-import { Icon } from "@kaizen/component-library"
+import { Icon } from "../Icon"
 import chevronDownIcon from "../../icons/chevron-down.icon.svg"
 import ellipsisIcon from "../../icons/ellipsis.icon.svg"
 import classNames from "classnames"

--- a/packages/component-library/components/NavigationBar/components/Badge.tsx
+++ b/packages/component-library/components/NavigationBar/components/Badge.tsx
@@ -5,11 +5,11 @@ import { Icon } from "@kaizen/component-library"
  * this rule off.
  */
 // eslint-disable-next-line import/no-extraneous-dependencies
-const caMonogramIcon = require("@kaizen/component-library/icons/ca-monogram.icon.svg")
-  .default
+import caMonogramIcon from "@kaizen/component-library/icons/ca-monogram.icon.svg"
+
 // eslint-disable-next-line import/no-extraneous-dependencies
-const spinnerIcon = require("@kaizen/component-library/icons/spinner.icon.svg")
-  .default
+import spinnerIcon from "@kaizen/component-library/icons/spinner.icon.svg"
+
 import classNames from "classnames"
 import * as React from "react"
 

--- a/packages/component-library/components/NavigationBar/components/Badge.tsx
+++ b/packages/component-library/components/NavigationBar/components/Badge.tsx
@@ -1,7 +1,7 @@
 import { Icon } from "../../Icon"
 
-import caMonogramIcon from "../../icons/ca-monogram.icon.svg"
-import spinnerIcon from "../../icons/spinner.icon.svg"
+import caMonogramIcon from "../../../icons/ca-monogram.icon.svg"
+import spinnerIcon from "../../../icons/spinner.icon.svg"
 
 import classNames from "classnames"
 import * as React from "react"

--- a/packages/component-library/components/NavigationBar/components/Badge.tsx
+++ b/packages/component-library/components/NavigationBar/components/Badge.tsx
@@ -1,13 +1,6 @@
-import { Icon } from "@kaizen/component-library"
-/**
- * Eslint throws a false negative for modules that use require. Ensure you
- * are importing @kaizen/component-library into your package before turning
- * this rule off.
- */
-// eslint-disable-next-line import/no-extraneous-dependencies
-import caMonogramIcon from "@kaizen/component-library/icons/ca-monogram.icon.svg"
+import { Icon } from "../../Icon"
 
-// eslint-disable-next-line import/no-extraneous-dependencies
+import caMonogramIcon from "@kaizen/component-library/icons/ca-monogram.icon.svg"
 import spinnerIcon from "@kaizen/component-library/icons/spinner.icon.svg"
 
 import classNames from "classnames"

--- a/packages/component-library/components/NavigationBar/components/Badge.tsx
+++ b/packages/component-library/components/NavigationBar/components/Badge.tsx
@@ -1,7 +1,7 @@
 import { Icon } from "../../Icon"
 
-import caMonogramIcon from "@kaizen/component-library/icons/ca-monogram.icon.svg"
-import spinnerIcon from "@kaizen/component-library/icons/spinner.icon.svg"
+import caMonogramIcon from "../../icons/ca-monogram.icon.svg"
+import spinnerIcon from "../../icons/spinner.icon.svg"
 
 import classNames from "classnames"
 import * as React from "react"

--- a/packages/component-library/components/NavigationBar/components/Indicator.tsx
+++ b/packages/component-library/components/NavigationBar/components/Indicator.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { Icon } from "@kaizen/component-library"
+import { Icon } from "../../../Icon"
 
 const styles = require("./Indicator.module.scss")
 /**

--- a/packages/component-library/components/NavigationBar/components/Indicator.tsx
+++ b/packages/component-library/components/NavigationBar/components/Indicator.tsx
@@ -8,8 +8,7 @@ const styles = require("./Indicator.module.scss")
  * this rule off.
  */
 // eslint-disable-next-line import/no-extraneous-dependencies
-const fullIcon = require("@kaizen/component-library/icons/full.icon.svg")
-  .default
+import fullIcon from "@kaizen/component-library/icons/full.icon.svg"
 
 const Indicator = () => (
   <span className={styles.container}>

--- a/packages/component-library/components/NavigationBar/components/Link.tsx
+++ b/packages/component-library/components/NavigationBar/components/Link.tsx
@@ -5,8 +5,8 @@ import { Icon } from "@kaizen/component-library"
  * this rule off.
  */
 // eslint-disable-next-line import/no-extraneous-dependencies
-const chevronRightIcon = require("@kaizen/component-library/icons/chevron-right.icon.svg")
-  .default
+import chevronRightIcon from "@kaizen/component-library/icons/chevron-right.icon.svg"
+
 import classNames from "classnames"
 import * as React from "react"
 

--- a/packages/component-library/components/NavigationBar/components/Menu.tsx
+++ b/packages/component-library/components/NavigationBar/components/Menu.tsx
@@ -10,12 +10,11 @@ import {
  * this rule off.
  */
 // eslint-disable-next-line import/no-extraneous-dependencies
-const arrowLeftIcon = require("@kaizen/component-library/icons/arrow-left.icon.svg")
-  .default
+import arrowLeftIcon from "@kaizen/component-library/icons/arrow-left.icon.svg"
 
 // eslint-disable-next-line import/no-extraneous-dependencies
-const chevronDownIcon = require("@kaizen/component-library/icons/chevron-down.icon.svg")
-  .default
+import chevronDownIcon from "@kaizen/component-library/icons/chevron-down.icon.svg"
+
 import classNames from "classnames"
 import * as React from "react"
 import Media from "react-media"

--- a/packages/component-library/components/Notification/components/GenericNotification.tsx
+++ b/packages/component-library/components/Notification/components/GenericNotification.tsx
@@ -1,19 +1,9 @@
-import { Icon } from "@kaizen/component-library"
-/**
- * Eslint throws a false negative for modules that use require. Ensure you
- * are importing @kaizen/component-library into your package before turning
- * this rule off.
- */
-// eslint-disable-next-line import/no-extraneous-dependencies
-import closeIcon from "@kaizen/component-library/icons/close.icon.svg"
-// eslint-disable-next-line import/no-extraneous-dependencies
-import exclamationIcon from "@kaizen/component-library/icons/exclamation.icon.svg"
+import { Icon } from "../../Icon"
 
-// eslint-disable-next-line import/no-extraneous-dependencies
-import informationIcon from "@kaizen/component-library/icons/information.icon.svg"
-
-// eslint-disable-next-line import/no-extraneous-dependencies
-import successIcon from "@kaizen/component-library/icons/success.icon.svg"
+import closeIcon from "../../../icons/close.icon.svg"
+import exclamationIcon from "../../../icons/exclamation.icon.svg"
+import informationIcon from "../../../icons/information.icon.svg"
+import successIcon from "../../../icons/success.icon.svg"
 
 import classnames from "classnames"
 import * as React from "react"

--- a/packages/component-library/components/Notification/components/GenericNotification.tsx
+++ b/packages/component-library/components/Notification/components/GenericNotification.tsx
@@ -5,17 +5,16 @@ import { Icon } from "@kaizen/component-library"
  * this rule off.
  */
 // eslint-disable-next-line import/no-extraneous-dependencies
-const closeIcon = require("@kaizen/component-library/icons/close.icon.svg")
-  .default
+import closeIcon from "@kaizen/component-library/icons/close.icon.svg"
 // eslint-disable-next-line import/no-extraneous-dependencies
-const exclamationIcon = require("@kaizen/component-library/icons/exclamation.icon.svg")
-  .default
+import exclamationIcon from "@kaizen/component-library/icons/exclamation.icon.svg"
+
 // eslint-disable-next-line import/no-extraneous-dependencies
-const informationIcon = require("@kaizen/component-library/icons/information.icon.svg")
-  .default
+import informationIcon from "@kaizen/component-library/icons/information.icon.svg"
+
 // eslint-disable-next-line import/no-extraneous-dependencies
-const successIcon = require("@kaizen/component-library/icons/success.icon.svg")
-  .default
+import successIcon from "@kaizen/component-library/icons/success.icon.svg"
+
 import classnames from "classnames"
 import * as React from "react"
 

--- a/packages/component-library/components/OffCanvas/components/Header.tsx
+++ b/packages/component-library/components/OffCanvas/components/Header.tsx
@@ -1,12 +1,5 @@
-/**
- * Eslint throws a false negative for modules that use require. Ensure you
- * are importing @kaizen/component-library into your package before turning
- * this rule off.
- */
-// eslint-disable-next-line import/no-extraneous-dependencies
-import closeIcon from "@kaizen/component-library/icons/close.icon.svg"
-
 import * as React from "react"
+import closeIcon from "../../../icons/close.icon.svg"
 import IconButton from "../../Button/IconButton"
 
 const styles = require("./Header.module.scss")

--- a/packages/component-library/components/OffCanvas/components/Header.tsx
+++ b/packages/component-library/components/OffCanvas/components/Header.tsx
@@ -4,8 +4,8 @@
  * this rule off.
  */
 // eslint-disable-next-line import/no-extraneous-dependencies
-const closeIcon = require("@kaizen/component-library/icons/close.icon.svg")
-  .default
+import closeIcon from "@kaizen/component-library/icons/close.icon.svg"
+
 import * as React from "react"
 import IconButton from "../../Button/IconButton"
 

--- a/packages/component-library/draft-templates/ComponentName.tsx
+++ b/packages/component-library/draft-templates/ComponentName.tsx
@@ -1,7 +1,7 @@
 import * as React from "react"
 
 // import { Icon } from "@kaizen/component-library"
-// const minusIcon = require("@kaizen/component-library/icons/minus.icon.svg").default
+// import minusIcon from "@kaizen/component-library/icons/minus.icon.svg"
 
 const styles = require("./styles.scss")
 

--- a/packages/component-library/stories/Button.stories.tsx
+++ b/packages/component-library/stories/Button.stories.tsx
@@ -1,6 +1,6 @@
 import { Button } from "@kaizen/component-library"
-const configureIcon = require("@kaizen/component-library/icons/configure.icon.svg")
-  .default
+import configureIcon from "@kaizen/component-library/icons/configure.icon.svg"
+
 import { action } from "@storybook/addon-actions"
 import React, { useCallback, useRef } from "react"
 import { ButtonRef } from "../components/Button"

--- a/packages/component-library/stories/Icon.stories.tsx
+++ b/packages/component-library/stories/Icon.stories.tsx
@@ -1,8 +1,7 @@
 import * as React from "react"
 
 import { Icon } from "@kaizen/component-library"
-const configureIcon = require("@kaizen/component-library/icons/configure.icon.svg")
-  .default
+import configureIcon from "@kaizen/component-library/icons/configure.icon.svg"
 
 export default {
   title: "Icon (React)",

--- a/packages/component-library/stories/Layout.stories.tsx
+++ b/packages/component-library/stories/Layout.stories.tsx
@@ -11,11 +11,8 @@ import {
   ToastNotification,
 } from "@kaizen/component-library"
 import academyIcon from "@kaizen/component-library/icons/academy.icon.svg"
-
 import caMonogramIcon from "@kaizen/component-library/icons/ca-monogram.icon.svg"
-
 import supportIcon from "@kaizen/component-library/icons/support.icon.svg"
-
 import { TitleBlock } from "@kaizen/draft-title-block"
 
 export default {

--- a/packages/component-library/stories/Layout.stories.tsx
+++ b/packages/component-library/stories/Layout.stories.tsx
@@ -10,12 +10,12 @@ import {
   Text,
   ToastNotification,
 } from "@kaizen/component-library"
-const academyIcon = require("@kaizen/component-library/icons/academy.icon.svg")
-  .default
-const caMonogramIcon = require("@kaizen/component-library/icons/ca-monogram.icon.svg")
-  .default
-const supportIcon = require("@kaizen/component-library/icons/support.icon.svg")
-  .default
+import academyIcon from "@kaizen/component-library/icons/academy.icon.svg"
+
+import caMonogramIcon from "@kaizen/component-library/icons/ca-monogram.icon.svg"
+
+import supportIcon from "@kaizen/component-library/icons/support.icon.svg"
+
 import { TitleBlock } from "@kaizen/draft-title-block"
 
 export default {

--- a/packages/component-library/stories/NavigationBar.stories.tsx
+++ b/packages/component-library/stories/NavigationBar.stories.tsx
@@ -2,12 +2,11 @@ import * as React from "react"
 
 import { Icon, Link, Menu, NavigationBar } from "@kaizen/component-library"
 
-const academyIcon = require("@kaizen/component-library/icons/academy.icon.svg")
-  .default
-const caMonogramIcon = require("@kaizen/component-library/icons/ca-monogram.icon.svg")
-  .default
-const supportIcon = require("@kaizen/component-library/icons/support.icon.svg")
-  .default
+import academyIcon from "@kaizen/component-library/icons/academy.icon.svg"
+
+import caMonogramIcon from "@kaizen/component-library/icons/ca-monogram.icon.svg"
+
+import supportIcon from "@kaizen/component-library/icons/support.icon.svg"
 
 export default {
   title: "NavigationBar (React)",

--- a/site/package.json
+++ b/site/package.json
@@ -11,6 +11,7 @@
     "@babel/preset-typescript": "^7.6.0",
     "@kaizen/component-library": "*",
     "@kaizen/design-tokens": "*",
+    "@kaizen/hosted-assets": "^1.0.1",
     "@mdx-js/mdx": "^1.4.5",
     "@mdx-js/react": "^1.4.5",
     "classnames": "^2.2.6",

--- a/site/src/components/Footer.tsx
+++ b/site/src/components/Footer.tsx
@@ -2,8 +2,7 @@ import { Icon, Paragraph } from "@kaizen/component-library"
 import classnames from "classnames"
 import * as React from "react"
 
-const companyLogo = require("@kaizen/component-library/icons/ca-monogram.icon.svg")
-  .default
+import companyLogo from "@kaizen/component-library/icons/ca-monogram.icon.svg"
 
 const styles = require("./Footer.scss")
 

--- a/site/src/docs-components/DoOrDontItem.tsx
+++ b/site/src/docs-components/DoOrDontItem.tsx
@@ -3,10 +3,10 @@ import classnames from "classnames"
 
 import * as React from "react"
 
-const success = require("@kaizen/component-library/icons/success-white.icon.svg")
-  .default
-const exclamation = require("@kaizen/component-library/icons/exclamation-white.icon.svg")
-  .default
+import success from "@kaizen/component-library/icons/success-white.icon.svg"
+
+import exclamation from "@kaizen/component-library/icons/exclamation-white.icon.svg"
+
 const styles = require("./DoOrDontTag.scss")
 
 type Variant = "do" | "dont"

--- a/site/src/docs-components/DoOrDontItem.tsx
+++ b/site/src/docs-components/DoOrDontItem.tsx
@@ -2,9 +2,7 @@ import { Icon } from "@kaizen/component-library"
 import classnames from "classnames"
 
 import * as React from "react"
-
 import success from "@kaizen/component-library/icons/success-white.icon.svg"
-
 import exclamation from "@kaizen/component-library/icons/exclamation-white.icon.svg"
 
 const styles = require("./DoOrDontTag.scss")

--- a/site/src/docs-components/WhenOrWhenNotToUse.tsx
+++ b/site/src/docs-components/WhenOrWhenNotToUse.tsx
@@ -4,7 +4,6 @@ import classnames from "classnames"
 import * as React from "react"
 
 import success from "@kaizen/component-library/icons/success-white.icon.svg"
-
 import exclamation from "@kaizen/component-library/icons/exclamation-white.icon.svg"
 
 const styles = require("./WhenOrWhenNotToUse.scss")

--- a/site/src/docs-components/WhenOrWhenNotToUse.tsx
+++ b/site/src/docs-components/WhenOrWhenNotToUse.tsx
@@ -3,10 +3,10 @@ import classnames from "classnames"
 
 import * as React from "react"
 
-const success = require("@kaizen/component-library/icons/success-white.icon.svg")
-  .default
-const exclamation = require("@kaizen/component-library/icons/exclamation-white.icon.svg")
-  .default
+import success from "@kaizen/component-library/icons/success-white.icon.svg"
+
+import exclamation from "@kaizen/component-library/icons/exclamation-white.icon.svg"
+
 const styles = require("./WhenOrWhenNotToUse.scss")
 
 type Variant = "whenToUse" | "whenNotToUse"

--- a/site/src/docs-components/icons/IconTile.tsx
+++ b/site/src/docs-components/icons/IconTile.tsx
@@ -3,7 +3,7 @@ import classnames from "classnames"
 import * as React from "react"
 
 const iconStyles = require("@kaizen/component-library/components/Icon/Icon.module.scss")
-const tick = require("@kaizen/component-library/icons/check.icon.svg").default
+import tick from "@kaizen/component-library/icons/check.icon.svg"
 
 const styles = require("./IconGrid.scss")
 

--- a/site/src/docs-components/icons/InteractionStates.tsx
+++ b/site/src/docs-components/icons/InteractionStates.tsx
@@ -4,8 +4,7 @@ import * as React from "react"
 import Card from "../Card"
 
 const iconStyles = require("@kaizen/component-library/components/Icon/Icon.module.scss")
-const enso = require("@kaizen/component-library/icons/ca-monogram.icon.svg")
-  .default
+import enso from "@kaizen/component-library/icons/ca-monogram.icon.svg"
 
 const styles = require("./IconsPage.scss")
 

--- a/site/src/pages/404.tsx
+++ b/site/src/pages/404.tsx
@@ -8,8 +8,7 @@ import Layout from "../components/Layout"
 import md from "../components/markdownComponents"
 import PageHeader from "../components/PageHeader"
 
-const exclamationIcon = require("@kaizen/component-library/icons/exclamation.icon.svg")
-  .default
+import exclamationIcon from "@kaizen/component-library/icons/exclamation.icon.svg"
 
 const FourOhFourPageHeader = (
   <PageHeader

--- a/site/src/pages/index.tsx
+++ b/site/src/pages/index.tsx
@@ -1,5 +1,4 @@
-import { Button } from "@kaizen/component-library"
-import { Heading } from "@kaizen/component-library/components/Heading"
+import { Button, Heading } from "@kaizen/component-library"
 import { assetUrl } from "@kaizen/hosted-assets"
 import { graphql, useStaticQuery, withPrefix } from "gatsby"
 import * as React from "react"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,5 +11,6 @@
     "allowJs": false,
     "noEmit": true
   },
-  "files": ["./types.d.ts"]
+  "include": ["./types.d.ts", "./packages/**/*", "./draft-packages/**/*"],
+  "exclude": ["**/node_modules"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,5 +10,7 @@
     "strict": true,
     "allowJs": false,
     "noEmit": true
-  }
+  },
+  "files": ["./types.d.ts"],
+  "include": ["./packages/**/*"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,5 @@
     "allowJs": false,
     "noEmit": true
   },
-  "files": ["./types.d.ts"],
-  "include": ["./packages/**/*"]
+  "files": ["./types.d.ts"]
 }

--- a/types.d.ts
+++ b/types.d.ts
@@ -1,0 +1,17 @@
+declare module "*.icon.svg" {
+  const content: {
+    id: string
+    viewBox: string
+  }
+  export default content
+}
+
+declare module "*.css" {
+  const classes: { [key: string]: string }
+  export default classes
+}
+
+declare module "*.scss" {
+  const classes: { [key: string]: string }
+  export default classes
+}

--- a/types.d.ts
+++ b/types.d.ts
@@ -1,11 +1,3 @@
-declare module "*.icon.svg" {
-  const content: {
-    id: string
-    viewBox: string
-  }
-  export default content
-}
-
 declare module "*.css" {
   const classes: { [key: string]: string }
   export default classes
@@ -14,4 +6,12 @@ declare module "*.css" {
 declare module "*.scss" {
   const classes: { [key: string]: string }
   export default classes
+}
+
+declare module "*.icon.svg" {
+  const content: {
+    id: string
+    viewBox: string
+  }
+  export default content
 }


### PR DESCRIPTION
**About** 
Previously, we used `require` for including any assets that don't come with typescript types, such as icons and styles. This PR add types for icons and styles so we can then import them like other assets. 

**Motivation**
We experienced some weird eslint errors (both false positives and false negatives) when using a mix of imports and require. 