### PR TITLE
feat: allow uncontrolled Elm TextArea to be pre-fillable

### DIFF
--- a/draft-packages/form/KaizenDraft/Form/Primitives/Input/Input.elm
+++ b/draft-packages/form/KaizenDraft/Form/Primitives/Input/Input.elm
@@ -28,6 +28,7 @@ import Html exposing (..)
 import Html.Attributes
 import Html.Events exposing (onFocus, onInput)
 import Html.Extra exposing (nothing)
+import Json.Encode
 import KaizenDraft.Events.Events as Events
 
 
@@ -250,7 +251,9 @@ view (Config config) =
                 [ Html.Attributes.value config.inputValue ]
 
             else
-                []
+                [ Html.Attributes.property "defaultValue"
+                    (Json.Encode.string config.inputValue)
+                ]
 
         placeholderAttr =
             [ Html.Attributes.placeholder config.placeholder ]

--- a/draft-packages/form/KaizenDraft/Form/Primitives/TextArea/TextArea.elm
+++ b/draft-packages/form/KaizenDraft/Form/Primitives/TextArea/TextArea.elm
@@ -24,6 +24,7 @@ import CssModules exposing (css)
 import Html exposing (..)
 import Html.Attributes
 import Html.Events exposing (onFocus, onInput)
+import Json.Encode
 import KaizenDraft.Events.Events as Events
 
 
@@ -222,7 +223,9 @@ view (Config config) =
                 [ Html.Attributes.value config.textAreaValue ]
 
             else
-                []
+                [ Html.Attributes.property "defaultValue"
+                    (Json.Encode.string config.textAreaValue)
+                ]
 
         placeholderAttr =
             [ Html.Attributes.placeholder config.placeholder ]

--- a/draft-packages/stories/ElmTextAreaField.stories.tsx
+++ b/draft-packages/stories/ElmTextAreaField.stories.tsx
@@ -6,7 +6,8 @@ loadElmStories(
   require("./TextAreaField.stories.elm"),
   [
     "Default",
-    "Default, Prefilled Value",
+    "Default, Controlled, Prefilled Value",
+    "Default, Uncontrolled, Prefilled Value",
     "Default, Description",
     "Default, Error",
     "Default, Error & Description",

--- a/draft-packages/stories/ElmTextField.stories.tsx
+++ b/draft-packages/stories/ElmTextField.stories.tsx
@@ -2,6 +2,9 @@ import { loadElmStories } from "@cultureamp/elm-storybook"
 
 loadElmStories("TextField (Elm)", module, require("./TextFieldStories.elm"), [
   "Default",
+  "Default, Controlled, Prefilled Value",
+  "Default, Uncontrolled, Prefilled Value",
+  "Default /w icon",
   "Default /w icon",
   "Default /w string description",
   "Default /w html description",

--- a/draft-packages/stories/TextAreaField.stories.elm
+++ b/draft-packages/stories/TextAreaField.stories.elm
@@ -70,7 +70,7 @@ main =
                         )
                     ]
                     False
-        , storyOf "Default, Prefilled Value" config <|
+        , storyOf "Default, Controlled, Prefilled Value" config <|
             \m ->
                 storyContainer
                     [ TextAreaField.view
@@ -81,6 +81,22 @@ main =
                             |> TextAreaField.autoComplete False
                             |> TextAreaField.onBlurWithValue TextFieldMsg
                             |> TextAreaField.textAreaValue "A prefilled value in controlled mode"
+                            |> TextAreaField.onEnter TextFieldEnter
+                            |> TextAreaField.rows 4
+                        )
+                    ]
+                    False
+        , storyOf "Default, Uncontrolled, Prefilled Value" config <|
+            \m ->
+                storyContainer
+                    [ TextAreaField.view
+                        (TextAreaField.default
+                            |> TextAreaField.id "the-id"
+                            |> TextAreaField.labelText "Your reply"
+                            |> TextAreaField.controlled False
+                            |> TextAreaField.autoComplete False
+                            |> TextAreaField.onBlurWithValue TextFieldMsg
+                            |> TextAreaField.textAreaValue "A prefilled value in uncontrolled mode"
                             |> TextAreaField.onEnter TextFieldEnter
                             |> TextAreaField.rows 4
                         )

--- a/draft-packages/stories/TextFieldStories.elm
+++ b/draft-packages/stories/TextFieldStories.elm
@@ -67,6 +67,30 @@ main =
                         |> TextField.placeholder "Placeholder"
                         |> TextField.onEnter TextFieldEnter
                     )
+        , storyOf "Default, Controlled, Prefilled Value" config <|
+            \m ->
+                TextField.view
+                    (TextField.default
+                        |> TextField.id "the-id"
+                        |> TextField.labelText "Default TextField"
+                        |> TextField.controlled True
+                        |> TextField.autoComplete False
+                        |> TextField.onBlurWithValue TextFieldMsg
+                        |> TextField.inputValue "A prefilled value in controlled mode"
+                        |> TextField.onEnter TextFieldEnter
+                    )
+        , storyOf "Default, Uncontrolled, Prefilled Value" config <|
+            \m ->
+                TextField.view
+                    (TextField.default
+                        |> TextField.id "the-id"
+                        |> TextField.labelText "Default TextField"
+                        |> TextField.controlled False
+                        |> TextField.autoComplete False
+                        |> TextField.onBlurWithValue TextFieldMsg
+                        |> TextField.inputValue "A prefilled value in controlled mode"
+                        |> TextField.onEnter TextFieldEnter
+                    )
         , storyOf "Default /w icon" config <|
             \m ->
                 TextField.view


### PR DESCRIPTION
- it makes use of the defaultValue html property, to set
  a default value when the dom node is first created
- it's less risky than the controlled variant, which can have
  issues on old devices as the component isnt' updated quickly
  enough. Users can experience sluggish text entry or strange
  cursor behaviour.
- however, there is a big limitation: you cannot automatically change
  the value once the dom element has been created (for example, pressing
  button to fill the value). Most forms don't require this functionality.
- also do the same for `TextField`

Stories:

https://dev.cultureamp.design/mab/uncontrolled-elm-text-area-field/storybook/?path=/story/textfield-elm--default-controlled-prefilled-value
https://dev.cultureamp.design/mab/uncontrolled-elm-text-area-field/storybook/?path=/story/textfield-elm--default-uncontrolled-prefilled-value
https://dev.cultureamp.design/mab/uncontrolled-elm-text-area-field/storybook/?path=/story/textareafield-elm--default-controlled-prefilled-value
https://dev.cultureamp.design/mab/uncontrolled-elm-text-area-field/storybook/?path=/story/textareafield-elm--default-uncontrolled-prefilled-value