### PR TITLE
fix: navigation bar design review

### DIFF
--- a/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/_styles.scss
+++ b/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/_styles.scss
@@ -26,6 +26,7 @@ $navbar-breakpoint-condensed-large-up: 1150px;
 
 :export {
   caBreakpointMobileMax: #{$ca-breakpoint-tablet - 1};
+  navbarBreakpointExtendedMin: $navbar-breakpoint-extended-large-up;
 }
 
 @mixin navbar-mobile-only {

--- a/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/_styles.scss
+++ b/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/_styles.scss
@@ -176,7 +176,6 @@ $navbar-breakpoint-condensed-large-up: 1150px;
   .linkIcon + .linkText {
     padding: 0;
     @include ca-margin($start: 8px);
-
     @include navbar-mobile-only {
       @include ca-margin($start: 0);
     }
@@ -230,6 +229,7 @@ $navbar-breakpoint-condensed-large-up: 1150px;
       .linkText {
         @include font-heading-5;
         @include ca-inherit-baseline;
+        font-weight: $kz-typography-button-secondary-font-weight;
         display: none;
       }
     }

--- a/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/components/Link.module.scss
+++ b/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/components/Link.module.scss
@@ -11,10 +11,4 @@
 
 :global(.__react_component_tooltip) {
   @include font-extra-small;
-  @include navbar-extended-large-up {
-    display: none;
-  }
-  @include navbar-mobile-only {
-    display: none;
-  }
 }

--- a/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/components/Link.tsx
+++ b/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/components/Link.tsx
@@ -1,6 +1,7 @@
 import { Heading, Icon } from "@kaizen/component-library"
 import classNames from "classnames"
 import * as React from "react"
+import Media from "react-media"
 import ReactTooltip from "react-tooltip"
 import uuid from "uuid/v4"
 import { NavBarContext } from "../context"
@@ -51,19 +52,27 @@ export default class Link extends React.PureComponent<LinkProps> {
     return (
       <>
         {icon && small && (
-          <ReactTooltip
-            className={hasExtendedNavigation}
-            id={toolId}
-            place={"left"}
-            effect={"solid"}
+          <Media
+            query={`(max-width: ${styles.caBreakpointMobileMax}), (min-width: ${styles.navbarBreakpointExtendedMin})`}
           >
-            <span className={styles.tooltip}>
-              <Heading color="white" variant="heading-6">
-                {text}
-              </Heading>
-              {tooltip && tooltip}
-            </span>
-          </ReactTooltip>
+            {matches =>
+              matches ? null : (
+                <ReactTooltip
+                  className={hasExtendedNavigation}
+                  id={toolId}
+                  place={"left"}
+                  effect={"solid"}
+                >
+                  <span className={styles.tooltip}>
+                    <Heading color="white" variant="heading-6">
+                      {text}
+                    </Heading>
+                    {tooltip && tooltip}
+                  </span>
+                </ReactTooltip>
+              )
+            }
+          </Media>
         )}
 
         <a


### PR DESCRIPTION
<img width="247" alt="Screen Shot 2020-09-22 at 3 02 25 pm" src="https://user-images.githubusercontent.com/13988803/93840495-b6edc400-fce4-11ea-9331-64c5bc1846a0.png">

Final Items now render with font weight as per design.

![image (6)](https://user-images.githubusercontent.com/13988803/93840542-df75be00-fce4-11ea-95c4-8f0b94116962.png)

Tooltips no longer appear on hover in murmur on desktop.