### PR TITLE
feat: add positive, negative and neutral delta icons

### DIFF
--- a/packages/component-library/icons/delta-negative.svg
+++ b/packages/component-library/icons/delta-negative.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="none" viewBox="0 0 20 20"><path fill="#000" fill-rule="evenodd" d="M6.775 16H16V6.775h-2.05V12.5L5.45 4 4 5.45l8.5 8.5H6.775V16z" clip-rule="evenodd"/></svg>

--- a/packages/component-library/icons/delta-none.svg
+++ b/packages/component-library/icons/delta-none.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="none" viewBox="0 0 20 20"><path fill="#35374A" d="M4 9h12v2H4V9z"/></svg>

--- a/packages/component-library/icons/delta-positive.svg
+++ b/packages/component-library/icons/delta-positive.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="none" viewBox="0 0 20 20"><path fill="#000" fill-rule="evenodd" d="M6.775 4H16v9.225h-2.05V7.5L5.45 16 4 14.55l8.5-8.5H6.775V4z" clip-rule="evenodd"/></svg>


### PR DESCRIPTION
add new icons 20x20

They are used on the tooltip of a program trend
<img width="489" alt="Program_Trend" src="https://user-images.githubusercontent.com/995875/94221981-91a0c600-ff2f-11ea-93b2-5f3ddcc8468f.png">

<img width="139" alt="Program_Trend" src="https://user-images.githubusercontent.com/995875/94222012-a1b8a580-ff2f-11ea-8274-42b64a8a00b9.png">



