### PR TITLE
ci: Create a dist config, added types to files in config

### DIFF
--- a/draft-packages/avatar/tsconfig.dist.json
+++ b/draft-packages/avatar/tsconfig.dist.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../../tsconfig.dist.json",
   "compilerOptions": {
     "allowJs": false,
     "declaration": true,

--- a/draft-packages/badge/tsconfig.dist.json
+++ b/draft-packages/badge/tsconfig.dist.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../../tsconfig.dist.json",
   "compilerOptions": {
     "allowJs": false,
     "declaration": true,

--- a/draft-packages/button/tsconfig.dist.json
+++ b/draft-packages/button/tsconfig.dist.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../../tsconfig.dist.json",
   "compilerOptions": {
     "allowJs": false,
     "declaration": true,

--- a/draft-packages/card/tsconfig.dist.json
+++ b/draft-packages/card/tsconfig.dist.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../../tsconfig.dist.json",
   "compilerOptions": {
     "allowJs": false,
     "declaration": true,

--- a/draft-packages/checkbox-group/tsconfig.dist.json
+++ b/draft-packages/checkbox-group/tsconfig.dist.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../../tsconfig.dist.json",
   "compilerOptions": {
     "allowJs": false,
     "declaration": true,

--- a/draft-packages/collapsible/tsconfig.dist.json
+++ b/draft-packages/collapsible/tsconfig.dist.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../../tsconfig.dist.json",
   "compilerOptions": {
     "allowJs": false,
     "declaration": true,

--- a/draft-packages/divider/tsconfig.dist.json
+++ b/draft-packages/divider/tsconfig.dist.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../../tsconfig.dist.json",
   "compilerOptions": {
     "allowJs": false,
     "declaration": true,

--- a/draft-packages/dropdown-menu/tsconfig.dist.json
+++ b/draft-packages/dropdown-menu/tsconfig.dist.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../../tsconfig.dist.json",
   "compilerOptions": {
     "allowJs": false,
     "declaration": true,

--- a/draft-packages/dropdown/tsconfig.dist.json
+++ b/draft-packages/dropdown/tsconfig.dist.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../../tsconfig.dist.json",
   "compilerOptions": {
     "allowJs": false,
     "declaration": true,

--- a/draft-packages/empty-state/tsconfig.dist.json
+++ b/draft-packages/empty-state/tsconfig.dist.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../../tsconfig.dist.json",
   "compilerOptions": {
     "allowJs": false,
     "declaration": true,

--- a/draft-packages/events/tsconfig.dist.json
+++ b/draft-packages/events/tsconfig.dist.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../../tsconfig.dist.json",
   "compilerOptions": {
     "allowJs": false,
     "declaration": true,

--- a/draft-packages/form/tsconfig.dist.json
+++ b/draft-packages/form/tsconfig.dist.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../../tsconfig.dist.json",
   "compilerOptions": {
     "allowJs": false,
     "declaration": true,

--- a/draft-packages/guidance-block/tsconfig.dist.json
+++ b/draft-packages/guidance-block/tsconfig.dist.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../../tsconfig.dist.json",
   "compilerOptions": {
     "allowJs": false,
     "declaration": true,

--- a/draft-packages/hero-card/tsconfig.dist.json
+++ b/draft-packages/hero-card/tsconfig.dist.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../../tsconfig.dist.json",
   "compilerOptions": {
     "allowJs": false,
     "declaration": true,

--- a/draft-packages/hero-panel/tsconfig.dist.json
+++ b/draft-packages/hero-panel/tsconfig.dist.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../../tsconfig.dist.json",
   "compilerOptions": {
     "allowJs": false,
     "declaration": true,

--- a/draft-packages/hierarchical-menu/tsconfig.dist.json
+++ b/draft-packages/hierarchical-menu/tsconfig.dist.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../../tsconfig.dist.json",
   "compilerOptions": {
     "allowJs": false,
     "declaration": true,

--- a/draft-packages/hierarchical-select/tsconfig.dist.json
+++ b/draft-packages/hierarchical-select/tsconfig.dist.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../../tsconfig.dist.json",
   "compilerOptions": {
     "allowJs": false,
     "declaration": true,

--- a/draft-packages/illustration/tsconfig.dist.json
+++ b/draft-packages/illustration/tsconfig.dist.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../../tsconfig.dist.json",
   "compilerOptions": {
     "allowJs": false,
     "declaration": true,

--- a/draft-packages/likert-scale-legacy/tsconfig.dist.json
+++ b/draft-packages/likert-scale-legacy/tsconfig.dist.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../../tsconfig.dist.json",
   "compilerOptions": {
     "allowJs": false,
     "declaration": true,

--- a/draft-packages/loading-placeholder/tsconfig.dist.json
+++ b/draft-packages/loading-placeholder/tsconfig.dist.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../../tsconfig.dist.json",
   "compilerOptions": {
     "allowJs": false,
     "declaration": true,

--- a/draft-packages/loading-spinner/tsconfig.dist.json
+++ b/draft-packages/loading-spinner/tsconfig.dist.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../../tsconfig.dist.json",
   "compilerOptions": {
     "allowJs": false,
     "declaration": true,

--- a/draft-packages/menu/tsconfig.dist.json
+++ b/draft-packages/menu/tsconfig.dist.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../../tsconfig.dist.json",
   "compilerOptions": {
     "allowJs": false,
     "declaration": true,

--- a/draft-packages/modal/tsconfig.dist.json
+++ b/draft-packages/modal/tsconfig.dist.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../../tsconfig.dist.json",
   "compilerOptions": {
     "allowJs": false,
     "declaration": true,

--- a/draft-packages/popover/tsconfig.dist.json
+++ b/draft-packages/popover/tsconfig.dist.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../../tsconfig.dist.json",
   "compilerOptions": {
     "allowJs": false,
     "declaration": true,

--- a/draft-packages/radio-group/tsconfig.dist.json
+++ b/draft-packages/radio-group/tsconfig.dist.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../../tsconfig.dist.json",
   "compilerOptions": {
     "allowJs": false,
     "declaration": true,

--- a/draft-packages/radio/tsconfig.dist.json
+++ b/draft-packages/radio/tsconfig.dist.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../../tsconfig.dist.json",
   "compilerOptions": {
     "allowJs": false,
     "declaration": true,

--- a/draft-packages/select/tsconfig.dist.json
+++ b/draft-packages/select/tsconfig.dist.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../../tsconfig.dist.json",
   "compilerOptions": {
     "allowJs": false,
     "declaration": true,

--- a/draft-packages/split-button/tsconfig.dist.json
+++ b/draft-packages/split-button/tsconfig.dist.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../../tsconfig.dist.json",
   "compilerOptions": {
     "allowJs": false,
     "declaration": true,

--- a/draft-packages/table/tsconfig.dist.json
+++ b/draft-packages/table/tsconfig.dist.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../../tsconfig.dist.json",
   "compilerOptions": {
     "allowJs": false,
     "declaration": true,

--- a/draft-packages/tabs/tsconfig.dist.json
+++ b/draft-packages/tabs/tsconfig.dist.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../../tsconfig.dist.json",
   "compilerOptions": {
     "allowJs": false,
     "declaration": true,

--- a/draft-packages/tag/tsconfig.dist.json
+++ b/draft-packages/tag/tsconfig.dist.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../../tsconfig.dist.json",
   "compilerOptions": {
     "allowJs": false,
     "declaration": true,

--- a/draft-packages/tile/tsconfig.dist.json
+++ b/draft-packages/tile/tsconfig.dist.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../../tsconfig.dist.json",
   "compilerOptions": {
     "allowJs": false,
     "declaration": true,

--- a/draft-packages/title-block-zen/tsconfig.dist.json
+++ b/draft-packages/title-block-zen/tsconfig.dist.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../../tsconfig.dist.json",
   "compilerOptions": {
     "allowJs": false,
     "declaration": true,

--- a/draft-packages/tooltip/tsconfig.dist.json
+++ b/draft-packages/tooltip/tsconfig.dist.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../../tsconfig.dist.json",
   "compilerOptions": {
     "allowJs": false,
     "declaration": true,

--- a/draft-packages/user-interactions/tsconfig.dist.json
+++ b/draft-packages/user-interactions/tsconfig.dist.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../../tsconfig.dist.json",
   "compilerOptions": {
     "allowJs": false,
     "declaration": true,

--- a/draft-packages/vertical-progress-step/tsconfig.dist.json
+++ b/draft-packages/vertical-progress-step/tsconfig.dist.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../../tsconfig.dist.json",
   "compilerOptions": {
     "allowJs": false,
     "declaration": true,

--- a/draft-packages/well/tsconfig.dist.json
+++ b/draft-packages/well/tsconfig.dist.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../../tsconfig.dist.json",
   "compilerOptions": {
     "allowJs": false,
     "declaration": true,

--- a/draft-packages/zen-navigation-bar/tsconfig.dist.json
+++ b/draft-packages/zen-navigation-bar/tsconfig.dist.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../../tsconfig.dist.json",
   "compilerOptions": {
     "allowJs": false,
     "declaration": true,

--- a/draft-packages/zen-off-canvas/tsconfig.dist.json
+++ b/draft-packages/zen-off-canvas/tsconfig.dist.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../../tsconfig.dist.json",
   "compilerOptions": {
     "allowJs": false,
     "declaration": true,

--- a/legacy-packages/menu-list/tsconfig.dist.json
+++ b/legacy-packages/menu-list/tsconfig.dist.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../../tsconfig.dist.json",
   "compilerOptions": {
     "allowJs": false,
     "declaration": true,

--- a/legacy-packages/title-block/tsconfig.dist.json
+++ b/legacy-packages/title-block/tsconfig.dist.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../../tsconfig.dist.json",
   "compilerOptions": {
     "allowJs": false,
     "declaration": true,

--- a/packages/component-library/components/Notification/components/GenericNotification.tsx
+++ b/packages/component-library/components/Notification/components/GenericNotification.tsx
@@ -37,6 +37,7 @@ type State = {
 class GenericNotification extends React.Component<Props, State> {
   static defaultProps = {
     persistent: false,
+
     autohide: false,
     autohideDelay: "short",
   }

--- a/packages/component-library/tsconfig.dist.json
+++ b/packages/component-library/tsconfig.dist.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../../tsconfig.dist.json",
   "include": ["components/**/*", "draft/**/*", "util/**/*", "index.ts"],
   "compilerOptions": {
     "allowJs": false,

--- a/packages/generator/generators/draft/templates/tsconfig.txt
+++ b/packages/generator/generators/draft/templates/tsconfig.txt
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../../tsconfig.dist.json",
   "compilerOptions": {
     "allowJs": false,
     "declaration": true,

--- a/packages/hosted-assets/tsconfig.dist.json
+++ b/packages/hosted-assets/tsconfig.dist.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../../tsconfig.dist.json",
   "include": ["./index.ts"],
   "compilerOptions": {
     "outDir": "dist",

--- a/tsconfig.dist.json
+++ b/tsconfig.dist.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": [
+    "./draft-packages/stories/*",
+    "./packages/component-library/stories/*",
+    "**/node_modules"
+  ]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,7 @@
     "allowJs": false,
     "noEmit": true
   },
-  "include": ["./types.d.ts", "./packages/**/*", "./draft-packages/**/*"],
+  "files": ["./types.d.ts"],
+  "include": ["./packages/**/*", "./draft-packages/**/*"],
   "exclude": ["**/node_modules"]
 }


### PR DESCRIPTION
## About 
When updating the types for SVGs and styles last week, the `prepublish` script wasn't checked. An assumption was made that the options set for `include/exclude` would be merged when it's extended, but it was overridden. This means the types that are needed to compile individual packages (the types for icons and styles) were missing. 

What this means:
```
// The "root" tsconfig that all other configs extend from 
{
  "compilerOptions": {
    /* stuff */
  },
  "include": ["./packages/**/*", "./draft-packages/**/*", "./types.d.ts" ],
  "exclude": ["**/node_modules"]
}
```

```
// an example from kaizen/component-library
 /* stuff */
"compilerOptions": {
    /* stuff */
 },
"include": [
  "components/**/*",
  "draft/**/*",
  "util/**/*",
  "index.ts",
  // NO types.d.ts file here. This property overrides what we set in the root config, not merged
 ],
}
```

Related to #781 and #782 