### PR TITLE
fix: Revert z-index update to dropdown menu

### DIFF
--- a/packages/component-library/styles/layers.scss
+++ b/packages/component-library/styles/layers.scss
@@ -1,8 +1,8 @@
 $ca-z-index-body: 0;
+$ca-z-index-dropdown: 1000;
 $ca-z-index-sticky: 1020;
 $ca-z-index-fixed: 1030;
 $ca-z-index-modal-backdrop: 1040;
 $ca-z-index-modal: 1050;
-$ca-z-index-dropdown: 1055;
 $ca-z-index-popover: 1060;
 $ca-z-index-tooltip: 1070;


### PR DESCRIPTION
Follows from [this PR](https://github.com/cultureamp/kaizen-design-system/pull/785).

It turns out that we're using the dropdown z-index for other items, which was causing layout bugs on perform. I don't have the time to look into this, so doing a quick revert for now.