### PR TITLE
fix: Ensure delta-flat icon has path fill set to black

### DIFF
--- a/packages/component-library/icons/delta-flat.icon.svg
+++ b/packages/component-library/icons/delta-flat.icon.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="none" viewBox="0 0 20 20"><path fill="#35374A" d="M4 9h12v2H4V9z"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="none" viewBox="0 0 20 20"><path fill="#000" d="M4 9h12v2H4V9z"/></svg>


### PR DESCRIPTION
The svgo-loader expects this value to ensure automatically convert the fill to `currentColor`