### PR TITLE
ci: Update CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,8 +2,8 @@
 # https://help.github.com/articles/about-code-owners/
 
 # Require Design Systems Team approval for any new packages or this file
-/CODEOWNERS @cultureamp/design-systems
-/packages/ @cultureamp/design-systems
+/CODEOWNERS @cultureamp/frontend-avocadoes
+/packages/ @cultureamp/frontend-avocadoes
 /draft-packages/ @ghost
 
 # Exclude modifications to existing packages by assigning it to no one

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,8 +2,8 @@
 # https://help.github.com/articles/about-code-owners/
 
 # Require Design Systems Team approval for any new packages or this file
-/CODEOWNERS @cultureamp/frontend-avocadoes
-/packages/ @cultureamp/frontend-avocadoes
+/CODEOWNERS @cultureamp/frontend-avocados
+/packages/ @cultureamp/frontend-avocados
 /draft-packages/ @ghost
 
 # Exclude modifications to existing packages by assigning it to no one


### PR DESCRIPTION
# Objective
Update the CODEOWNERS for core Kaizen to the FE Advocates 

# Motivation and Context 
Previously DST Engineers were the codeowners for core Kaizen - I'd like to extend this to the entire advocacy program to reduce bus factor and reduce us becoming a bottleneck. 