### PR TITLE
feat: Allow TitleBlockZen to collapse when no navigation

### DIFF
--- a/draft-packages/stories/TitleBlockZen.stories.scss
+++ b/draft-packages/stories/TitleBlockZen.stories.scss
@@ -1,4 +1,6 @@
 @import "~@kaizen/component-library/styles/layout";
+@import "~@kaizen/design-tokens/sass/color";
+@import "~@kaizen/design-tokens/sass/spacing";
 @import "../title-block-zen/KaizenDraft/TitleBlockZen/TitleBlockBreakpoints.scss";
 
 body {
@@ -14,5 +16,46 @@ body {
 
   @include title-block-medium-and-small {
     margin: 0;
+  }
+}
+
+$content-margin-width-on-medium-and-small: 12px;
+
+.fakeSkirtContainer {
+  display: flex;
+  width: 100%;
+  justify-content: center;
+}
+
+.fakeSkirtContainerWithBackground {
+  composes: fakeSkirtContainer;
+  background-color: $kz-color-wisteria-700;
+}
+
+.fakeSkirtContent {
+  min-height: 4rem;
+  max-width: $kz-layout-content-max-width;
+  margin: 0 $kz-layout-content-side-margin;
+  width: 100%;
+
+  @media (max-width: $kz-layout-breakpoints-large - 1px) {
+    margin: 0 $content-margin-width-on-medium-and-small;
+  }
+}
+
+.fakeSkirtCard {
+  composes: wrapper from "~@kaizen/draft-card/KaizenDraft/Card/styles.module.scss";
+  margin-bottom: $kz-spacing-md * -1;
+  padding: $kz-spacing-md;
+  @media (max-width: $kz-layout-breakpoints-large) {
+    margin-left: $content-margin-width-on-medium-and-small * -1;
+    margin-right: $content-margin-width-on-medium-and-small * -1;
+    border-bottom-left-radius: 0;
+    border-bottom-right-radius: 0;
+  }
+  @media (max-width: $kz-layout-breakpoints-medium) {
+    border-radius: 0;
+    margin-left: $content-margin-width-on-medium-and-small * -1;
+    margin-right: $content-margin-width-on-medium-and-small * -1;
   }
 }

--- a/draft-packages/stories/TitleBlockZen.stories.tsx
+++ b/draft-packages/stories/TitleBlockZen.stories.tsx
@@ -836,10 +836,10 @@ export const DefaultCollapsedNavigation = () => (
       }}
       collapseNavigationAreaWhenPossible
     />
-    <div style={{ backgroundColor: "#4b4d68", height: "4rem" }}>
-      <div style={{ maxWidth: "1392px", margin: "0 auto" }}>
+    <div className={styles.fakeSkirtContainerWithBackground}>
+      <div className={styles.fakeSkirtContent}>
         <Paragraph variant="body" color="white-reduced-opacity">
-          I am some text that should feel nicely butted up on wide screens
+          I am some text that should feel nicely butted up
         </Paragraph>
       </div>
     </div>
@@ -847,6 +847,39 @@ export const DefaultCollapsedNavigation = () => (
 )
 
 DefaultCollapsedNavigation.storyName = "Default (collapsed navigation)"
+
+export const DefaultCollapsedNavigationCard = () => (
+  <>
+    <TitleBlockZen
+      title="Page title"
+      subtitle="Subtitle goes here"
+      handleHamburgerClick={() => {
+        alert("Hamburger clicked")
+      }}
+      breadcrumb={{
+        path: "#",
+        text: "Back to home",
+        handleClick: event => {
+          alert("breadcrumb clicked!")
+        },
+      }}
+      collapseNavigationAreaWhenPossible
+    />
+    <div className={styles.fakeSkirtContainerWithBackground}>
+      <div className={styles.fakeSkirtContent}>
+        <div className={styles.fakeSkirtCard}>
+          <Paragraph variant="body">
+            I am a card that should feel nicely butted up
+          </Paragraph>
+        </div>
+      </div>
+    </div>
+  </>
+)
+
+DefaultCollapsedNavigationCard.story = {
+  name: "Default (collapsed navigation with card)",
+}
 
 export const AdminVariantNavigation = () => (
   <>
@@ -866,10 +899,12 @@ export const AdminVariantNavigation = () => (
       }}
       collapseNavigationAreaWhenPossible
     />
-    <div style={{ backgroundColor: "#f6f6f6", height: "4rem" }}>
-      <div style={{ maxWidth: "1392px", margin: "0 auto" }}>
+    <div className={styles.fakeSkirtContainer}>
+      <div className={styles.fakeSkirtContent}>
         <Paragraph variant="body">
-          I am some text that should feel nicely butted up on wide screens
+          I am some text that should feel tightly butted up to the nav space.
+          The responsibility for the admin variant is to move things down
+          yourself if you need to.
         </Paragraph>
       </div>
     </div>

--- a/draft-packages/stories/TitleBlockZen.stories.tsx
+++ b/draft-packages/stories/TitleBlockZen.stories.tsx
@@ -818,3 +818,62 @@ export const DefaultOnlyLongTitle = () => (
 )
 
 DefaultOnlyLongTitle.storyName = "Default (only long title)"
+
+export const DefaultCollapsedNavigation = () => (
+  <>
+    <TitleBlockZen
+      title="Page title"
+      subtitle="Subtitle goes here"
+      handleHamburgerClick={() => {
+        alert("Hamburger clicked")
+      }}
+      breadcrumb={{
+        path: "#",
+        text: "Back to home",
+        handleClick: event => {
+          alert("breadcrumb clicked!")
+        },
+      }}
+      collapseNavigationAreaWhenPossible
+    />
+    <div style={{ backgroundColor: "#4b4d68", height: "4rem" }}>
+      <div style={{ maxWidth: "1392px", margin: "0 auto" }}>
+        <Paragraph variant="body" color="white-reduced-opacity">
+          I am some text that should feel nicely butted up on wide screens
+        </Paragraph>
+      </div>
+    </div>
+  </>
+)
+
+DefaultCollapsedNavigation.storyName = "Default (collapsed navigation)"
+
+export const AdminVariantNavigation = () => (
+  <>
+    <TitleBlockZen
+      variant="admin"
+      title="Page title"
+      subtitle="Subtitle goes here"
+      handleHamburgerClick={() => {
+        alert("Hamburger clicked")
+      }}
+      breadcrumb={{
+        path: "#",
+        text: "Back to home",
+        handleClick: event => {
+          alert("breadcrumb clicked!")
+        },
+      }}
+      collapseNavigationAreaWhenPossible
+    />
+    <div style={{ backgroundColor: "#f6f6f6", height: "4rem" }}>
+      <div style={{ maxWidth: "1392px", margin: "0 auto" }}>
+        <Paragraph variant="body">
+          I am some text that should feel nicely butted up on wide screens
+        </Paragraph>
+      </div>
+    </div>
+  </>
+)
+
+AdminVariantNavigation.storyName = "Admin (collapsed navigation)"

--- a/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/TitleBlockZen.scss
+++ b/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/TitleBlockZen.scss
@@ -14,7 +14,7 @@ $title-block-separator-height: 3px;
 $tab-container-height-default: $ca-grid * 3;
 $tab-container-height-small: $ca-grid * 2.5;
 $tab-container-height-default-collapsed: $ca-grid + 0.1875rem;
-$tab-container-height-small-collapsed: $ca-grid + 0.1875rem;
+$tab-container-height-medium-and-small-collapsed: $ca-grid * 0.75;
 
 .titleBlock {
   position: relative;
@@ -426,23 +426,22 @@ $tab-container-height-small-collapsed: $ca-grid + 0.1875rem;
 
 .navigationTabsContainerCollapsed {
   height: $tab-container-height-default-collapsed;
+  @include title-block-medium-and-small {
+    height: $tab-container-height-medium-and-small-collapsed;
+  }
 }
 
 .navigationTabScrollerContainer {
-  @include title-block-small {
-    display: none;
-    overflow-x: scroll;
-    scrollbar-width: none;
-    width: 100vw;
-
-    &::-webkit-scrollbar {
-      display: none;
-    }
-  }
-
   .hasNavigationTabs & {
     @include title-block-small {
       display: block;
+      overflow-x: scroll;
+      scrollbar-width: none;
+      width: 100vw;
+
+      &::-webkit-scrollbar {
+        display: none;
+      }
     }
   }
 }

--- a/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/TitleBlockZen.scss
+++ b/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/TitleBlockZen.scss
@@ -13,6 +13,8 @@ $breadcrumb-breakpoint-width: $kz-layout-content-max-width +
 $title-block-separator-height: 3px;
 $tab-container-height-default: $ca-grid * 3;
 $tab-container-height-small: $ca-grid * 2.5;
+$tab-container-height-default-collapsed: $ca-grid + 0.1875rem;
+$tab-container-height-small-collapsed: $ca-grid + 0.1875rem;
 
 .titleBlock {
   position: relative;
@@ -420,6 +422,10 @@ $tab-container-height-small: $ca-grid * 2.5;
   @include title-block-small {
     height: $tab-container-height-small;
   }
+}
+
+.navigationTabsContainerCollapsed {
+  height: $tab-container-height-default-collapsed;
 }
 
 .navigationTabScrollerContainer {

--- a/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/TitleBlockZen.spec.tsx
+++ b/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/TitleBlockZen.spec.tsx
@@ -482,8 +482,6 @@ describe("<TitleBlockZen />", () => {
   })
 
   describe("when a secondary action is passed with only an href", () => {
-    const testOnClickFn = jest.fn()
-
     const secondaryActionWithLinkAndOnClick = {
       label: "secondaryActionLabel",
       href: "secondaryActionHref",

--- a/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/TitleBlockZen.tsx
+++ b/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/TitleBlockZen.tsx
@@ -283,9 +283,13 @@ const renderNavigationTabs = (
         [styles.navigationTabsContainerCollapsed]: collapse,
       })}
     >
-      <span className={styles.navigationTabEdgeShadowLeft} />
-      {navigationTabs}
-      <span className={styles.navigationTabEdgeShadowRight} />
+      {!collapse && (
+        <>
+          <span className={styles.navigationTabEdgeShadowLeft} />
+          {navigationTabs}
+          <span className={styles.navigationTabEdgeShadowRight} />
+        </>
+      )}
     </div>
   </div>
 )

--- a/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/TitleBlockZen.tsx
+++ b/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/TitleBlockZen.tsx
@@ -43,6 +43,7 @@ export interface TitleBlockProps {
   secondaryActions?: SecondaryActionsProps
   secondaryOverflowMenuItems?: TitleBlockMenuItemProps[]
   navigationTabs?: NavigationTabs
+  collapseNavigationAreaWhenPossible?: boolean
   textDirection?: TextDirection
   surveyStatus?: SurveyStatus
   titleAutomationId?: string
@@ -272,9 +273,16 @@ const renderBreadcrumb = (
 
 // We want to accept undefined here because the NavigationTabs container is
 // important for the flex-based layout (it pushes Secondary Actions over to the right)
-const renderNavigationTabs = (navigationTabs: NavigationTabs | undefined) => (
+const renderNavigationTabs = (
+  navigationTabs: NavigationTabs | undefined,
+  collapse: boolean
+) => (
   <div className={styles.navigationTabScrollerContainer}>
-    <div className={styles.navigationTabsContainer}>
+    <div
+      className={classNames(styles.navigationTabsContainer, {
+        [styles.navigationTabsContainerCollapsed]: collapse,
+      })}
+    >
       <span className={styles.navigationTabEdgeShadowLeft} />
       {navigationTabs}
       <span className={styles.navigationTabEdgeShadowRight} />
@@ -416,6 +424,7 @@ const TitleBlockZen = ({
   secondaryActions,
   secondaryOverflowMenuItems,
   navigationTabs,
+  collapseNavigationAreaWhenPossible = false,
   textDirection,
   surveyStatus,
   titleAutomationId = "TitleBlock__Title",
@@ -429,6 +438,11 @@ const TitleBlockZen = ({
   const [isSmallOrMediumViewport, setSmallOrMediumViewport] = React.useState(
     false
   )
+  const hasNavigationTabs = navigationTabs && navigationTabs.length > 0
+  const collapseNavigationArea =
+    collapseNavigationAreaWhenPossible &&
+    !hasNavigationTabs &&
+    secondaryActions === undefined
 
   const updateOnViewportChange = mediaQuery => {
     if (mediaQuery.matches && !isSmallOrMediumViewport) {
@@ -457,8 +471,7 @@ const TitleBlockZen = ({
           [styles.adminVariant]: variant === "admin",
           [styles.hasLongTitle]: title && title.length >= 30,
           [styles.hasLongSubtitle]: subtitle && subtitle.length >= 18,
-          [styles.hasNavigationTabs]:
-            navigationTabs && navigationTabs.length > 0,
+          [styles.hasNavigationTabs]: hasNavigationTabs,
         })}
       >
         <div className={styles.titleRow}>
@@ -557,7 +570,7 @@ const TitleBlockZen = ({
                   sectionTitleAutomationId,
                   sectionTitleDescriptionAutomationId
                 )}
-              {renderNavigationTabs(navigationTabs)}
+              {renderNavigationTabs(navigationTabs, collapseNavigationArea)}
               {(secondaryActions || secondaryOverflowMenuItems) && (
                 <SecondaryActions
                   secondaryActions={secondaryActions}


### PR DESCRIPTION
The current implementation of `TitleBlockZen` intentionally includes a large space where the navigation tabs would appear, even when there are no tabs that would fill that space. This makes it rather awkward to implement designs that butt up more tightly to fill that area with content.

To counter that, this PR adds a `collapseNavigationAreaWhenPossible` prop to the component that decreases that space to a more "natural" feeling padding.

Example stories:

* [Admin variant](https://dev.cultureamp.design/allow-title-block-to-collapse-when-no-navigation/storybook/?path=/story/titleblockzen-react--admin-variant-navigation)
* [Default with collapsed nav](https://dev.cultureamp.design/allow-title-block-to-collapse-when-no-navigation/storybook/?path=/story/titleblockzen-react--default-collapsed-navigation)
* [Default with collapsed nav and card](https://dev.cultureamp.design/allow-title-block-to-collapse-when-no-navigation/storybook/?path=/story/titleblockzen-react--default-collapsed-navigation-card)