### PR TITLE
fix: Use correct props for button

### DIFF
--- a/draft-packages/guidance-block/KaizenDraft/GuidanceBlock/GuidanceBlock.tsx
+++ b/draft-packages/guidance-block/KaizenDraft/GuidanceBlock/GuidanceBlock.tsx
@@ -1,10 +1,5 @@
-import {
-  Button,
-  ButtonProps,
-  Heading,
-  Icon,
-  Paragraph,
-} from "@kaizen/component-library"
+import { Button, ButtonProps } from "@kaizen/draft-button"
+import { Heading, Icon, Paragraph } from "@kaizen/component-library"
 import configureIcon from "@kaizen/component-library/icons/arrow-forward.icon.svg"
 import closeIcon from "@kaizen/component-library/icons/close.icon.svg"
 import classnames from "classnames"


### PR DESCRIPTION
Reverts erroneous import introduced in [this PR](https://github.com/cultureamp/kaizen-design-system/pull/781/files#), where the button/buttonProps were changed from draft to core. 