### PR TITLE
fix: Revert "feat: Uplift the table to the new Zen designs"

### DIFF
--- a/draft-packages/stories/Table.stories.tsx
+++ b/draft-packages/stories/Table.stories.tsx
@@ -13,6 +13,7 @@ import {
 } from "../table"
 import styles from "./Table.stories.scss"
 
+import commentIcon from "@kaizen/component-library/icons/comment.icon.svg"
 import chevronDownIcon from "@kaizen/component-library/icons/chevron-down.icon.svg"
 import chevronUpIcon from "@kaizen/component-library/icons/chevron-up.icon.svg"
 
@@ -47,6 +48,7 @@ const ExampleTableHeaderRow = ({ checkable = false }) => (
     />
     <TableHeaderRowCell
       labelText="Comments"
+      icon={commentIcon}
       width={2 / 12}
       onClick={() => alert("Sort!")}
     />
@@ -133,6 +135,29 @@ DefaultKaizenSiteDemo.story = {
   name: "Default (Kaizen Site Demo)",
 }
 
+export const HeaderWithWhiteBackground = () => (
+  <Container>
+    <TableContainer>
+      <TableHeader backgroundColor="white">
+        <ExampleTableHeaderRow checkable />
+      </TableHeader>
+      <TableCard>
+        <ExampleTableRow expandable={false} />
+      </TableCard>
+      <TableCard>
+        <ExampleTableRow expandable={false} />
+      </TableCard>
+      <TableCard>
+        <ExampleTableRow expandable={false} />
+      </TableCard>
+    </TableContainer>
+  </Container>
+)
+
+HeaderWithWhiteBackground.story = {
+  name: "Header with white background",
+}
+
 export const Multiline = () => (
   <Container>
     <TableContainer>
@@ -202,6 +227,48 @@ export const Clickable = () => (
   </Container>
 )
 
+export const ExpandedDeprecated = () => {
+  const [expandedId, setExpandedId] = React.useState<string | null>("second")
+  const toggleExpanded = id => {
+    if (expandedId === id) {
+      setExpandedId(null)
+      return
+    }
+    setExpandedId(id)
+  }
+  return (
+    <Container>
+      <TableContainer>
+        <TableHeader>
+          <ExampleTableHeaderRow checkable />
+        </TableHeader>
+        {["first", "second", "third"].map(id => {
+          const expanded = expandedId === id
+          return (
+            <TableCard expanded={expanded} onClick={() => toggleExpanded(id)}>
+              <ExampleTableRow expanded={expanded} />
+              {expanded && (
+                <TableContainer>
+                  <TableCard>
+                    <ExampleTableRow expandable={false} />
+                  </TableCard>
+                  <TableCard>
+                    <ExampleTableRow expandable={false} />
+                  </TableCard>
+                </TableContainer>
+              )}
+            </TableCard>
+          )
+        })}
+      </TableContainer>
+    </Container>
+  )
+}
+
+ExpandedDeprecated.story = {
+  name: "Expanded (deprecated)",
+}
+
 export const ExpandedPopout = () => {
   const [expandedId, setExpandedId] = React.useState<string | null>("second")
   const toggleExpanded = id => {
@@ -258,6 +325,63 @@ ExpandedPopout.story = {
   name: "Expanded popout",
 }
 
+export const ExpandedWithCustomContentDeprecated = () => {
+  const [expandedId, setExpandedId] = React.useState<string | null>("second")
+  const toggleExpanded = id => {
+    if (expandedId === id) {
+      setExpandedId(null)
+      return
+    }
+    setExpandedId(id)
+  }
+  return (
+    <Container>
+      <TableContainer>
+        <TableHeader>
+          <ExampleTableHeaderRow checkable />
+        </TableHeader>
+        {["first", "second", "third"].map(id => {
+          const expanded = expandedId === id
+          return (
+            <>
+              <TableCard onClick={() => toggleExpanded(id)}>
+                <ExampleTableRow />
+              </TableCard>
+              {expanded && (
+                <TableCard expanded={expanded}>
+                  <div className={styles.customExpandedHeader}>
+                    <Paragraph tag="div" variant="body">
+                      Overall progress
+                    </Paragraph>
+                  </div>
+                  <TableContainer>
+                    <TableCard onClick={() => toggleExpanded(id)}>
+                      <ExampleTableRow expanded={expanded} />
+                    </TableCard>
+                  </TableContainer>
+                  <TableContainer>
+                    <ExampleTableHeaderRow />
+                    <TableCard>
+                      <ExampleTableRow expandable={false} />
+                    </TableCard>
+                    <TableCard>
+                      <ExampleTableRow expandable={false} />
+                    </TableCard>
+                  </TableContainer>
+                </TableCard>
+              )}
+            </>
+          )
+        })}
+      </TableContainer>
+    </Container>
+  )
+}
+
+ExpandedWithCustomContentDeprecated.story = {
+  name: "Expanded with custom content (deprecated)",
+}
+
 export const NoHeader = () => (
   <Container>
     <TableContainer>
@@ -276,24 +400,4 @@ export const NoHeader = () => (
 
 NoHeader.story = {
   name: "No header",
-}
-
-export const ExtraSpacing = () => (
-  <Container>
-    <TableContainer variant="default">
-      <TableCard>
-        <ExampleTableRow expandable={false} />
-      </TableCard>
-      <TableCard>
-        <ExampleTableRow expandable={false} />
-      </TableCard>
-      <TableCard>
-        <ExampleTableRow expandable={false} />
-      </TableCard>
-    </TableContainer>
-  </Container>
-)
-
-ExtraSpacing.story = {
-  name: "Default variant (extra spacing)",
 }

--- a/draft-packages/table/CHANGELOG.md
+++ b/draft-packages/table/CHANGELOG.md
@@ -3,17 +3,6 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [1.7.0](https://github.com/cultureamp/kaizen-design-system/compare/@kaizen/draft-table@1.6.64...@kaizen/draft-table@1.7.0) (2020-10-09)
-
-
-### Features
-
-* Uplift the table to the new Zen designs  ([#803](https://github.com/cultureamp/kaizen-design-system/issues/803)) ([c279420](https://github.com/cultureamp/kaizen-design-system/commit/c279420254fb534adad6cce7ffad8328bbbb18ec))
-
-
-
-
-
 ## [1.6.64](https://github.com/cultureamp/kaizen-design-system/compare/@kaizen/draft-table@1.6.63...@kaizen/draft-table@1.6.64) (2020-10-08)
 
 **Note:** Version bump only for package @kaizen/draft-table

--- a/draft-packages/table/KaizenDraft/Table/Table.spec.tsx
+++ b/draft-packages/table/KaizenDraft/Table/Table.spec.tsx
@@ -1,6 +1,7 @@
 import { cleanup, render } from "@testing-library/react"
 import * as React from "react"
 import {
+  AllowedTableHeaderBackgroundColors,
   TableCard,
   TableContainer,
   TableHeader,
@@ -67,6 +68,27 @@ const Wrapper: React.FunctionComponent = () => (
 )
 
 describe("Table", () => {
+  describe("Table props", () => {
+    const testCases: AllowedTableHeaderBackgroundColors[] = ["ash", "white"]
+
+    testCases.forEach(variant => {
+      it(`renders the correct element for <TableHeader backgroundColor={${variant}} />`, () => {
+        const paragraphMock = render(
+          <TableHeader
+            backgroundColor={variant}
+            data-testid={TestId.tableHeader}
+          >
+            Example
+          </TableHeader>
+        )
+        const paragraphClasslist = paragraphMock.getByTestId(TestId.tableHeader)
+          .classList
+        expect(paragraphClasslist).toContain("header")
+        expect(paragraphClasslist).toContain(variant)
+      })
+    })
+  })
+
   describe("Custom HTML props", () => {
     for (const [key, value] of Object.entries(TestId)) {
       it(`${key} accepts custom data-* attributes`, () => {

--- a/draft-packages/table/KaizenDraft/Table/Table.tsx
+++ b/draft-packages/table/KaizenDraft/Table/Table.tsx
@@ -5,56 +5,35 @@ import * as React from "react"
 import styles from "./styles.scss"
 import sortDescendingIcon from "@kaizen/component-library/icons/sort-descending.icon.svg"
 
-type TableContainer = React.FunctionComponent<TableContainerProps>
-type TableContainerProps = {
-  variant?: "compact" | "default"
-}
-export const TableContainer: TableContainer = ({
-  variant = "compact",
-  children,
-  ...otherProps
-}) => (
-  <div
-    role="table"
-    className={classNames(styles.container, {
-      [styles.defaultSpacing]: variant === "default",
-    })}
-    {...otherProps}
-  >
+type TableContainer = React.FunctionComponent
+export const TableContainer: TableContainer = ({ children, ...otherProps }) => (
+  <div className={styles.container} role="table" {...otherProps}>
     {children}
   </div>
 )
 
-/**
- * @deprecated backgroundColor is deprecated. Header props now have transparet backgrounds
- */
 export type AllowedTableHeaderBackgroundColors = "ash" | "white"
 
 type TableHeader = React.FunctionComponent<{
   backgroundColor?: AllowedTableHeaderBackgroundColors
 }>
 export const TableHeader: TableHeader = ({
-  backgroundColor,
   children,
+  backgroundColor = "ash",
   ...otherProps
-}) => {
-  if (backgroundColor) {
-    // eslint-disable-next-line no-console
-    console.warn(
-      "DEPRECATED(table): backgroundColor is deprecated - this prop has no effect"
-    )
-  }
-
-  return (
-    <div role="rowgroup" {...otherProps}>
-      {children}
-    </div>
-  )
-}
+}) => (
+  <div
+    className={classNames(styles.header, styles[backgroundColor])}
+    role="rowgroup"
+    {...otherProps}
+  >
+    {children}
+  </div>
+)
 
 type TableHeaderRow = React.FunctionComponent
 export const TableHeaderRow: TableHeaderRow = ({ children, ...otherProps }) => (
-  <div className={classNames(styles.row)} role="rowheader" {...otherProps}>
+  <div className={styles.headerRow} role="rowheader" {...otherProps}>
     {children}
   </div>
 )
@@ -108,11 +87,7 @@ export const TableHeaderRowCell: TableHeaderRowCell = ({
           />
         </div>
       )}
-      <Heading
-        tag="div"
-        variant="heading-6"
-        color={active ? "dark" : "dark-reduced-opacity"}
-      >
+      <Heading tag="div" variant="heading-6">
         {labelText}
       </Heading>
     </div>

--- a/draft-packages/table/KaizenDraft/Table/TableHeaderRow.elm
+++ b/draft-packages/table/KaizenDraft/Table/TableHeaderRow.elm
@@ -27,10 +27,10 @@ defaults =
 
 view : Config msg -> List (Html msg) -> Html msg
 view (Config config) children =
-    div [ styles.class .row, role "rowheader" ] children
+    div [ styles.class .headerRow, role "rowheader" ] children
 
 
 styles =
     css "@kaizen/draft-table/KaizenDraft/Table/styles.scss"
-        { row = "row"
+        { headerRow = "headerRow"
         }

--- a/draft-packages/table/KaizenDraft/Table/TableHeaderRowCell.elm
+++ b/draft-packages/table/KaizenDraft/Table/TableHeaderRowCell.elm
@@ -9,7 +9,6 @@ module KaizenDraft.Table.TableHeaderRowCell exposing
     )
 
 import CssModules exposing (css)
-import Heading.Heading as Heading exposing (TypeVariant(..), view)
 import Html exposing (Attribute, Html, button, div, text)
 import Html.Attributes exposing (style)
 import Html.Attributes.Aria exposing (role)
@@ -95,10 +94,7 @@ view (Config config) =
         , styles.class .headerRowCell
         , role "columnheader"
         ]
-        [ Heading.view
-            (Heading.h1 |> Heading.variant Heading6)
-            [ Html.text config.labelText ]
-        ]
+        [ text config.labelText ]
 
 
 styles =

--- a/draft-packages/table/KaizenDraft/Table/styles.scss
+++ b/draft-packages/table/KaizenDraft/Table/styles.scss
@@ -1,7 +1,6 @@
 @import "~@kaizen/design-tokens/sass/color";
 @import "~@kaizen/design-tokens/sass/border";
 @import "~@kaizen/design-tokens/sass/shadow";
-@import "~@kaizen/design-tokens/sass/spacing";
 @import "~@kaizen/component-library/styles/animation";
 @import "~@kaizen/component-library/styles/border";
 @import "~@kaizen/component-library/styles/color";
@@ -9,9 +8,6 @@
 @import "~@kaizen/component-library/styles/layout";
 @import "~@kaizen/component-library/components/Button/styles";
 
-// Taken from design-tokens/sass/shadow
-// we need control of the x and y offset in this component
-$box-shadow-color-sm: rgba(53, 55, 74, 0.09);
 $row-height: 60px;
 
 .anchorReset {
@@ -30,12 +26,28 @@ $row-height: 60px;
   margin-bottom: $ca-grid * 0.5;
 }
 
+.header {
+  border: solid 1px $ca-border-color;
+
+  &.ash {
+    background-color: $kz-color-ash;
+  }
+
+  &.white {
+    background-color: $kz-color-white;
+  }
+}
+
+.headerRow {
+  display: flex;
+}
+
 .headerRowCell {
   @include button-reset;
   text-overflow: ellipsis;
   overflow-x: hidden;
   white-space: nowrap;
-  padding: 0 $ca-grid;
+  padding: 0 $ca-grid * 0.8;
   height: $ca-grid * 1.5;
   display: flex;
   align-items: center;
@@ -68,17 +80,20 @@ $row-height: 60px;
 .card {
   @include button-reset;
   background: $kz-color-white;
-  border: solid 1px rgba($kz-color-wisteria-700, 0.1);
+  border: solid 1px $ca-border-color;
+  // Reverting back from $kz-shadow-small-box-shadow as an interim.
+  // @see https://cultureamp.slack.com/archives/CETLTFG9G/p1588658249280300?thread_ts=1588587636.273700&cid=CETLTFG9G
+  box-shadow: $ca-box-shadow;
   transition: box-shadow $ca-duration-rapid, border-color $ca-duration-rapid,
     margin $ca-duration-rapid, padding $ca-duration-rapid,
     width $ca-duration-rapid;
-
-  // This is an optical hack to stop the card shadow from overlapping over
-  // the proceeding cards
-  box-shadow: 0px 4px 6px rgba(53, 55, 74, 0.04);
-
   // These css properties are required for when the rows are anchor elements
   composes: anchorReset;
+
+  &:first-child {
+    border-top-left-radius: $kz-border-solid-border-radius;
+    border-top-right-radius: $kz-border-solid-border-radius;
+  }
 
   &:not(:first-child) {
     margin-top: -1px;
@@ -96,19 +111,6 @@ $row-height: 60px;
   &.well {
     margin-top: ($ca-grid * 0.5);
   }
-}
-
-// target the first child card when there is a heading present
-[role="rowgroup"] + .card {
-  border-top-left-radius: $kz-border-solid-border-radius;
-  border-top-right-radius: $kz-border-solid-border-radius;
-  box-shadow: $kz-shadow-small-box-shadow;
-}
-
-.card:first-child {
-  border-top-left-radius: $kz-border-solid-border-radius;
-  border-top-right-radius: $kz-border-solid-border-radius;
-  box-shadow: $kz-shadow-small-box-shadow;
 }
 
 .row {
@@ -152,13 +154,9 @@ $row-height: 60px;
 
 .rowCell {
   min-height: $row-height;
-  padding: 0 $kz-spacing-md;
+  padding: 0 $ca-grid * 0.8;
   display: flex;
   align-items: center;
   // These css properties are required for when the cells are anchor elements
   composes: anchorReset;
-
-  .defaultSpacing & {
-    padding: $kz-spacing-md * 0.5 $kz-spacing-md;
-  }
 }

--- a/draft-packages/table/package.json
+++ b/draft-packages/table/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kaizen/draft-table",
-  "version": "1.7.0",
+  "version": "1.6.64",
   "description": "The draft Table component",
   "scripts": {
     "prepublish": "tsc --project tsconfig.dist.json",


### PR DESCRIPTION
Reverts cultureamp/kaizen-design-system#803

This was mistakenly published as a minor change when it should have been a major change. I have unpublished the package on NPM and will reopen my previous PR so we have a clean version history and changelog