### PR TITLE
fix: Add style disabled options in <Select>

### DIFF
--- a/draft-packages/select/KaizenDraft/Select/Select.tsx
+++ b/draft-packages/select/KaizenDraft/Select/Select.tsx
@@ -150,6 +150,7 @@ const Option: typeof components.Option = props => (
       className={classNames("needsclick", styles.option, {
         [styles.focusedOption]: props.isFocused,
         [styles.selectedOption]: props.isSelected,
+        [styles.disabledOption]: props.isDisabled,
       })}
     />
   </div>

--- a/draft-packages/select/KaizenDraft/Select/styles.react.scss
+++ b/draft-packages/select/KaizenDraft/Select/styles.react.scss
@@ -74,6 +74,11 @@
     background-color: $kz-color-cluny-100;
   }
 
+  .disabledOption {
+    cursor: not-allowed;
+    opacity: 0.3;
+  }
+
   .noOptionsMessage {
     @include base-font-style();
   }

--- a/draft-packages/stories/Select.stories.tsx
+++ b/draft-packages/stories/Select.stories.tsx
@@ -16,7 +16,7 @@ const NarrowStoryContainer = ({ children }: { children: React.ReactNode }) => (
 
 const options = [
   { value: "Mindy", label: "Mindy" },
-  { value: "Jaime", label: "Jaime" },
+  { value: "Jaime", label: "Jaime", isDisabled: true },
   { value: "Rafa", label: "Rafa" },
   { value: "Elaine", label: "Elaine" },
   { value: "Julio", label: "Julio" },


### PR DESCRIPTION
# Objective

This adds a specific style to the `Option` values with the `<Select>` component when the `isDisabled` attribute for that option is set to `true.

<img width="315" alt="image" src="https://user-images.githubusercontent.com/4353/95849982-d637b880-0d9b-11eb-87c9-bd3652b46251.png">

<img width="311" alt="image" src="https://user-images.githubusercontent.com/4353/95850000-df288a00-0d9b-11eb-9873-fbf9056e7310.png">

You can view this live in the branch preview: https://dev.cultureamp.design/select/add-disabled-style/storybook/?path=/story/select-react--single

# Motivation and Context 

Currently the `isDisabled` attribute functions correctly — the option cannot be chosen — but it does not look any different from the enabled options and so could case confusion.

The disabled class sets the opacity to 30%, which is the same as the overall disabled style for the `<Select>`. It also adds a `not-allowed` cursor on hover to make it clear to users that the action is disabled.

# Checklist

[x] If this contains visual changes, has it been reviewed by a designer? 
[x] I have considered likely risks of these changes and got someone else to QA as appropriate
[x] I have or will communicate these changes to the front end practice

# Additional Considerations
~- Does there need to be right-to-left (RTL) options for localization and internationalization?~
~- Has the test suite been updated?~
~- Have you done cross-browser testing for our [supported browsers](https://academy.cultureamp.com/hc/en-us/articles/204539569-Supported-browsers-for-Participants)?~
~- Have you updated any relevant documentation or left useful comments in the code?~
~- Have you reviewed Culture Amp's Web Accessibility guide [Current Compliance, Going Forward, Statement and Answers for Customers](https://cultureamp.atlassian.net/wiki/spaces/Prod/pages/428572998/Web+Accessibility)?~
~- If this contains substantial visual changes, especially far reaching ones, have you unlocked the Chromatic step in the pipeline?~
~- Have Storybook stories been updated?~
