### PR TITLE
feat: navigation bar improvements

### DIFF
--- a/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/NavigationBar.tsx
+++ b/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/NavigationBar.tsx
@@ -1,6 +1,9 @@
 import * as React from "react"
 
-import { ZenControlledOffCanvas } from "@kaizen/draft-zen-off-canvas"
+import {
+  ZenControlledOffCanvas,
+  toggleMobileNavigation,
+} from "@kaizen/draft-zen-off-canvas"
 import classNames from "classnames"
 import Media from "react-media"
 import uuid from "uuid/v4"
@@ -30,10 +33,22 @@ type Props = {
   footerComponent?: React.ReactNode
   children?: Navigation
 }
+const ROOT_MENU_ID = "mobile-navigation"
 
 type State = {
   mobileKey: number
 }
+export const openMobileNavigation = () =>
+  toggleMobileNavigation({
+    id: ROOT_MENU_ID,
+    state: "open",
+  })
+
+export const closeMobileNavigation = () =>
+  toggleMobileNavigation({
+    id: ROOT_MENU_ID,
+    state: "close",
+  })
 
 export default class NavigationBar extends React.Component<Props, State> {
   static displayName = "NavigationBar"
@@ -85,7 +100,7 @@ export default class NavigationBar extends React.Component<Props, State> {
                 productSwitcher={headerComponent && headerComponent.mobile}
                 links={children}
                 heading="Menu"
-                menuId="menu"
+                menuId={ROOT_MENU_ID}
                 colorScheme={colorScheme}
               />
             ) : (

--- a/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/NavigationBar.tsx
+++ b/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/NavigationBar.tsx
@@ -49,7 +49,7 @@ export const openMobileNavigation = () =>
 export const closeMobileNavigation = () =>
   toggleZenOffCanvas({
     id: ROOT_MENU_ID,
-    state: "close",
+    state: "closed",
   })
 
 export default class NavigationBar extends React.Component<Props, State> {

--- a/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/NavigationBar.tsx
+++ b/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/NavigationBar.tsx
@@ -2,7 +2,7 @@ import * as React from "react"
 
 import {
   ZenControlledOffCanvas,
-  toggleMobileNavigation,
+  toggleZenOffCanvas,
 } from "@kaizen/draft-zen-off-canvas"
 import classNames from "classnames"
 import Media from "react-media"
@@ -31,6 +31,7 @@ type Props = {
     mobile: React.ReactElement
   }
   footerComponent?: React.ReactNode
+  showMobileTrigger?: boolean
   children?: Navigation
 }
 const ROOT_MENU_ID = "mobile-navigation"
@@ -38,14 +39,15 @@ const ROOT_MENU_ID = "mobile-navigation"
 type State = {
   mobileKey: number
 }
+
 export const openMobileNavigation = () =>
-  toggleMobileNavigation({
+  toggleZenOffCanvas({
     id: ROOT_MENU_ID,
     state: "open",
   })
 
 export const closeMobileNavigation = () =>
-  toggleMobileNavigation({
+  toggleZenOffCanvas({
     id: ROOT_MENU_ID,
     state: "close",
   })
@@ -73,6 +75,7 @@ export default class NavigationBar extends React.Component<Props, State> {
       colorScheme = "cultureamp",
       headerComponent,
       onNavigationChange,
+      showMobileTrigger = true,
     } = this.props
 
     return (
@@ -87,6 +90,7 @@ export default class NavigationBar extends React.Component<Props, State> {
               onNavigationChange(event)
             }
           },
+          colorScheme,
           hasExtendedNavigation: !!children?.secondary?.length,
         }}
       >
@@ -102,6 +106,7 @@ export default class NavigationBar extends React.Component<Props, State> {
                 heading="Menu"
                 menuId={ROOT_MENU_ID}
                 colorScheme={colorScheme}
+                withTrigger={showMobileTrigger}
               />
             ) : (
               <header

--- a/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/context.tsx
+++ b/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/context.tsx
@@ -1,11 +1,13 @@
 import React from "react"
-import { NavigationChange } from "./types"
+import { NavigationChange, ColorScheme } from "./types"
 
 type NavBarContextType = {
   handleNavigationChange?: NavigationChange
   hasExtendedNavigation: boolean
+  colorScheme: ColorScheme
 }
 
 export const NavBarContext = React.createContext<NavBarContextType>({
   hasExtendedNavigation: false,
+  colorScheme: "cultureamp",
 })

--- a/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/index.ts
+++ b/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/index.ts
@@ -1,3 +1,7 @@
-export { default as ZenNavigationBar } from "./NavigationBar"
+export {
+  default as ZenNavigationBar,
+  openMobileNavigation,
+  closeMobileNavigation,
+} from "./NavigationBar"
 export { default as Link } from "./components/Link"
 export { default as Menu } from "./components/Menu"

--- a/draft-packages/zen-off-canvas/KaizenDraft/ZenOffCanvas/OffCanvas.module.scss
+++ b/draft-packages/zen-off-canvas/KaizenDraft/ZenOffCanvas/OffCanvas.module.scss
@@ -34,45 +34,12 @@ $menu-footer-height: 80px;
 }
 
 .trigger {
-  @include button-reset;
   position: absolute;
-  top: $ca-grid / 2;
-  left: $ca-grid / 2;
+  top: 0;
+  left: 0;
   color: $kz-color-cluny-500;
-  height: $hamburger-width;
-  width: $hamburger-width;
-  padding-bottom: $hamburger-layer-height;
-
   &:hover {
     cursor: pointer;
-  }
-}
-
-.hamburger {
-  width: $hamburger-width;
-  height: $hamburger-layer-height;
-  background-color: $kz-color-cluny-500;
-  position: relative;
-  display: block;
-
-  &::before {
-    content: "";
-    width: $hamburger-width;
-    height: $hamburger-layer-height;
-    position: absolute;
-    top: $hamburger-layer-height + $hamburger-layer-spacing;
-    left: 0;
-    background-color: $kz-color-cluny-500;
-  }
-
-  &::after {
-    content: "";
-    width: $hamburger-width;
-    height: $hamburger-layer-height;
-    position: absolute;
-    top: ($hamburger-layer-height + $hamburger-layer-spacing) * 2;
-    left: 0;
-    background-color: $kz-color-cluny-500;
   }
 }
 

--- a/draft-packages/zen-off-canvas/KaizenDraft/ZenOffCanvas/ZenOffCanvas.tsx
+++ b/draft-packages/zen-off-canvas/KaizenDraft/ZenOffCanvas/ZenOffCanvas.tsx
@@ -8,6 +8,7 @@ import Menu from "./components/Menu"
 import styles from "./OffCanvas.module.scss"
 import { IconButton } from "@kaizen/draft-button"
 import hamburgerIcon from "@kaizen/component-library/icons/hamburger.icon.svg"
+import { GenericModal, ModalBody } from "@kaizen/draft-modal"
 
 type ZenOffCanvasProps = {
   links?: any
@@ -49,7 +50,15 @@ export const OffCanvasContext = React.createContext<OffCanvasContext>({
   resetVisibleMenus: () => undefined,
 })
 
-export const ZenOffCanvasProvider: React.FunctionComponent = ({ children }) => {
+type ZenOffCanvasProvider = {
+  children: React.ReactNode
+  outside?: React.ReactNode
+}
+
+export const ZenOffCanvasProvider: React.FunctionComponent<ZenOffCanvasProvider> = ({
+  children,
+  outside,
+}) => {
   const [visibleMenus, setVisibleMenus] = useState<string[]>([])
 
   useEffect(() => {
@@ -80,8 +89,16 @@ export const ZenOffCanvasProvider: React.FunctionComponent = ({ children }) => {
         toggleVisibleMenu,
         resetVisibleMenus,
       }}
-      children={children}
-    />
+    >
+      {outside}
+      <GenericModal
+        isOpen={visibleMenus.length > 0}
+        onEscapeKeyup={resetVisibleMenus}
+        onOutsideModalClick={resetVisibleMenus}
+      >
+        <ModalBody>{children}</ModalBody>
+      </GenericModal>
+    </OffCanvasContext.Provider>
   )
 }
 
@@ -130,20 +147,23 @@ export const ZenOffCanvas: React.FunctionComponent<ZenOffCanvasProps> = ({
 export const ZenControlledOffCanvas: React.FunctionComponent<
   ZenOffCanvasProps & { withTrigger: boolean }
 > = props => (
-  <ZenOffCanvasProvider>
-    {props.withTrigger && (
-      <OffCanvasContext.Consumer>
-        {({ toggleVisibleMenu }) => (
-          <span className={styles.trigger}>
-            <IconButton
-              label="Open Navigation"
-              icon={hamburgerIcon}
-              onClick={() => toggleVisibleMenu(props.menuId)}
-            />
-          </span>
-        )}
-      </OffCanvasContext.Consumer>
-    )}
+  <ZenOffCanvasProvider
+    outside={
+      props.withTrigger && (
+        <OffCanvasContext.Consumer>
+          {({ toggleVisibleMenu }) => (
+            <span className={styles.trigger}>
+              <IconButton
+                label="Open Navigation"
+                icon={hamburgerIcon}
+                onClick={() => toggleVisibleMenu(props.menuId)}
+              />
+            </span>
+          )}
+        </OffCanvasContext.Consumer>
+      )
+    }
+  >
     <ZenOffCanvas {...props} />
   </ZenOffCanvasProvider>
 )

--- a/draft-packages/zen-off-canvas/KaizenDraft/ZenOffCanvas/ZenOffCanvas.tsx
+++ b/draft-packages/zen-off-canvas/KaizenDraft/ZenOffCanvas/ZenOffCanvas.tsx
@@ -6,6 +6,8 @@ import Header from "./components/Header"
 import Menu from "./components/Menu"
 
 import styles from "./OffCanvas.module.scss"
+import { IconButton } from "@kaizen/draft-button"
+import hamburgerIcon from "@kaizen/component-library/icons/hamburger.icon.svg"
 
 type ZenOffCanvasProps = {
   links?: any
@@ -125,18 +127,23 @@ export const ZenOffCanvas: React.FunctionComponent<ZenOffCanvasProps> = ({
   )
 }
 
-export const ZenControlledOffCanvas: React.FunctionComponent<ZenOffCanvasProps> = props => (
+export const ZenControlledOffCanvas: React.FunctionComponent<
+  ZenOffCanvasProps & { withTrigger: boolean }
+> = props => (
   <ZenOffCanvasProvider>
-    <OffCanvasContext.Consumer>
-      {({ toggleVisibleMenu }) => (
-        <button
-          className={styles.trigger}
-          onClick={() => toggleVisibleMenu(props.menuId)}
-        >
-          <span className={styles.hamburger} />
-        </button>
-      )}
-    </OffCanvasContext.Consumer>
+    {props.withTrigger && (
+      <OffCanvasContext.Consumer>
+        {({ toggleVisibleMenu }) => (
+          <span className={styles.trigger}>
+            <IconButton
+              label="Open Navigation"
+              icon={hamburgerIcon}
+              onClick={() => toggleVisibleMenu(props.menuId)}
+            />
+          </span>
+        )}
+      </OffCanvasContext.Consumer>
+    )}
     <ZenOffCanvas {...props} />
   </ZenOffCanvasProvider>
 )

--- a/draft-packages/zen-off-canvas/KaizenDraft/ZenOffCanvas/ZenOffCanvas.tsx
+++ b/draft-packages/zen-off-canvas/KaizenDraft/ZenOffCanvas/ZenOffCanvas.tsx
@@ -24,7 +24,7 @@ type ToggleMobileNavEvent = {
   type: "TOGGLE_MOBILE_NAV"
   payload: {
     id: string
-    state: "open" | "close"
+    state: "open" | "closed"
   }
 }
 
@@ -67,7 +67,7 @@ export const ZenOffCanvasProvider: React.FunctionComponent<ZenOffCanvasProvider>
       if (state === "open") {
         setVisibleMenus([id])
       }
-      if (state === "close") {
+      if (state === "closed") {
         resetVisibleMenus()
       }
     })

--- a/draft-packages/zen-off-canvas/KaizenDraft/ZenOffCanvas/components/Header.module.scss
+++ b/draft-packages/zen-off-canvas/KaizenDraft/ZenOffCanvas/components/Header.module.scss
@@ -31,3 +31,9 @@
     color: $kz-color-wisteria-800;
   }
 }
+
+.close {
+  button:hover {
+    cursor: pointer;
+  }
+}

--- a/draft-packages/zen-off-canvas/KaizenDraft/ZenOffCanvas/components/Header.module.scss
+++ b/draft-packages/zen-off-canvas/KaizenDraft/ZenOffCanvas/components/Header.module.scss
@@ -32,7 +32,7 @@
   }
 }
 
-.close {
+.closed {
   button:hover {
     cursor: pointer;
   }

--- a/draft-packages/zen-off-canvas/KaizenDraft/ZenOffCanvas/components/Header.tsx
+++ b/draft-packages/zen-off-canvas/KaizenDraft/ZenOffCanvas/components/Header.tsx
@@ -27,7 +27,7 @@ const Header = ({
   >
     {leftComponent}
     <span className={styles.heading}>{heading}</span>
-    <span className={styles.close}>
+    <span className={styles.closed}>
       <IconButton
         label="Close"
         icon={closeIcon}

--- a/draft-packages/zen-off-canvas/KaizenDraft/ZenOffCanvas/components/Header.tsx
+++ b/draft-packages/zen-off-canvas/KaizenDraft/ZenOffCanvas/components/Header.tsx
@@ -27,12 +27,14 @@ const Header = ({
   >
     {leftComponent}
     <span className={styles.heading}>{heading}</span>
-    <IconButton
-      label="Close"
-      icon={closeIcon}
-      onClick={onClose}
-      reversed={colorScheme !== "content"}
-    />
+    <span className={styles.close}>
+      <IconButton
+        label="Close"
+        icon={closeIcon}
+        onClick={onClose}
+        reversed={colorScheme !== "content"}
+      />
+    </span>
   </div>
 )
 

--- a/draft-packages/zen-off-canvas/KaizenDraft/ZenOffCanvas/index.ts
+++ b/draft-packages/zen-off-canvas/KaizenDraft/ZenOffCanvas/index.ts
@@ -1,5 +1,7 @@
 export {
-  default as ZenControlledOffCanvas,
+  ZenControlledOffCanvas,
   ZenOffCanvas,
+  ZenOffCanvasProvider,
   OffCanvasContext,
+  toggleZenOffCanvas,
 } from "./ZenOffCanvas"

--- a/draft-packages/zen-off-canvas/package.json
+++ b/draft-packages/zen-off-canvas/package.json
@@ -33,6 +33,8 @@
   "dependencies": {
     "@kaizen/component-library": "^7.32.2",
     "@kaizen/draft-zen-navigation-bar": "^1.9.14",
+    "@kaizen/draft-button": "^2.0.4",
+    "@kaizen/draft-modal": "^3.0.6",
     "@types/classnames": "^2.2.10",
     "classnames": "^2.2.6",
     "ts-bus": "^2.3.1",

--- a/draft-packages/zen-off-canvas/package.json
+++ b/draft-packages/zen-off-canvas/package.json
@@ -35,6 +35,7 @@
     "@kaizen/draft-zen-navigation-bar": "^1.9.14",
     "@types/classnames": "^2.2.10",
     "classnames": "^2.2.6",
+    "ts-bus": "^2.3.1",
     "uuid": "^3.3.2"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -10011,6 +10011,11 @@ event-source-polyfill@^1.0.15:
   resolved "https://registry.yarnpkg.com/event-source-polyfill/-/event-source-polyfill-1.0.21.tgz#6b11b1299517a48e04540748b7c23f5a7620155b"
   integrity sha512-Mz8LO8hPgg2X6VcSXmq7gvgFU3kUnTZb4zU3tTYDx8cJHRXP15tjdpGUiP2IUUwOqAGZ1TEfe+KagjMXfFgwLA==
 
+eventemitter2@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/eventemitter2/-/eventemitter2-5.0.1.tgz#6197a095d5fb6b57e8942f6fd7eaad63a09c9452"
+  integrity sha1-YZegldX7a1folC9v1+qtY6CclFI=
+
 eventemitter3@^3.1.0:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-3.1.2.tgz#2d3d48f9c346698fce83a85d7d664e98535df6e7"
@@ -23318,6 +23323,13 @@ trough@^1.0.0:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/true-case-path/-/true-case-path-2.2.1.tgz#c5bf04a5bbec3fd118be4084461b3a27c4d796bf"
   integrity sha512-0z3j8R7MCjy10kc/g+qg7Ln3alJTodw9aDuVWZa3uiWqfuBMKeAeP2ocWcxoyM3D73yz3Jt/Pu4qPr4wHSdB/Q==
+
+ts-bus@^2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/ts-bus/-/ts-bus-2.3.1.tgz#a7805ad76b97813d6a0cdb8594af1826cc35036d"
+  integrity sha512-ZoiVKzctxeJvQ0ZB7Fc/wpbEEA5NEjdZWebisXk8raFfEFigDmwl1fKTcr+jNRfEcwFl1QJ4oiirxGR0YnPq1w==
+  dependencies:
+    eventemitter2 "^5.0.1"
 
 ts-dedent@^1.1.0, ts-dedent@^1.1.1:
   version "1.2.0"


### PR DESCRIPTION
Minor improvements / extensions to Navbar
- This extends the Navigation Bar to export a function that can toggle the navbar from anywhere, using a pub/sub system.
- We have also extended the Mobile Navigation to use the Generic Modal component to align closely to the help centre.
- We have replaced the mobile toggle with an icon button (old one had click target issues, see below)

#### Old
![Screen Shot 2020-10-16 at 1 28 47 pm](https://user-images.githubusercontent.com/13988803/96199394-dca07d00-0fb3-11eb-9b0a-c1d1f6e432ec.png)

#### New (now has hover state)
![Screen Shot 2020-10-16 at 1 30 05 pm](https://user-images.githubusercontent.com/13988803/96199340-bc70be00-0fb3-11eb-9755-cf9b649f6dcc.png)
![Screen Shot 2020-10-16 at 1 30 08 pm](https://user-images.githubusercontent.com/13988803/96199349-bed31800-0fb3-11eb-8a6c-ee2121e3ebf4.png)


