### PR TITLE
feat: Allow removal of dismiss button via empty dismissLabel string

### DIFF
--- a/draft-packages/modal/KaizenDraft/Modal/Presets/InputEditModal.tsx
+++ b/draft-packages/modal/KaizenDraft/Modal/Presets/InputEditModal.tsx
@@ -41,38 +41,46 @@ const InputEditModal = ({
   automationId,
   children,
   submitDisabled = false,
-}: Props) => (
-  <GenericModal
-    isOpen={isOpen}
-    onEscapeKeyup={onDismiss}
-    onOutsideModalClick={onDismiss}
-    automationId={automationId}
-  >
-    <div className={styles.modal} dir={localeDirection}>
-      <ModalHeader unpadded onDismiss={onDismiss}>
-        <div className={styles.header}>
-          <ModalAccessibleLabel>
-            <Text tag="h1" style="zen-heading-3" inline>
-              {title}
-            </Text>
-          </ModalAccessibleLabel>
-        </div>
-      </ModalHeader>
-      <ModalBody unpadded>
-        <div className={styles.body} dir={localeDirection}>
-          {children}
-        </div>
-      </ModalBody>
-      <ModalFooter
-        actions={[
-          { label: submitLabel, action: onSubmit, disabled: submitDisabled },
-          { label: dismissLabel, action: onDismiss },
-        ]}
-        appearance={type === "negative" ? "destructive" : "primary"}
-        automationId={automationId}
-      />
-    </div>
-  </GenericModal>
-)
+}: Props) => {
+  const submitAction = {
+    label: submitLabel,
+    action: onSubmit,
+    disabled: submitDisabled,
+  }
+  const footerActions = dismissLabel
+    ? [submitAction, { label: dismissLabel, action: onDismiss }]
+    : [submitAction]
+
+  return (
+    <GenericModal
+      isOpen={isOpen}
+      onEscapeKeyup={onDismiss}
+      onOutsideModalClick={onDismiss}
+      automationId={automationId}
+    >
+      <div className={styles.modal} dir={localeDirection}>
+        <ModalHeader unpadded onDismiss={onDismiss}>
+          <div className={styles.header}>
+            <ModalAccessibleLabel>
+              <Text tag="h1" style="zen-heading-3" inline>
+                {title}
+              </Text>
+            </ModalAccessibleLabel>
+          </div>
+        </ModalHeader>
+        <ModalBody unpadded>
+          <div className={styles.body} dir={localeDirection}>
+            {children}
+          </div>
+        </ModalBody>
+        <ModalFooter
+          actions={footerActions}
+          appearance={type === "negative" ? "destructive" : "primary"}
+          automationId={automationId}
+        />
+      </div>
+    </GenericModal>
+  )
+}
 
 export default InputEditModal


### PR DESCRIPTION
# Objective
Allows usages of `InputEditModal` to specify an empty string `dismissLabel` in order to remove the dismiss/cancel button

# Motivation and Context 
Context: We have an issue on Capture where people keep losing their comments because they accidentally close the modal. I am considering addressing this by auto-saving modal comments, like all of the other inputs on Capture. As a result, the Save/Cancel pattern becomes invalid, and we need just a single primary ‘Done’ button.

# Screenshots
![image](https://user-images.githubusercontent.com/1811583/96656409-763ca580-138b-11eb-89b6-5ca19fff98eb.png)

# Checklist
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
[ ] If this contains visual changes, has it been reviewed by a designer? 
[ ] I have considered likely risks of these changes and got someone else to QA as appropriate
[ ] I have or will communicate these changes to the front end practice

# Additional Considerations
- Does there need to be right-to-left (RTL) options for localization and internationalization?
- Has the test suite been updated?
- Have you done cross-browser testing for our [supported browsers](https://academy.cultureamp.com/hc/en-us/articles/204539569-Supported-browsers-for-Participants)?
- Have you updated any relevant documentation or left useful comments in the code?
- Have you reviewed Culture Amp's Web Accessibility guide [Current Compliance, Going Forward, Statement and Answers for Customers](https://cultureamp.atlassian.net/wiki/spaces/Prod/pages/428572998/Web+Accessibility)?
- If this contains substantial visual changes, especially far reaching ones, have you unlocked the Chromatic step in the pipeline? 
- Have Storybook stories been updated? 
