### PR TITLE
docs: fixed language across document

### DIFF
--- a/site/docs/guidelines/typography.mdx
+++ b/site/docs/guidelines/typography.mdx
@@ -65,7 +65,7 @@ import WhenNotToUse from "docs-components/WhenNotToUse"
 
 - **$% Large:** Currencies ($), Percentages (%) and Mathematical symbols (+,-,x) are stylistically smaller than numeric data and must use this specific type style when paired with the Data 123 Large.
 
-- **123 Medium:** Used type style to present data that is not considered ‘hero data’ but has importance within a report or summary.
+- **123 Medium:** Used to present data that is not considered ‘hero data’ but has importance within a report or summary.
 
 - **$% Medium:** Currencies ($), Percentages (%) and Mathematical symbols (+,-,x) are stylistically smaller than numeric data and must use this specific type style when paired with the Data 123 Medium.
 

--- a/site/docs/guidelines/typography.mdx
+++ b/site/docs/guidelines/typography.mdx
@@ -32,19 +32,19 @@ import WhenNotToUse from "docs-components/WhenNotToUse"
 
 ### Headings
 
-- **Display 0:** Used *only* for brand moments including introductory screens (Log In, Onboarding, Capture Intro etc) or outro pages (Positive, Negative etc.).
+- **Display 0:** Used *only* for brand moments including introductory screens (Log In, Onboarding, Capture Intro, etc.) or outro pages (Positive, Negative, etc.).
 
-- **Heading 1:** Used only for page titles in the [Title Block](/guidelines/header/#title-block) of the page [Header](/guidelines/header/) or Workflow Header.
+- **Heading 1:** Used *only* for page titles in the [Title Block](/guidelines/header/#title-block) of the page [Header](/guidelines/header/) or [Workflow Header](/guidelines/workflow/).
 
-- **Heading 2:** Also referred to as a Section Heading. Used to introduce major sections of content on a page, and in containers independent of the page hierarchy, such as [Modals](/components/modal/) or Drawers. Generally positioned outside of cards in most layouts, it can also be used inside if more appropriate to the surrounding context.
+- **Heading 2:** Also referred to as a Section Heading. Used to introduce major sections of content on a page, and in containers independent of the page hierarchy, such as [Modals](/components/modal/) or Drawers. Generally positioned outside of cards in most layouts, but can also be used inside if more appropriate to the surrounding context.
 
-- **Heading 3:** Use to label subsets or groupings of information within a section, or as a title in individual objects, such as a [Tile](/components/tile/) or [Guidance Block](/components/guidance-block/). Generally used within a card container. 
+- **Heading 3:** Used to label subsets or groupings of information within a section, or as a title in individual objects, such as a [Tile](/components/tile/) or [Guidance Block](/components/guidance-block/). Generally used within a card container. 
 
 - **Heading 4:** Used for the primary piece of information in a list item, such as the title of a survey/report or an employee name.
 
-- **Heading 5:** Primarily for long form content where an extra level of hierarchy is needed (such as Skills Coach, and educational content). Stylistically identical to Body Bold. **Avoid using Heading 5 with short form content in product screens.**
+- **Heading 5:** Primarily for long form content where an extra level of hierarchy is needed (such as Skills Coach and educational content). Stylistically identical to Body Bold. **Avoid using Heading 5 with short form content in product screens.**
 
-- **Heading 6:** Used for small headings on interactive elements, such as table headers, form inputs labels and in popovers and notifications.
+- **Heading 6:** Used for small headings on interactive elements, such as [table headers](/components/table/), form input labels and in [popovers]((/components/popover/)) and [notifications](/guidelines/notifications/).
 
 
 ### Paragraphs
@@ -61,22 +61,22 @@ import WhenNotToUse from "docs-components/WhenNotToUse"
 
 ### Data
 
-- **123 Large:** Use this type style to present the most important data (also referred to as hero data) on reporting pages.
+- **123 Large:** Used to present the most important data (also referred to as hero data) on reporting pages.
 
 - **$% Large:** Currencies ($), Percentages (%) and Mathematical symbols (+,-,x) are stylistically smaller than numeric data and must use this specific type style when paired with the Data 123 Large.
 
-- **123 Medium:** Use this type style to present data that is not considered ‘hero data’ but has importance within a report or summary.
+- **123 Medium:** Used type style to present data that is not considered ‘hero data’ but has importance within a report or summary.
 
 - **$% Medium:** Currencies ($), Percentages (%) and Mathematical symbols (+,-,x) are stylistically smaller than numeric data and must use this specific type style when paired with the Data 123 Medium.
 
-- **123 Small:** Use this type style to present data that doesn’t need to be prominent. There is no separate small style for Currencies ($), Percentages (%) and Mathematical symbols (+,-,x) because the symbols need to remain legible at this size.
+- **123 Small:** Used to present data that doesn’t need to be prominent. There is no separate small style for Currencies ($), Percentages (%) and Mathematical symbols (+,-,x) because the symbols need to remain legible at this size.
 
 
 ### Links
 
-- **Paragraph links:** Use when a link is located amongst a body of text (i.e. is within a sentence or paragraph) and cannot be clearly distinguished as a link by its color alone. In its default state, it shows an underline. In its hover state, the underline disappears.
+- **Paragraph links:** Used when a link is located amongst a body of text (i.e. is within a sentence or paragraph) and cannot be clearly distinguished as a link by its color alone. In its default state, it shows an underline. In its hover state, the underline disappears.
 
-- **Standalone links:** Use when a link is isolated from a body of text (i.e. is not within a sentence or paragraph) and can be clearly distinguished as a link by its color alone. In its default state, it does not show an underline. In its hover state the underline appears.
+- **Standalone links:** Used when a link is isolated from a body of text (i.e. is not within a sentence or paragraph) and can be clearly distinguished as a link by its color alone. In its default state, it does not show an underline. In its hover state the underline appears.
 
 ### Abbreviations
 


### PR DESCRIPTION
Missed some of the comments from the [previous PR](https://github.com/cultureamp/kaizen-design-system/pull/834).

https://dev.cultureamp.design/katsambarcus-typography-guidelines/guidelines/typography/