### PR TITLE
feat: Added y box offset option to Popover component

### DIFF
--- a/draft-packages/popover/KaizenDraft/Popover/Popover.tsx
+++ b/draft-packages/popover/KaizenDraft/Popover/Popover.tsx
@@ -22,7 +22,7 @@ export interface Props {
   readonly dismissible?: boolean
   readonly singleLine?: boolean
   readonly children: React.ReactNode
-  readonly boxOffset?: number
+  readonly boxOffset?: BoxOffset
 }
 
 type Variant =
@@ -102,12 +102,22 @@ const Popover: Popover = React.forwardRef<HTMLDivElement, Props>(
   )
 )
 
-const getRootStyle = (boxOffset: number | undefined) => ({
-  transform:
-    boxOffset == null
-      ? "translateX(-50%)"
-      : `translateX(calc(-50% + ${boxOffset}px)`,
-})
+type BoxOffset = number | undefined | {
+  xOffset: string,
+  yOffset: string
+}
+
+const getRootStyle = (boxOffset: BoxOffset) => {
+  if (boxOffset == null) {
+    return { transform: "translateX(-50%)"}
+  }
+
+  const translate = typeof boxOffset === "number"
+    ? `translateX(calc(-50% + ${boxOffset}px))`
+    : `translate(${boxOffset.xOffset}, ${boxOffset.yOffset})`
+
+  return { transform: translate }
+}
 
 const mapVariantToBoxClass = (variant: Variant): string => {
   switch (variant) {

--- a/draft-packages/popover/KaizenDraft/Popover/Popover.tsx
+++ b/draft-packages/popover/KaizenDraft/Popover/Popover.tsx
@@ -38,6 +38,14 @@ type Position = "start" | "center" | "end"
 
 type Size = "small" | "large"
 
+type BoxOffset =
+  | number
+  | undefined
+  | {
+      xOffset: number // to ensure a non-breaking change, xOffset can only be a number
+      yOffset: string
+    }
+
 type Popover = React.FunctionComponent<Props>
 
 const Popover: Popover = React.forwardRef<HTMLDivElement, Props>(
@@ -102,14 +110,6 @@ const Popover: Popover = React.forwardRef<HTMLDivElement, Props>(
   )
 )
 
-type BoxOffset =
-  | number
-  | undefined
-  | {
-      xOffset: string
-      yOffset: string
-    }
-
 const getRootStyle = (boxOffset: BoxOffset) => {
   if (boxOffset == null) {
     return { transform: "translateX(-50%)" }
@@ -118,7 +118,7 @@ const getRootStyle = (boxOffset: BoxOffset) => {
   const translate =
     typeof boxOffset === "number"
       ? `translateX(calc(-50% + ${boxOffset}px))`
-      : `translate(${boxOffset.xOffset}, ${boxOffset.yOffset})`
+      : `translate(${boxOffset.xOffset}px, ${boxOffset.yOffset})`
 
   return { transform: translate }
 }
@@ -138,14 +138,17 @@ const mapVariantToBoxClass = (variant: Variant): string => {
   }
 }
 
-const getArrowStyle = (boxOffset: number | undefined, side: Side) => {
+const getArrowStyle = (boxOffset: BoxOffset, side: Side) => {
   const rotate = side === "top" ? "rotate(180deg)" : ""
-  const translate =
-    boxOffset == null
-      ? ""
-      : // Because we shifted the popover in the parent, we need to readjust the
-        // arrow back to where it was.
-        `translateX(${boxOffset * -1}px)`
+  let translate = ""
+  if (boxOffset != null) {
+    translate =
+      typeof boxOffset === "number"
+        ? `translateX(${boxOffset * -1}px)`
+        : // Because we shifted the popover in the parent, we need to readjust the
+          // arrow back to where it was.
+          `translateX(${boxOffset.xOffset * -1}px)`
+  }
 
   return rotate || translate
     ? {

--- a/draft-packages/popover/KaizenDraft/Popover/Popover.tsx
+++ b/draft-packages/popover/KaizenDraft/Popover/Popover.tsx
@@ -143,16 +143,13 @@ const mapVariantToBoxClass = (variant: Variant): string => {
 const getArrowStyle = (boxOffset: BoxOffset, side: Side) => {
   const rotate = side === "top" ? "rotate(180deg)" : ""
   let translate = ""
-  if (
-    boxOffset != null &&
-    (typeof boxOffset === "number" || boxOffset.xOffset != null)
-  ) {
-    translate =
-      typeof boxOffset === "number"
-        ? `translateX(${boxOffset * -1}px)`
-        : // Because we shifted the popover in the parent, we need to readjust the
-          // arrow back to where it was.
-          `translateX(${boxOffset.xOffset * -1}px)`
+  if (boxOffset != null) {
+    if (typeof boxOffset === "number") {
+      translate = `translateX(${boxOffset * -1}px)`
+    } else if (boxOffset.xOffset != null)
+      // Because we shifted the popover in the parent, we need to readjust the
+      // arrow back to where it was.
+      translate = `translateX(${boxOffset.xOffset * -1}px)`
   }
 
   return rotate || translate

--- a/draft-packages/popover/KaizenDraft/Popover/Popover.tsx
+++ b/draft-packages/popover/KaizenDraft/Popover/Popover.tsx
@@ -102,19 +102,23 @@ const Popover: Popover = React.forwardRef<HTMLDivElement, Props>(
   )
 )
 
-type BoxOffset = number | undefined | {
-  xOffset: string,
-  yOffset: string
-}
+type BoxOffset =
+  | number
+  | undefined
+  | {
+      xOffset: string
+      yOffset: string
+    }
 
 const getRootStyle = (boxOffset: BoxOffset) => {
   if (boxOffset == null) {
-    return { transform: "translateX(-50%)"}
+    return { transform: "translateX(-50%)" }
   }
 
-  const translate = typeof boxOffset === "number"
-    ? `translateX(calc(-50% + ${boxOffset}px))`
-    : `translate(${boxOffset.xOffset}, ${boxOffset.yOffset})`
+  const translate =
+    typeof boxOffset === "number"
+      ? `translateX(calc(-50% + ${boxOffset}px))`
+      : `translate(${boxOffset.xOffset}, ${boxOffset.yOffset})`
 
   return { transform: translate }
 }

--- a/draft-packages/popover/KaizenDraft/Popover/Popover.tsx
+++ b/draft-packages/popover/KaizenDraft/Popover/Popover.tsx
@@ -42,8 +42,8 @@ type BoxOffset =
   | number
   | undefined
   | {
-      xOffset: number | null // to ensure a non-breaking change, xOffset can only be a number
-      yOffset: string
+      xOffset?: number // to ensure a non-breaking change, xOffset can only be a number
+      yOffset?: string
     }
 
 type Popover = React.FunctionComponent<Props>

--- a/draft-packages/popover/KaizenDraft/Popover/Popover.tsx
+++ b/draft-packages/popover/KaizenDraft/Popover/Popover.tsx
@@ -42,7 +42,7 @@ type BoxOffset =
   | number
   | undefined
   | {
-      xOffset: number // to ensure a non-breaking change, xOffset can only be a number
+      xOffset: number | null // to ensure a non-breaking change, xOffset can only be a number
       yOffset: string
     }
 
@@ -118,7 +118,9 @@ const getRootStyle = (boxOffset: BoxOffset) => {
   const translate =
     typeof boxOffset === "number"
       ? `translateX(calc(-50% + ${boxOffset}px))`
-      : `translate(${boxOffset.xOffset}px, ${boxOffset.yOffset})`
+      : `translate(${
+          boxOffset.xOffset == null ? "-50%" : `${boxOffset.xOffset}px`
+        }, ${boxOffset.yOffset})`
 
   return { transform: translate }
 }
@@ -141,7 +143,10 @@ const mapVariantToBoxClass = (variant: Variant): string => {
 const getArrowStyle = (boxOffset: BoxOffset, side: Side) => {
   const rotate = side === "top" ? "rotate(180deg)" : ""
   let translate = ""
-  if (boxOffset != null) {
+  if (
+    boxOffset != null &&
+    (typeof boxOffset === "number" || boxOffset.xOffset != null)
+  ) {
     translate =
       typeof boxOffset === "number"
         ? `translateX(${boxOffset * -1}px)`

--- a/draft-packages/stories/Popover.stories.tsx
+++ b/draft-packages/stories/Popover.stories.tsx
@@ -1,5 +1,7 @@
+import { DismissiblePositiveAutohide } from "@kaizen/component-library/stories/InlineNotification.stories"
 import { Popover } from "@kaizen/draft-popover"
 import * as React from "react"
+import { Avatar } from "../avatar"
 
 export default {
   title: "Popover (React)",
@@ -195,3 +197,20 @@ export const BoxOffset = () => (
 )
 
 BoxOffset.storyName = "Box offset"
+
+export const BoxWithYOffset = () => (
+  <Container>
+    <Popover
+      heading="Default"
+      boxOffset={{ yOffset: "calc(-100% + -12px)" }}
+    >
+      Popover body that explains something useful, is optional, and not critical
+      to completing a task.
+    </Popover>
+    <div style={{ margin: "200px auto auto", width: "fit-content" }}>
+      <Avatar fullName="Test user"></Avatar>
+    </div>
+  </Container>
+)
+
+BoxWithYOffset.storyName = "Popover with Y offset positioning"

--- a/draft-packages/stories/Popover.stories.tsx
+++ b/draft-packages/stories/Popover.stories.tsx
@@ -200,10 +200,7 @@ BoxOffset.storyName = "Box offset"
 
 export const BoxWithYOffset = () => (
   <Container>
-    <Popover
-      heading="Default"
-      boxOffset={{ yOffset: "calc(-100% + -12px)" }}
-    >
+    <Popover heading="Default" boxOffset={{ yOffset: "calc(-100% + -12px)" }}>
       Popover body that explains something useful, is optional, and not critical
       to completing a task.
     </Popover>


### PR DESCRIPTION
# Objective
Due to the fact we don't have a way to set yPosition relative to target in popover, this is an intermediary solution to fix that problem. Ideally, we'd actually do this as part of the popover class, but this method allows us to set this in the meantime prior to the popover component re-engineering process.

# Motivation and Context 
In the 1-on-1s tool, we want to set positioning of the popover to be above an icon, but due to the way we set the x offset, it makes the y offset positioning unnecessarily difficult.

A conscious decision that was made was that we will not be adding the padding for the little notch as part of this y offset so all of those calculations are up to the user; in the eventual ideal solution, this would be taken into consideration.

# Checklist
[ ] If this contains visual changes, has it been reviewed by a designer? 
[x] I have considered likely risks of these changes and got someone else to QA as appropriate
[x] I have or will communicate these changes to the front end practice

# Additional Considerations
- Does there need to be right-to-left (RTL) options for localization and internationalization?
- Has the test suite been updated?
- Have you done cross-browser testing for our [supported browsers](https://academy.cultureamp.com/hc/en-us/articles/204539569-Supported-browsers-for-Participants)?
- Have you updated any relevant documentation or left useful comments in the code?
- Have you reviewed Culture Amp's Web Accessibility guide [Current Compliance, Going Forward, Statement and Answers for Customers](https://cultureamp.atlassian.net/wiki/spaces/Prod/pages/428572998/Web+Accessibility)?
- If this contains substantial visual changes, especially far reaching ones, have you unlocked the Chromatic step in the pipeline? 
- Have Storybook stories been updated? 

**If you're new to Kaizen, please ask #prod_design_systems to set up an onboarding session to get you up to speed.** If you have an urgent PR to merge before that happens, it is safest to ask Design Systems team to review it to catch any issues.
