### PR TITLE
fix: button should only be working when working prop is true

### DIFF
--- a/draft-packages/button/KaizenDraft/Button/components/GenericButton.tsx
+++ b/draft-packages/button/KaizenDraft/Button/components/GenericButton.tsx
@@ -106,7 +106,7 @@ const GenericButton = forwardRef(
         )
       }
 
-      if (props.href && !props.disabled && !("working" in props)) {
+      if (props.href && !props.disabled && !props.working) {
         return renderLink(props, buttonRef as Ref<HTMLAnchorElement>)
       }
 
@@ -181,8 +181,8 @@ const renderButton = (props: Props, ref: Ref<HTMLButtonElement>) => {
       onMouseDown={(e: any) => onMouseDown && onMouseDown(e)}
       type={type}
       title={label}
-      aria-label={("working" in props && props.workingLabel) || label}
-      aria-disabled={disabled || "working" in props ? true : undefined}
+      aria-label={(props.working && props.workingLabel) || label}
+      aria-disabled={disabled || props.working ? true : undefined}
       tabIndex={
         disableTabFocusAndIUnderstandTheAccessibilityImplications
           ? -1
@@ -243,7 +243,7 @@ const buttonClass = (props: Props) => {
     [styles.reverseColorSeedling]: props.reverseColor === "seedling",
     [styles.reverseColorWisteria]: props.reverseColor === "wisteria",
     [styles.reverseColorYuzu]: props.reverseColor === "yuzu",
-    [styles.working]: !props.iconButton && "working" in props,
+    [styles.working]: !props.iconButton && props.working,
   })
 }
 
@@ -299,7 +299,7 @@ const renderDefaultContent = props => (
 
 const renderContent: React.FunctionComponent<Props> = props => (
   <span className={styles.content}>
-    {"working" in props && !props.iconButton
+    {props.working && !props.iconButton
       ? renderWorkingContent(props)
       : renderDefaultContent(props)}
   </span>

--- a/draft-packages/stories/Button.stories.tsx
+++ b/draft-packages/stories/Button.stories.tsx
@@ -1,7 +1,7 @@
 import * as colorTokens from "@kaizen/design-tokens/tokens/color.json"
 import { Button, CustomButtonProps, ButtonRef } from "../button"
 import configureIcon from "@kaizen/component-library/icons/configure.icon.svg"
-import React, { useCallback, useRef } from "react"
+import React, { useCallback, useRef, useState } from "react"
 
 export default {
   title: "Button (Zen) (React)",
@@ -27,7 +27,7 @@ const reversedBg = {
   },
 }
 
-const clickAction = () => alert("This shouldn't fire")
+const clickAction = () => alert("This shouldn't fire when button is working")
 
 export const DefaultKaizenSiteDemo = args => <Button {...args} />
 DefaultKaizenSiteDemo.storyName = "Default (Kaizen Site Demo)"
@@ -37,15 +37,27 @@ export const DefaultDisabled = args => (
 )
 DefaultDisabled.storyName = "Default, Disabled"
 
-export const DefaultWorking = () => (
-  <Button
-    label="Label"
-    onClick={clickAction}
-    working
-    workingLabel="Submitting"
-    workingLabelHidden
-  />
-)
+export const DefaultWorking = () => {
+  const [working, setWorking] = useState(false)
+  return (
+    <>
+      <Button
+        label="Click here to test"
+        onClick={() => setWorking(!working)}
+        primary
+      />
+      <div style={{ marginTop: "10px" }}>
+        <Button
+          label="Label"
+          onClick={clickAction}
+          working={working}
+          workingLabel="Submitting"
+          workingLabelHidden
+        />
+      </div>
+    </>
+  )
+}
 
 DefaultWorking.story = {
   name: "Default, Working",


### PR DESCRIPTION
# Objective
<!-- Describe what this change achieves, and the details of how it works. -->

# Motivation and Context 
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

# Screenshots (if appropriate)

# Checklist
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
[ ] If this contains visual changes, has it been reviewed by a designer? 
[ ] I have considered likely risks of these changes and got someone else to QA as appropriate
[ ] I have or will communicate these changes to the front end practice

# Additional Considerations
- Does there need to be right-to-left (RTL) options for localization and internationalization?
- Has the test suite been updated?
- Have you done cross-browser testing for our [supported browsers](https://academy.cultureamp.com/hc/en-us/articles/204539569-Supported-browsers-for-Participants)?
- Have you updated any relevant documentation or left useful comments in the code?
- Have you reviewed Culture Amp's Web Accessibility guide [Current Compliance, Going Forward, Statement and Answers for Customers](https://cultureamp.atlassian.net/wiki/spaces/Prod/pages/428572998/Web+Accessibility)?
- If this contains substantial visual changes, especially far reaching ones, have you unlocked the Chromatic step in the pipeline? 
- Have Storybook stories been updated? 

**If you're new to Kaizen, please ask #prod_design_systems to set up an onboarding session to get you up to speed.** If you have an urgent PR to merge before that happens, it is safest to ask Design Systems team to review it to catch any issues.
