### PR TITLE
docs: Remove CheckboxGroup/RadioGroup story styles

### DIFF
--- a/draft-packages/stories/CheckboxGroup.stories.scss
+++ b/draft-packages/stories/CheckboxGroup.stories.scss
@@ -1,9 +1,0 @@
-@import "~@kaizen/component-library/styles/color";
-
-a {
-  color: $ca-link-text-color;
-  text-decoration: none;
-  &:hover {
-    text-decoration: underline;
-  }
-}

--- a/draft-packages/stories/CheckboxGroup.stories.tsx
+++ b/draft-packages/stories/CheckboxGroup.stories.tsx
@@ -1,7 +1,6 @@
 import { CheckboxGroup } from "@kaizen/draft-checkbox-group"
 import { CheckboxField, Label } from "@kaizen/draft-form"
 import * as React from "react"
-import styles from "./CheckboxGroup.stories.scss"
 
 interface RenderProps {
   checkedStatus: string

--- a/draft-packages/stories/RadioGroup.stories.scss
+++ b/draft-packages/stories/RadioGroup.stories.scss
@@ -1,9 +1,0 @@
-@import "~@kaizen/component-library/styles/color";
-
-a {
-  color: $ca-link-text-color;
-  text-decoration: none;
-  &:hover {
-    text-decoration: underline;
-  }
-}

--- a/draft-packages/stories/RadioGroup.stories.tsx
+++ b/draft-packages/stories/RadioGroup.stories.tsx
@@ -2,7 +2,6 @@ import { Label } from "@kaizen/draft-form"
 import { Radio } from "@kaizen/draft-radio"
 import { RadioGroup } from "@kaizen/draft-radio-group"
 import * as React from "react"
-import styles from "./RadioGroup.stories.scss"
 
 type RenderProps = {
   selectedOption: string


### PR DESCRIPTION
# Objective

Prevent global type selectors in some stories from affecting the look of other stories. Closes #770.

# Motivation and Context 

We have occasionally run into cases where an `a` type selector in two particular stories files has affected another story, due to the fact that they end up in the global namespace. This is dangerous because it could mislead engineers and potentially cause visual bugs in production.

# Checklist
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
[ ] If this contains visual changes, has it been reviewed by a designer? 
[ x ] I have considered likely risks of these changes and got someone else to QA as appropriate
[ ] I have or will communicate these changes to the front end practice
