### PR TITLE
feat: Add 'guidance' as a variant for popovers

### DIFF
--- a/draft-packages/popover/KaizenDraft/Popover/Popover.tsx
+++ b/draft-packages/popover/KaizenDraft/Popover/Popover.tsx
@@ -3,6 +3,7 @@ import closeIcon from "@kaizen/component-library/icons/close.icon.svg"
 import negativeIcon from "@kaizen/component-library/icons/exclamation.icon.svg"
 import informativeIcon from "@kaizen/component-library/icons/information.icon.svg"
 import positiveIcon from "@kaizen/component-library/icons/success.icon.svg"
+import guidanceIcon from "@kaizen/component-library/icons/guidance.icon.svg"
 
 import classNames from "classnames"
 import * as React from "react"
@@ -28,6 +29,7 @@ export interface Props {
 type Variant =
   | "default"
   | "informative"
+  | "guidance"
   | "positive"
   | "negative"
   | "cautionary"
@@ -129,6 +131,8 @@ const mapVariantToBoxClass = (variant: Variant): string => {
   switch (variant) {
     case "informative":
       return styles.informativeBox
+    case "guidance":
+      return styles.guidanceBox
     case "positive":
       return styles.positiveBox
     case "negative":
@@ -163,6 +167,8 @@ const mapVariantToIconClass = (variant: Variant) => {
   switch (variant) {
     case "informative":
       return styles.informativeIcon
+    case "guidance":
+      return styles.guidanceIcon
     case "positive":
       return styles.positiveIcon
     case "negative":
@@ -180,6 +186,8 @@ const mapVariantToIcon = (
   switch (variant) {
     case "informative":
       return informativeIcon
+    case "guidance":
+      return guidanceIcon
     case "positive":
       return positiveIcon
     case "negative":
@@ -195,6 +203,8 @@ const mapArrowVariantToClass = (variant: Variant): string => {
   switch (variant) {
     case "informative":
       return styles.informativeArrow
+    case "guidance":
+      return styles.guidanceArrow
     case "positive":
       return styles.positiveArrow
     case "negative":

--- a/draft-packages/popover/KaizenDraft/Popover/styles.scss
+++ b/draft-packages/popover/KaizenDraft/Popover/styles.scss
@@ -80,6 +80,16 @@ $large: 450px;
   @include arrow($kz-color-cluny-100, $kz-color-cluny-200);
 }
 
+.guidanceBox {
+  @extend %box;
+  background: $kz-color-cluny-100;
+  border-color: $kz-color-cluny-200;
+}
+
+.guidanceArrow {
+  @include arrow($kz-color-cluny-100, $kz-color-cluny-200);
+}
+
 .positiveBox {
   @extend %box;
   background: $kz-color-seedling-100;
@@ -133,6 +143,10 @@ $large: 450px;
 }
 
 .informativeIcon {
+  color: $kz-color-cluny-500;
+}
+
+.guidanceIcon {
   color: $kz-color-cluny-500;
 }
 

--- a/draft-packages/stories/Popover.stories.tsx
+++ b/draft-packages/stories/Popover.stories.tsx
@@ -92,6 +92,15 @@ export const InformativeLargeWithSingleLine = () => (
 
 InformativeLargeWithSingleLine.storyName = "Informative Large with singleLine"
 
+export const Guidance = () => (
+  <Container>
+    <Popover heading="Guidance" variant="guidance">
+      Popover body that explains something useful, is optional, and not critical
+      to completing a task.
+    </Popover>
+  </Container>
+)
+
 export const Positive = () => (
   <Container>
     <Popover heading="Positive" variant="positive">


### PR DESCRIPTION
# Objective
Add the 'guidance' variant for popovers.

# Motivation and Context 
We need to add this variant in as the lightbulb icon is going to be introduced to represent recommendations or tips, and we do not yet have a popover variant that allows for that. It is also important so we can achieve consistency as demonstrated in the design.

# Screenshots (if appropriate)
## Design
<img width="1091" alt="Screen Shot 2020-11-05 at 11 33 34" src="https://user-images.githubusercontent.com/8261468/98182802-bf2f5500-1f5a-11eb-98b0-f92e4a94bff8.png">

## Storybook component
<img width="290" alt="Screen Shot 2020-11-05 at 11 22 59" src="https://user-images.githubusercontent.com/8261468/98182192-44b20580-1f59-11eb-8245-80901ddd4f79.png">

# Checklist
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
[x] If this contains visual changes, has it been reviewed by a designer? 
[x] I have considered likely risks of these changes and got someone else to QA as appropriate
[ ] I have or will communicate these changes to the front end practice
