### PR TITLE
chore: Add deprecated line to Dropdown and related components

### DIFF
--- a/packages/component-library/components/Dropdown/Dropdown.tsx
+++ b/packages/component-library/components/Dropdown/Dropdown.tsx
@@ -21,6 +21,9 @@ export type DropdownProps = {
   iconPosition?: "start" | "end"
 }
 
+/**
+ * @deprecated Dropdown is deprecated. Please use draft-menu instead.
+ */
 class Dropdown extends React.Component<DropdownProps, DropdownState> {
   static displayName = "Dropdown"
   static defaultProps = {

--- a/packages/component-library/components/Dropdown/DropdownMenu.tsx
+++ b/packages/component-library/components/Dropdown/DropdownMenu.tsx
@@ -12,6 +12,9 @@ type DropdownMenuProps = {
   } | null
 }
 
+/**
+ * @deprecated DropdownMenu is deprecated. Please use draft-menu instead.
+ */
 class DropdownMenu extends React.Component<DropdownMenuProps> {
   static displayName = "DropdownMenu"
   menu = React.createRef<HTMLDivElement>()

--- a/packages/component-library/components/MenuList/MenuHeader.tsx
+++ b/packages/component-library/components/MenuList/MenuHeader.tsx
@@ -4,6 +4,9 @@ import * as React from "react"
 
 import styles from "./Menu.module.scss"
 
+/**
+ * @deprecated MenuHeader is deprecated. Please use draft-menu instead (it has its own menu header component).
+ */
 const MenuHeader = (props: { title: string }) => (
   <div className={styles.header}>
     <span className={styles.header__title}>{props.title}</span>

--- a/packages/component-library/components/MenuList/MenuItem.tsx
+++ b/packages/component-library/components/MenuList/MenuItem.tsx
@@ -6,6 +6,9 @@ import { Icon } from "../Icon"
 
 import styles from "./Menu.module.scss"
 
+/**
+ * @deprecated MenuItem is deprecated. Please use draft-menu instead (it has its own menu item component).
+ */
 const MenuItem = (props: {
   icon?: React.SVGAttributes<SVGSymbolElement>
   hoverIcon?: boolean

--- a/packages/component-library/components/MenuList/MenuList.tsx
+++ b/packages/component-library/components/MenuList/MenuList.tsx
@@ -3,6 +3,9 @@
 import * as React from "react"
 import styles from "./Menu.module.scss"
 
+/**
+ * @deprecated MenuList is deprecated. Please use draft-menu instead.
+ */
 const MenuList = (props: { children: React.ReactNode }) => (
   <div className={styles.menuList}>{props.children}</div>
 )

--- a/packages/component-library/components/MenuList/MenuSeparator.tsx
+++ b/packages/component-library/components/MenuList/MenuSeparator.tsx
@@ -4,6 +4,9 @@ import * as React from "react"
 
 import styles from "./Menu.module.scss"
 
+/**
+ * @deprecated MenuSeparator is deprecated. Please use draft-menu instead (it has its own separator component).
+ */
 const MenuSeparator = () => <hr className={styles.separator} />
 MenuSeparator.displayName = "MenuSeparator"
 


### PR DESCRIPTION
# Objective

Make engineers aware that deprecated components are in fact deprecated. Closes #852.

# Motivation and Context 

The `draft-menu` component should be used for every case that these deprecated components used to cover.

# Screenshots (if appropriate)

# Checklist
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
[ ] If this contains visual changes, has it been reviewed by a designer? 
[ x ] I have considered likely risks of these changes and got someone else to QA as appropriate
[ x ] I have or will communicate these changes to the front end practice
