### PR TITLE
feat: Allow custom icons for popovers

### DIFF
--- a/draft-packages/popover/KaizenDraft/Popover/Popover.tsx
+++ b/draft-packages/popover/KaizenDraft/Popover/Popover.tsx
@@ -23,6 +23,9 @@ export interface Props {
   readonly singleLine?: boolean
   readonly children: React.ReactNode
   readonly boxOffset?: BoxOffset
+  // For almost all intents and purposes, you should be using a pre-defined variant.
+  // Please avoid using a custom icon unless you have a very good reason to do so.
+  readonly customIcon?: React.SVGAttributes<SVGSymbolElement>
 }
 
 type Variant =
@@ -63,6 +66,7 @@ const Popover: Popover = React.forwardRef<HTMLDivElement, Props>(
       onClose,
       singleLine = false,
       boxOffset,
+      customIcon,
     },
     ref
   ) => (
@@ -81,7 +85,10 @@ const Popover: Popover = React.forwardRef<HTMLDivElement, Props>(
                   mapVariantToIconClass(variant)
                 )}
               >
-                <Icon role="presentation" icon={mapVariantToIcon(variant)} />
+                <Icon
+                  role="presentation"
+                  icon={customIcon ? customIcon : mapVariantToIcon(variant)}
+                />
               </span>
             )}
             <div className={styles.singleLine}>{heading}</div>

--- a/draft-packages/popover/KaizenDraft/Popover/Popover.tsx
+++ b/draft-packages/popover/KaizenDraft/Popover/Popover.tsx
@@ -23,8 +23,8 @@ export interface Props {
   readonly singleLine?: boolean
   readonly children: React.ReactNode
   readonly boxOffset?: BoxOffset
-  // For almost all intents and purposes, you should be using a pre-defined variant.
-  // Please avoid using a custom icon unless you have a very good reason to do so.
+  /** For almost all intents and purposes, you should be using a pre-defined variant.
+  Please avoid using a custom icon unless you have a very good reason to do so. **/
   readonly customIcon?: React.SVGAttributes<SVGSymbolElement>
 }
 

--- a/draft-packages/stories/Popover.stories.tsx
+++ b/draft-packages/stories/Popover.stories.tsx
@@ -2,6 +2,7 @@ import { DismissiblePositiveAutohide } from "@kaizen/component-library/stories/I
 import { Popover } from "@kaizen/draft-popover"
 import * as React from "react"
 import { Avatar } from "../avatar"
+import guidanceIcon from "@kaizen/component-library/icons/guidance.icon.svg"
 
 export default {
   title: "Popover (React)",
@@ -91,6 +92,21 @@ export const InformativeLargeWithSingleLine = () => (
 )
 
 InformativeLargeWithSingleLine.storyName = "Informative Large with singleLine"
+
+export const InformativeWithCustomIcon = () => (
+  <Container>
+    <Popover
+      heading="Informative"
+      variant="informative"
+      customIcon={guidanceIcon}
+    >
+      Popover body that explains something useful, is optional, and not critical
+      to completing a task.
+    </Popover>
+  </Container>
+)
+
+InformativeWithCustomIcon.storyName = "Informative with a custom icon"
 
 export const Positive = () => (
   <Container>


### PR DESCRIPTION
# Objective
Allows you to pass a custom icon into the popover, to override the icon for a specific variant.

# Motivation and Context 
Testing for default agenda items in 1-1s has suggested that the guidance icon is more appropriate than an informative icon. At the moment the icon usage is tied to the variant. We want to allow for a custom icon to allow this kind of 'snowflake' where suitable.

This change was previously introduced as a new variant due to a misunderstanding on my behalf.
https://github.com/cultureamp/kaizen-design-system/pull/853
https://cultureamp.slack.com/archives/C2ZNME08P/p1604544453303100

# Screenshots (if appropriate)
## Original informative variant
<img width="251" alt="Screen Shot 2020-11-10 at 13 42 38" src="https://user-images.githubusercontent.com/8261468/98621102-a65be080-235a-11eb-95ba-547dd7c1b6bf.png">

## Informative variant with a custom icon
<img width="271" alt="Screen Shot 2020-11-10 at 13 42 26" src="https://user-images.githubusercontent.com/8261468/98621108-a8be3a80-235a-11eb-9b82-9ab51e7e8ef4.png">

# Checklist
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] If this contains visual changes, has it been reviewed by a designer? 
- [x] I have considered likely risks of these changes and got someone else to QA as appropriate
- [x] I have or will communicate these changes to the front end practice
