### PR TITLE
feat: Add tooltip to the Table header

### DIFF
--- a/draft-packages/stories/Table.stories.tsx
+++ b/draft-packages/stories/Table.stories.tsx
@@ -16,8 +16,13 @@ import styles from "./Table.stories.scss"
 import chevronDownIcon from "@kaizen/component-library/icons/chevron-down.icon.svg"
 import chevronUpIcon from "@kaizen/component-library/icons/chevron-up.icon.svg"
 
-const Container: React.FunctionComponent = ({ children }) => (
-  <div style={{ margin: "1rem auto", width: "100%", maxWidth: "60rem" }}>
+const Container: React.FunctionComponent<{
+  children: React.ReactNode
+  style?: Record<string, string>
+}> = ({ children, style }) => (
+  <div
+    style={{ margin: "1rem auto", width: "100%", maxWidth: "60rem", ...style }}
+  >
     {children}
   </div>
 )
@@ -317,7 +322,7 @@ export const HeaderAlignmentAndWrapping = () => (
             align="end"
           />
           <TableHeaderRowCell
-            labelText="This column has no wrapping"
+            labelText="This column has no wrapping. This column has no wrapping."
             width={1 / 4}
             wrapping="nowrap"
           />
@@ -344,6 +349,65 @@ export const HeaderAlignmentAndWrapping = () => (
             <div className={styles.countAndExpander}>
               <Paragraph variant="body">24</Paragraph>
             </div>
+          </TableRowCell>
+        </TableRow>
+      </TableCard>
+    </TableContainer>
+  </Container>
+)
+
+HeaderAlignmentAndWrapping.storyName = "Header alignments and wrapping"
+
+export const Tooltip = () => (
+  // Extra margin added, so we can see the tooltip above
+  <Container style={{ marginTop: "200px" }}>
+    <TableContainer>
+      <TableHeader>
+        <TableHeaderRow>
+          <TableHeaderRowCell
+            labelText="This column has no tooltip"
+            width={1 / 4}
+          />
+          <TableHeaderRowCell
+            labelText="This column has a tooltip"
+            width={1 / 4}
+            tooltipInfo="This is a tooltip"
+          />
+          <TableHeaderRowCell
+            labelText="This column has a tooltip, and has wrapped content!"
+            width={1 / 4}
+            wrapping="wrap"
+            tooltipInfo="This is a tooltip"
+          />
+          <TableHeaderRowCell
+            labelText="End (right) aligned"
+            width={1 / 4}
+            tooltipInfo="This is a tooltip"
+            align="end"
+          />
+        </TableHeaderRow>
+      </TableHeader>
+      <TableCard>
+        <TableRow>
+          <TableRowCell width={1 / 4}>
+            <Paragraph tag="div" variant="body">
+              This is a cell
+            </Paragraph>
+          </TableRowCell>
+          <TableRowCell width={1 / 4}>
+            <Paragraph tag="div" variant="body">
+              This is a cell
+            </Paragraph>
+          </TableRowCell>
+          <TableRowCell width={1 / 4}>
+            <Paragraph tag="div" variant="body">
+              This is a cell
+            </Paragraph>
+          </TableRowCell>
+          <TableRowCell width={1 / 4}>
+            <Paragraph tag="div" variant="body">
+              This is a cell
+            </Paragraph>
           </TableRowCell>
         </TableRow>
       </TableCard>

--- a/draft-packages/table/KaizenDraft/Table/Table.tsx
+++ b/draft-packages/table/KaizenDraft/Table/Table.tsx
@@ -4,6 +4,8 @@ import classNames from "classnames"
 import * as React from "react"
 import styles from "./styles.scss"
 import sortDescendingIcon from "@kaizen/component-library/icons/sort-descending.icon.svg"
+import exclamationIcon from "@kaizen/component-library/icons/exclamation.icon.svg"
+import { Tooltip } from "@kaizen/draft-tooltip"
 
 type TableContainer = React.FunctionComponent<TableContainerProps>
 type TableContainerProps = {
@@ -81,18 +83,19 @@ type TableHeaderRowCell = React.FunctionComponent<{
   active?: boolean
   wrapping?: "nowrap" | "wrap"
   align?: "start" | "center" | "end"
+  tooltipInfo?: string
 }>
 export const TableHeaderRowCell: TableHeaderRowCell = ({
+  labelText,
+  automationId,
   onClick,
   width,
   flex,
-  labelText,
   icon,
   checkable,
   checkedStatus,
   onCheck,
   active,
-  automationId,
   // I can't say for cetin why "nowrap" was the default value. Normally you wouldn't
   // want to clip off information because it doesn't fit on one line.
   // My assumption is that because since the cell width rows are decoupled, a heading
@@ -101,14 +104,20 @@ export const TableHeaderRowCell: TableHeaderRowCell = ({
   // Anyway, we can override this default behaviour by setting wrapping to "wrap".
   wrapping = "nowrap",
   align = "start",
+  tooltipInfo,
+  // There aren't any other props in the type definition, so I'm unsure why we
+  // have this spread.
   ...otherProps
 }) => {
-  const label = icon ? (
-    <span className={styles.headerRowCellIcon}>
-      <Icon icon={icon} title={labelText} />
-    </span>
-  ) : (
-    <div className={styles.headerRowCellCheckboxContainer}>
+  // For this "cellContents" variable, we start at the inner most child, and
+  // wrap it elements, depending on what the props dictate.
+  let cellContents = (
+    <div className={styles.headerRowCellLabelAndIcons}>
+      {icon && (
+        <span className={styles.headerRowCellIcon}>
+          <Icon icon={icon} title={labelText} />
+        </span>
+      )}
       {checkable && (
         <div className={styles.headerRowCellCheckbox}>
           <Checkbox
@@ -118,49 +127,70 @@ export const TableHeaderRowCell: TableHeaderRowCell = ({
           />
         </div>
       )}
-      <Heading
-        tag="div"
-        variant="heading-6"
-        color={active ? "dark" : "dark-reduced-opacity"}
-      >
-        {labelText}
-      </Heading>
+      {tooltipInfo != null ? (
+        <div className={styles.headerRowCellTooltipIcon}>
+          <Icon icon={exclamationIcon} role="presentation" />
+        </div>
+      ) : null}
+      {/* If an "icon" is supplied, the label is displayed inside the icon aria title instead */}
+      {!icon ? (
+        <div className={styles.headerRowCellLabel}>
+          <Heading
+            tag="div"
+            variant="heading-6"
+            color={active ? "dark" : "dark-reduced-opacity"}
+          >
+            {labelText}
+          </Heading>
+        </div>
+      ) : null}
+      {active && <Icon icon={sortDescendingIcon} role="presentation" />}
     </div>
   )
 
-  const style = {
-    width: ratioToPercent(width),
-    flex,
-  }
-  const classes = classNames(styles.headerRowCell, {
-    [styles.headerRowCellWrap]: wrapping === "wrap",
-    [styles.headerRowCellAlignCenter]: align === "center",
-    [styles.headerRowCellAlignEnd]: align === "end",
-  })
-
-  return onClick ? (
+  cellContents = onClick ? (
     <button
       data-automation-id={automationId}
-      style={style}
-      className={classNames(classes, {
-        [styles.active]: active,
-      })}
+      className={styles.headerRowCellButton}
       onClick={onClick}
-      role="columnheader"
-      {...otherProps}
     >
-      {label}
-      {active && <Icon icon={sortDescendingIcon} role="presentation" />}
+      {cellContents}
     </button>
   ) : (
+    // This div wrapper probably isn't needed, but it's a bit easier
+    // for this flex positioning, to have the dom tree depth match for
+    // each permutation.
+    <div className={styles.headerRowCellNoButton}>{cellContents}</div>
+  )
+
+  cellContents =
+    tooltipInfo != null ? (
+      <Tooltip text={tooltipInfo} className={styles.headerRowCellTooltip}>
+        {cellContents}
+      </Tooltip>
+    ) : (
+      // Again, this wrapper is just to make the dom tree consistent between
+      // different permutations.
+      <div className={styles.headerRowCellTooltip}>{cellContents}</div>
+    )
+
+  return (
     <div
+      className={classNames(styles.headerRowCell, {
+        [styles.headerRowCellNoWrap]: wrapping === "nowrap",
+        [styles.headerRowCellAlignCenter]: align === "center",
+        [styles.headerRowCellAlignEnd]: align === "end",
+        [styles.headerRowCellActive]: active,
+      })}
+      style={{
+        width: ratioToPercent(width),
+        flex,
+      }}
       data-automation-id={automationId}
-      style={style}
-      className={classes}
       role="columnheader"
       {...otherProps}
     >
-      {label}
+      {cellContents}
     </div>
   )
 }

--- a/draft-packages/table/KaizenDraft/Table/Table.tsx
+++ b/draft-packages/table/KaizenDraft/Table/Table.tsx
@@ -165,7 +165,10 @@ export const TableHeaderRowCell: TableHeaderRowCell = ({
 
   cellContents =
     tooltipInfo != null ? (
-      <Tooltip text={tooltipInfo} className={styles.headerRowCellTooltip}>
+      <Tooltip
+        text={tooltipInfo}
+        classNameAndIHaveSpokenToDST={styles.headerRowCellTooltip}
+      >
         {cellContents}
       </Tooltip>
     ) : (

--- a/draft-packages/table/KaizenDraft/Table/TableHeaderRowCell.elm
+++ b/draft-packages/table/KaizenDraft/Table/TableHeaderRowCell.elm
@@ -95,13 +95,16 @@ view (Config config) =
         , styles.class .headerRowCell
         , role "columnheader"
         ]
-        [ Heading.view
-            (Heading.h1 |> Heading.variant Heading6)
-            [ Html.text config.labelText ]
+        [div
+            [ styles.class .headerRowCellNoButton ]
+            [ Heading.view
+                (Heading.h1 |> Heading.variant Heading6)
+                [ Html.text config.labelText ]
+            ]
         ]
-
 
 styles =
     css "@kaizen/draft-table/KaizenDraft/Table/styles.scss"
         { headerRowCell = "headerRowCell"
+        , headerRowCellNoButton = "headerRowCellNoButton"
         }

--- a/draft-packages/table/KaizenDraft/Table/styles.scss
+++ b/draft-packages/table/KaizenDraft/Table/styles.scss
@@ -68,13 +68,11 @@ $row-height: 60px;
 
 // The .headerRowCell wrapper is required to increase the specificity, as so
 // we can override the `Tooltip` component's styling.
-.headerRowCell {
-  .headerRowCellTooltip {
-    flex: 1 1 100%;
-    width: 100%;
-    display: flex;
-    align-items: stretch;
-  }
+.headerRowCell .headerRowCellTooltip {
+  flex: 1 1 100%;
+  width: 100%;
+  display: flex;
+  align-items: stretch;
 }
 
 .headerRowCellButton {

--- a/draft-packages/table/KaizenDraft/Table/styles.scss
+++ b/draft-packages/table/KaizenDraft/Table/styles.scss
@@ -41,6 +41,7 @@ $row-height: 60px;
 
 .headerRowCellNoWrap {
   .headerRowCellLabel {
+    // It appears that this ellipsis is not showing 🤔
     text-overflow: ellipsis;
     overflow: hidden;
     white-space: nowrap;

--- a/draft-packages/table/KaizenDraft/Table/styles.scss
+++ b/draft-packages/table/KaizenDraft/Table/styles.scss
@@ -66,13 +66,15 @@ $row-height: 60px;
   margin-right: 10px;
 }
 
-.headerRowCellTooltip {
-  flex: 1 1 100%;
-  width: 100%;
-  /* stylelint-disable */
-  display: flex !important; // We need to override the Tooltip styling 😬
-  /* stylelint-enable */
-  align-items: stretch;
+// The .headerRowCell wrapper is required to increase the specificity, as so
+// we can override the `Tooltip` component's styling.
+.headerRowCell {
+  .headerRowCellTooltip {
+    flex: 1 1 100%;
+    width: 100%;
+    display: flex;
+    align-items: stretch;
+  }
 }
 
 .headerRowCellButton {

--- a/draft-packages/table/KaizenDraft/Table/styles.scss
+++ b/draft-packages/table/KaizenDraft/Table/styles.scss
@@ -69,7 +69,9 @@ $row-height: 60px;
 .headerRowCellTooltip {
   flex: 1 1 100%;
   width: 100%;
+  /* stylelint-disable */
   display: flex !important; // We need to override the Tooltip styling 😬
+  /* stylelint-enable */
   align-items: stretch;
 }
 

--- a/draft-packages/table/KaizenDraft/Table/styles.scss
+++ b/draft-packages/table/KaizenDraft/Table/styles.scss
@@ -31,53 +31,80 @@ $row-height: 60px;
 }
 
 .headerRowCell {
-  @include button-reset;
-  text-overflow: ellipsis;
-  overflow-x: hidden;
-  white-space: nowrap;
-  // The 8px usually makes the height of the header cell 40px
-  padding: 8px $ca-grid;
   display: flex;
-  align-items: center;
+  align-items: stretch;
   text-align: start;
   justify-content: flex-start;
+  // This is required as so the tooltip will display directly above the header cell
+  position: relative;
 }
 
-.headerRowCellWrap {
-  white-space: normal;
+.headerRowCellNoWrap {
+  .headerRowCellLabel {
+    text-overflow: ellipsis;
+    overflow: hidden;
+    white-space: nowrap;
+  }
 }
 
 .headerRowCellAlignCenter {
-  text-align: center;
-  justify-content: center;
+  .headerRowCellLabelAndIcons {
+    text-align: center;
+    justify-content: center;
+  }
 }
 
 .headerRowCellAlignEnd {
-  text-align: end;
-  justify-content: flex-end;
+  .headerRowCellLabelAndIcons {
+    text-align: end;
+    justify-content: flex-end;
+  }
 }
 
 .headerRowCellCheckbox {
   margin-right: 10px;
 }
 
-.headerRowCellCheckboxContainer {
+.headerRowCellTooltip {
+  flex: 1 1 100%;
+  width: 100%;
+  display: flex !important; // We need to override the Tooltip styling 😬
+  align-items: stretch;
+}
+
+.headerRowCellButton {
+  @include button-reset;
+}
+
+.headerRowCellButton,
+.headerRowCellNoButton {
+  display: flex;
+  align-items: stretch;
+  width: 100%;
+  // The 8px usually makes the height of the header cell 40px
+  padding: 8px $ca-grid;
+  // Ensures that the 100% doesn't go outside of the `headerRowCell` width
+  box-sizing: border-box;
+}
+
+.headerRowCellLabelAndIcons {
   display: flex;
   align-items: center;
+  flex: 1 1 100%;
+  width: 100%;
+}
+
+.headerRowCellTooltipIcon {
+  color: $kz-color-cluny-500;
+  margin-right: $ca-grid / 4;
 }
 
 .headerRowCellIcon {
   color: $kz-color-wisteria-500;
   height: 20px;
 
-  .active & {
+  .headerRowCellActive & {
     color: $kz-color-wisteria-800;
-  }
-}
-
-.active {
-  .header & {
-    background-color: $kz-color-wisteria-100;
   }
 }
 

--- a/draft-packages/tooltip/KaizenDraft/Tooltip/Tooltip.tsx
+++ b/draft-packages/tooltip/KaizenDraft/Tooltip/Tooltip.tsx
@@ -9,14 +9,18 @@ type Props = {
   position?: Position
   text: string
   children?: React.ReactNode
-  className?: string
+  classNameAndIHaveSpokenToDST?: string
 }
 
 const Tooltip = (props: Props) => (
   <span
-    className={classnames(styles.tooltipWrap, props.className, {
-      [styles.inline]: props.inline === true,
-    })}
+    className={classnames(
+      styles.tooltipWrap,
+      props.classNameAndIHaveSpokenToDST,
+      {
+        [styles.inline]: props.inline === true,
+      }
+    )}
   >
     {props.children}
     <span

--- a/draft-packages/tooltip/KaizenDraft/Tooltip/Tooltip.tsx
+++ b/draft-packages/tooltip/KaizenDraft/Tooltip/Tooltip.tsx
@@ -9,11 +9,12 @@ type Props = {
   position?: Position
   text: string
   children?: React.ReactNode
+  className?: string
 }
 
 const Tooltip = (props: Props) => (
   <span
-    className={classnames(styles.tooltipWrap, {
+    className={classnames(styles.tooltipWrap, props.className, {
       [styles.inline]: props.inline === true,
     })}
   >


### PR DESCRIPTION
# Objective
Adds a `tooltipInfo` property to the `Table` component. Using this prop will wrap the cell in a tooltip, and add a blue info icon to the left hand side.

The problem with simply wrapping the heading cell with a `Tooltip`, is that it ruined a lot of the flex styling. To overcome this, I needed to make some minor refactors to `TableHeaderRowCell`.

# Motivation and Context 

On the new Evaluation Cycle dashboards work, we needed to include a tooltip, to provide more context on the table header column name. We've had some confusion from customers in regards to when a request is "from" someone, vs "for" someone. We have very little horizontal realestate on this table, so a Tooltip was our option of last resort.

# Screenshots

![image](https://user-images.githubusercontent.com/4495057/98763638-93b2db80-242e-11eb-83f4-b1e5e0477032.png)

# Checklist
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] If this contains visual changes, has it been reviewed by a designer?  - Approved by Stuart
* [X] I have considered likely risks of these changes and got someone else to QA as appropriate
* [X] I have or will communicate these changes to the front end practice
