### PR TITLE
fix: Add coverage of .js and .d.ts files to clean scripts that were missing them

### DIFF
--- a/packages/design-tokens/package.json
+++ b/packages/design-tokens/package.json
@@ -21,7 +21,7 @@
     "build": "yarn clean && yarn prepublish",
     "build:less": "json-to-flat-sass './tokens/*.json' 'less' --extension 'less' --caseType 'kebab' && prettier less/* --write",
     "build:sass": "json-to-flat-sass './tokens/*.json' 'sass' --extension 'scss' --caseType 'kebab' && prettier sass/* --write",
-    "clean": "rimraf 'dist/**' 'tokens/*.js'",
+    "clean": "rimraf 'dist/**' 'tokens/**/*.js' 'tokens/**/*.d.ts' 'tokens/**/*.map'",
     "prepublish": "yarn build:less && yarn build:sass"
   },
   "devDependencies": {

--- a/packages/generator/package.json
+++ b/packages/generator/package.json
@@ -4,6 +4,9 @@
   "description": "Quickly scaffolds new components in Kaizen",
   "main": "index.js",
   "license": "MIT",
+  "scripts": {
+    "clean": "rimraf 'generators/**/*.js' 'generators/**/*.d.ts'"
+  },
   "files": [
     "generators"
   ],

--- a/packages/hosted-assets/package.json
+++ b/packages/hosted-assets/package.json
@@ -21,6 +21,6 @@
     "prepublish": "tsc --project tsconfig.dist.json",
     "build": "yarn clean && yarn prepublish",
     "build:watch": "yarn clean && yarn prepublish --watch",
-    "clean": "rm -rf dist"
+    "clean": "rm -rf dist && rimraf '*.d.ts' '*.js'"
   }
 }


### PR DESCRIPTION
# Objective

Adds coverage of `.js` and `.d.ts` files to the `clean` script in the `package.json` of a few packages.

# Motivation and Context 

I (and possibly others) was running into problems every time I tried to push a branch, because the auto-linting that Prettier runs was erroring on this files and aborting the push:

![Screen Shot 2020-11-12 at 4 57 30 pm](https://user-images.githubusercontent.com/6406263/98903814-69cfe680-250c-11eb-9ccb-c6b3d473c97a.png)

# Checklist
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
[ ] If this contains visual changes, has it been reviewed by a designer? 
[ ] I have considered likely risks of these changes and got someone else to QA as appropriate
[ x ] I have or will communicate these changes to the front end practice