### PR TITLE
chore: Fix stylelint warnings for color names

### DIFF
--- a/draft-packages/dropdown-menu/KaizenDraft/DropdownMenu/DropdownMenu.scss
+++ b/draft-packages/dropdown-menu/KaizenDraft/DropdownMenu/DropdownMenu.scss
@@ -7,7 +7,7 @@
 
 .dropdown {
   position: relative;
-  background: #fff;
+  background: white;
   border: $kz-border-solid-border-width $kz-border-solid-border-style
     $ca-border-color;
   border-radius: $kz-border-solid-border-radius;

--- a/draft-packages/likert-scale-legacy/KaizenDraft/LikertScaleLegacy/styles.module.scss
+++ b/draft-packages/likert-scale-legacy/KaizenDraft/LikertScaleLegacy/styles.module.scss
@@ -313,14 +313,14 @@ $fifth: mix($start, $end, 0%);
     .likertItem {
       .likertItemFill {
         height: 25px;
-        background: #fff;
+        background: white;
         border: 1px solid #d7d8d8;
       }
 
       &:first-child,
       &:last-child {
         .likertItemFill {
-          background: #fff;
+          background: white;
           border-width: 2px;
         }
       }

--- a/draft-packages/popover/KaizenDraft/Popover/styles.scss
+++ b/draft-packages/popover/KaizenDraft/Popover/styles.scss
@@ -53,7 +53,7 @@ $large: 450px;
 }
 
 %box {
-  background: #fff;
+  background: white;
   border: $kz-border-solid-border-width $kz-border-solid-border-style
     $kz-color-wisteria-200;
   filter: drop-shadow(0 0 7px rgba(0, 0, 0, 0.1));
@@ -67,7 +67,7 @@ $large: 450px;
 }
 
 .defaultArrow {
-  @include arrow(#fff, $kz-color-wisteria-200);
+  @include arrow(white, $kz-color-wisteria-200);
 }
 
 .informativeBox {
@@ -152,7 +152,7 @@ $large: 450px;
   @include button-reset;
   margin-left: auto;
   display: inherit;
-  color: add-alpha(#000, 50%);
+  color: add-alpha(black, 50%);
 }
 
 .arrowSideBottom {

--- a/draft-packages/split-button/KaizenDraft/SplitButton/styles.scss
+++ b/draft-packages/split-button/KaizenDraft/SplitButton/styles.scss
@@ -272,7 +272,7 @@ version since the React version relies on kaizen's MenuList
  */
 
 .menuList {
-  background: #fff;
+  background: white;
   border: $kz-border-solid-border-width $kz-border-solid-border-style
     $kz-color-wisteria-200;
   box-shadow: $kz-shadow-small-box-shadow;

--- a/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/_styles.scss
+++ b/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/_styles.scss
@@ -397,7 +397,7 @@ $navbar-breakpoint-condensed-large-up: 1150px;
 
     // show custom focus ring when :focus-visible
     &:global(.focus-visible) {
-      color: #fff;
+      color: white;
       outline: 2px solid $kz-color-cluny-500;
     }
   }

--- a/legacy-packages/menu-list/KaizenDraft/MenuList/MenuList.scss
+++ b/legacy-packages/menu-list/KaizenDraft/MenuList/MenuList.scss
@@ -13,7 +13,7 @@
 $side-padding: 3/4 * $ca-grid;
 
 .menuList {
-  background: #fff;
+  background: white;
   border: $kz-border-solid-border-width $kz-border-solid-border-style
     $kz-color-wisteria-100;
   box-shadow: $kz-shadow-small-box-shadow;

--- a/legacy-packages/title-block/KaizenDraft/TitleBlock/NavigationButton.scss
+++ b/legacy-packages/title-block/KaizenDraft/TitleBlock/NavigationButton.scss
@@ -46,17 +46,17 @@
   border-bottom-color: $kz-color-cluny-500;
 
   &.reversed {
-    border-bottom-color: #fff;
+    border-bottom-color: white;
   }
 }
 
 .reversed {
-  color: #fff;
+  color: white;
 
   &.button {
     &:hover {
-      color: #fff;
-      border-bottom-color: #fff;
+      color: white;
+      border-bottom-color: white;
     }
   }
 }

--- a/legacy-packages/title-block/KaizenDraft/TitleBlock/TitleBlock.scss
+++ b/legacy-packages/title-block/KaizenDraft/TitleBlock/TitleBlock.scss
@@ -14,7 +14,7 @@
 }
 
 .titleBlock {
-  background-color: #fff;
+  background-color: white;
   border-bottom: 1px solid $ca-border-color;
   width: inherit;
 
@@ -127,7 +127,7 @@
   .breadcrumb:hover &,
   .breadcrumb:focus & {
     background-color: $kz-color-cluny-500;
-    color: #fff;
+    color: white;
     transform: scale(1.1);
   }
 }
@@ -268,7 +268,7 @@
     margin: 0;
     border-bottom: 1px solid $ca-border-color;
     width: 100%;
-    background: #fff;
+    background: white;
   }
 
   .navButtonsContainer {
@@ -296,16 +296,16 @@
 //--------------------- REVERSE COLORS ---------------------//
 
 .reversed {
-  color: #fff;
+  color: white;
 
   @include ca-media-tablet-and-up {
     .title {
-      color: #fff;
+      color: white;
     }
   }
 
   .subtitle {
-    color: #fff;
+    color: white;
   }
 
   .breadcrumb {
@@ -313,13 +313,13 @@
 
     &:hover {
       .circle {
-        background-color: add-alpha(#fff, 40%);
+        background-color: add-alpha(white, 40%);
       }
     }
   }
 
   .circle {
-    background-color: add-alpha(#fff, 20%);
+    background-color: add-alpha(white, 20%);
     color: $kz-color-white;
   }
 
@@ -331,7 +331,7 @@
     background-color: transparent;
 
     @include ca-media-mobile {
-      border-bottom: 1px solid #fff;
+      border-bottom: 1px solid white;
     }
   }
 }

--- a/packages/component-library/components/MenuList/Menu.module.scss
+++ b/packages/component-library/components/MenuList/Menu.module.scss
@@ -12,7 +12,7 @@
 $side-padding: 3/4 * $ca-grid;
 
 .menuList {
-  background: #fff;
+  background: white;
   border: $kz-border-solid-border-width $kz-border-solid-border-style
     $kz-color-wisteria-200;
   box-shadow: $kz-shadow-small-box-shadow;

--- a/packages/component-library/components/NavigationBar/NavigationBar.module.scss
+++ b/packages/component-library/components/NavigationBar/NavigationBar.module.scss
@@ -13,7 +13,7 @@
     background: $kz-color-wisteria-700;
 
     a {
-      color: #fff;
+      color: white;
     }
   }
 

--- a/packages/component-library/components/NavigationBar/_styles.scss
+++ b/packages/component-library/components/NavigationBar/_styles.scss
@@ -36,12 +36,12 @@ $link-margin: $ca-grid / 4;
 
   border-radius: $kz-border-solid-border-radius;
 
-  color: rgba(#fff, 0.8);
+  color: rgba(white, 0.8);
   padding: 0;
   text-decoration: none;
 
   &.active {
-    color: #fff; // override hyperlink hover color
+    color: white; // override hyperlink hover color
     outline: none; // override native focus styles
     text-decoration: none;
 
@@ -62,7 +62,7 @@ $link-margin: $ca-grid / 4;
     top: 0;
     left: 0;
     right: 0;
-    background-color: #fff;
+    background-color: white;
     transition: transform $ca-navigation-bar__animation-ease
       $ca-navigation-bar__animation-timing;
 
@@ -76,7 +76,7 @@ $link-margin: $ca-grid / 4;
   }
 
   &:hover {
-    color: #fff; // override hyperlink hover color
+    color: white; // override hyperlink hover color
     text-decoration: none;
 
     .linkText::before {
@@ -119,7 +119,7 @@ $link-margin: $ca-grid / 4;
 
       &:hover,
       &:focus {
-        background-color: rgba(#fff, 0.1);
+        background-color: rgba(white, 0.1);
 
         .linkIcon {
           opacity: 0.7;
@@ -127,7 +127,7 @@ $link-margin: $ca-grid / 4;
       }
 
       &:active {
-        background-color: rgba(#fff, 0.2);
+        background-color: rgba(white, 0.2);
         transform: translateY(1px);
 
         .linkIcon {
@@ -160,7 +160,7 @@ $link-margin: $ca-grid / 4;
 
     // show custom focus ring when :focus-visible
     &:global(.focus-visible) {
-      color: #fff;
+      color: white;
       outline: 2px solid $kz-color-cluny-500;
     }
   }

--- a/packages/component-library/components/NavigationBar/components/Badge.module.scss
+++ b/packages/component-library/components/NavigationBar/components/Badge.module.scss
@@ -5,7 +5,7 @@
 
 .badge {
   background-color: $kz-color-coral-500;
-  color: #fff;
+  color: white;
   font-weight: $ca-weight-medium;
   text-decoration: none;
   text-transform: uppercase;

--- a/packages/component-library/components/NavigationBar/components/Menu.module.scss
+++ b/packages/component-library/components/NavigationBar/components/Menu.module.scss
@@ -91,7 +91,7 @@ $menu__square-size: $ca-grid * 2;
   }
 
   > * {
-    color: #fff;
+    color: white;
     background-color: $kz-color-wisteria-800;
     border-radius: $kz-border-solid-border-radius;
     padding: 3px 0; // @TODO-DST - No magic padding

--- a/packages/component-library/components/OffCanvas/components/Header.module.scss
+++ b/packages/component-library/components/OffCanvas/components/Header.module.scss
@@ -21,5 +21,5 @@
 .heading {
   @include ca-type-inter-display;
   @include ca-inherit-baseline;
-  color: #fff;
+  color: white;
 }

--- a/packages/component-library/styles/color.scss
+++ b/packages/component-library/styles/color.scss
@@ -1,6 +1,6 @@
 @import "~@kaizen/design-tokens/sass/color";
-$white: #fff;
-$black: #000;
+$white: white;
+$black: black;
 
 @function add-tint($color, $percentage) {
   @return mix($white, $color, $percentage);

--- a/packages/deprecated-component-library-helpers/styles/color.scss
+++ b/packages/deprecated-component-library-helpers/styles/color.scss
@@ -1,6 +1,6 @@
 @import "~@kaizen/design-tokens/sass/color";
-$white: #fff;
-$black: #000;
+$white: white;
+$black: black;
 
 @function add-tint($color, $percentage) {
   @return mix($white, $color, $percentage);

--- a/packages/design-tokens/sass/color.scss
+++ b/packages/design-tokens/sass/color.scss
@@ -39,7 +39,7 @@ $kz-color-peach-500: #fa7558;
 $kz-color-peach-600: #b85d4a;
 $kz-color-ash: #ececef;
 $kz-color-stone: #f6f6f6;
-$kz-color-white: #ffffff;
+$kz-color-white: white;
 $kz-deprecated-color-lapis: #253c64;
 $kz-deprecated-color-ocean: #1b7688;
 $kz-deprecated-color-ink: #3e4543;

--- a/site/src/components/ContentOnly.scss
+++ b/site/src/components/ContentOnly.scss
@@ -15,7 +15,7 @@
 }
 
 .content {
-  background-color: #fff;
+  background-color: white;
   border-radius: 7px;
   box-shadow: var(--card-box-shadow);
   padding: 0;

--- a/site/src/components/Footer.scss
+++ b/site/src/components/Footer.scss
@@ -7,7 +7,7 @@ $reverse-variant-color: $kz-color-wisteria-700;
 .footerExtraContent {
   .reverseVariant & {
     background-color: $reverse-variant-color;
-    color: #fff;
+    color: white;
   }
 }
 
@@ -19,7 +19,7 @@ $reverse-variant-color: $kz-color-wisteria-700;
 
   .reverseVariant & {
     background-color: $reverse-variant-color;
-    color: #fff;
+    color: white;
   }
 }
 

--- a/site/src/components/PageHeader.scss
+++ b/site/src/components/PageHeader.scss
@@ -8,7 +8,7 @@
   justify-items: center;
   background: $kz-color-wisteria-700;
   padding: calc(var(--ca-grid) * 3.5) var(--ca-grid);
-  color: #fff;
+  color: white;
 
   @include ca-media-mobile() {
     padding-bottom: calc(var(--ca-grid) * 3.5);

--- a/site/src/components/SidebarAndContent.scss
+++ b/site/src/components/SidebarAndContent.scss
@@ -33,7 +33,7 @@ $tableOfContents-width: $ca-grid * 10;
 
 .content {
   grid-area: content;
-  background-color: #fff;
+  background-color: white;
   border-radius: 7px;
   box-shadow: var(--card-box-shadow);
   padding: 0;

--- a/site/src/pages/index.scss
+++ b/site/src/pages/index.scss
@@ -26,7 +26,7 @@
 }
 
 %imageContainer {
-  background: #fff;
+  background: white;
   width: 240px;
   height: 240px;
   transition: transform $kz-animation-duration-rapid

--- a/site/src/styles/global.scss
+++ b/site/src/styles/global.scss
@@ -24,7 +24,7 @@ body {
   font-family: $ca-inter-font-family;
 
   @include ca-media-mobile() {
-    background-color: #fff;
+    background-color: white;
   }
 }
 


### PR DESCRIPTION
# Objective

Fixes stylelint warnings that were appearing in pre-commit linting.

These were all based on the rule preferring `black` and `white` over `#000`/`#000000` and `#fff`/`#ffffff`.

![image](https://user-images.githubusercontent.com/6406263/98905648-e0baae80-250f-11eb-9eb3-68f6bd140665.png)

# Checklist
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
[ ] If this contains visual changes, has it been reviewed by a designer? 
[ ] I have considered likely risks of these changes and got someone else to QA as appropriate
[ x ] I have or will communicate these changes to the front end practice