### PR TITLE
docs: Update drawer.mdx

### DIFF
--- a/site/docs/components/drawer.mdx
+++ b/site/docs/components/drawer.mdx
@@ -18,11 +18,11 @@ import WhenNotToUse from "docs-components/WhenNotToUse"
 
 ### UI Kit
 
-<iframe style="border: 1px solid rgba(0, 0, 0, 0.1);" width="800" height="450" src="https://www.figma.com/embed?embed_host=share&url=https%3A%2F%2Fwww.figma.com%2Ffile%2FGMxm8rvDCbj0Xw3TQWBZ8b%2FZen-UI-Kit%3Fnode-id%3D13514%253A75372" allowfullscreen></iframe>
+<iframe style="border: 1px solid rgba(0, 0, 0, 0.1);" width="800" height="450" src="https://www.figma.com/embed?embed_host=share&url=https%3A%2F%2Fwww.figma.com%2Ffile%2Fe3TyAOZKfLg9cA01Iy1Mgm%2FKaizen-Site-embed%3Fnode-id%3D87950%253A39194" allowfullscreen></iframe>
 
 ### Examples
 
-<iframe style="border: 1px solid rgba(0, 0, 0, 0.1);" width="800" height="450" src="https://www.figma.com/embed?embed_host=share&url=https%3A%2F%2Fwww.figma.com%2Ffile%2FGMxm8rvDCbj0Xw3TQWBZ8b%2FZen-UI-Kit%3Fnode-id%3D13514%253A75611" allowfullscreen></iframe>
+<iframe style="border: 1px solid rgba(0, 0, 0, 0.1);" width="800" height="450" src="https://www.figma.com/embed?embed_host=share&url=https%3A%2F%2Fwww.figma.com%2Ffile%2Fe3TyAOZKfLg9cA01Iy1Mgm%2FKaizen-Site-embed%3Fnode-id%3D87950%253A39184" allowfullscreen></iframe>
 
 ## To keep in mind
 


### PR DESCRIPTION
**Objective**

Update embed links to point to correct Figma file. 

**Motivation and Context**

Embedded examples were pointing to the UI Kit. I have updated these to point to the Figma file set up specifically for Kaizen site embeds. Content of examples hasn't changed. 