### PR TITLE
feat: Add ability to change the table sorting arrow from descending to ascending

### DIFF
--- a/draft-packages/stories/Table.stories.tsx
+++ b/draft-packages/stories/Table.stories.tsx
@@ -414,4 +414,52 @@ export const Tooltip = () => (
   </Container>
 )
 
-HeaderAlignmentAndWrapping.storyName = "Header alignments and wrapping"
+Tooltip.storyName = "Tooltip"
+
+export const AnchorLink = () => (
+  // Extra margin added, so we can see the tooltip above
+  <Container style={{ marginTop: "200px" }}>
+    <TableContainer>
+      <TableHeader>
+        <TableHeaderRow>
+          <TableHeaderRowCell
+            labelText="This is an anchor"
+            width={1 / 2}
+            onClick={e => {
+              e.preventDefault()
+              alert("Header was clicked")
+            }}
+            href="#?foo=bar"
+            sorting="ascending"
+          />
+          <TableHeaderRowCell
+            labelText="This is an anchor"
+            width={1 / 2}
+            onClick={e => {
+              e.preventDefault()
+              alert("Header was clicked")
+            }}
+            href="#?foo=bar"
+          />
+        </TableHeaderRow>
+      </TableHeader>
+      <TableCard>
+        <TableRow>
+          <TableRowCell width={1 / 2}>
+            <Paragraph tag="div" variant="body">
+              Notice that you can open it in a new tab
+            </Paragraph>
+          </TableRowCell>
+          <TableRowCell width={1 / 2}>
+            <Paragraph tag="div" variant="body">
+              Typically you'd need to hook this up with your routing library
+              (eg. react-router)
+            </Paragraph>
+          </TableRowCell>
+        </TableRow>
+      </TableCard>
+    </TableContainer>
+  </Container>
+)
+
+AnchorLink.storyName = "Anchor Link"

--- a/draft-packages/stories/Table.stories.tsx
+++ b/draft-packages/stories/Table.stories.tsx
@@ -34,7 +34,7 @@ const ExampleTableHeaderRow = ({ checkable = false }) => (
       onCheck={evt => {
         alert(evt.target.value)
       }}
-      active={true}
+      sorting="descending"
       onClick={() => alert("Sort!")}
       labelText="Resource name"
       width={4 / 12}

--- a/draft-packages/table/KaizenDraft/Table/Table.tsx
+++ b/draft-packages/table/KaizenDraft/Table/Table.tsx
@@ -88,6 +88,9 @@ type TableHeaderRowCell = React.FunctionComponent<{
    * @deprecated
    */
   active?: boolean
+  /**
+   * Shows an up or down arrow, to show that the column is sorted.
+   */
   sorting?: "ascending" | "descending"
   wrapping?: "nowrap" | "wrap"
   align?: "start" | "center" | "end"

--- a/draft-packages/table/KaizenDraft/Table/Table.tsx
+++ b/draft-packages/table/KaizenDraft/Table/Table.tsx
@@ -74,7 +74,10 @@ const ratioToPercent = (width?: number) =>
 type TableHeaderRowCell = React.FunctionComponent<{
   labelText: string
   automationId?: string
-  onClick?: (e: React.MouseEvent<HTMLButtonElement>) => any
+  onClick?:
+    | ((e: React.MouseEvent<HTMLButtonElement>) => any)
+    | ((e: React.MouseEvent<HTMLAnchorElement>) => any)
+  href?: string
   width?: number
   flex?: string
   icon?: React.SVGAttributes<SVGSymbolElement>
@@ -100,6 +103,7 @@ export const TableHeaderRowCell: TableHeaderRowCell = ({
   labelText,
   automationId,
   onClick,
+  href,
   width,
   flex,
   icon,
@@ -170,11 +174,22 @@ export const TableHeaderRowCell: TableHeaderRowCell = ({
     </div>
   )
 
-  cellContents = onClick ? (
+  cellContents = href ? (
+    <a
+      data-automation-id={automationId}
+      className={styles.headerRowCellButton}
+      href={href}
+      onClick={
+        onClick as (e: React.MouseEvent<HTMLAnchorElement>) => any | undefined
+      }
+    >
+      {cellContents}
+    </a>
+  ) : onClick ? (
     <button
       data-automation-id={automationId}
       className={styles.headerRowCellButton}
-      onClick={onClick}
+      onClick={onClick as (e: React.MouseEvent<HTMLButtonElement>) => any}
     >
       {cellContents}
     </button>

--- a/draft-packages/table/KaizenDraft/Table/Table.tsx
+++ b/draft-packages/table/KaizenDraft/Table/Table.tsx
@@ -2,6 +2,7 @@ import { Heading, Icon } from "@kaizen/component-library"
 import { Checkbox, CheckedStatus } from "@kaizen/draft-form"
 import classNames from "classnames"
 import * as React from "react"
+import sortAscendingIcon from "@kaizen/component-library/icons/sort-ascending.icon.svg"
 import sortDescendingIcon from "@kaizen/component-library/icons/sort-descending.icon.svg"
 import exclamationIcon from "@kaizen/component-library/icons/exclamation.icon.svg"
 import { Tooltip } from "@kaizen/draft-tooltip"
@@ -80,7 +81,14 @@ type TableHeaderRowCell = React.FunctionComponent<{
   checkable?: boolean
   checkedStatus?: CheckedStatus
   onCheck?: (event: React.ChangeEvent<HTMLInputElement>) => any
+  /**
+   * This boolean would show a "sort by" icon in the table cell header.
+   * The problem was that the arrow was pointing in the descending direction only.
+   * Please use `sorting` prop instead.
+   * @deprecated
+   */
   active?: boolean
+  sorting?: "ascending" | "descending"
   wrapping?: "nowrap" | "wrap"
   align?: "start" | "center" | "end"
   tooltipInfo?: string
@@ -96,6 +104,7 @@ export const TableHeaderRowCell: TableHeaderRowCell = ({
   checkedStatus,
   onCheck,
   active,
+  sorting: sortingRaw,
   // I can't say for cetin why "nowrap" was the default value. Normally you wouldn't
   // want to clip off information because it doesn't fit on one line.
   // My assumption is that because since the cell width rows are decoupled, a heading
@@ -109,6 +118,9 @@ export const TableHeaderRowCell: TableHeaderRowCell = ({
   // have this spread.
   ...otherProps
 }) => {
+  // `active` is the legacy prop
+  const sorting = sortingRaw || (active ? "descending" : undefined)
+
   // For this "cellContents" variable, we start at the inner most child, and
   // wrap it elements, depending on what the props dictate.
   let cellContents = (
@@ -138,13 +150,20 @@ export const TableHeaderRowCell: TableHeaderRowCell = ({
           <Heading
             tag="div"
             variant="heading-6"
-            color={active ? "dark" : "dark-reduced-opacity"}
+            color={sorting ? "dark" : "dark-reduced-opacity"}
           >
             {labelText}
           </Heading>
         </div>
       ) : null}
-      {active && <Icon icon={sortDescendingIcon} role="presentation" />}
+      {sorting && (
+        <Icon
+          icon={
+            sorting === "ascending" ? sortAscendingIcon : sortDescendingIcon
+          }
+          role="presentation"
+        />
+      )}
     </div>
   )
 
@@ -183,7 +202,7 @@ export const TableHeaderRowCell: TableHeaderRowCell = ({
         [styles.headerRowCellNoWrap]: wrapping === "nowrap",
         [styles.headerRowCellAlignCenter]: align === "center",
         [styles.headerRowCellAlignEnd]: align === "end",
-        [styles.headerRowCellActive]: active,
+        [styles.headerRowCellActive]: !!sorting,
       })}
       style={{
         width: ratioToPercent(width),

--- a/draft-packages/table/KaizenDraft/Table/styles.scss
+++ b/draft-packages/table/KaizenDraft/Table/styles.scss
@@ -77,6 +77,8 @@ $row-height: 60px;
 
 .headerRowCellButton {
   @include button-reset;
+  text-decoration: none;
+  color: $kz-color-wisteria-800;
 }
 
 .headerRowCellButton,

--- a/draft-packages/table/KaizenDraft/Table/styles.scss
+++ b/draft-packages/table/KaizenDraft/Table/styles.scss
@@ -77,8 +77,7 @@ $row-height: 60px;
 
 .headerRowCellButton {
   @include button-reset;
-  text-decoration: none;
-  color: $kz-color-wisteria-800;
+  composes: anchorReset;
 }
 
 .headerRowCellButton,


### PR DESCRIPTION
* Add ability to change the table sorting arrow from descending to ascending. Before, we only had an `active` prop, which accepted true or false. Now there's a `sorting` prop, with `ascending` | `descending` | undefined.

![image](https://user-images.githubusercontent.com/4495057/99209764-0a2d5000-2818-11eb-9ab4-52f530c4c371.png)

* Side update: add `href` property to the table header. In perform, our sort values are stored in the url. Whenever we use routing, we should (pretty much) always use `a`nchor tags, this allows the user to do things like open the link in a new tab etc.
![image](https://user-images.githubusercontent.com/4495057/99213182-0eaa3680-2821-11eb-9f33-e8d490120ee4.png)

# Checklist
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] If this contains visual changes, has it been reviewed by a designer? 
* [X] I have considered likely risks of these changes and got someone else to QA as appropriate
* [X] I have or will communicate these changes to the front end practice
