### PR TITLE
feat: add automation id to heading

### DIFF
--- a/packages/component-library/components/Heading/Heading.tsx
+++ b/packages/component-library/components/Heading/Heading.tsx
@@ -41,6 +41,7 @@ export interface HeadingProps {
    */
   classNameAndIHaveSpokenToDST?: string
   children: React.ReactNode
+  automationId?: string
   /**
    * HTML elements that are allowed on Headings. When not supplied, the tag is inferred from
    * the variant. E.g. display-0 will infer h1
@@ -59,8 +60,12 @@ export const Heading = ({
   tag,
   variant,
   color = "dark",
+  automationId,
   ...otherProps
 }: HeadingProps) => {
+  const dataAutomationId = automationId
+    ? { "data-automation-id": automationId }
+    : { "data-automation-id": "" }
   const inferredTag =
     tag === undefined ? translateHeadingLevelToTag(variant) : tag
 
@@ -72,7 +77,11 @@ export const Heading = ({
     VARIANTS_24PX_OR_GREATER.includes(variant) ? styles.large : styles.small,
   ])
 
-  return createElement(inferredTag, { ...otherProps, className }, children)
+  return createElement(
+    inferredTag,
+    { ...otherProps, className, ...dataAutomationId },
+    children
+  )
 }
 
 /**


### PR DESCRIPTION
# Objective
There are cucumber tests that rely on finding a heading with a certain `data-automation-id`. These headings were not using the Kaizen component. Adding the automation id to the heading will ensure these cucumber tests don't break.

# Motivation and Context 
Ensures cucumber tests looking for a specific data-automation-id on a heading don't break when updating to kaizen heading 

# Checklist
[ ] If this contains visual changes, has it been reviewed by a designer? 
[ ] I have considered likely risks of these changes and got someone else to QA as appropriate
[x ] I have or will communicate these changes to the front end practice

