### PR TITLE
feat: created hover ability for header table row cells

### DIFF
--- a/draft-packages/stories/Table.stories.tsx
+++ b/draft-packages/stories/Table.stories.tsx
@@ -26,7 +26,7 @@ const Container: React.FunctionComponent<{
   </div>
 )
 
-const ExampleTableHeaderRow = ({ checkable = false }) => (
+const ExampleTableHeaderRow = ({ checkable = false, showHover = false }) => (
   <TableHeaderRow>
     <TableHeaderRowCell
       checkable={checkable}
@@ -39,24 +39,28 @@ const ExampleTableHeaderRow = ({ checkable = false }) => (
       labelText="Resource name"
       width={4 / 12}
       wrapping="wrap"
+      sortingArrowsOnHover={showHover ? "descending" : undefined}
     />
     <TableHeaderRowCell
       onClick={() => alert("Sort!")}
       labelText="Supplementary information"
       width={4 / 12}
       wrapping="wrap"
+      sortingArrowsOnHover={showHover ? "descending" : undefined}
     />
     <TableHeaderRowCell
       labelText="Date"
       width={2 / 12}
       onClick={() => alert("Sort!")}
       wrapping="wrap"
+      sortingArrowsOnHover={showHover ? "descending" : undefined}
     />
     <TableHeaderRowCell
       labelText="Comments"
       width={2 / 12}
       onClick={() => alert("Sort!")}
       wrapping="wrap"
+      sortingArrowsOnHover={showHover ? "descending" : undefined}
     />
   </TableHeaderRow>
 )
@@ -463,3 +467,24 @@ export const AnchorLink = () => (
 )
 
 AnchorLink.storyName = "Anchor Link"
+
+export const HoverHeaderCell = () => (
+  <Container>
+    <TableContainer>
+      <TableHeader>
+        <ExampleTableHeaderRow checkable showHover />
+      </TableHeader>
+      <TableCard>
+        <ExampleTableRow expandable={false} />
+      </TableCard>
+      <TableCard>
+        <ExampleTableRow expandable={false} />
+      </TableCard>
+      <TableCard>
+        <ExampleTableRow expandable={false} />
+      </TableCard>
+    </TableContainer>
+  </Container>
+)
+
+HoverHeaderCell.storyName = "Header row hover"

--- a/draft-packages/table/KaizenDraft/Table/Table.tsx
+++ b/draft-packages/table/KaizenDraft/Table/Table.tsx
@@ -98,6 +98,7 @@ type TableHeaderRowCell = React.FunctionComponent<{
   wrapping?: "nowrap" | "wrap"
   align?: "start" | "center" | "end"
   tooltipInfo?: string
+  sortingArrowsOnHover?: "ascending" | "descending" | undefined
 }>
 export const TableHeaderRowCell: TableHeaderRowCell = ({
   labelText,
@@ -112,7 +113,7 @@ export const TableHeaderRowCell: TableHeaderRowCell = ({
   onCheck,
   active,
   sorting: sortingRaw,
-  // I can't say for cetin why "nowrap" was the default value. Normally you wouldn't
+  // I can't say for certain why "nowrap" was the default value. Normally you wouldn't
   // want to clip off information because it doesn't fit on one line.
   // My assumption is that because since the cell width rows are decoupled, a heading
   // cell with a word longer than the column width would push the columns out of
@@ -121,12 +122,21 @@ export const TableHeaderRowCell: TableHeaderRowCell = ({
   wrapping = "nowrap",
   align = "start",
   tooltipInfo,
+  // if set, this will show the arrow in the direction provided
+  // when the header cell is hovered over.
+  sortingArrowsOnHover,
   // There aren't any other props in the type definition, so I'm unsure why we
   // have this spread.
   ...otherProps
 }) => {
   // `active` is the legacy prop
   const sorting = sortingRaw || (active ? "descending" : undefined)
+  const [isHovered, setIsHovered] = React.useState(false)
+
+  const updateHoverState = (hoverState: boolean) => {
+    if (sortingArrowsOnHover && hoverState != isHovered)
+      setIsHovered(hoverState)
+  }
 
   // For this "cellContents" variable, we start at the inner most child, and
   // wrap it elements, depending on what the props dictate.
@@ -163,10 +173,12 @@ export const TableHeaderRowCell: TableHeaderRowCell = ({
           </Heading>
         </div>
       ) : null}
-      {sorting && (
+      {(sorting || (isHovered && sortingArrowsOnHover)) && (
         <Icon
           icon={
-            sorting === "ascending" ? sortAscendingIcon : sortDescendingIcon
+            sorting === "ascending" || sortingArrowsOnHover === "ascending"
+              ? sortAscendingIcon
+              : sortDescendingIcon
           }
           role="presentation"
         />
@@ -182,6 +194,10 @@ export const TableHeaderRowCell: TableHeaderRowCell = ({
       onClick={
         onClick as (e: React.MouseEvent<HTMLAnchorElement>) => any | undefined
       }
+      onMouseEnter={() => updateHoverState(true)}
+      onFocus={() => updateHoverState(true)}
+      onMouseLeave={() => updateHoverState(false)}
+      onBlur={() => updateHoverState(false)}
     >
       {cellContents}
     </a>
@@ -190,6 +206,10 @@ export const TableHeaderRowCell: TableHeaderRowCell = ({
       data-automation-id={automationId}
       className={styles.headerRowCellButton}
       onClick={onClick as (e: React.MouseEvent<HTMLButtonElement>) => any}
+      onMouseEnter={() => updateHoverState(true)}
+      onFocus={() => updateHoverState(true)}
+      onMouseLeave={() => updateHoverState(false)}
+      onBlur={() => updateHoverState(false)}
     >
       {cellContents}
     </button>


### PR DESCRIPTION
# Objective
Our design style guides have stated that table header row cells that can be sorted should show the arrow on hover/focus. To prevent issues across platform, I have made this optional for now but added in the capability.

# Screenshots (if appropriate)
BEFORE: (note you can't see anything as there's no hover effect)
![Screen Shot 2020-11-23 at 1 05 20 pm](https://user-images.githubusercontent.com/6839317/99924006-98f81a80-2d8c-11eb-87a9-a9135624db71.png)

AFTER:
On hover:
![Screen Shot 2020-11-23 at 1 05 23 pm](https://user-images.githubusercontent.com/6839317/99924017-a31a1900-2d8c-11eb-87cd-72e5f4e4f30c.png)
On focus:
![Screen Shot 2020-11-23 at 1 06 23 pm](https://user-images.githubusercontent.com/6839317/99924034-b331f880-2d8c-11eb-9b38-2d8fee0b421b.png)

# Checklist
[x] If this contains visual changes, has it been reviewed by a designer? 
[x] I have considered likely risks of these changes and got someone else to QA as appropriate
[x] I have or will communicate these changes to the front end practice

# Additional Considerations
- Does there need to be right-to-left (RTL) options for localization and internationalization?
- Has the test suite been updated?
- Have you done cross-browser testing for our [supported browsers](https://academy.cultureamp.com/hc/en-us/articles/204539569-Supported-browsers-for-Participants)?
- Have you updated any relevant documentation or left useful comments in the code?
- Have you reviewed Culture Amp's Web Accessibility guide [Current Compliance, Going Forward, Statement and Answers for Customers](https://cultureamp.atlassian.net/wiki/spaces/Prod/pages/428572998/Web+Accessibility)?
- If this contains substantial visual changes, especially far reaching ones, have you unlocked the Chromatic step in the pipeline? 
- Have Storybook stories been updated? 

**If you're new to Kaizen, please ask #prod_design_systems to set up an onboarding session to get you up to speed.** If you have an urgent PR to merge before that happens, it is safest to ask Design Systems team to review it to catch any issues.
