### PR TITLE
feat: Add prominent variant to TextAreaField (React)

### DIFF
--- a/draft-packages/form/KaizenDraft/Form/Primitives/FieldMessage/FieldMessage.elm
+++ b/draft-packages/form/KaizenDraft/Form/Primitives/FieldMessage/FieldMessage.elm
@@ -11,6 +11,8 @@ styles =
         , default = "default"
         , reversed = "reversed"
         , message = "message"
+        , positionTop = "positionTop"
+        , positionBottom = "positionBottom"
         }
 
 
@@ -19,7 +21,9 @@ type FieldMessageStatus
     | Success
     | Error
 
-
+type FieldMessagePosition
+    = Top
+    | Bottom
 
 -- CONFIG
 
@@ -35,6 +39,7 @@ type alias ConfigValue msg =
     , message : String
     , messageHtml : Maybe (List (Html msg))
     , status : FieldMessageStatus
+    , position : FieldMessagePosition
     }
 
 
@@ -46,6 +51,7 @@ defaults =
     , message = ""
     , messageHtml = Nothing
     , status = Default
+    , position = Bottom
     }
 
 
@@ -122,6 +128,8 @@ view (Config config) =
                     , ( .default, config.status == Default )
                     , ( .error, config.status == Error )
                     , ( .reversed, config.reversed )
+                    , ( .positionTop, config.position == Top )
+                    , ( .positionBottom, config.position == Bottom )
                     ]
                ]
         )

--- a/draft-packages/form/KaizenDraft/Form/Primitives/FieldMessage/FieldMessage.tsx
+++ b/draft-packages/form/KaizenDraft/Form/Primitives/FieldMessage/FieldMessage.tsx
@@ -10,6 +10,7 @@ export type FieldMessageProps = {
   message?: React.ReactNode
   status?: FieldMessageStatus
   reversed?: boolean
+  position?: "top" | "bottom"
 }
 
 type FieldMessage = React.SFC<FieldMessageProps>
@@ -20,6 +21,7 @@ const FieldMessage: FieldMessage = ({
   message,
   status = "default",
   reversed = false,
+  position = "bottom",
 }) => (
   <div
     id={id}
@@ -28,6 +30,8 @@ const FieldMessage: FieldMessage = ({
       [styles.reversed]: reversed,
       [styles.default]: status === "default",
       [styles.error]: status === "error",
+      [styles.positionBottom]: position === "bottom",
+      [styles.positionTop]: position === "top",
     })}
   >
     {message}

--- a/draft-packages/form/KaizenDraft/Form/Primitives/FieldMessage/styles.scss
+++ b/draft-packages/form/KaizenDraft/Form/Primitives/FieldMessage/styles.scss
@@ -1,5 +1,6 @@
 @import "~@kaizen/design-tokens/sass/color";
 @import "~@kaizen/design-tokens/sass/border";
+@import "~@kaizen/design-tokens/sass/spacing";
 @import "~@kaizen/deprecated-component-library-helpers/styles/type";
 
 $message-error-color: $kz-color-wisteria-800;
@@ -13,7 +14,6 @@ $ca-palette-input-validation-negative: $kz-color-coral-600;
 .message {
   @include kz-typography-paragraph-small;
   @include ca-inherit-baseline;
-  margin-top: 4px;
 }
 
 .default {
@@ -29,4 +29,12 @@ $ca-palette-input-validation-negative: $kz-color-coral-600;
   color: $message-error-color;
   border-radius: $message-border-radius;
   background: $kz-color-coral-300;
+}
+
+.positionBottom {
+  margin-top: $kz-spacing-xs;
+}
+
+.positionTop {
+  margin-bottom: $kz-spacing-xs;
 }

--- a/draft-packages/form/KaizenDraft/Form/Primitives/FieldMessage/styles.scss
+++ b/draft-packages/form/KaizenDraft/Form/Primitives/FieldMessage/styles.scss
@@ -17,10 +17,10 @@ $ca-palette-input-validation-negative: $kz-color-coral-600;
 }
 
 .default {
-  color: rgba($kz-color-wisteria-800, 0.8);
+  color: rgba($kz-color-wisteria-800, 0.75);
 
   &.reversed {
-    color: $kz-color-white;
+    color: rgba($kz-color-white, 0.8);
   }
 }
 

--- a/draft-packages/form/KaizenDraft/Form/Primitives/Label/Label.tsx
+++ b/draft-packages/form/KaizenDraft/Form/Primitives/Label/Label.tsx
@@ -13,6 +13,7 @@ export type LabelProps = {
   labelPosition?: "start" | "end"
   labelType?: LabelType
   reversed?: boolean
+  variant?: "default" | "prominent"
 }
 
 type Label = React.SFC<LabelProps>
@@ -25,6 +26,7 @@ const Label: Label = ({
   labelType = "text",
   labelPosition = "end",
   reversed = false,
+  variant = "default",
   children,
 }) => (
   <label
@@ -37,6 +39,7 @@ const Label: Label = ({
       [styles.checkbox]: labelType === "checkbox",
       [styles.toggle]: labelType === "toggle",
       [styles.radio]: labelType === "radio",
+      [styles.prominent]: variant === "prominent",
     })}
   >
     {children}

--- a/draft-packages/form/KaizenDraft/Form/Primitives/Label/styles.scss
+++ b/draft-packages/form/KaizenDraft/Form/Primitives/Label/styles.scss
@@ -1,4 +1,5 @@
 @import "~@kaizen/design-tokens/sass/color";
+@import "~@kaizen/design-tokens/sass/spacing";
 @import "~@kaizen/design-tokens/sass/typography";
 @import "~@kaizen/deprecated-component-library-helpers/styles/type";
 @import "~@kaizen/deprecated-component-library-helpers/styles/layout";
@@ -70,4 +71,14 @@ $label-start-margin: 10px;
   .appendedLabel {
     @include ca-margin($start: $label-start-margin);
   }
+}
+
+.prominent {
+  font-family: $kz-typography-heading-4-font-family;
+  font-weight: $kz-typography-heading-4-font-weight;
+  font-size: $kz-typography-heading-4-font-size;
+  line-height: $kz-typography-heading-4-line-height;
+  letter-spacing: $kz-typography-heading-4-letter-spacing;
+  display: block;
+  margin-bottom: $kz-spacing-xs;
 }

--- a/draft-packages/form/KaizenDraft/Form/Primitives/TextArea/TextArea.tsx
+++ b/draft-packages/form/KaizenDraft/Form/Primitives/TextArea/TextArea.tsx
@@ -15,6 +15,7 @@ type Props = {
   status?: InputStatus
   autogrow?: boolean
   textAreaRef?: React.RefObject<HTMLTextAreaElement>
+  maxLength?: number
   onChange?: (event: React.ChangeEvent<HTMLTextAreaElement>) => any
   onBlur?: (event: React.FocusEvent<HTMLTextAreaElement>) => any
   onFocus?: (event: React.FocusEvent<HTMLTextAreaElement>) => any
@@ -30,6 +31,7 @@ const TextArea = (props: Props) => {
     rows = 3,
     status = "default",
     autogrow,
+    maxLength,
     onBlur,
     onFocus,
     automationId,
@@ -100,6 +102,7 @@ const TextArea = (props: Props) => {
         defaultValue={defaultValue}
         ref={textAreaRef}
         style={getTextAreaStyle()}
+        maxLength={maxLength}
       />
 
       {/* Textareas aren't able to have pseudo elements like ::after on them,

--- a/draft-packages/form/KaizenDraft/Form/TextAreaField/TextAreaField.tsx
+++ b/draft-packages/form/KaizenDraft/Form/TextAreaField/TextAreaField.tsx
@@ -22,6 +22,7 @@ type Props = {
   autogrow?: boolean
   description?: React.ReactNode
   textAreaRef?: React.RefObject<HTMLTextAreaElement>
+  variant?: "default" | "prominent"
   onChange?: (event: React.ChangeEvent<HTMLTextAreaElement>) => any
   onBlur?: (event: React.FocusEvent<HTMLTextAreaElement>) => any
   onFocus?: (event: React.FocusEvent<HTMLTextAreaElement>) => any
@@ -39,6 +40,7 @@ const TextAreaField: React.FunctionComponent<Props> = props => {
     description,
     inline,
     reversed,
+    variant,
     placeholder,
     textAreaRef,
     onChange,
@@ -46,6 +48,19 @@ const TextAreaField: React.FunctionComponent<Props> = props => {
     onFocus,
     rows,
   } = props
+
+  const renderDescription = (position: "top" | "bottom") => {
+    if (!description) return null
+    return (
+      <FieldMessage
+        id={`${id}-field-message`}
+        automationId={`${id}-field-description`}
+        message={description}
+        reversed={reversed}
+        position={position}
+      />
+    )
+  }
 
   return (
     <FieldGroup
@@ -59,7 +74,9 @@ const TextAreaField: React.FunctionComponent<Props> = props => {
         htmlFor={`${id}-field-textarea`}
         labelText={labelText}
         reversed={reversed}
+        variant={variant}
       />
+      {variant === "prominent" && renderDescription("top")}
       <TextArea
         id={`${id}-field-textarea`}
         automationId={`${id}-field-textarea`}
@@ -85,14 +102,7 @@ const TextAreaField: React.FunctionComponent<Props> = props => {
           reversed={reversed}
         />
       )}
-      {description && (
-        <FieldMessage
-          id={`${id}-field-message`}
-          automationId={`${id}-field-description`}
-          message={description}
-          reversed={reversed}
-        />
-      )}
+      {variant === "default" && renderDescription("bottom")}
     </FieldGroup>
   )
 }

--- a/draft-packages/form/KaizenDraft/Form/TextAreaField/TextAreaField.tsx
+++ b/draft-packages/form/KaizenDraft/Form/TextAreaField/TextAreaField.tsx
@@ -23,6 +23,7 @@ type Props = {
   description?: React.ReactNode
   textAreaRef?: React.RefObject<HTMLTextAreaElement>
   variant?: "default" | "prominent"
+  maxLength?: number
   onChange?: (event: React.ChangeEvent<HTMLTextAreaElement>) => any
   onBlur?: (event: React.FocusEvent<HTMLTextAreaElement>) => any
   onFocus?: (event: React.FocusEvent<HTMLTextAreaElement>) => any
@@ -41,6 +42,7 @@ const TextAreaField: React.FunctionComponent<Props> = props => {
     inline,
     reversed,
     variant,
+    maxLength,
     placeholder,
     textAreaRef,
     onChange,
@@ -92,6 +94,7 @@ const TextAreaField: React.FunctionComponent<Props> = props => {
         status={status}
         autogrow={autogrow}
         textAreaRef={textAreaRef}
+        maxLength={maxLength}
       />
       {validationMessage && (
         <FieldMessage

--- a/draft-packages/stories/TextAreaField.stories.tsx
+++ b/draft-packages/stories/TextAreaField.stories.tsx
@@ -1,4 +1,3 @@
-import colorTokens from "@kaizen/design-tokens/tokens/color.json"
 import { TextAreaField } from "@kaizen/draft-form"
 
 import React from "react"

--- a/draft-packages/stories/TextAreaField.stories.tsx
+++ b/draft-packages/stories/TextAreaField.stories.tsx
@@ -235,3 +235,39 @@ export const ReversedErrorAndDesc = () => (
 
 ReversedErrorAndDesc.storyName = "Reversed, Error & Description"
 ReversedErrorAndDesc.parameters = { ...reversedBg }
+
+export const DefaultProminent = () => (
+  <ExampleContainer>
+    <TextAreaField id="reply" labelText="Your reply" variant="prominent" />
+  </ExampleContainer>
+)
+
+DefaultProminent.storyName = "Default, Prominent"
+
+export const DefaultProminentDesc = () => (
+  <ExampleContainer>
+    <TextAreaField
+      id="reply"
+      labelText="Your reply"
+      variant="prominent"
+      description="Your reply will only be seen by you"
+    />
+  </ExampleContainer>
+)
+
+DefaultProminentDesc.storyName = "Default, Prominent with description"
+
+export const ReversedProminent = () => (
+  <ExampleContainer>
+    <TextAreaField
+      id="reply"
+      labelText="Your reply"
+      variant="prominent"
+      description="Your reply will only be seen by you"
+      reversed
+    />
+  </ExampleContainer>
+)
+
+ReversedProminent.storyName = "Reversed, Prominent"
+ReversedProminent.parameters = { ...reversedBg }


### PR DESCRIPTION
# Objective
Adds the `prominent` variation on the TextAreaField component which exists in the UI Kit: https://www.figma.com/file/GMxm8rvDCbj0Xw3TQWBZ8b/Zen-UI-Kit?node-id=1929%3A30084

Also adds a `maxLength` prop to `TextArea` and `TextAreaField`, and updates the colour of the `FieldMessage` text to match the UI Kit.

# Motivation and Context 
I'm adding this to Capture and need this variation :-)

# Screenshots (if appropriate)
https://dev.cultureamp.design/dug/prominent-text-area/storybook/?path=/story/textareafield-react--default-prominent-desc

![image](https://user-images.githubusercontent.com/1811583/100305618-89c7d580-2ff5-11eb-97ee-5d0f5d34e333.png)

![image](https://user-images.githubusercontent.com/1811583/100305630-91877a00-2ff5-11eb-856c-5acd9ad6be53.png)

![image](https://user-images.githubusercontent.com/1811583/100309699-99e4b280-2fff-11eb-8d89-b127d9d4c24f.png)

# Checklist
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
[ ] If this contains visual changes, has it been reviewed by a designer? 
[ ] I have considered likely risks of these changes and got someone else to QA as appropriate
[ ] I have or will communicate these changes to the front end practice

# Additional Considerations
- Does there need to be right-to-left (RTL) options for localization and internationalization?
- Has the test suite been updated?
- Have you done cross-browser testing for our [supported browsers](https://academy.cultureamp.com/hc/en-us/articles/204539569-Supported-browsers-for-Participants)?
- Have you updated any relevant documentation or left useful comments in the code?
- Have you reviewed Culture Amp's Web Accessibility guide [Current Compliance, Going Forward, Statement and Answers for Customers](https://cultureamp.atlassian.net/wiki/spaces/Prod/pages/428572998/Web+Accessibility)?
- If this contains substantial visual changes, especially far reaching ones, have you unlocked the Chromatic step in the pipeline? 
- Have Storybook stories been updated? 

**If you're new to Kaizen, please ask #prod_design_systems to set up an onboarding session to get you up to speed.** If you have an urgent PR to merge before that happens, it is safest to ask Design Systems team to review it to catch any issues.
