### PR TITLE
fix: fixed issue where hover on table row moves label for center/right aligned cells

### DIFF
--- a/draft-packages/stories/Table.stories.tsx
+++ b/draft-packages/stories/Table.stories.tsx
@@ -469,10 +469,44 @@ export const AnchorLink = () => (
 AnchorLink.storyName = "Anchor Link"
 
 export const HoverHeaderCell = () => (
-  <Container>
+  <Container style={{ marginTop: "200px" }}>
     <TableContainer>
       <TableHeader>
-        <ExampleTableHeaderRow checkable showHover />
+        <TableHeaderRow>
+          <TableHeaderRowCell
+            sorting="descending"
+            onClick={() => alert("Sort!")}
+            labelText="Resource name"
+            width={4 / 12}
+            wrapping="wrap"
+            sortingArrowsOnHover="descending"
+          />
+          <TableHeaderRowCell
+            onClick={() => alert("Sort!")}
+            labelText="Supplementary information"
+            width={4 / 12}
+            wrapping="wrap"
+            sortingArrowsOnHover="descending"
+            align="center"
+          />
+          <TableHeaderRowCell
+            labelText="Date"
+            width={2 / 12}
+            onClick={() => alert("Sort!")}
+            wrapping="wrap"
+            sortingArrowsOnHover="descending"
+            align="end"
+            tooltipInfo="This is a tooltip"
+          />
+          <TableHeaderRowCell
+            labelText="Comments"
+            width={2 / 12}
+            onClick={() => alert("Sort!")}
+            wrapping="wrap"
+            sortingArrowsOnHover="descending"
+            align="end"
+          />
+        </TableHeaderRow>
       </TableHeader>
       <TableCard>
         <ExampleTableRow expandable={false} />

--- a/draft-packages/table/KaizenDraft/Table/Table.tsx
+++ b/draft-packages/table/KaizenDraft/Table/Table.tsx
@@ -167,21 +167,28 @@ export const TableHeaderRowCell: TableHeaderRowCell = ({
           <Heading
             tag="div"
             variant="heading-6"
-            color={sorting ? "dark" : "dark-reduced-opacity"}
+            color={sorting || isHovered ? "dark" : "dark-reduced-opacity"}
           >
             {labelText}
           </Heading>
         </div>
       ) : null}
       {(sorting || (isHovered && sortingArrowsOnHover)) && (
-        <Icon
-          icon={
-            sorting === "ascending" || sortingArrowsOnHover === "ascending"
-              ? sortAscendingIcon
-              : sortDescendingIcon
-          }
-          role="presentation"
-        />
+        <div
+          className={classNames({
+            [styles.headerRowCellIconAlignCenter]: align === "center",
+            [styles.headerRowCellIconAlignEnd]: align === "end",
+          })}
+        >
+          <Icon
+            icon={
+              sorting === "ascending" || sortingArrowsOnHover === "ascending"
+                ? sortAscendingIcon
+                : sortDescendingIcon
+            }
+            role="presentation"
+          />
+        </div>
       )}
     </div>
   )

--- a/draft-packages/table/KaizenDraft/Table/styles.scss
+++ b/draft-packages/table/KaizenDraft/Table/styles.scss
@@ -209,3 +209,19 @@ $row-height: 60px;
     padding: $kz-spacing-md * 0.5 $kz-spacing-md;
   }
 }
+
+.rowCellAlignCenter {
+  justify-content: center;
+  text-align: center;
+}
+
+.rowCellAlignEnd {
+  justify-content: flex-end;
+  text-align: right;
+}
+
+.headerRowCellIconAlignCenter,
+.headerRowCellIconAlignEnd {
+  //makes sure the label doesn't move on hover when not left aligned
+  margin-right: -20px;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1975,6 +1975,28 @@
     "@types/yargs" "^15.0.0"
     chalk "^4.0.0"
 
+"@kaizen/component-library@^7.30.4":
+  version "7.33.1"
+  resolved "https://registry.yarnpkg.com/@kaizen/component-library/-/component-library-7.33.1.tgz#2573fec05c77136bca28ee2f44e5e9e7e171d53d"
+  integrity sha512-ITNTiP09Vb57xkK+4IjgSYOYFHvcfAsN25MlFRRQ98puvAkFDdqv75pY+Y9gQC0VcGTRDbfBWjNybz6Bbamy5A==
+  dependencies:
+    "@kaizen/deprecated-component-library-helpers" "^1.6.13"
+    "@kaizen/hosted-assets" "^1.0.2"
+    "@types/classnames" "^2.2.6"
+    "@types/lodash" "^4.14.132"
+    "@types/react-select" "^3.0.5"
+    "@types/uuid" "^3.4.4"
+    classnames "^2.2.6"
+    lodash "^4.17.11"
+    motion-ui cultureamp/motion-ui
+    react-animate-height "^2.0.15"
+    react-focus-lock "^1.19.1"
+    react-media "^1.9.2"
+    react-select "^3.1.0"
+    react-tooltip "^4.2.6"
+    react-transition-group "^2.9.0"
+    uuid "^3.3.2"
+
 "@kaizen/draft-button@^1.7.4":
   version "1.13.12"
   resolved "https://registry.yarnpkg.com/@kaizen/draft-button/-/draft-button-1.13.12.tgz#b6478a3e1922101d7eb2591250395d146f2bc1a6"
@@ -16238,7 +16260,7 @@ moment@^2.15.1, moment@^2.18.1, moment@^2.24.0, moment@^2.27.0:
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.1.tgz#b2be769fa31940be9eeea6469c075e35006fa3d3"
   integrity sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==
 
-motion-ui@cultureamp/motion-ui:
+motion-ui@cultureamp/motion-ui, "motion-ui@github:cultureamp/motion-ui":
   version "2.0.3"
   resolved "https://codeload.github.com/cultureamp/motion-ui/tar.gz/8be21797f0b63740fc38493b8ea2b947d248b222"
 


### PR DESCRIPTION
# Objective
Just updating a UX behaviour to a better one to prevent labels in the header table row cell component from moving around when they are center or right aligned and hover is available.

# Motivation and Context 
It was okay, but pretty poor UX so this is just improving it.

# Checklist
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
[x] If this contains visual changes, has it been reviewed by a designer? 
[x] I have considered likely risks of these changes and got someone else to QA as appropriate
[x] I have or will communicate these changes to the front end practice

# Additional Considerations
- Does there need to be right-to-left (RTL) options for localization and internationalization?
- Has the test suite been updated?
- Have you done cross-browser testing for our [supported browsers](https://academy.cultureamp.com/hc/en-us/articles/204539569-Supported-browsers-for-Participants)?
- Have you updated any relevant documentation or left useful comments in the code?
- Have you reviewed Culture Amp's Web Accessibility guide [Current Compliance, Going Forward, Statement and Answers for Customers](https://cultureamp.atlassian.net/wiki/spaces/Prod/pages/428572998/Web+Accessibility)?
- If this contains substantial visual changes, especially far reaching ones, have you unlocked the Chromatic step in the pipeline? 
- Have Storybook stories been updated? 

**If you're new to Kaizen, please ask #prod_design_systems to set up an onboarding session to get you up to speed.** If you have an urgent PR to merge before that happens, it is safest to ask Design Systems team to review it to catch any issues.
