### PR TITLE
feat: Allow generic textarea props on TextArea and TextAreaField

### DIFF
--- a/draft-packages/form/KaizenDraft/Form/Primitives/TextArea/TextArea.tsx
+++ b/draft-packages/form/KaizenDraft/Form/Primitives/TextArea/TextArea.tsx
@@ -3,7 +3,7 @@ import classnames from "classnames"
 import React, { useState, useEffect, useRef } from "react"
 import styles from "./styles.scss"
 
-type Props = {
+interface Props extends React.HTMLAttributes<HTMLTextAreaElement> {
   id: string
   automationId?: string
   rows?: number
@@ -35,6 +35,10 @@ const TextArea = (props: Props) => {
     onBlur,
     onFocus,
     automationId,
+    value,
+    onChange: propsOnChange,
+    textAreaRef: propsTextAreaRef,
+    ...genericTextAreaProps
   } = props
 
   const [textAreaHeight, setTextAreaHeight] = useState("auto")
@@ -43,7 +47,7 @@ const TextArea = (props: Props) => {
     autogrow ? defaultValue : undefined
   )
   // ^ holds an internal state of the value so that autogrow can still work with uncontrolled textareas
-  const textAreaRef = props.textAreaRef || useRef(null)
+  const textAreaRef = propsTextAreaRef || useRef(null)
 
   useEffect(() => {
     if (!autogrow) return
@@ -63,8 +67,8 @@ const TextArea = (props: Props) => {
         // see https://medium.com/@lucasalgus/creating-a-custom-auto-resize-textarea-component-for-your-react-web-application-6959c0ad68bc#2dee
 
         setInternalValue(event.target.value)
-        if (props.onChange) {
-          props.onChange(event)
+        if (propsOnChange) {
+          propsOnChange(event)
         }
       }
 
@@ -94,15 +98,16 @@ const TextArea = (props: Props) => {
         placeholder={placeholder}
         name={name}
         rows={rows}
-        onChange={onChange || props.onChange}
+        onChange={onChange || propsOnChange}
         onBlur={onBlur}
         onFocus={onFocus}
         data-automation-id={automationId}
-        value={props.value || internalValue}
+        value={value || internalValue}
         defaultValue={defaultValue}
         ref={textAreaRef}
         style={getTextAreaStyle()}
         maxLength={maxLength}
+        {...genericTextAreaProps}
       />
 
       {/* Textareas aren't able to have pseudo elements like ::after on them,

--- a/draft-packages/form/KaizenDraft/Form/Primitives/TextArea/TextArea.tsx
+++ b/draft-packages/form/KaizenDraft/Form/Primitives/TextArea/TextArea.tsx
@@ -1,41 +1,30 @@
 import { InputStatus } from "@kaizen/draft-form"
 import classnames from "classnames"
-import React, { useState, useEffect, useRef } from "react"
+import React, {
+  useState,
+  useEffect,
+  useRef,
+  TextareaHTMLAttributes,
+} from "react"
 import styles from "./styles.scss"
 
-interface Props extends React.HTMLAttributes<HTMLTextAreaElement> {
-  id: string
+interface Props extends TextareaHTMLAttributes<HTMLTextAreaElement> {
   automationId?: string
-  rows?: number
-  value?: string
-  defaultValue?: string
-  placeholder?: string
-  name?: string
   reversed?: boolean
   status?: InputStatus
   autogrow?: boolean
   textAreaRef?: React.RefObject<HTMLTextAreaElement>
-  maxLength?: number
-  onChange?: (event: React.ChangeEvent<HTMLTextAreaElement>) => any
-  onBlur?: (event: React.FocusEvent<HTMLTextAreaElement>) => any
-  onFocus?: (event: React.FocusEvent<HTMLTextAreaElement>) => any
 }
 
 const TextArea = (props: Props) => {
   const {
-    id,
+    value,
     defaultValue,
-    placeholder,
-    name,
     reversed,
     rows = 3,
     status = "default",
     autogrow,
-    maxLength,
-    onBlur,
-    onFocus,
     automationId,
-    value,
     onChange: propsOnChange,
     textAreaRef: propsTextAreaRef,
     ...genericTextAreaProps
@@ -89,24 +78,17 @@ const TextArea = (props: Props) => {
   return (
     <div className={styles.wrapper} style={getWrapperStyle()}>
       <textarea
-        id={id}
         className={classnames(styles.textarea, {
           [styles.default]: !reversed,
           [styles.reversed]: reversed,
           [styles.error]: status === "error",
         })}
-        placeholder={placeholder}
-        name={name}
         rows={rows}
         onChange={onChange || propsOnChange}
-        onBlur={onBlur}
-        onFocus={onFocus}
         data-automation-id={automationId}
         value={value || internalValue}
-        defaultValue={defaultValue}
         ref={textAreaRef}
         style={getTextAreaStyle()}
-        maxLength={maxLength}
         {...genericTextAreaProps}
       />
 

--- a/draft-packages/form/KaizenDraft/Form/TextAreaField/TextAreaField.tsx
+++ b/draft-packages/form/KaizenDraft/Form/TextAreaField/TextAreaField.tsx
@@ -7,7 +7,7 @@ import {
 } from "@kaizen/draft-form"
 import React from "react"
 
-type Props = {
+interface Props extends React.HTMLAttributes<HTMLTextAreaElement> {
   id: string
   labelText: string | React.ReactNode
   rows?: number
@@ -49,6 +49,7 @@ const TextAreaField: React.FunctionComponent<Props> = props => {
     onBlur,
     onFocus,
     rows,
+    ...genericTextAreaProps
   } = props
 
   const renderDescription = (position: "top" | "bottom") => {
@@ -95,6 +96,7 @@ const TextAreaField: React.FunctionComponent<Props> = props => {
         autogrow={autogrow}
         textAreaRef={textAreaRef}
         maxLength={maxLength}
+        {...genericTextAreaProps}
       />
       {validationMessage && (
         <FieldMessage

--- a/draft-packages/form/KaizenDraft/Form/TextAreaField/TextAreaField.tsx
+++ b/draft-packages/form/KaizenDraft/Form/TextAreaField/TextAreaField.tsx
@@ -5,28 +5,18 @@ import {
   Label,
   TextArea,
 } from "@kaizen/draft-form"
-import React from "react"
+import React, { TextareaHTMLAttributes } from "react"
 
-interface Props extends React.HTMLAttributes<HTMLTextAreaElement> {
-  id: string
+interface Props extends TextareaHTMLAttributes<HTMLTextAreaElement> {
   labelText: string | React.ReactNode
-  rows?: number
-  placeholder?: string
-  name?: string
-  value?: string
   inline?: boolean
   reversed?: boolean
-  defaultValue?: string
   validationMessage?: string
   status?: InputStatus
   autogrow?: boolean
   description?: React.ReactNode
   textAreaRef?: React.RefObject<HTMLTextAreaElement>
   variant?: "default" | "prominent"
-  maxLength?: number
-  onChange?: (event: React.ChangeEvent<HTMLTextAreaElement>) => any
-  onBlur?: (event: React.FocusEvent<HTMLTextAreaElement>) => any
-  onFocus?: (event: React.FocusEvent<HTMLTextAreaElement>) => any
 }
 
 const TextAreaField: React.FunctionComponent<Props> = props => {


### PR DESCRIPTION
# Objective
Allows consumers of `TextAreaField` and `TextArea` to send in any generic `textarea` props.

# Motivation and Context 
If you need to add a generic prop to our text area component (such as `maxLength` or any `aria` property`) - we need to go through the process of adding it to the component in Kaizen, then update the package on the consuming repo, which is a time consuming process, and causes code bloat. 

# Checklist
[ ] I have considered likely risks of these changes and got someone else to QA as appropriate
[ ] I have or will communicate these changes to the front end practice

# Additional Considerations
- Does there need to be right-to-left (RTL) options for localization and internationalization?
- Has the test suite been updated?
- Have you done cross-browser testing for our [supported browsers](https://academy.cultureamp.com/hc/en-us/articles/204539569-Supported-browsers-for-Participants)?
- Have you updated any relevant documentation or left useful comments in the code?
- Have you reviewed Culture Amp's Web Accessibility guide [Current Compliance, Going Forward, Statement and Answers for Customers](https://cultureamp.atlassian.net/wiki/spaces/Prod/pages/428572998/Web+Accessibility)?
- If this contains substantial visual changes, especially far reaching ones, have you unlocked the Chromatic step in the pipeline? 
- Have Storybook stories been updated? 

**If you're new to Kaizen, please ask #prod_design_systems to set up an onboarding session to get you up to speed.** If you have an urgent PR to merge before that happens, it is safest to ask Design Systems team to review it to catch any issues.
