### PR TITLE
feat: Tooltip to allow for React.ReactNode, instead of just string

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -152,12 +152,6 @@ module.exports = {
     "jsdoc/newline-after-description": "off",
     "linebreak-style": "off",
     "max-classes-per-file": ["error", 1],
-    "max-len": [
-      "warn",
-      {
-        code: 120,
-      },
-    ],
     "new-parens": "error",
     "newline-per-chained-call": "off",
     "no-bitwise": "error",

--- a/draft-packages/tooltip/KaizenDraft/Tooltip/Tooltip.tsx
+++ b/draft-packages/tooltip/KaizenDraft/Tooltip/Tooltip.tsx
@@ -7,7 +7,7 @@ type Position = "above" | "below"
 type Props = {
   inline?: boolean
   position?: Position
-  text: string
+  text: React.ReactNode
   children?: React.ReactNode
   classNameAndIHaveSpokenToDST?: string
 }


### PR DESCRIPTION
# Objective
Tooltip to allow for React.ReactNode, instead of just string

# Motivation and Context 
In perform, we needed to be able to have a multi line tooltip. The tooltip has a new line for every collaborator on a cycle.

# Screenshots

<img width="234" alt="image" src="https://user-images.githubusercontent.com/4495057/100689793-4eece580-33d9-11eb-9cf5-c102d60b0bbf.png">

# Side fix:

* Remove the max-len eslint rule, since this is now enforced by prettier. Prettier is more lenient for things like comments, and large string values, hence the rule conflict. This also removes the one lint warning that we have at the moment.

In perform, we actually have the `--max-warnings=0` option set, which will stops the warning list from growing. LMK if you'd like me to update this in kaizen also.

<img width="894" alt="image" src="https://user-images.githubusercontent.com/4495057/100689837-60ce8880-33d9-11eb-86ec-fab8e3c29cce.png">


# Checklist
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
[ ] If this contains visual changes, has it been reviewed by a designer? - NA
[X] I have considered likely risks of these changes and got someone else to QA as appropriate
[X] I have or will communicate these changes to the front end practice
