### PR TITLE
fix: Extend tsconfig from the distribution config

### DIFF
--- a/packages/react-deprecate-warning/tsconfig.dist.json
+++ b/packages/react-deprecate-warning/tsconfig.dist.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../../tsconfig.dist.json",
   "compilerOptions": {
     "allowJs": false,
     "declaration": true,


### PR DESCRIPTION
# Objective
Use the correct tsconfig for the new @kaizen/react-deprecate-warning package.

# Motivation and Context 
The react-deprecate-component package was extending from the old distribution config (tsconfig.json), which includes stories that we'd rather not publish with the package. 

# Screenshots (if appropriate)

# Checklist
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
~[ ] If this contains visual changes, has it been reviewed by a designer?~ 
~[ ] I have considered likely risks of these changes and got someone else to QA as appropriate~
[ ] I have or will communicate these changes to the front end practice
