### PR TITLE
feat: Allow for the modal confirmation button to be optional

### DIFF
--- a/draft-packages/modal/KaizenDraft/Modal/Presets/ConfirmationModal.tsx
+++ b/draft-packages/modal/KaizenDraft/Modal/Presets/ConfirmationModal.tsx
@@ -24,7 +24,7 @@ interface Props {
   readonly isOpen: boolean
   readonly type: ModalType
   readonly title: string
-  readonly onConfirm: () => void
+  readonly onConfirm?: () => void
   readonly onDismiss: () => void
   readonly confirmLabel?: string
   readonly dismissLabel?: string
@@ -58,48 +58,53 @@ const ConfirmationModal = ({
   dismissLabel = "Cancel",
   automationId,
   children,
-}: Props) => (
-  <GenericModal
-    isOpen={isOpen}
-    onEscapeKeyup={onDismiss}
-    onOutsideModalClick={onDismiss}
-    automationId={automationId}
-  >
-    <div className={styles.modal}>
-      <ModalHeader unpadded reversed onDismiss={onDismiss}>
-        <div
-          className={classnames(styles.header, {
-            [styles.cautionaryHeader]: type === "cautionary",
-            [styles.informativeHeader]: type === "informative",
-            [styles.negativeHeader]: type === "negative",
-            [styles.positiveHeader]: type === "positive",
-          })}
-        >
-          <div className={styles.iconContainer}>
-            <div className={styles.spotIcon}>{getIcon(type)}</div>
+}: Props) => {
+  const footerActions: Array<{ label: string; action: () => void }> = []
+  if (onConfirm) {
+    footerActions.push({ label: confirmLabel, action: onConfirm })
+  }
+  footerActions.push({ label: dismissLabel, action: onDismiss })
+
+  return (
+    <GenericModal
+      isOpen={isOpen}
+      onEscapeKeyup={onDismiss}
+      onOutsideModalClick={onDismiss}
+      automationId={automationId}
+    >
+      <div className={styles.modal}>
+        <ModalHeader unpadded reversed onDismiss={onDismiss}>
+          <div
+            className={classnames(styles.header, {
+              [styles.cautionaryHeader]: type === "cautionary",
+              [styles.informativeHeader]: type === "informative",
+              [styles.negativeHeader]: type === "negative",
+              [styles.positiveHeader]: type === "positive",
+            })}
+          >
+            <div className={styles.iconContainer}>
+              <div className={styles.spotIcon}>{getIcon(type)}</div>
+            </div>
+            <ModalAccessibleLabel>
+              <Heading tag="h1" variant="heading-1">
+                {title}
+              </Heading>
+            </ModalAccessibleLabel>
           </div>
-          <ModalAccessibleLabel>
-            <Heading tag="h1" variant="heading-1">
-              {title}
-            </Heading>
-          </ModalAccessibleLabel>
-        </div>
-      </ModalHeader>
-      <ModalBody unpadded>
-        <div className={styles.body}>
-          <ModalAccessibleDescription>{children}</ModalAccessibleDescription>
-        </div>
-      </ModalBody>
-      <ModalFooter
-        actions={[
-          { label: confirmLabel, action: onConfirm },
-          { label: dismissLabel, action: onDismiss },
-        ]}
-        appearance={type === "negative" ? "destructive" : "primary"}
-        automationId={automationId}
-      />
-    </div>
-  </GenericModal>
-)
+        </ModalHeader>
+        <ModalBody unpadded>
+          <div className={styles.body}>
+            <ModalAccessibleDescription>{children}</ModalAccessibleDescription>
+          </div>
+        </ModalBody>
+        <ModalFooter
+          actions={footerActions}
+          appearance={type === "negative" ? "destructive" : "primary"}
+          automationId={automationId}
+        />
+      </div>
+    </GenericModal>
+  )
+}
 
 export default ConfirmationModal

--- a/draft-packages/popover/KaizenDraft/Popover/index.ts
+++ b/draft-packages/popover/KaizenDraft/Popover/index.ts
@@ -1,1 +1,1 @@
-export { default as Popover } from "./Popover"
+export { default as Popover, Props as PopoverProps } from "./Popover"

--- a/draft-packages/split-button/KaizenDraft/SplitButton/index.ts
+++ b/draft-packages/split-button/KaizenDraft/SplitButton/index.ts
@@ -1,1 +1,1 @@
-export { default as SplitButton } from "./SplitButton"
+export { default as SplitButton, SplitButtonProps } from "./SplitButton"


### PR DESCRIPTION
# Objective
Allow for the modal confirmation button to be optional

# Motivation and Context 
I was requested to show a cautionary modal, to let admins know that they can't view their own reviews. The designs only have one button.

# Screenshots (if appropriate)

<img width="738" alt="image" src="https://user-images.githubusercontent.com/4495057/101001810-b494c980-35b3-11eb-9b13-c848d80643be.png">

# Side updates

Export props for the Popover and SplitButton components. Sometimes in perform, we add wrappers around the kaizen components to enhance the functionality. The common use case being linking them to react-router, or automatically assigning the translation strings. Exporting the props in kaizen, then allows for the wrapper component to take in the same props as its child.

# Checklist
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
[X] If this contains visual changes, has it been reviewed by a designer? 
[X] I have considered likely risks of these changes and got someone else to QA as appropriate
[X] I have or will communicate these changes to the front end practice
