### PR TITLE
fix: Don't set TextArea if calculated height is 0

### DIFF
--- a/draft-packages/form/KaizenDraft/Form/Primitives/TextArea/TextArea.tsx
+++ b/draft-packages/form/KaizenDraft/Form/Primitives/TextArea/TextArea.tsx
@@ -40,10 +40,12 @@ const TextArea = (props: Props) => {
 
   useEffect(() => {
     if (!autogrow) return
+    const scrollHeight = textAreaRef.current!.scrollHeight
+    if (scrollHeight < 1) return
     const borderWidth = textAreaRef.current
       ? parseInt(getComputedStyle(textAreaRef.current).borderTopWidth, 10)
       : 0
-    const newHeight = textAreaRef.current!.scrollHeight + borderWidth * 2
+    const newHeight = scrollHeight + borderWidth * 2
     setParentHeight(`${newHeight}px`)
     setTextAreaHeight(`${newHeight}px`)
   }, [internalValue])


### PR DESCRIPTION
This can happen if the textarea is added to the DOM tree but not actually rendered on screen (e.g. it's in a collapsible section).

The result is a textarea that's been given a 4px height (the border height) once it's rendered:
![image](https://user-images.githubusercontent.com/1811583/101305820-95d65180-3897-11eb-96fd-1a1e1f979666.png)

In an ideal world, we would render a clone of the textarea off-screen to get the actual height, but this is a much quicker fix to resolve the issue for the most part for now.