### PR TITLE
ci: Ignore linting on git push to reset canary branches

### DIFF
--- a/.buildkite/scripts/release.sh
+++ b/.buildkite/scripts/release.sh
@@ -90,7 +90,7 @@ main() {
 
     echo "Resetting canary branch..."
     git reset --hard master
-    git push --force
+    git push --force --no-verify
 
   fi
 


### PR DESCRIPTION
# Objective
The canary branch fails because `elm-format`, `eslint` etc are not installed before the pre-push hook is called. 

# Motivation and Context 
When resetting the canary branch, `git push` will activate the pre-push hook. We can assume that if something is on master it is green and hence can be safely pushed to the canary branch without running pre-push checks. 

# Screenshots (if appropriate)

# Checklist
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
[ ] If this contains visual changes, has it been reviewed by a designer? 
[ ] I have considered likely risks of these changes and got someone else to QA as appropriate
[ ] I have or will communicate these changes to the front end practice

