### PR TITLE
feat: Move design tokens from a dependency to a peerDependency

### DIFF
--- a/packages/deprecated-component-library-helpers/package.json
+++ b/packages/deprecated-component-library-helpers/package.json
@@ -15,7 +15,7 @@
   "sideEffects": false,
   "private": false,
   "license": "MIT",
-  "dependencies": {
+  "peerDependencies": {
     "@kaizen/design-tokens": "^2.1.3"
   }
 }


### PR DESCRIPTION
# Objective
Moves design tokens from a dependency to a peerDependency. 

# Motivation and Context 
The target repo will have a version of design tokens that the package can resolve to, so enforcing this package to BYO it's own design tokens doesn't make sense.