### PR TITLE
feat: Move design tokens to peer dependency

### DIFF
--- a/packages/deprecated-component-library-helpers/package.json
+++ b/packages/deprecated-component-library-helpers/package.json
@@ -15,7 +15,7 @@
   "sideEffects": false,
   "private": false,
   "license": "MIT",
-  "dependencies": {
+  "peerDependencies": {
     "@kaizen/design-tokens": "^2.1.3"
   }
 }


### PR DESCRIPTION
BREAKING CHANGE: Tokens are now a peer dependency of component-library-helpers. When upgrading ensure dependants are using v2 or greater

# Objective
Moves design tokens from a dependency to a peerDependency.  

# Motivation and Context 
The target repo will have a version of design tokens that the package can resolve to, so enforcing this package to BYO it's own design tokens doesn't make sense. The content is the same as [this PR](https://github.com/cultureamp/kaizen-design-system/pull/891), but will be released as a breaking change.