### PR TITLE
feat: Add ability to use custom element on back of Tile

### DIFF
--- a/draft-packages/stories/Tile.stories.tsx
+++ b/draft-packages/stories/Tile.stories.tsx
@@ -9,6 +9,7 @@ import {
 } from "@kaizen/draft-tile"
 import { Coaching } from "@kaizen/draft-illustration"
 import { Tag } from "@kaizen/draft-tag"
+import { Paragraph } from "@kaizen/component-library"
 
 import bookmarkIcon from "@kaizen/component-library/icons/bookmark-off.icon.svg"
 
@@ -97,6 +98,18 @@ export const Information = () => (
 )
 
 Information.storyName = "Information tile"
+
+export const InformationCustomInfoElement = () => (
+  <InformationTile
+    title="Tile heading"
+    metadata="Metadata"
+    information={<Paragraph variant="body">Anything can go here</Paragraph>}
+    footer={<Tag variant="statusLive">Live</Tag>}
+  />
+)
+
+InformationCustomInfoElement.storyName =
+  "Information tile (custom information element)"
 
 export const TileGridWithTiles = () => (
   <TileGrid>

--- a/draft-packages/tile/KaizenDraft/Tile/components/GenericTile.tsx
+++ b/draft-packages/tile/KaizenDraft/Tile/components/GenericTile.tsx
@@ -26,7 +26,7 @@ export interface GenericTileProps {
   readonly title: string
   readonly metadata?: string
   readonly children?: React.ReactNode
-  readonly information?: TileInformation
+  readonly information?: TileInformation | React.ReactNode
 }
 
 interface Props extends GenericTileProps {
@@ -88,10 +88,30 @@ const GenericTile: GenericTile = ({
     </div>
   )
 
+  const renderInformation = informationProp => {
+    if ("text" in informationProp) {
+      return (
+        <>
+          <Paragraph variant="body">{informationProp.text}</Paragraph>
+          {(informationProp.primaryAction ||
+            informationProp.secondaryAction) && (
+            <div className={styles.footer}>
+              {renderActions(
+                informationProp.primaryAction,
+                informationProp.secondaryAction,
+                !isFlipped
+              )}
+            </div>
+          )}
+        </>
+      )
+    }
+
+    return informationProp
+  }
+
   const renderBack = () => {
     if (!information) return
-
-    const { text, primaryAction, secondaryAction } = information
 
     return (
       <div className={classNames(styles.face, styles.faceBack)}>
@@ -105,12 +125,7 @@ const GenericTile: GenericTile = ({
         </div>
         {renderTitle()}
         <div className={styles.information}>
-          <Paragraph variant="body">{text}</Paragraph>
-          {(primaryAction || secondaryAction) && (
-            <div className={styles.footer}>
-              {renderActions(primaryAction, secondaryAction, !isFlipped)}
-            </div>
-          )}
+          {renderInformation(information)}
         </div>
       </div>
     )


### PR DESCRIPTION
# Objective
<!-- Describe what this change achieves, and the details of how it works. -->
This makes it so the `information` prop can either be the info object or a custom element, thus allowing more flexibility with what can be displayed on the back of the card.

# Motivation and Context 
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

# Screenshots (if appropriate)

# Checklist
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
[ ] If this contains visual changes, has it been reviewed by a designer? 
[ ] I have considered likely risks of these changes and got someone else to QA as appropriate
[ ] I have or will communicate these changes to the front end practice

# Additional Considerations
- Does there need to be right-to-left (RTL) options for localization and internationalization?
- Has the test suite been updated?
- Have you done cross-browser testing for our [supported browsers](https://academy.cultureamp.com/hc/en-us/articles/204539569-Supported-browsers-for-Participants)?
- Have you updated any relevant documentation or left useful comments in the code?
- Have you reviewed Culture Amp's Web Accessibility guide [Current Compliance, Going Forward, Statement and Answers for Customers](https://cultureamp.atlassian.net/wiki/spaces/Prod/pages/428572998/Web+Accessibility)?
- If this contains substantial visual changes, especially far reaching ones, have you unlocked the Chromatic step in the pipeline? 
- Have Storybook stories been updated? 

**If you're new to Kaizen, please ask #prod_design_systems to set up an onboarding session to get you up to speed.** If you have an urgent PR to merge before that happens, it is safest to ask Design Systems team to review it to catch any issues.
