### PR TITLE
fix: Restore defaultValue on textarea

### DIFF
--- a/draft-packages/form/KaizenDraft/Form/Primitives/TextArea/TextArea.tsx
+++ b/draft-packages/form/KaizenDraft/Form/Primitives/TextArea/TextArea.tsx
@@ -36,6 +36,7 @@ const TextArea = (props: Props) => {
     autogrow ? defaultValue : undefined
   )
   // ^ holds an internal state of the value so that autogrow can still work with uncontrolled textareas
+  // essentially forces the textarea into an (interally) controlled mode if autogrow is true
   const textAreaRef = propsTextAreaRef || useRef(null)
 
   useEffect(() => {
@@ -77,6 +78,8 @@ const TextArea = (props: Props) => {
     }
   }
 
+  const controlledValue = value || internalValue
+
   return (
     <div className={styles.wrapper} style={getWrapperStyle()}>
       <textarea
@@ -88,7 +91,9 @@ const TextArea = (props: Props) => {
         rows={rows}
         onChange={onChange || propsOnChange}
         data-automation-id={automationId}
-        value={value || internalValue}
+        value={controlledValue}
+        defaultValue={controlledValue ? undefined : defaultValue}
+        // ^ React throws a warning if you specify both a value and a defaultValue
         ref={textAreaRef}
         style={getTextAreaStyle()}
         {...genericTextAreaProps}

--- a/draft-packages/stories/TextAreaField.stories.tsx
+++ b/draft-packages/stories/TextAreaField.stories.tsx
@@ -180,7 +180,7 @@ export const DefaultErrorAndDesc = () => (
 
 DefaultErrorAndDesc.storyName = "Default, Error & Description"
 
-export const DefaultAutogrow = () => (
+export const DefaultAutogrowControlled = () => (
   <ExampleContainer>
     <WithState
       defaultValue={"This\ntext\narea\nwill\ngrow\nand\nshrink\nwith\ncontent"}
@@ -195,6 +195,22 @@ export const DefaultAutogrow = () => (
         />
       )}
     ></WithState>
+  </ExampleContainer>
+)
+
+DefaultAutogrowControlled.story = {
+  name: "Default, Autogrow Controlled",
+}
+
+export const DefaultAutogrow = () => (
+  <ExampleContainer>
+    <TextAreaField
+      id="reply"
+      labelText="Your reply"
+      rows={1}
+      defaultValue="A prefilled value in uncontrolled mode"
+      autogrow
+    />
   </ExampleContainer>
 )
 


### PR DESCRIPTION
When autogrow was added to this component, I created something called `internalValue` for when the textarea is uncontrolled by the consumer, but autogrow still needs to know the value. React throws an error if you specify both a `value` and `defaultValue` on a textarea, so I took away this defaultValue assignment, which was no longer required at the time with `internalValue` now taking over. I then decided that I wanted to avoid holding the internal state if I could (when autogrow is false), but didn't add this back in. This meant that uncontrolled textareas no longer had their default value going through.
