### PR TITLE
fix: Add explicit visibility style rule

### DIFF
--- a/draft-packages/divider/KaizenDraft/Divider/styles.module.scss
+++ b/draft-packages/divider/KaizenDraft/Divider/styles.module.scss
@@ -7,7 +7,7 @@
   margin: 0;
   border-radius: $kz-border-solid-border-radius;
   // This is here to protect against a global style in a consumer.
-  // See app/assets/stylesheets/legacy/modules/_body.scss in Murmur.
+  // https://github.com/cultureamp/murmur/blob/master/app/assets/stylesheets/legacy/modules/_body.scss
   visibility: visible;
 }
 

--- a/draft-packages/divider/KaizenDraft/Divider/styles.module.scss
+++ b/draft-packages/divider/KaizenDraft/Divider/styles.module.scss
@@ -6,6 +6,7 @@
   border: 0;
   margin: 0;
   border-radius: $kz-border-solid-border-radius;
+  visibility: visible;
 }
 
 .content {

--- a/draft-packages/divider/KaizenDraft/Divider/styles.module.scss
+++ b/draft-packages/divider/KaizenDraft/Divider/styles.module.scss
@@ -6,6 +6,8 @@
   border: 0;
   margin: 0;
   border-radius: $kz-border-solid-border-radius;
+  // This is here to protect against a global style in a consumer.
+  // See app/assets/stylesheets/legacy/modules/_body.scss in Murmur.
   visibility: visible;
 }
 


### PR DESCRIPTION
# Objective

Add an explicit `visibility: visible` rule to the `hr` element in the Divider component.

# Motivation and Context 

Murmur, our biggest consuming repo, has [global styles](https://github.com/cultureamp/murmur/blob/master/app/assets/stylesheets/legacy/modules/_body.scss#L95) that include
```
hr {
  visibility: hidden;
}
```
This makes for a poor user experience when someone uses the Divider component in Murmur, because they can't see it and may waste time figuring out why.

Removing this global rule from Murmur is risky, and adding an explicit rule to Kaizen seems like a compromise that is fairly harmless and does not couple the component to Murmur in any way.