### PR TITLE
docs: added figma embed

### DIFF
--- a/site/docs/components/rich-text-editor.mdx
+++ b/site/docs/components/rich-text-editor.mdx
@@ -16,6 +16,10 @@ import DoAndDontContainer from "docs-components/DoAndDontContainer"
 import Do from "docs-components/Do"
 import Dont from "docs-components/Dont"
 
+## Visuals
+
+<iframe style="border: 1px solid rgba(0, 0, 0, 0.1);" width="800" height="450" src="https://www.figma.com/embed?embed_host=share&url=https%3A%2F%2Fwww.figma.com%2Ffile%2Fe3TyAOZKfLg9cA01Iy1Mgm%2FKaizen-Site-embed%3Fnode-id%3D109544%253A41636" allowfullscreen></iframe>
+
 ## To keep in mind
 - The output of a Rich Text Editor can appear in the context of a larger page, and can present information that comes from a user rather than the system. In support of this: 
     - We offer only limited formatting options. 


### PR DESCRIPTION
Fixed resizing issues of the UI kit component and created a embed for docs

# Objective
<!-- Describe what this change achieves, and the details of how it works. -->

# Motivation and Context 
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

# Screenshots (if appropriate)

# Checklist
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
[ ] If this contains visual changes, has it been reviewed by a designer? 
[ ] I have considered likely risks of these changes and got someone else to QA as appropriate
[ ] I have or will communicate these changes to the front end practice

# Additional Considerations
- Does there need to be right-to-left (RTL) options for localization and internationalization?
- Has the test suite been updated?
- Have you done cross-browser testing for our [supported browsers](https://academy.cultureamp.com/hc/en-us/articles/204539569-Supported-browsers-for-Participants)?
- Have you updated any relevant documentation or left useful comments in the code?
- Have you reviewed Culture Amp's Web Accessibility guide [Current Compliance, Going Forward, Statement and Answers for Customers](https://cultureamp.atlassian.net/wiki/spaces/Prod/pages/428572998/Web+Accessibility)?
- If this contains substantial visual changes, especially far reaching ones, have you unlocked the Chromatic step in the pipeline? 
- Have Storybook stories been updated? 

**If you're new to Kaizen, please ask #prod_design_systems to set up an onboarding session to get you up to speed.** If you have an urgent PR to merge before that happens, it is safest to ask Design Systems team to review it to catch any issues.
