### PR TITLE
fix: Refine filter menu button styling

### DIFF
--- a/draft-packages/filter-menu-button/KaizenDraft/FilterMenuButton/FilterSplitButton.module.scss
+++ b/draft-packages/filter-menu-button/KaizenDraft/FilterMenuButton/FilterSplitButton.module.scss
@@ -3,8 +3,6 @@
 @import "~@kaizen/component-library/styles/type";
 @import "~@kaizen/design-tokens/sass/typography";
 
-$button-width: 383px;
-
 // The styling and mixin in this file originally comes from @kaizen/draft-button styles.module.scss and I modify it to suit with the `SplitButton` for `FilterMenuButton`.
 
 @mixin button-reset {
@@ -45,7 +43,7 @@ $button-width: 383px;
   @include button-reset;
   @include button-base;
 
-  max-width: $button-width;
+  max-width: 500px;
   padding-right: $ca-grid * 0.75;
   padding-left: $ca-grid * 0.75;
   border-top-left-radius: $kz-border-solid-border-radius;

--- a/draft-packages/filter-menu-button/KaizenDraft/FilterMenuButton/FilterSplitButton.module.scss
+++ b/draft-packages/filter-menu-button/KaizenDraft/FilterMenuButton/FilterSplitButton.module.scss
@@ -115,3 +115,12 @@
   font-weight: $kz-typography-heading-6-font-weight;
   margin-right: $ca-grid / 3;
 }
+
+// This is a temporary solution to mark an active state of the button
+// until it's decided whether this should be part of kaizen button or not
+.buttonActive {
+  border: $kz-border-solid-border-width $kz-border-solid-border-style;
+  border-color: $kz-color-cluny-400;
+  border-radius: $kz-border-solid-border-radius;
+  background: $kz-color-cluny-100;
+}

--- a/draft-packages/filter-menu-button/KaizenDraft/FilterMenuButton/FilterSplitButton.tsx
+++ b/draft-packages/filter-menu-button/KaizenDraft/FilterMenuButton/FilterSplitButton.tsx
@@ -57,7 +57,7 @@ export const FilterSplitButton = ({
   }
 
   return (
-    <div>
+    <div className={classnames({ [styles.buttonActive]: isDropdownVisible })}>
       <Button
         secondary={true}
         label={labelText}


### PR DESCRIPTION
# Objective
Refine the styling of the `FilterMenuButton` component to match with the latest Figma design.

# Motivation and Context 
When we first release the `FilterMenuButton` component, there's some styling that hasn't been implemented yet due to the decision that hasn't been made within the broader design/frontend practice.

Some of the design that hasn't been implemented:
* Active state for the button when it's clicked and the dropdown content is visible
* The button that's expanded as the metadata text grows.

# Screenshots (if appropriate)
### Active state for the clicked button
<img width="497" alt="image" src="https://user-images.githubusercontent.com/924319/102943919-81d45600-450d-11eb-9274-dc375f8abc39.png">

### Longer metadata text area
<img width="780" alt="image" src="https://user-images.githubusercontent.com/924319/102943979-9dd7f780-450d-11eb-85bf-65d93e645001.png">


# Checklist
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] If this contains visual changes, has it been reviewed by a designer? 
- [ ] I have considered likely risks of these changes and got someone else to QA as appropriate
- [ ] I have or will communicate these changes to the front end practice

# Additional Considerations
- Does there need to be right-to-left (RTL) options for localization and internationalization?
- Has the test suite been updated?
- Have you done cross-browser testing for our [supported browsers](https://academy.cultureamp.com/hc/en-us/articles/204539569-Supported-browsers-for-Participants)?
- Have you updated any relevant documentation or left useful comments in the code?
- Have you reviewed Culture Amp's Web Accessibility guide [Current Compliance, Going Forward, Statement and Answers for Customers](https://cultureamp.atlassian.net/wiki/spaces/Prod/pages/428572998/Web+Accessibility)?
- If this contains substantial visual changes, especially far reaching ones, have you unlocked the Chromatic step in the pipeline? 
- Have Storybook stories been updated? 

**If you're new to Kaizen, please ask #prod_design_systems to set up an onboarding session to get you up to speed.** If you have an urgent PR to merge before that happens, it is safest to ask Design Systems team to review it to catch any issues.
