### PR TITLE
fix: console error, where boolean was passed into `className`

### DIFF
--- a/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/components/Link.tsx
+++ b/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/components/Link.tsx
@@ -61,12 +61,7 @@ class Link extends React.PureComponent<LinkProps> {
           >
             {matches =>
               matches ? null : (
-                <ReactTooltip
-                  className={hasExtendedNavigation}
-                  id={this.toolId}
-                  place={"left"}
-                  effect={"solid"}
-                >
+                <ReactTooltip id={this.toolId} place={"left"} effect={"solid"}>
                   <span className={styles.tooltip}>
                     <Heading color="white" variant="heading-6">
                       {text}


### PR DESCRIPTION
In an effort to clean up the console errors in perf-ui, here's one of them. It appears we were passing a boolean into `className`

<img width="1297" alt="image" src="https://user-images.githubusercontent.com/4495057/102956589-8fe59f00-452c-11eb-8533-b146590e8439.png">
