### PR TITLE
feat: point deprecated helpers default font to Inter

### DIFF
--- a/packages/deprecated-component-library-helpers/styles/type.scss
+++ b/packages/deprecated-component-library-helpers/styles/type.scss
@@ -10,9 +10,14 @@ $ca-weight-medium: 500;
 $ca-weight-semibold: 500; // Note: in Sketch, semibold is 600. But murmur has an existing value of semibold=500 that is heavily used.
 
 // Combine these into a Sass map ($ca-default-font) once node-sass includes libsass 3.5.0.beta.3 with this bug fix: https://github.com/sass/libsass/issues/2309
-$ca-default-font-family: "Open Sans", Helvetica, Arial, sans-serif;
-$ca-default-font-base-size: 0.875rem; /* 14px */
-$ca-default-font-descender-height: 0.115;
+$ca-inter-font-family: "Inter";
+$ca-inter-font-base-size: 1rem; /* 16px */
+$ca-inter-font-descender-height: 0.14;
+
+// Combine these into a Sass map ($ca-default-font) once node-sass includes libsass 3.5.0.beta.3 with this bug fix: https://github.com/sass/libsass/issues/2309
+$ca-default-font-family: $ca-inter-font-family;
+$ca-default-font-base-size: $ca-inter-font-base-size;
+$ca-default-font-descender-height: $ca-inter-font-descender-height;
 
 // Combine these into a Sass map ($ca-default-font) once node-sass includes libsass 3.5.0.beta.3 with this bug fix: https://github.com/sass/libsass/issues/2309
 $ca-ideal-sans-font-family: "Ideal Sans A", "Ideal Sans B",
@@ -20,23 +25,18 @@ $ca-ideal-sans-font-family: "Ideal Sans A", "Ideal Sans B",
 $ca-ideal-sans-font-base-size: 1rem; /* 16px */
 $ca-ideal-sans-font-descender-height: 0.14;
 
-// Combine these into a Sass map ($ca-default-font) once node-sass includes libsass 3.5.0.beta.3 with this bug fix: https://github.com/sass/libsass/issues/2309
-$ca-inter-font-family: "Inter", $ca-default-font-family;
-$ca-inter-font-base-size: 1rem; /* 16px */
-$ca-inter-font-descender-height: 0.14;
-
 $ca-greycliff-font-base-size: 1rem; /* 16px */
 $ca-greycliff-font-descender-height: 0.098;
 
 // Locale-specific fonts
-$ca-locale-he-font-family: "Open Sans", Tahoma, sans-serif;
-$ca-locale-ar-font-family: "Open Sans", Tahoma, sans-serif;
 $ca-ideal-locale-ar-font-family: "Ideal Sans A", "Ideal Sans B", Tahoma,
   sans-serif;
 $ca-ideal-locale-he-font-family: "Ideal Sans A", "Ideal Sans B", Tahoma,
   sans-serif;
 $ca-inter-locale-ar-font-family: "Inter", Tahoma, sans-serif;
 $ca-inter-locale-he-font-family: "Inter", Tahoma, sans-serif;
+$ca-locale-he-font-family: $ca-inter-locale-ar-font-family;
+$ca-locale-ar-font-family: $ca-inter-locale-he-font-family;
 
 // Inspired by Basekick from SEEK: https://github.com/michaeltaranto/basekick
 @mixin ca-type(


### PR DESCRIPTION
DUPLICATE OF https://github.com/cultureamp/kaizen-design-system/pull/916
**Note: this is a canary release**



# Motivation and Context 
The motivation is to test murmur against this branch which replaces open sans with inter.

# Details
These same changes were originally made in this  (canary) PR: https://github.com/cultureamp/kaizen-design-system/pull/916. That PR created a canary release from `@kaizen/component-library` but it did not appear to create a canary release for `@kaizen/deprecated-component-library-helpers` (which also had changes). I resumed work on this, and only just realised. I'm not sure why - is there a limitation where you can only do one canary release per PR per package? This was three months ago, so not worth worrying about! This PR, which only changes code in depredated-component-library-helpers is an attempt to create a canary release for just `depredated-component-library-helpers`, rather than `depredated-component-library-helper` and `component-library`.

This commit is the actual code for this PR: https://github.com/cultureamp/kaizen-design-system/pull/916/commits/acafb6fa7786bfd673927d756c4d3895423d0c38. It seems that the canary branch is behind master, which is why there are many commits in this PR unrelated to this commit.
