### PR TITLE
fix: remove the max-width to make the button expand with the metadata

### DIFF
--- a/draft-packages/filter-menu-button/KaizenDraft/FilterMenuButton/FilterSplitButton.module.scss
+++ b/draft-packages/filter-menu-button/KaizenDraft/FilterMenuButton/FilterSplitButton.module.scss
@@ -43,7 +43,6 @@
   @include button-reset;
   @include button-base;
 
-  max-width: 500px;
   padding-right: $ca-grid * 0.75;
   padding-left: $ca-grid * 0.75;
   border-top-left-radius: $kz-border-solid-border-radius;

--- a/draft-packages/filter-menu-button/docs/FilterMenuButton.stories.tsx
+++ b/draft-packages/filter-menu-button/docs/FilterMenuButton.stories.tsx
@@ -64,6 +64,9 @@ const dropdownOptions = [
   { id: 2, label: "Aquatic" },
   { id: 3, label: "Venomous" },
   { id: 4, label: "Egg-laying" },
+  { id: 5, label: "Water-proof feathers" },
+  { id: 6, label: "Cold-blooded" },
+  { id: 7, label: "Warm-blooded" },
 ]
 
 export const DefaultWithChildrenSimpleFilter = () => {


### PR DESCRIPTION
# Objective
Remove the `max-width` from the action button to make the button expand along with the metadata.

# Motivation and Context 
**Previously with `max-width: 500px`**
<img width="843" alt="CleanShot 2021-01-12 at 10 42 24@2x" src="https://user-images.githubusercontent.com/924319/104251022-f07c5200-54c2-11eb-8453-e5a9d9f24650.png">

**Updated Version**
<img width="864" alt="CleanShot 2021-01-12 at 10 43 39@2x" src="https://user-images.githubusercontent.com/924319/104251078-10ac1100-54c3-11eb-9286-4454e6f9fb21.png">

# Checklist
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
[x] If this contains visual changes, has it been reviewed by a designer? 
[ ] I have considered likely risks of these changes and got someone else to QA as appropriate
[ ] I have or will communicate these changes to the front end practice

# Additional Considerations
- Does there need to be right-to-left (RTL) options for localization and internationalization?
- Has the test suite been updated?
- Have you done cross-browser testing for our [supported browsers](https://academy.cultureamp.com/hc/en-us/articles/204539569-Supported-browsers-for-Participants)?
- Have you updated any relevant documentation or left useful comments in the code?
- Have you reviewed Culture Amp's Web Accessibility guide [Current Compliance, Going Forward, Statement and Answers for Customers](https://cultureamp.atlassian.net/wiki/spaces/Prod/pages/428572998/Web+Accessibility)?
- If this contains substantial visual changes, especially far reaching ones, have you unlocked the Chromatic step in the pipeline? 
- Have Storybook stories been updated? 

**If you're new to Kaizen, please ask #prod_design_systems to set up an onboarding session to get you up to speed.** If you have an urgent PR to merge before that happens, it is safest to ask Design Systems team to review it to catch any issues.
