### PR TITLE
fix: update styling for FilterMenuButton metadata label

### DIFF
--- a/draft-packages/filter-menu-button/KaizenDraft/FilterMenuButton/FilterSplitButton.module.scss
+++ b/draft-packages/filter-menu-button/KaizenDraft/FilterMenuButton/FilterSplitButton.module.scss
@@ -63,7 +63,6 @@
 
   &:hover {
     background: $kz-color-cluny-100;
-    color: $kz-color-cluny-500;
   }
 }
 
@@ -73,7 +72,6 @@
 
   &:hover {
     background: $kz-color-cluny-100;
-    color: $kz-color-cluny-500;
   }
 }
 
@@ -111,8 +109,14 @@
 }
 
 .filterName {
-  font-weight: $kz-typography-heading-6-font-weight;
+  font-weight: $kz-typography-button-primary-font-weight;
   margin-right: $ca-grid / 3;
+}
+
+.metadata {
+  font-size: $kz-typography-button-secondary-font-size;
+  font-weight: $kz-typography-button-secondary-font-weight;
+  letter-spacing: $kz-typography-button-secondary-letter-spacing;
 }
 
 // This is a temporary solution to mark an active state of the button

--- a/draft-packages/filter-menu-button/KaizenDraft/FilterMenuButton/FilterSplitButton.tsx
+++ b/draft-packages/filter-menu-button/KaizenDraft/FilterMenuButton/FilterSplitButton.tsx
@@ -39,7 +39,7 @@ export const FilterSplitButton = ({
           })}
         >
           <span className={styles.filterName}>{labelText}</span>
-          <span>{metadata}</span>
+          <span className={styles.metadata}>{metadata}</span>
         </button>
         {onFilterClear ? (
           <button

--- a/draft-packages/filter-menu-button/KaizenDraft/FilterMenuButton/styles.module.scss
+++ b/draft-packages/filter-menu-button/KaizenDraft/FilterMenuButton/styles.module.scss
@@ -23,9 +23,3 @@ $menuContentVerticalPadding: 6px; // this comes from the MenuContent component, 
   padding: calc(#{$kz-spacing-sm} - #{$menuContentVerticalPadding})
     calc(#{$kz-spacing-sm} - #{$menuContentHorizontalPadding});
 }
-
-.metadata {
-  @include kz-typography-paragraph-small;
-  @include ca-inherit-baseline;
-  color: $kz-color-wisteria-800;
-}


### PR DESCRIPTION
# Objective
Add metadata class for the label with a style that matches secondary button.
In this change, I also add hover state for the button to use Cluny 600
to make it thicker for an accessibility purpose

# Motivation and Context 
Make the metadata label for the `FilterMenuButton` component thicker

# Screenshots (if appropriate)

# Checklist
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
[x] If this contains visual changes, has it been reviewed by a designer? 
[ ] I have considered likely risks of these changes and got someone else to QA as appropriate
[ ] I have or will communicate these changes to the front end practice

# Additional Considerations
- Does there need to be right-to-left (RTL) options for localization and internationalization?
- Has the test suite been updated?
- Have you done cross-browser testing for our [supported browsers](https://academy.cultureamp.com/hc/en-us/articles/204539569-Supported-browsers-for-Participants)?
- Have you updated any relevant documentation or left useful comments in the code?
- Have you reviewed Culture Amp's Web Accessibility guide [Current Compliance, Going Forward, Statement and Answers for Customers](https://cultureamp.atlassian.net/wiki/spaces/Prod/pages/428572998/Web+Accessibility)?
- If this contains substantial visual changes, especially far reaching ones, have you unlocked the Chromatic step in the pipeline? 
- Have Storybook stories been updated? 

**If you're new to Kaizen, please ask #prod_design_systems to set up an onboarding session to get you up to speed.** If you have an urgent PR to merge before that happens, it is safest to ask Design Systems team to review it to catch any issues.
