### PR TITLE
feat: Allow greater customisation of action buttons on all modals

### DIFF
--- a/draft-packages/modal/KaizenDraft/Modal/Presets/ConfirmationModal.tsx
+++ b/draft-packages/modal/KaizenDraft/Modal/Presets/ConfirmationModal.tsx
@@ -9,6 +9,7 @@ import {
   PositiveFemale,
 } from "@kaizen/draft-illustration"
 
+import { ButtonProps } from "@kaizen/draft-button"
 import {
   GenericModal,
   ModalAccessibleDescription,
@@ -30,6 +31,8 @@ export interface ConfirmationModalProps {
   readonly dismissLabel?: string
   readonly automationId?: string
   readonly children: React.ReactNode
+  readonly confirmButtonProps?: ButtonProps
+  readonly dismissButtonProps?: ButtonProps
 }
 
 type ConfirmationModal = React.FunctionComponent<ConfirmationModalProps>
@@ -57,13 +60,23 @@ const ConfirmationModal = ({
   confirmLabel = "Confirm",
   dismissLabel = "Cancel",
   automationId,
+  confirmButtonProps,
+  dismissButtonProps,
   children,
 }: ConfirmationModalProps) => {
-  const footerActions: Array<{ label: string; action: () => void }> = []
-  if (onConfirm) {
-    footerActions.push({ label: confirmLabel, action: onConfirm })
+  const footerActions: ButtonProps[] = []
+  if (onConfirm || confirmButtonProps) {
+    footerActions.push({
+      onClick: onConfirm,
+      label: confirmLabel,
+      ...confirmButtonProps,
+    })
   }
-  footerActions.push({ label: dismissLabel, action: onDismiss })
+  footerActions.push({
+    onClick: onDismiss,
+    label: dismissLabel,
+    ...dismissButtonProps,
+  })
 
   return (
     <GenericModal

--- a/draft-packages/modal/KaizenDraft/Modal/Presets/InformationModal.tsx
+++ b/draft-packages/modal/KaizenDraft/Modal/Presets/InformationModal.tsx
@@ -2,6 +2,7 @@ import * as React from "react"
 
 import { Text } from "@kaizen/component-library"
 
+import { ButtonProps } from "@kaizen/draft-button"
 import {
   GenericModal,
   ModalAccessibleLabel,
@@ -18,6 +19,7 @@ export interface InformationModalProps {
   readonly onConfirm?: () => void
   readonly onDismiss: () => void
   readonly confirmLabel?: string
+  readonly confirmButtonProps?: ButtonProps
   readonly automationId?: string
   readonly renderBackground?: () => React.ReactNode
   readonly children: React.ReactNode
@@ -31,6 +33,7 @@ const InformationModal = ({
   onConfirm,
   onDismiss,
   confirmLabel = "Confirm",
+  confirmButtonProps,
   automationId,
   renderBackground,
   children,
@@ -61,7 +64,9 @@ const InformationModal = ({
       </ModalBody>
       {onConfirm != null && (
         <ModalFooter
-          actions={[{ label: confirmLabel, action: onConfirm }]}
+          actions={[
+            { label: confirmLabel, onClick: onConfirm, ...confirmButtonProps },
+          ]}
           appearance={"primary"}
           automationId={automationId}
         />

--- a/draft-packages/modal/KaizenDraft/Modal/Presets/InputEditModal.tsx
+++ b/draft-packages/modal/KaizenDraft/Modal/Presets/InputEditModal.tsx
@@ -1,8 +1,8 @@
-import classnames from "classnames"
 import * as React from "react"
 
 import { Text } from "@kaizen/component-library"
 
+import { ButtonProps } from "@kaizen/draft-button"
 import {
   GenericModal,
   ModalAccessibleLabel,
@@ -24,7 +24,8 @@ export interface InputEditModalProps {
   readonly dismissLabel?: string
   readonly automationId?: string
   readonly children: React.ReactNode
-  readonly submitDisabled?: boolean
+  readonly submitButtonProps?: ButtonProps
+  readonly dismissButtonProps?: ButtonProps
 }
 
 type InputEditModal = React.FunctionComponent<InputEditModalProps>
@@ -40,7 +41,8 @@ const InputEditModal = ({
   dismissLabel = "Cancel",
   automationId,
   children,
-  submitDisabled = false,
+  submitButtonProps,
+  dismissButtonProps,
 }: InputEditModalProps) => (
   <GenericModal
     isOpen={isOpen}
@@ -64,8 +66,8 @@ const InputEditModal = ({
       </ModalBody>
       <ModalFooter
         actions={[
-          { label: submitLabel, action: onSubmit, disabled: submitDisabled },
-          { label: dismissLabel, action: onDismiss },
+          { label: submitLabel, onClick: onSubmit, ...submitButtonProps },
+          { label: dismissLabel, onClick: onDismiss, ...dismissButtonProps },
         ]}
         appearance={type === "negative" ? "destructive" : "primary"}
         automationId={automationId}

--- a/draft-packages/modal/KaizenDraft/Modal/Presets/RoadblockModal.tsx
+++ b/draft-packages/modal/KaizenDraft/Modal/Presets/RoadblockModal.tsx
@@ -1,9 +1,9 @@
-import classnames from "classnames"
 import * as React from "react"
 
 import { Heading } from "@kaizen/component-library"
 import { Negative } from "@kaizen/draft-illustration"
 
+import { ButtonProps } from "@kaizen/draft-button"
 import {
   GenericModal,
   ModalAccessibleDescription,
@@ -20,6 +20,7 @@ export interface RoadblockModalProps {
   readonly title: string
   readonly onDismiss: () => void
   readonly dismissLabel?: string
+  readonly dismissButtonProps?: ButtonProps
   readonly automationId?: string
   readonly children: React.ReactNode
 }
@@ -31,6 +32,7 @@ const RoadblockModal = ({
   title,
   onDismiss,
   dismissLabel = "Back",
+  dismissButtonProps,
   automationId,
   children,
 }: RoadblockModalProps) => (
@@ -62,7 +64,9 @@ const RoadblockModal = ({
         </div>
       </ModalBody>
       <ModalFooter
-        actions={[{ label: dismissLabel, action: onDismiss }]}
+        actions={[
+          { label: dismissLabel, onClick: onDismiss, ...dismissButtonProps },
+        ]}
         appearance="primary"
         automationId={automationId}
       />

--- a/draft-packages/modal/KaizenDraft/Modal/Primitives/ModalFooter.tsx
+++ b/draft-packages/modal/KaizenDraft/Modal/Primitives/ModalFooter.tsx
@@ -1,18 +1,13 @@
 import * as React from "react"
 
-import { Button } from "@kaizen/draft-button"
+import { Button, ButtonProps } from "@kaizen/draft-button"
 import GenericModalSection from "./GenericModalSection"
 
 import styles from "./ModalFooter.scss"
 
 export interface ModalFooterProps {
   readonly unpadded?: boolean
-  readonly actions: Array<{
-    label: string
-    action: (event: React.MouseEvent) => any
-    icon?: React.SVGAttributes<SVGSymbolElement>
-    disabled?: boolean
-  }>
+  readonly actions: ButtonProps[]
   readonly appearance?: "primary" | "destructive"
   readonly automationId?: string
 }
@@ -29,14 +24,13 @@ const ModalFooter: ModalFooter = props => {
           <div className={styles.actionButton} key={a.label}>
             <Button
               type="button"
-              icon={a.icon}
-              label={a.label}
-              onClick={a.action}
+              onClick={a.onClick}
               primary={index === 0 && appearance === "primary"}
               destructive={index === 0 && appearance === "destructive"}
               secondary={index > 0}
               disabled={a.disabled}
               data-automation-id={`${automationId}-action-${index}`}
+              {...a}
             />
           </div>
         ))}

--- a/draft-packages/modal/docs/Modal.stories.tsx
+++ b/draft-packages/modal/docs/Modal.stories.tsx
@@ -161,6 +161,37 @@ export const ConfirmationNegative = () => (
 
 ConfirmationNegative.storyName = "Confirmation (negative)"
 
+export const ConfirmationCustomButtons = () => (
+  <ModalStateContainer isInitiallyOpen={false}>
+    {({ open, close, isOpen }) => (
+      <div>
+        <Button label="Open modal" onClick={open} />
+        <ConfirmationModal
+          isOpen={isOpen}
+          type="negative"
+          title="Negative title"
+          onConfirm={close}
+          onDismiss={close}
+          confirmButtonProps={{
+            label: "Confirm",
+            working: true,
+            workingLabel: "Working…",
+          }}
+        >
+          <div style={{ textAlign: "center" }}>
+            <Paragraph tag="p" variant="body">
+              Modals contain smaller pieces of content and can provide
+              additional information to aid the user.
+            </Paragraph>
+          </div>
+        </ConfirmationModal>
+      </div>
+    )}
+  </ModalStateContainer>
+)
+
+ConfirmationCustomButtons.storyName = "Confirmation w/ custom button props"
+
 export const InputEditPositive = () => (
   <ModalStateContainer isInitiallyOpen={false}>
     {({ open, close, isOpen }) => (
@@ -486,7 +517,7 @@ export const GenericModalPadded = () => (
                 actions={[
                   {
                     label: "Confirm",
-                    action: () => close(),
+                    onClick: () => close(),
                   },
                 ]}
               >
@@ -529,7 +560,7 @@ export const GenericModalUnpadded = () => (
                 actions={[
                   {
                     label: "Confirm",
-                    action: () => close(),
+                    onClick: () => close(),
                   },
                 ]}
                 unpadded


### PR DESCRIPTION
BREAKING CHANGE: `submitDisabled` prop on `InputEditModal` has been removed. Use `submitButtonProps={{ working: true }}` instead.

# Objective
Allows consumers of all modal types to specify any `ButtonProps` for its action buttons.

eg.
```
<ConfirmationModal
  (...usual modal props)
  confirmButtonProps={{
    label: "Confirm",
    working: true,
    workingLabel: "Working…",
  }}
/>
```

# Motivation and Context 
The reason this has come up is because we have a need to use the `working` prop on the confirm button for `ConfirmationModal`. This is something that has come up in the past with the `InputEditModal`, which caused a `submitDisabled` prop to be added (the `working` variant of `Button` didn't exist at the time).

# Alternate solution / Pros and Cons

There is an alternative solution, where we only expose the functionality we need, ie. we create a new prop on `ConfirmationModal` for `confirmButtonWorking`.

Pros of the approach in this PR:
* We only need to do this once. If there's ever a need for consumers to customise these buttons further, or if the Button API changes, we don't need to then adjust the modal API as well each time.

Cons of the approach in this PR:
* Bit less intuitive for consumers and opens up possibilities for consumers to use modals in some weird ways.
* Creates a bit of awkwardness with the existing `confirmLabel` and `dismissLabel` props. Do we remove them and make those customisations go through this new prop?

<!---
# Checklist
 What types of changes does your code introduce? Put an `x` in all the boxes that apply: 
[ ] If this contains visual changes, has it been reviewed by a designer? 
[ ] I have considered likely risks of these changes and got someone else to QA as appropriate
[ ] I have or will communicate these changes to the front end practice

# Additional Considerations
- Does there need to be right-to-left (RTL) options for localization and internationalization?
- Has the test suite been updated?
- Have you done cross-browser testing for our [supported browsers](https://academy.cultureamp.com/hc/en-us/articles/204539569-Supported-browsers-for-Participants)?
- Have you updated any relevant documentation or left useful comments in the code?
- Have you reviewed Culture Amp's Web Accessibility guide [Current Compliance, Going Forward, Statement and Answers for Customers](https://cultureamp.atlassian.net/wiki/spaces/Prod/pages/428572998/Web+Accessibility)?
- If this contains substantial visual changes, especially far reaching ones, have you unlocked the Chromatic step in the pipeline? 
- Have Storybook stories been updated? 

**If you're new to Kaizen, please ask #prod_design_systems to set up an onboarding session to get you up to speed.** If you have an urgent PR to merge before that happens, it is safest to ask Design Systems team to review it to catch any issues.
-->
