### PR TITLE
fix: remove content wrapper for FilterMenuButton children

### DIFF
--- a/draft-packages/filter-menu-button/KaizenDraft/FilterMenuButton/FilterMenuButton.tsx
+++ b/draft-packages/filter-menu-button/KaizenDraft/FilterMenuButton/FilterMenuButton.tsx
@@ -83,9 +83,7 @@ export const FilterMenuButton = ({
         dropdownId={dropdownId}
       >
         <MenuContent>
-          <div className={styles.content} onClick={e => e.stopPropagation()}>
-            {children}
-          </div>
+          <div onClick={e => e.stopPropagation()}>{children}</div>
         </MenuContent>
       </StatelessMenu>
     </div>

--- a/draft-packages/filter-menu-button/KaizenDraft/FilterMenuButton/styles.module.scss
+++ b/draft-packages/filter-menu-button/KaizenDraft/FilterMenuButton/styles.module.scss
@@ -18,8 +18,3 @@ $menuContentVerticalPadding: 6px; // this comes from the MenuContent component, 
     margin: 0 ($gap / 2);
   }
 }
-
-.content {
-  padding: calc(#{$kz-spacing-sm} - #{$menuContentVerticalPadding})
-    calc(#{$kz-spacing-sm} - #{$menuContentHorizontalPadding});
-}

--- a/draft-packages/filter-menu-button/docs/FilterMenuButton.stories.scss
+++ b/draft-packages/filter-menu-button/docs/FilterMenuButton.stories.scss
@@ -1,4 +1,8 @@
 @import "~@kaizen/design-tokens/sass/color";
+@import "~@kaizen/design-tokens/sass/spacing";
+
+$menuContentHorizontalPadding: 4px; // this comes from the MenuContent component, which should be using tokens
+$menuContentVerticalPadding: 6px; // this comes from the MenuContent component, which should be using tokens
 
 .buttons {
   display: flex;
@@ -10,6 +14,8 @@
   & label {
     width: auto;
   }
+  padding: calc(#{$kz-spacing-sm} - #{$menuContentVerticalPadding})
+    calc(#{$kz-spacing-sm} - #{$menuContentHorizontalPadding});
 }
 
 .siteDemoWrapper {


### PR DESCRIPTION
# Objective
Remove the styling for `div` inside `MenuContent`

# Motivation and Context 
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The padding surrounding the children inside `MenuContent` makes it difficult for the consumer to style the children component to utilise the whole areas. These changes remove the style for the wrapper inside `MenuContent`.

# Screenshots (if appropriate)

# Checklist
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
[x] If this contains visual changes, has it been reviewed by a designer? 
[ ] I have considered likely risks of these changes and got someone else to QA as appropriate
[ ] I have or will communicate these changes to the front end practice

# Additional Considerations
- Does there need to be right-to-left (RTL) options for localization and internationalization?
- Has the test suite been updated?
- Have you done cross-browser testing for our [supported browsers](https://academy.cultureamp.com/hc/en-us/articles/204539569-Supported-browsers-for-Participants)?
- Have you updated any relevant documentation or left useful comments in the code?
- Have you reviewed Culture Amp's Web Accessibility guide [Current Compliance, Going Forward, Statement and Answers for Customers](https://cultureamp.atlassian.net/wiki/spaces/Prod/pages/428572998/Web+Accessibility)?
- If this contains substantial visual changes, especially far reaching ones, have you unlocked the Chromatic step in the pipeline? 
- Have Storybook stories been updated? 

**If you're new to Kaizen, please ask #prod_design_systems to set up an onboarding session to get you up to speed.** If you have an urgent PR to merge before that happens, it is safest to ask Design Systems team to review it to catch any issues.
