### PR TITLE
feat: Remove cursor css for Tag components

### DIFF
--- a/draft-packages/tag/KaizenDraft/Tag/Tag.scss
+++ b/draft-packages/tag/KaizenDraft/Tag/Tag.scss
@@ -19,7 +19,6 @@ $small: $ca-grid;
     $kz-border-borderless-border-color;
   border-radius: $ca-grid * 0.75;
   padding: 0 $ca-grid * 0.4;
-  cursor: default;
   box-sizing: border-box;
 }
 


### PR DESCRIPTION
# Objective
Remove cursor css for Tag components

# Motivation and Context 
In perform, we use the `Tag` component inside clickable table rows. Because the `Tag` component has a `cursor: default` css property, the cursor will actually change from a `pointer`, to a `default` cursor, if they hover over the Tag. It kind of makes the site look broken.

I think removing the custom cursor is the best thing to do. Although I'm not sure who to tag on this one, since there's no one on the git history.

# Screenshots

![image](https://user-images.githubusercontent.com/4495057/104971709-aad00400-5a43-11eb-911f-16dd7df99ccf.png)

# Checklist
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
[ ] If this contains visual changes, has it been reviewed by a designer? - NA
[X] I have considered likely risks of these changes and got someone else to QA as appropriate
[X] I have or will communicate these changes to the front end practice