### PR TITLE
feat: Added color token for solid borders

### DIFF
--- a/packages/design-tokens/less/border.less
+++ b/packages/design-tokens/less/border.less
@@ -3,6 +3,7 @@
 @kz-border-solid-border-width: 2px;
 @kz-border-solid-border-radius: 7px;
 @kz-border-solid-border-style: solid;
+@kz-border-solid-border-color: #e1e2ea;
 @kz-border-dashed-border-width: 2px;
 @kz-border-dashed-border-radius: 7px;
 @kz-border-dashed-border-style: dashed;

--- a/packages/design-tokens/sass/border.scss
+++ b/packages/design-tokens/sass/border.scss
@@ -3,6 +3,7 @@
 $kz-border-solid-border-width: 2px;
 $kz-border-solid-border-radius: 7px;
 $kz-border-solid-border-style: solid;
+$kz-border-solid-border-color: #e1e2ea;
 $kz-border-dashed-border-width: 2px;
 $kz-border-dashed-border-radius: 7px;
 $kz-border-dashed-border-style: dashed;

--- a/packages/design-tokens/sass/color.scss
+++ b/packages/design-tokens/sass/color.scss
@@ -39,7 +39,7 @@ $kz-color-peach-500: #fa7558;
 $kz-color-peach-600: #b85d4a;
 $kz-color-ash: #ececef;
 $kz-color-stone: #f6f6f6;
-$kz-color-white: white;
+$kz-color-white: #ffffff;
 $kz-deprecated-color-lapis: #253c64;
 $kz-deprecated-color-ocean: #1b7688;
 $kz-deprecated-color-ink: #3e4543;

--- a/packages/design-tokens/tokens/border.json
+++ b/packages/design-tokens/tokens/border.json
@@ -4,7 +4,8 @@
       "solid": {
         "borderWidth": "2px",
         "borderRadius": "7px",
-        "borderStyle": "solid"
+        "borderStyle": "solid",
+        "borderColor": "#e1e2ea"
       },
       "dashed": {
         "borderWidth": "2px",


### PR DESCRIPTION
# Objective
This adds a new border color token to the design tokens. 

# Motivation and Context 
In the current state, the default color for solid borders is wisteria-100. This formalises that decision as a token. As an added bonus, usage of this token will help us with the upcoming brand uplift.  

# Screenshots (if appropriate)

# Checklist
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
[ ] If this contains visual changes, has it been reviewed by a designer? 
[ ] I have considered likely risks of these changes and got someone else to QA as appropriate
[ ] I have or will communicate these changes to the front end practice

# Additional Considerations
- Does there need to be right-to-left (RTL) options for localization and internationalization?
- Has the test suite been updated?
- Have you done cross-browser testing for our [supported browsers](https://academy.cultureamp.com/hc/en-us/articles/204539569-Supported-browsers-for-Participants)?
- Have you updated any relevant documentation or left useful comments in the code?
- Have you reviewed Culture Amp's Web Accessibility guide [Current Compliance, Going Forward, Statement and Answers for Customers](https://cultureamp.atlassian.net/wiki/spaces/Prod/pages/428572998/Web+Accessibility)?
- If this contains substantial visual changes, especially far reaching ones, have you unlocked the Chromatic step in the pipeline? 
- Have Storybook stories been updated? 

**If you're new to Kaizen, please ask #prod_design_systems to set up an onboarding session to get you up to speed.** If you have an urgent PR to merge before that happens, it is safest to ask Design Systems team to review it to catch any issues.
