### PR TITLE
chore: add a Github workflow that adds comments to PRs with branch preview links

### DIFF
--- a/.github/workflows/add_branch_preview_link_to_pr.yml
+++ b/.github/workflows/add_branch_preview_link_to_pr.yml
@@ -1,0 +1,80 @@
+name: Add branch preview links to a PR comment
+
+# Note about "status" events:
+# - The workflow must be merged to master, a status on a commit in any branch will still run the workflow found on master
+# - "status" events (like those from buildkite) are different to "check" events from Github actions.
+# - You can check for a specific status using it's context. Find it using the API:
+#     curl \
+#       --header "Accept: application/vnd.github.v3+json" \
+#       --header 'Authorization: token ${PERSONAL_API_TOKEN}' \
+#       https://api.github.com/repos/${ORG}/${REPO}/commits/${SHA}/status
+# - You can trigger a "status" event manually for testing:
+#     curl -request POST --url "https://api.github.com/repos/${ORG}/${REPO}/statuses/${SHA}" \
+#      --header "Authorization: token ${PERSONAL_API_TOKEN}" \
+#      --header 'content-type: application/json' \
+#      --data '{"state": "success", "description": "my status", "context": "some/unique/identifier", "target_url": "http://link-in-status/"}'
+
+on:
+  - status
+
+jobs:
+  add_branch_preview_links_to_a_PR_comment:
+    runs-on: ubuntu-latest
+    if: github.event.state == 'success' && github.event.context == 'Branch preview'
+    steps:
+      - uses: actions/checkout@v1
+
+      - name: Find relevant PR
+        if: github.event.state == 'success'
+        uses: jwalton/gh-find-current-pr@v1
+        id: findPr
+        with:
+          sha: ${{ github.event.sha }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - run: echo "Found PR ${PR}"
+        if: success() && steps.findPr.outputs.number
+        env:
+          PR: ${{ steps.findPr.outputs.number }}
+
+      - name: Check if there is an existing comment
+        if: success() && steps.findPr.outputs.number
+        uses: peter-evans/find-comment@v1
+        id: find_comment
+        with:
+          issue-number: ${{ steps.findPr.outputs.number }}
+          comment-author: 'github-actions[bot]'
+          body-includes: ':sparkles: Here are your branch previews! :sparkles:'
+
+      - name: Create a new comment
+        if: success() && steps.find_comment.outputs.comment-id == 0
+        uses: peter-evans/create-or-update-comment@v1
+        with:
+          issue-number: ${{ steps.findPr.outputs.number }}
+          body: |
+            :sparkles: Here are your branch previews! :sparkles:
+
+            - [Kaizen site][1]
+            - [Storybook][2]
+
+            Last updated for commit ${{ github.event.sha }}: ${{ github.event.commit.commit.message }}
+
+            [1]: https://dev.cultureamp.design/${{ github.event.branches[0].name }}
+            [2]: https://dev.cultureamp.design/${{ github.event.branches[0].name }}/storybook
+
+      - name: Update an existing comment
+        if: success() && steps.find_comment.outputs.comment-id != 0
+        uses: peter-evans/create-or-update-comment@v1
+        with:
+          comment-id: ${{ steps.find_comment.outputs.comment-id }}
+          edit-mode: replace
+          body: |
+            :sparkles: Here are your branch previews! :sparkles:
+
+            - [Kaizen site][1]
+            - [Storybook][2]
+
+            Last updated for commit ${{ github.event.sha }}: ${{ github.event.commit.commit.message }}
+
+            [1]: https://dev.cultureamp.design/${{ github.event.branches[0].name }}
+            [2]: https://dev.cultureamp.design/${{ github.event.branches[0].name }}/storybook

--- a/.github/workflows/add_branch_preview_link_to_pr.yml
+++ b/.github/workflows/add_branch_preview_link_to_pr.yml
@@ -43,8 +43,8 @@ jobs:
         id: find_comment
         with:
           issue-number: ${{ steps.findPr.outputs.number }}
-          comment-author: 'github-actions[bot]'
-          body-includes: ':sparkles: Here are your branch previews! :sparkles:'
+          comment-author: "github-actions[bot]"
+          body-includes: ":sparkles: Here are your branch previews! :sparkles:"
 
       - name: Create a new comment
         if: success() && steps.find_comment.outputs.comment-id == 0


### PR DESCRIPTION
# Objective

Make the branch previews easier to find.

# Motivation and Context 

Currently the branch preview links are hidden inside the "status" checks, which are collapsed if the build is passing - it's not very easy for people to find the branch previews, especially if they are not familiar with Github.

# Screenshots (if appropriate)

[Here is what it looks like on a test repo](https://github.com/jasononeil/github-action-status-test/pull/2#issuecomment-768729378):

![image](https://user-images.githubusercontent.com/315158/106078199-f5d9cd80-614d-11eb-814c-5bffbe3aca35.png)


(Note: we can't test this on this repo until it's merged to master. Hopefully it all works as well as it does in the test repo!)

# Checklist
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] I have or will communicate these changes to the front end practice

