### PR TITLE
feat: Add ability to change the Menu auto hide behaviour

### DIFF
--- a/draft-packages/menu/KaizenDraft/Menu/Menu.tsx
+++ b/draft-packages/menu/KaizenDraft/Menu/Menu.tsx
@@ -29,7 +29,10 @@ export type GenericMenuProps = {
   menuVisible?: boolean
   automationId?: string
   dropdownId?: string
-
+  /**
+   * @default: true
+   */
+  autoHideOnClick?: boolean
   /**
    * The content to appear inside the dropdown when it is open
    */
@@ -48,6 +51,7 @@ const Menu: Menu = props => {
   const {
     align = "left",
     dropdownWidth = "default",
+    autoHideOnClick = true,
     menuVisible = false,
   } = props
 
@@ -96,6 +100,7 @@ export const render = (props: GenericMenuProps & RenderProps) => {
       hideMenuDropdown={props.hideMenuDropdown}
       width={props.dropdownWidth}
       id={props.dropdownId}
+      autoHideOnClick={props.autoHideOnClick}
     >
       {props.children}
     </MenuDropdown>

--- a/draft-packages/menu/KaizenDraft/Menu/Menu.tsx
+++ b/draft-packages/menu/KaizenDraft/Menu/Menu.tsx
@@ -30,9 +30,10 @@ export type GenericMenuProps = {
   automationId?: string
   dropdownId?: string
   /**
-   * @default: true
+   * Determines when the menu should automatically hide.
+   * @default: "on"
    */
-  autoHideOnClick?: boolean
+  autoHide?: "on" | "outside-click-only" | "off"
   /**
    * The content to appear inside the dropdown when it is open
    */
@@ -51,7 +52,7 @@ const Menu: Menu = props => {
   const {
     align = "left",
     dropdownWidth = "default",
-    autoHideOnClick = true,
+    autoHide = true,
     menuVisible = false,
   } = props
 
@@ -100,7 +101,7 @@ export const render = (props: GenericMenuProps & RenderProps) => {
       hideMenuDropdown={props.hideMenuDropdown}
       width={props.dropdownWidth}
       id={props.dropdownId}
-      autoHideOnClick={props.autoHideOnClick}
+      autoHide={props.autoHide}
     >
       {props.children}
     </MenuDropdown>

--- a/draft-packages/menu/KaizenDraft/Menu/Menu.tsx
+++ b/draft-packages/menu/KaizenDraft/Menu/Menu.tsx
@@ -52,7 +52,7 @@ const Menu: Menu = props => {
   const {
     align = "left",
     dropdownWidth = "default",
-    autoHide = true,
+    autoHide = "on",
     menuVisible = false,
   } = props
 
@@ -73,6 +73,7 @@ const Menu: Menu = props => {
   return render({
     ...props,
     align,
+    autoHide,
     isMenuVisible,
     dropdownButtonContainer,
     hideMenuDropdown,

--- a/draft-packages/menu/KaizenDraft/Menu/MenuDropdown.tsx
+++ b/draft-packages/menu/KaizenDraft/Menu/MenuDropdown.tsx
@@ -19,6 +19,11 @@ type MenuDropdownProps = {
 
 class MenuDropdown extends React.Component<MenuDropdownProps> {
   static displayName = "MenuDropdown"
+
+  static defaultProps = {
+    autoHide: "on",
+  }
+
   menu = React.createRef<HTMLDivElement>()
 
   componentDidMount() {

--- a/draft-packages/menu/KaizenDraft/Menu/MenuDropdown.tsx
+++ b/draft-packages/menu/KaizenDraft/Menu/MenuDropdown.tsx
@@ -14,6 +14,7 @@ type MenuDropdownProps = {
   } | null
   align?: "left" | "right"
   width?: "default" | "contain"
+  autoHideOnClick?: boolean
 }
 
 class MenuDropdown extends React.Component<MenuDropdownProps> {
@@ -21,13 +22,19 @@ class MenuDropdown extends React.Component<MenuDropdownProps> {
   menu = React.createRef<HTMLDivElement>()
 
   componentDidMount() {
-    document.addEventListener("click", this.handleDocumentClick, false)
+    const { autoHideOnClick } = this.props
+    if (autoHideOnClick) {
+      document.addEventListener("click", this.handleDocumentClick, false)
+    }
     window.addEventListener("resize", this.handleDocumentResize, false)
     this.positionMenu()
   }
 
   componentWillUnmount() {
-    document.removeEventListener("click", this.handleDocumentClick, false)
+    const { autoHideOnClick } = this.props
+    if (autoHideOnClick) {
+      document.removeEventListener("click", this.handleDocumentClick, false)
+    }
     window.removeEventListener("resize", this.handleDocumentResize, false)
   }
 

--- a/draft-packages/menu/docs/Menu.stories.tsx
+++ b/draft-packages/menu/docs/Menu.stories.tsx
@@ -86,19 +86,46 @@ export const LabelAndIcon = () => (
 
 LabelAndIcon.storyName = "Label and Icon (Kaizen Site Demo)"
 
-export const LabelAndIconWithoutAutoHide = () => (
+export const AutoHideBehaviours = () => (
   <StoryWrapper>
-    <Menu
-      button={<Button label="Label" icon={chevronDown} iconPosition="end" />}
-      dropdownId="dropdown"
-      autoHideOnClick={false}
-    >
-      <MenuInstance />
-    </Menu>
+    <Box mb={1}>
+      <Paragraph variant="body">
+        Auto hide turned on (default behaviour):
+      </Paragraph>
+      <Menu
+        button={<Button label="Label" icon={chevronDown} iconPosition="end" />}
+        dropdownId="dropdown"
+        autoHide="on"
+      >
+        <MenuInstance />
+      </Menu>
+    </Box>
+    <Box mb={1}>
+      <Paragraph variant="body">
+        Auto hide when clicking outside the menu, but not inside:
+      </Paragraph>
+      <Menu
+        button={<Button label="Label" icon={chevronDown} iconPosition="end" />}
+        dropdownId="dropdown"
+        autoHide="outside-click-only"
+      >
+        <MenuInstance />
+      </Menu>
+    </Box>
+    <Box mb={1}>
+      <Paragraph variant="body">Auto hide turned off:</Paragraph>
+      <Menu
+        button={<Button label="Label" icon={chevronDown} iconPosition="end" />}
+        dropdownId="dropdown"
+        autoHide="off"
+      >
+        <MenuInstance />
+      </Menu>
+    </Box>
   </StoryWrapper>
 )
 
-LabelAndIconWithoutAutoHide.storyName = "Label and Icon without auto hide"
+AutoHideBehaviours.storyName = "Auto hide behaviours"
 
 export const LabelAndIconReversed = () => (
   <StoryWrapper>

--- a/draft-packages/menu/docs/Menu.stories.tsx
+++ b/draft-packages/menu/docs/Menu.stories.tsx
@@ -86,6 +86,20 @@ export const LabelAndIcon = () => (
 
 LabelAndIcon.storyName = "Label and Icon (Kaizen Site Demo)"
 
+export const LabelAndIconWithoutAutoHide = () => (
+  <StoryWrapper>
+    <Menu
+      button={<Button label="Label" icon={chevronDown} iconPosition="end" />}
+      dropdownId="dropdown"
+      autoHideOnClick={false}
+    >
+      <MenuInstance />
+    </Menu>
+  </StoryWrapper>
+)
+
+LabelAndIconWithoutAutoHide.storyName = "Label and Icon without auto hide"
+
 export const LabelAndIconReversed = () => (
   <StoryWrapper>
     <Menu


### PR DESCRIPTION
# Objective
Add the ability to change the autohide behaviour of dropdowns

# Motivation and Context
We have a custom dropdown in perform, which has a list of checkbox items. We don't want the dropdown to hide every time we check a checkbox.

# Screenshots

There's a dropdown for every type of `autoHide` value in the storybook story.

![image](https://user-images.githubusercontent.com/4495057/106402293-ef649200-647c-11eb-8551-6515cc0cdf94.png)

# Checklist
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] If this contains visual changes, has it been reviewed by a designer?
- [ ] If this introduces either a new component or a breaking change to an existing component, has it been reviewed by an advocate? (Ask in #prod_design_systems)
- [ ] I have considered likely risks of these changes and got someone else to QA as appropriate
- [ ] I have or will communicate these changes to the front end practice

# Additional Considerations
- Does there need to be right-to-left (RTL) options for localization and internationalization?
- Has the test suite been updated?
- Have you done cross-browser testing for our [supported browsers](https://academy.cultureamp.com/hc/en-us/articles/204539569-Supported-browsers-for-Participants)?
- Have you updated any relevant documentation or left useful comments in the code?
- Have you reviewed Culture Amp's Web Accessibility guide [Current Compliance, Going Forward, Statement and Answers for Customers](https://cultureamp.atlassian.net/wiki/spaces/Prod/pages/428572998/Web+Accessibility)?
- If this contains substantial visual changes, especially far reaching ones, have you unlocked the Chromatic step in the pipeline?
- Have Storybook stories been updated?

**If you're new to Kaizen, please ask #prod_design_systems to set up an onboarding session to get you up to speed.** If you have an urgent PR to merge before that happens, it is safest to ask in #prod_design_systems to have a design system advocate review the PR to catch any issues.
