### PR TITLE
feat: Fix menu position, when not enough room above the toggle button

### DIFF
--- a/draft-packages/menu/KaizenDraft/Menu/MenuDropdown.tsx
+++ b/draft-packages/menu/KaizenDraft/Menu/MenuDropdown.tsx
@@ -42,8 +42,9 @@ class MenuDropdown extends React.Component<MenuDropdownProps> {
       const pos = this.props.position
       const { innerHeight } = window
       const rect = menu.current.getBoundingClientRect()
+      const offsetParentRect = menu.current.offsetParent?.getBoundingClientRect()
 
-      const buttonHeight = 48
+      const offsetParentHeight = offsetParentRect?.height || 0
 
       menu.current.style.bottom =
         // If the menu won't fit below the the menu button, show it above instead.
@@ -52,8 +53,8 @@ class MenuDropdown extends React.Component<MenuDropdownProps> {
         // ...but, do not display it above the menu button, if there's not enough
         // room, otherwise the user won't even be able to scroll high enough to
         // see the menu items!
-        rect.top - rect.height - buttonHeight - 5 >= 0
-          ? `${buttonHeight + 5}px`
+        rect.top - rect.height - offsetParentHeight - 10 >= 0
+          ? `${offsetParentHeight + 5}px`
           : "auto"
     }
   }

--- a/draft-packages/menu/KaizenDraft/Menu/MenuDropdown.tsx
+++ b/draft-packages/menu/KaizenDraft/Menu/MenuDropdown.tsx
@@ -43,6 +43,8 @@ class MenuDropdown extends React.Component<MenuDropdownProps> {
       const { innerHeight } = window
       const rect = menu.current.getBoundingClientRect()
 
+      const buttonHeight = 48
+
       menu.current.style.bottom =
         // If the menu won't fit below the the menu button, show it above instead.
         // For some reason, a 5px buffer was needed.
@@ -50,10 +52,8 @@ class MenuDropdown extends React.Component<MenuDropdownProps> {
         // ...but, do not display it above the menu button, if there's not enough
         // room, otherwise the user won't even be able to scroll high enough to
         // see the menu items!
-        rect.top - rect.height - 30 >= 0
-          ? // I'm unsure if this 24px is intentional or not. The menu ends up
-            // overlapping the dropdown menu.
-            "24px"
+        rect.top - rect.height - buttonHeight - 5 >= 0
+          ? `${buttonHeight + 5}px`
           : "auto"
     }
   }

--- a/draft-packages/menu/KaizenDraft/Menu/MenuDropdown.tsx
+++ b/draft-packages/menu/KaizenDraft/Menu/MenuDropdown.tsx
@@ -44,7 +44,17 @@ class MenuDropdown extends React.Component<MenuDropdownProps> {
       const rect = menu.current.getBoundingClientRect()
 
       menu.current.style.bottom =
-        pos.bottom > innerHeight - rect.height ? "24px" : "auto"
+        // If the menu won't fit below the the menu button, show it above instead.
+        // For some reason, a 5px buffer was needed.
+        pos.bottom + 5 > innerHeight - rect.height &&
+        // ...but, do not display it above the menu button, if there's not enough
+        // room, otherwise the user won't even be able to scroll high enough to
+        // see the menu items!
+        rect.top - rect.height - 30 >= 0
+          ? // I'm unsure if this 24px is intentional or not. The menu ends up
+            // overlapping the dropdown menu.
+            "24px"
+          : "auto"
     }
   }
 

--- a/draft-packages/menu/docs/Menu.stories.tsx
+++ b/draft-packages/menu/docs/Menu.stories.tsx
@@ -231,3 +231,37 @@ export const DropdownWidthContain = () => (
 )
 
 DropdownWidthContain.storyName = 'Label and Icon (dropdownWidth="contain")'
+
+export const MenuPositioning = () => (
+  <StoryWrapper>
+    <Paragraph variant="body">
+      Note that this menu is near the top of page. Resize your browser so it's
+      about 300px high. Note that the menu still shows below the menu button.
+    </Paragraph>
+    <Menu
+      button={<Button label="Label" icon={chevronDown} iconPosition="end" />}
+    >
+      <MenuInstance />
+    </Menu>
+    <div
+      style={{
+        height: "500px",
+        display: "flex",
+        flexDirection: "column",
+        justifyContent: "flex-end",
+      }}
+    >
+      <Paragraph variant="body">
+        Note that this menu is near the bottom of the page. If there is no room
+        below, it will display above the menu button.
+      </Paragraph>
+      <Menu
+        button={<Button label="Label" icon={chevronDown} iconPosition="end" />}
+      >
+        <MenuInstance />
+      </Menu>
+    </div>
+  </StoryWrapper>
+)
+
+MenuPositioning.storyName = "Menu positioning"


### PR DESCRIPTION
# Objective
Fix menu position, when not enough room above the toggle button.

# Motivation and Context
This problem would happen frequently in my personal dev environment, because I often have my dev tools below the viewport, therefore I do not have much vertical realestate. I don't know of any customer complaints, but I would assume that this issue has been seen by a few customers.

# Screenshots

Before:
![image](https://user-images.githubusercontent.com/4495057/106403383-8122ce00-6482-11eb-9332-e5cd5cebdbcf.png)

After:
![image](https://user-images.githubusercontent.com/4495057/106403441-e1197480-6482-11eb-8705-1090de4e9d23.png)

Storybook story, so we can test this behaviour:
![image](https://user-images.githubusercontent.com/4495057/106403476-08704180-6483-11eb-87cd-29d17a92b6a7.png)

# Side fix

* Fix the menu position, when placed above the dropdown button, so it's not overlapping it.

# Checklist
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] If this contains visual changes, has it been reviewed by a designer?
- [ ] If this introduces either a new component or a breaking change to an existing component, has it been reviewed by an advocate? (Ask in #prod_design_systems)
- [x] I have considered likely risks of these changes and got someone else to QA as appropriate
- [x] I have or will communicate these changes to the front end practice