### PR TITLE
feat(canary): Add theme switcher preset to add CSS Variables to the root of story iframes

### DIFF
--- a/draft-packages/button/KaizenDraft/Button/decision-tokens.scss
+++ b/draft-packages/button/KaizenDraft/Button/decision-tokens.scss
@@ -1,0 +1,21 @@
+@import "~@kaizen/design-tokens/sass/theme";
+
+$dt-color-background-active: $kz-color-wisteria-100;
+$dt-color-background-hover: $kz-color-wisteria-100;
+$dt-color-background-focus: $kz-color-wisteria-100;
+$dt-color-border-color-base: $kz-color-wisteria-500;
+$dt-color-border-color-hover: $kz-color-wisteria-700;
+$dt-color-border-color-focus: $kz-color-wisteria-700;
+$dt-color-border-color-disabled: $kz-color-wisteria-500;
+$dt-color-color-disabled: $kz-color-wisteria-800;
+
+@if $rebrand {
+  $dt-color-background-active: $kz-color-stone;
+  $dt-color-background-focus: $kz-color-stone;
+  $dt-color-background-hover: $kz-color-stone;
+  $dt-color-border-color-base: $kz-color-iron-500;
+  $dt-color-border-color-hover: $kz-color-slate-700;
+  $dt-color-border-color-focus: $kz-color-slate-700;
+  $dt-color-border-color-disabled: $kz-color-iron-500;
+  $dt-color-color-disabled: $kz-color-wisteria-800;
+}

--- a/draft-packages/button/KaizenDraft/Button/decision-tokens.scss
+++ b/draft-packages/button/KaizenDraft/Button/decision-tokens.scss
@@ -1,5 +1,6 @@
-@import "~@kaizen/design-tokens/sass/theme";
+@import "~@kaizen/design-tokens/sass/color";
 
+// Zen theme
 $dt-color-background-active: $kz-color-wisteria-100;
 $dt-color-background-hover: $kz-color-wisteria-100;
 $dt-color-background-focus: $kz-color-wisteria-100;
@@ -9,13 +10,15 @@ $dt-color-border-color-focus: $kz-color-wisteria-700;
 $dt-color-border-color-disabled: $kz-color-wisteria-500;
 $dt-color-color-disabled: $kz-color-wisteria-800;
 
-@if $rebrand {
-  $dt-color-background-active: $kz-color-stone;
-  $dt-color-background-focus: $kz-color-stone;
-  $dt-color-background-hover: $kz-color-stone;
-  $dt-color-border-color-base: $kz-color-iron-500;
-  $dt-color-border-color-hover: $kz-color-slate-700;
-  $dt-color-border-color-focus: $kz-color-slate-700;
-  $dt-color-border-color-disabled: $kz-color-iron-500;
-  $dt-color-color-disabled: $kz-color-wisteria-800;
-}
+// Heart theme overrides
+$dt-color-background-active: var(--kz-color-stone, $kz-color-wisteria-100);
+$dt-color-background-focus: var(--kz-color-stone, $kz-color-wisteria-100);
+$dt-color-background-hover: var(--kz-color-stone, $kz-color-wisteria-100);
+$dt-color-border-color-base: var(--kz-color-iron-500, $kz-color-wisteria-500);
+$dt-color-border-color-hover: var(--kz-color-slate-700, $kz-color-wisteria-700);
+$dt-color-border-color-focus: var(--kz-color-slate-700, $kz-color-wisteria-700);
+$dt-color-border-color-disabled: var(
+  --kz-color-iron-500,
+  $kz-color-wisteria-500
+);
+$dt-color-color-disabled: var(--kz-color-wisteria-800, $kz-color-wisteria-800);

--- a/draft-packages/button/KaizenDraft/Button/styles.scss
+++ b/draft-packages/button/KaizenDraft/Button/styles.scss
@@ -4,6 +4,7 @@
 @import "~@kaizen/design-tokens/sass/color";
 @import "~@kaizen/design-tokens/sass/border";
 @import "~@kaizen/design-tokens/sass/typography";
+@import "./decision-tokens.scss";
 
 $caButton-border-width: $kz-border-solid-border-width;
 $caButton-focus-border-width: $kz-border-focus-ring-border-width;
@@ -73,16 +74,16 @@ $caButton-verticalPaddingForm: calc(
   // applied to elements that have no enabled/disabled states.
   &:not(:disabled) {
     background: $kz-color-white;
-    border-color: $kz-color-wisteria-500;
+    border-color: $dt-color-border-color-base;
     color: $kz-color-wisteria-800;
 
     &:hover {
-      background: $kz-color-wisteria-100;
-      border-color: $kz-color-wisteria-700;
+      background: $dt-color-background-hover;
+      border-color: $dt-color-border-color-hover;
     }
 
     &:active {
-      background: $kz-color-wisteria-100;
+      background: $dt-color-background-active;
       transform: translateY(1px);
     }
 
@@ -95,8 +96,8 @@ $caButton-verticalPaddingForm: calc(
       }
 
       &:global(.focus-visible) {
-        background: $kz-color-wisteria-100;
-        border-color: $kz-color-wisteria-700;
+        background: $dt-color-background-focus;
+        border-color: $dt-color-border-color-focus;
       }
 
       // show custom focus ring when :focus-visible
@@ -122,8 +123,8 @@ $caButton-verticalPaddingForm: calc(
     @include working-state;
     opacity: 0.3;
     background: $kz-color-white;
-    border-color: $kz-color-wisteria-500;
-    color: $kz-color-wisteria-800;
+    border-color: $dt-color-border-color-disabled;
+    color: $dt-color-color-disabled;
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "@storybook/addon-a11y": "^6.1.9",
     "@storybook/addon-essentials": "^6.1.9",
     "@storybook/addons": "^6.1.9",
+    "@storybook/components": "^6.1.16",
     "@storybook/core-events": "^6.1.11",
     "@storybook/react": "^6.1.9",
     "@storybook/theming": "^6.1.9",

--- a/storybook/main.ts
+++ b/storybook/main.ts
@@ -18,6 +18,7 @@ module.exports = {
   ],
   addons: [
     path.resolve("./storybook/gtm-addon/register"),
+    path.resolve("./storybook/theme-switcher-addon/register"),
     "@storybook/addon-essentials",
     "@storybook/addon-a11y",
   ],

--- a/storybook/theme-switcher-addon/addon.tsx
+++ b/storybook/theme-switcher-addon/addon.tsx
@@ -1,0 +1,49 @@
+import React, { useState, useEffect } from "react"
+import { tokens } from "./tokens"
+
+export const App = () => {
+  const [theme, setTheme] = useState("zen")
+  useEffect(() => {
+    let storyRoot
+    if (
+      document &&
+      document.getElementById("storybook-preview-iframe") &&
+      document.getElementById("storybook-preview-iframe").contentWindow
+        .document &&
+      document
+        .getElementById("storybook-preview-iframe")
+        .contentWindow.document.getElementById("root")
+    ) {
+      storyRoot = document
+        .getElementById("storybook-preview-iframe")
+        .contentWindow.document.getElementById("root")
+    } else {
+      return
+    }
+
+    tokens.forEach(({ name, value }) => {
+      if (theme === "zen") {
+        storyRoot.style.removeProperty(name)
+      } else {
+        storyRoot.style.setProperty(name, value)
+      }
+    })
+  })
+
+  return (
+    <div style={{ padding: "1rem" }}>
+      <label htmlFor="theme-switcher">
+        <span style={{ paddingRight: "0.5rem" }}>Select Theme:</span>
+        <select
+          id="theme-switcher"
+          name="theme"
+          value={theme}
+          onChange={evt => setTheme(evt.target.value)}
+        >
+          <option value="zen">Zen</option>
+          <option value="heart">Heart</option>
+        </select>
+      </label>
+    </div>
+  )
+}

--- a/storybook/theme-switcher-addon/preset.ts
+++ b/storybook/theme-switcher-addon/preset.ts
@@ -1,0 +1,4 @@
+// eslint-disable-next-line prefer-arrow/prefer-arrow-functions
+export function managerEntries(entry = []) {
+  return [...entry, require.resolve("./register")]
+}

--- a/storybook/theme-switcher-addon/register.tsx
+++ b/storybook/theme-switcher-addon/register.tsx
@@ -1,59 +1,15 @@
-// /my-addon/src/register.js
-
-import React, { useState, useEffect } from "react"
+import React from "react"
 import { addons, types } from "@storybook/addons"
 import { AddonPanel } from "@storybook/components"
-import { tokens } from "./tokens"
+import { App } from "./addon"
 
 const ADDON_ID = "theme-switcher"
 const PANEL_ID = `${ADDON_ID}/panel`
 
-const App = () => {
-  const [theme, setTheme] = useState("zen")
-  useEffect(() => {
-    let iframe
-    if (
-      document &&
-      document.getElementById("storybook-preview-iframe") &&
-      document.getElementById("storybook-preview-iframe").contentWindow.document
-    ) {
-      iframe = document.getElementById("storybook-preview-iframe").contentWindow
-        .document
-    } else {
-      return
-    }
-
-    if (theme === "zen") {
-      tokens.forEach(({ name }) => {
-        if (iframe.getElementById("root")) {
-          iframe.getElementById("root").style.removeProperty(name)
-        }
-      })
-    } else {
-      tokens.forEach(({ name, value }) => {
-        if (iframe.getElementById("root")) {
-          iframe.getElementById("root").style.setProperty(name, value)
-        }
-      })
-    }
-  })
-
-  return (
-    <label htmlFor="theme-switcher">
-      Toggle Heart theme?
-      <input
-        id="theme-switcher"
-        type="checkbox"
-        onClick={() => (theme === "zen" ? setTheme("heart") : setTheme("zen"))}
-      />
-    </label>
-  )
-}
-
 addons.register(ADDON_ID, api => {
   addons.add(PANEL_ID, {
     type: types.PANEL,
-    title: "Theme Switcher",
+    title: "Theme",
     render: ({ active, key }) => (
       <AddonPanel active={active} key={key}>
         <App />

--- a/storybook/theme-switcher-addon/register.tsx
+++ b/storybook/theme-switcher-addon/register.tsx
@@ -1,0 +1,63 @@
+// /my-addon/src/register.js
+
+import React, { useState, useEffect } from "react"
+import { addons, types } from "@storybook/addons"
+import { AddonPanel } from "@storybook/components"
+import { tokens } from "./tokens"
+
+const ADDON_ID = "theme-switcher"
+const PANEL_ID = `${ADDON_ID}/panel`
+
+const App = () => {
+  const [theme, setTheme] = useState("zen")
+  useEffect(() => {
+    let iframe
+    if (
+      document &&
+      document.getElementById("storybook-preview-iframe") &&
+      document.getElementById("storybook-preview-iframe").contentWindow.document
+    ) {
+      iframe = document.getElementById("storybook-preview-iframe").contentWindow
+        .document
+    } else {
+      return
+    }
+
+    if (theme === "zen") {
+      tokens.forEach(({ name }) => {
+        if (iframe.getElementById("root")) {
+          iframe.getElementById("root").style.removeProperty(name)
+        }
+      })
+    } else {
+      tokens.forEach(({ name, value }) => {
+        if (iframe.getElementById("root")) {
+          iframe.getElementById("root").style.setProperty(name, value)
+        }
+      })
+    }
+  })
+
+  return (
+    <label htmlFor="theme-switcher">
+      Toggle Heart theme?
+      <input
+        id="theme-switcher"
+        type="checkbox"
+        onClick={() => (theme === "zen" ? setTheme("heart") : setTheme("zen"))}
+      />
+    </label>
+  )
+}
+
+addons.register(ADDON_ID, api => {
+  addons.add(PANEL_ID, {
+    type: types.PANEL,
+    title: "Theme Switcher",
+    render: ({ active, key }) => (
+      <AddonPanel active={active} key={key}>
+        <App />
+      </AddonPanel>
+    ),
+  })
+})

--- a/storybook/theme-switcher-addon/tokens.ts
+++ b/storybook/theme-switcher-addon/tokens.ts
@@ -1,0 +1,194 @@
+export const tokens = [
+  {
+    name: "--kz-color-wisteria-100",
+    value: "#f4edf8",
+  },
+  {
+    name: "--kz-color-wisteria-200",
+    value: "#dfc9ea",
+  },
+  {
+    name: "--kz-color-wisteria-300",
+    value: "#c9a5dd",
+  },
+  {
+    name: "--kz-color-wisteria-400",
+    value: "#ae67b1",
+  },
+  {
+    name: "--kz-color-wisteria-500",
+    value: "#844587",
+  },
+  {
+    name: "--kz-color-wisteria-600",
+    value: "#5f3361",
+  },
+  {
+    name: "--kz-color-wisteria-700",
+    value: "#4a234d",
+  },
+  {
+    name: "--kz-color-wisteria-800",
+    value: "#2f2438",
+  },
+  {
+    name: "--kz-color-cluny-100",
+    value: "#e6f6ff",
+  },
+  {
+    name: "--kz-color-cluny-200",
+    value: "#bde2f5",
+  },
+  {
+    name: "--kz-color-cluny-300",
+    value: "#73c0e8",
+  },
+  {
+    name: "--kz-color-cluny-400",
+    value: "#008bd6",
+  },
+  {
+    name: "--kz-color-cluny-500",
+    value: "#0168b3",
+  },
+  {
+    name: "--kz-color-cluny-600",
+    value: "#004970",
+  },
+  {
+    name: "--kz-color-cluny-700",
+    value: "#003157",
+  },
+  {
+    name: "--kz-color-seedling-100",
+    value: "#e8f8f4",
+  },
+  {
+    name: "--kz-color-seedling-200",
+    value: "#c4ede2",
+  },
+  {
+    name: "--kz-color-seedling-300",
+    value: "#8fdbc7",
+  },
+  {
+    name: "--kz-color-seedling-400",
+    value: "#5dcbad",
+  },
+  {
+    name: "--kz-color-seedling-500",
+    value: "#3caf90",
+  },
+  {
+    name: "--kz-color-seedling-600",
+    value: "#2c7d67",
+  },
+  {
+    name: "--kz-color-seedling-700",
+    value: "#22594a",
+  },
+  {
+    name: "--kz-color-yuzu-100",
+    value: "#fff9e4",
+  },
+  {
+    name: "--kz-color-yuzu-200",
+    value: "#ffeeb3",
+  },
+  {
+    name: "--kz-color-yuzu-300",
+    value: "#ffe36e",
+  },
+  {
+    name: "--kz-color-yuzu-400",
+    value: "#ffca4d",
+  },
+  {
+    name: "--kz-color-yuzu-500",
+    value: "#ffb600",
+  },
+  {
+    name: "--kz-color-yuzu-600",
+    value: "#c68600",
+  },
+  {
+    name: "--kz-color-yuzu-700",
+    value: "#876400",
+  },
+  {
+    name: "--kz-color-coral-100",
+    value: "#fdeaee",
+  },
+  {
+    name: "--kz-color-coral-200",
+    value: "#f9c2cb",
+  },
+  {
+    name: "--kz-color-coral-300",
+    value: "#f597a8",
+  },
+  {
+    name: "--kz-color-coral-400",
+    value: "#e0707d",
+  },
+  {
+    name: "--kz-color-coral-500",
+    value: "#c93b55",
+  },
+  {
+    name: "--kz-color-coral-600",
+    value: "#a82433",
+  },
+  {
+    name: "--kz-color-coral-700",
+    value: "#6c1e20",
+  },
+  {
+    name: "--kz-color-peach-100",
+    value: "#fff0e8",
+  },
+  {
+    name: "--kz-color-peach-200",
+    value: "#ffd1b9",
+  },
+  {
+    name: "--kz-color-peach-300",
+    value: "#ffb08a",
+  },
+  {
+    name: "--kz-color-peach-400",
+    value: "#ff9461",
+  },
+  {
+    name: "--kz-color-peach-500",
+    value: "#e96c2f",
+  },
+  {
+    name: "--kz-color-peach-600",
+    value: "#b74302",
+  },
+  {
+    name: "--kz-color-peach-700",
+    value: "#903c00",
+  },
+  {
+    name: "--kz-color-ash",
+    value: "#e6e5e5",
+  },
+  {
+    name: "--kz-color-stone",
+    value: "#f9f9f9",
+  },
+  {
+    name: "--kz-color-white",
+    value: "#ffffff",
+  },
+  {
+    name: "--kz-color-iron-500",
+    value: "#8c8c97",
+  },
+  {
+    name: "--kz-color-slate-700",
+    value: "#524e56",
+  },
+]

--- a/yarn.lock
+++ b/yarn.lock
@@ -3401,6 +3401,14 @@
     core-js "^3.0.1"
     global "^4.3.2"
 
+"@storybook/client-logger@6.1.16":
+  version "6.1.16"
+  resolved "https://registry.yarnpkg.com/@storybook/client-logger/-/client-logger-6.1.16.tgz#5523e9ebea22eda526e5d86d126d3139455e0481"
+  integrity sha512-k8vjm/WICYIY5avbg7g3vWBvp9eb8iHrvgcsM3LWt6mafHW/GxJK7IYTleAhDI9+sTj1oTMU+7zTCc0OTmQ51A==
+  dependencies:
+    core-js "^3.0.1"
+    global "^4.3.2"
+
 "@storybook/client-logger@6.1.9":
   version "6.1.9"
   resolved "https://registry.yarnpkg.com/@storybook/client-logger/-/client-logger-6.1.9.tgz#1d61a64000d4691780d75e19b78fd44adfdb5d9c"
@@ -3448,6 +3456,32 @@
     polished "^3.4.4"
     react-color "^2.17.0"
     react-popper-tooltip "^3.1.0"
+    react-syntax-highlighter "^13.5.0"
+    react-textarea-autosize "^8.1.1"
+    ts-dedent "^2.0.0"
+
+"@storybook/components@^6.1.16":
+  version "6.1.16"
+  resolved "https://registry.yarnpkg.com/@storybook/components/-/components-6.1.16.tgz#5f58a50b6a4953f5f035713e66da618fdaf39c65"
+  integrity sha512-OhtsNKrfSXdVREqO9f89Yr4esP99kVNfzXOIL8WYdYoqW8AsGeznWcdUCkmDOJax0GuinJfRthZNoyTXDEm2Nw==
+  dependencies:
+    "@popperjs/core" "^2.5.4"
+    "@storybook/client-logger" "6.1.16"
+    "@storybook/csf" "0.0.1"
+    "@storybook/theming" "6.1.16"
+    "@types/overlayscrollbars" "^1.9.0"
+    "@types/react-color" "^3.0.1"
+    "@types/react-syntax-highlighter" "11.0.4"
+    core-js "^3.0.1"
+    fast-deep-equal "^3.1.1"
+    global "^4.3.2"
+    lodash "^4.17.15"
+    markdown-to-jsx "^6.11.4"
+    memoizerific "^1.11.3"
+    overlayscrollbars "^1.10.2"
+    polished "^3.4.4"
+    react-color "^2.17.0"
+    react-popper-tooltip "^3.1.1"
     react-syntax-highlighter "^13.5.0"
     react-textarea-autosize "^8.1.1"
     ts-dedent "^2.0.0"
@@ -3672,6 +3706,24 @@
     prettier "~2.0.5"
     regenerator-runtime "^0.13.7"
     source-map "^0.7.3"
+
+"@storybook/theming@6.1.16":
+  version "6.1.16"
+  resolved "https://registry.yarnpkg.com/@storybook/theming/-/theming-6.1.16.tgz#012711c0bd224cc6c089ec6c0239bc86c5b2842b"
+  integrity sha512-gFcqbTALWdLI6hwUSob3Gn7iIcyp9qp9Oib+8f00ZHDfZnWr8CDQPJ3PcZ322uf35gskDstk8eKqviSZSDUQug==
+  dependencies:
+    "@emotion/core" "^10.1.1"
+    "@emotion/is-prop-valid" "^0.8.6"
+    "@emotion/styled" "^10.0.23"
+    "@storybook/client-logger" "6.1.16"
+    core-js "^3.0.1"
+    deep-object-diff "^1.1.0"
+    emotion-theming "^10.0.19"
+    global "^4.3.2"
+    memoizerific "^1.11.3"
+    polished "^3.4.4"
+    resolve-from "^5.0.0"
+    ts-dedent "^2.0.0"
 
 "@storybook/theming@6.1.9":
   version "6.1.9"
@@ -19387,7 +19439,7 @@ react-media@^1.9.2:
     json2mq "^0.2.0"
     prop-types "^15.5.10"
 
-react-popper-tooltip@^3.1.0:
+react-popper-tooltip@^3.1.0, react-popper-tooltip@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/react-popper-tooltip/-/react-popper-tooltip-3.1.1.tgz#329569eb7b287008f04fcbddb6370452ad3f9eac"
   integrity sha512-EnERAnnKRptQBJyaee5GJScWNUKQPDD2ywvzZyUjst/wj5U64C8/CnSYLNEmP2hG0IJ3ZhtDxE8oDN+KOyavXQ==


### PR DESCRIPTION
# Objective
This gives consumers of Kaizen the ability to see the difference between Heart and Zen themes.

# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

# Screenshots (if appropriate)

# Checklist
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] If this contains visual changes, has it been reviewed by a designer?
- [ ] If this introduces either a new component or a breaking change to an existing component, has it been reviewed by an advocate? (Ask in #prod_design_systems)
- [ ] I have considered likely risks of these changes and got someone else to QA as appropriate
- [ ] I have or will communicate these changes to the front end practice

# Additional Considerations
- Does there need to be right-to-left (RTL) options for localization and internationalization?
- Has the test suite been updated?
- Have you done cross-browser testing for our [supported browsers](https://academy.cultureamp.com/hc/en-us/articles/204539569-Supported-browsers-for-Participants)?
- Have you updated any relevant documentation or left useful comments in the code?
- Have you reviewed Culture Amp's Web Accessibility guide [Current Compliance, Going Forward, Statement and Answers for Customers](https://cultureamp.atlassian.net/wiki/spaces/Prod/pages/428572998/Web+Accessibility)?
- If this contains substantial visual changes, especially far reaching ones, have you unlocked the Chromatic step in the pipeline?
- Have Storybook stories been updated?

**If you're new to Kaizen, please ask #prod_design_systems to set up an onboarding session to get you up to speed.** If you have an urgent PR to merge before that happens, it is safest to ask in #prod_design_systems to have a design system advocate review the PR to catch any issues.
