### PR TITLE
fix: Remove unused dependencies from component-library

### DIFF
--- a/packages/component-library/package.json
+++ b/packages/component-library/package.json
@@ -35,17 +35,12 @@
     "@kaizen/hosted-assets": "^1.1.0",
     "@types/classnames": "^2.2.6",
     "@types/lodash": "^4.14.132",
-    "@types/react-select": "^3.0.5",
     "@types/uuid": "^8.3.0",
     "classnames": "^2.2.6",
     "lodash": "^4.17.11",
     "motion-ui": "cultureamp/motion-ui",
-    "react-animate-height": "^2.0.15",
     "react-focus-lock": "^1.19.1",
     "react-media": "^1.9.2",
-    "react-select": "^3.1.0",
-    "react-tooltip": "^4.2.6",
-    "react-transition-group": "^4.4.1",
     "uuid": "^3.3.2"
   },
   "devDependencies": {


### PR DESCRIPTION
# Objective
Removed a bunch of dependencies that are not used in component-library.

# Motivation and Context
`@kaizen/component-library` brings along a bunch of dependencies that it no longer needs. This PR removes them. 

# Screenshots (if appropriate)

# Checklist
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] If this contains visual changes, has it been reviewed by a designer?
- [ ] If this introduces either a new component or a breaking change to an existing component, has it been reviewed by an advocate? (Ask in #prod_design_systems)
- [ ] I have considered likely risks of these changes and got someone else to QA as appropriate
- [ ] I have or will communicate these changes to the front end practice

# Additional Considerations
- Does there need to be right-to-left (RTL) options for localization and internationalization?
- Has the test suite been updated?
- Have you done cross-browser testing for our [supported browsers](https://academy.cultureamp.com/hc/en-us/articles/204539569-Supported-browsers-for-Participants)?
- Have you updated any relevant documentation or left useful comments in the code?
- Have you reviewed Culture Amp's Web Accessibility guide [Current Compliance, Going Forward, Statement and Answers for Customers](https://cultureamp.atlassian.net/wiki/spaces/Prod/pages/428572998/Web+Accessibility)?
- If this contains substantial visual changes, especially far reaching ones, have you unlocked the Chromatic step in the pipeline?
- Have Storybook stories been updated?

**If you're new to Kaizen, please ask #prod_design_systems to set up an onboarding session to get you up to speed.** If you have an urgent PR to merge before that happens, it is safest to ask in #prod_design_systems to have a design system advocate review the PR to catch any issues.
