### PR TITLE
feat: point legacy Open Sans vars at Inter (release canary PR to master)

### DIFF
--- a/packages/component-library/styles/type.scss
+++ b/packages/component-library/styles/type.scss
@@ -11,9 +11,14 @@ $ca-weight-medium: 500;
 $ca-weight-semibold: 500; // Note: in Sketch, semibold is 600. But murmur has an existing value of semibold=500 that is heavily used.
 
 // Combine these into a Sass map ($ca-default-font) once node-sass includes libsass 3.5.0.beta.3 with this bug fix: https://github.com/sass/libsass/issues/2309
-$ca-default-font-family: "Open Sans", Helvetica, Arial, sans-serif;
-$ca-default-font-base-size: 0.875rem; /* 14px */
-$ca-default-font-descender-height: 0.115;
+$ca-inter-font-family: "Inter";
+$ca-inter-font-base-size: 1rem; /* 16px */
+$ca-inter-font-descender-height: 0.14;
+
+// Combine these into a Sass map ($ca-default-font) once node-sass includes libsass 3.5.0.beta.3 with this bug fix: https://github.com/sass/libsass/issues/2309
+$ca-default-font-family: $ca-inter-font-family;
+$ca-default-font-base-size: $ca-inter-font-base-size;
+$ca-default-font-descender-height: $ca-inter-font-descender-height;
 
 // Combine these into a Sass map ($ca-default-font) once node-sass includes libsass 3.5.0.beta.3 with this bug fix: https://github.com/sass/libsass/issues/2309
 $ca-ideal-sans-font-family: "Ideal Sans A", "Ideal Sans B",
@@ -21,20 +26,15 @@ $ca-ideal-sans-font-family: "Ideal Sans A", "Ideal Sans B",
 $ca-ideal-sans-font-base-size: 1rem; /* 16px */
 $ca-ideal-sans-font-descender-height: 0.14;
 
-// Combine these into a Sass map ($ca-default-font) once node-sass includes libsass 3.5.0.beta.3 with this bug fix: https://github.com/sass/libsass/issues/2309
-$ca-inter-font-family: "Inter", $ca-default-font-family;
-$ca-inter-font-base-size: 1rem; /* 16px */
-$ca-inter-font-descender-height: 0.14;
-
 // Locale-specific fonts
-$ca-locale-he-font-family: "Open Sans", Tahoma, sans-serif;
-$ca-locale-ar-font-family: "Open Sans", Tahoma, sans-serif;
 $ca-ideal-locale-ar-font-family: "Ideal Sans A", "Ideal Sans B", Tahoma,
   sans-serif;
 $ca-ideal-locale-he-font-family: "Ideal Sans A", "Ideal Sans B", Tahoma,
   sans-serif;
 $ca-inter-locale-ar-font-family: "Inter", Tahoma, sans-serif;
 $ca-inter-locale-he-font-family: "Inter", Tahoma, sans-serif;
+$ca-locale-he-font-family: $ca-inter-locale-ar-font-family;
+$ca-locale-ar-font-family: $ca-inter-locale-he-font-family;
 
 // Inspired by Basekick from SEEK: https://github.com/michaeltaranto/basekick
 @mixin ca-type(

--- a/packages/component-library/styles/type.scss
+++ b/packages/component-library/styles/type.scss
@@ -11,7 +11,7 @@ $ca-weight-medium: 500;
 $ca-weight-semibold: 500; // Note: in Sketch, semibold is 600. But murmur has an existing value of semibold=500 that is heavily used.
 
 // Combine these into a Sass map ($ca-default-font) once node-sass includes libsass 3.5.0.beta.3 with this bug fix: https://github.com/sass/libsass/issues/2309
-$ca-inter-font-family: "Inter";
+$ca-inter-font-family: "Inter", sans-serif;
 $ca-inter-font-base-size: 1rem; /* 16px */
 $ca-inter-font-descender-height: 0.14;
 

--- a/packages/component-library/styles/type.scss
+++ b/packages/component-library/styles/type.scss
@@ -11,7 +11,8 @@ $ca-weight-medium: 500;
 $ca-weight-semibold: 500; // Note: in Sketch, semibold is 600. But murmur has an existing value of semibold=500 that is heavily used.
 
 // Combine these into a Sass map ($ca-default-font) once node-sass includes libsass 3.5.0.beta.3 with this bug fix: https://github.com/sass/libsass/issues/2309
-$ca-inter-font-family: "Inter", sans-serif;
+$ca-inter-font-family: "Inter", "Noto Sans", Helvetica, Arial, sans-serif;
+
 $ca-inter-font-base-size: 1rem; /* 16px */
 $ca-inter-font-descender-height: 0.14;
 

--- a/packages/deprecated-component-library-helpers/styles/type.scss
+++ b/packages/deprecated-component-library-helpers/styles/type.scss
@@ -10,7 +10,7 @@ $ca-weight-medium: 500;
 $ca-weight-semibold: 500; // Note: in Sketch, semibold is 600. But murmur has an existing value of semibold=500 that is heavily used.
 
 // Combine these into a Sass map ($ca-default-font) once node-sass includes libsass 3.5.0.beta.3 with this bug fix: https://github.com/sass/libsass/issues/2309
-$ca-inter-font-family: "Inter";
+$ca-inter-font-family: "Inter", "Noto Sans", Helvetica, Arial, sans-serif;
 $ca-inter-font-base-size: 1rem; /* 16px */
 $ca-inter-font-descender-height: 0.14;
 

--- a/packages/deprecated-component-library-helpers/styles/type.scss
+++ b/packages/deprecated-component-library-helpers/styles/type.scss
@@ -10,9 +10,14 @@ $ca-weight-medium: 500;
 $ca-weight-semibold: 500; // Note: in Sketch, semibold is 600. But murmur has an existing value of semibold=500 that is heavily used.
 
 // Combine these into a Sass map ($ca-default-font) once node-sass includes libsass 3.5.0.beta.3 with this bug fix: https://github.com/sass/libsass/issues/2309
-$ca-default-font-family: "Open Sans", Helvetica, Arial, sans-serif;
-$ca-default-font-base-size: 0.875rem; /* 14px */
-$ca-default-font-descender-height: 0.115;
+$ca-inter-font-family: "Inter";
+$ca-inter-font-base-size: 1rem; /* 16px */
+$ca-inter-font-descender-height: 0.14;
+
+// Combine these into a Sass map ($ca-default-font) once node-sass includes libsass 3.5.0.beta.3 with this bug fix: https://github.com/sass/libsass/issues/2309
+$ca-default-font-family: $ca-inter-font-family;
+$ca-default-font-base-size: $ca-inter-font-base-size;
+$ca-default-font-descender-height: $ca-inter-font-descender-height;
 
 // Combine these into a Sass map ($ca-default-font) once node-sass includes libsass 3.5.0.beta.3 with this bug fix: https://github.com/sass/libsass/issues/2309
 $ca-ideal-sans-font-family: "Ideal Sans A", "Ideal Sans B",
@@ -20,23 +25,18 @@ $ca-ideal-sans-font-family: "Ideal Sans A", "Ideal Sans B",
 $ca-ideal-sans-font-base-size: 1rem; /* 16px */
 $ca-ideal-sans-font-descender-height: 0.14;
 
-// Combine these into a Sass map ($ca-default-font) once node-sass includes libsass 3.5.0.beta.3 with this bug fix: https://github.com/sass/libsass/issues/2309
-$ca-inter-font-family: "Inter", $ca-default-font-family;
-$ca-inter-font-base-size: 1rem; /* 16px */
-$ca-inter-font-descender-height: 0.14;
-
 $ca-greycliff-font-base-size: 1rem; /* 16px */
 $ca-greycliff-font-descender-height: 0.098;
 
 // Locale-specific fonts
-$ca-locale-he-font-family: "Open Sans", Tahoma, sans-serif;
-$ca-locale-ar-font-family: "Open Sans", Tahoma, sans-serif;
 $ca-ideal-locale-ar-font-family: "Ideal Sans A", "Ideal Sans B", Tahoma,
   sans-serif;
 $ca-ideal-locale-he-font-family: "Ideal Sans A", "Ideal Sans B", Tahoma,
   sans-serif;
 $ca-inter-locale-ar-font-family: "Inter", Tahoma, sans-serif;
 $ca-inter-locale-he-font-family: "Inter", Tahoma, sans-serif;
+$ca-locale-he-font-family: $ca-inter-locale-ar-font-family;
+$ca-locale-ar-font-family: $ca-inter-locale-he-font-family;
 
 // Inspired by Basekick from SEEK: https://github.com/michaeltaranto/basekick
 @mixin ca-type(


### PR DESCRIPTION
# Objective

Release this Canary PR (https://github.com/cultureamp/kaizen-design-system/pull/828) to master (more details are in that PR).

Copy of the commit message regarding the breaking change:

```
BREAKING CHANGE

The breaking change is in only in the most legacy parts of Kaizen (`ca-` scss mixins and variables)
that are only used in the Big M repo.

For all other repos (non Big M), this won't affect them, so this release can be blindy
upgraded without testing. However, if you're unsure you can just do a search
for `ca-` in scss files in your repo, and if there are no results, no need to
worry about the major update

If you are bumping the Big M repo with this release, please PM michael.bylstra@cultureamp.com
for more details.

Description of changes:

- This removes all traces of Open Sans from Kaizen, and
makes Inter the default for $ca-default-font-xxx
- the $ca-default-font-xxx vars are legacy (in both files) and should be
removed eventually, but this is far easier (not a breaking change, codewise)
The nice thing is that the name $ca-default-font-xxx is still applicable, so
there's no need to change the name like we needed to do for $ca-font-ideal-sans!
```

# Motivation and Context
Get rid of Open Sans which is now 3 uplifts old!


# Checklist
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] If this contains visual changes, has it been reviewed by a designer?
- [ ] If this introduces either a new component or a breaking change to an existing component, has it been reviewed by an advocate? (Ask in #prod_design_systems)
- [x] I have considered likely risks of these changes and got someone else to QA as appropriate
- [x] I have or will communicate these changes to the front end practice
