### PR TITLE
fix: Fix spacing issues on Menu dropdown

### DIFF
--- a/draft-packages/menu/KaizenDraft/Menu/components/MenuContent.module.scss
+++ b/draft-packages/menu/KaizenDraft/Menu/components/MenuContent.module.scss
@@ -16,7 +16,7 @@ $side-padding: 1/2 * $ca-grid;
   color: $kz-color-wisteria-800;
   border-radius: $kz-border-solid-border-radius;
   box-shadow: $kz-shadow-large-box-shadow;
-  padding: 6px 4px;
+  padding: 6px 0;
   text-align: left;
   width: 100%;
 
@@ -28,6 +28,7 @@ $side-padding: 1/2 * $ca-grid;
 .header {
   padding: 10px $side-padding 5px;
   color: $kz-color-wisteria-800;
+  margin: 0 4px;
 }
 
 .header__title {
@@ -48,6 +49,7 @@ $side-padding: 1/2 * $ca-grid;
   border: none;
   text-align: left;
   padding: 8px $side-padding;
+  margin: 0 4px;
   min-height: 1.75 * $ca-grid;
   border-radius: 4px;
   font-family: $kz-typography-paragraph-body-font-family;

--- a/draft-packages/menu/KaizenDraft/Menu/components/MenuContent.module.scss
+++ b/draft-packages/menu/KaizenDraft/Menu/components/MenuContent.module.scss
@@ -9,6 +9,8 @@
 $side-padding: 1/2 * $ca-grid;
 
 .menuContent {
+  display: flex;
+  flex-direction: column;
   box-sizing: border-box;
   background: $kz-color-white;
   color: $kz-color-wisteria-800;
@@ -44,7 +46,6 @@ $side-padding: 1/2 * $ca-grid;
   box-sizing: border-box;
   background: none;
   border: none;
-  width: 100%;
   text-align: left;
   padding: 8px $side-padding;
   min-height: 1.75 * $ca-grid;

--- a/draft-packages/menu/KaizenDraft/Menu/components/MenuContent.module.scss
+++ b/draft-packages/menu/KaizenDraft/Menu/components/MenuContent.module.scss
@@ -7,6 +7,7 @@
 @import "~@kaizen/component-library/styles/animation";
 
 $side-padding: 1/2 * $ca-grid;
+$gutter: 4px;
 
 .menuContent {
   display: flex;
@@ -16,7 +17,7 @@ $side-padding: 1/2 * $ca-grid;
   color: $kz-color-wisteria-800;
   border-radius: $kz-border-solid-border-radius;
   box-shadow: $kz-shadow-large-box-shadow;
-  padding: 6px 0;
+  padding: ($gutter + 2px) 0;
   text-align: left;
   width: 100%;
 
@@ -28,7 +29,7 @@ $side-padding: 1/2 * $ca-grid;
 .header {
   padding: 10px $side-padding 5px;
   color: $kz-color-wisteria-800;
-  margin: 0 4px;
+  margin: 0 $gutter;
 }
 
 .header__title {
@@ -49,7 +50,7 @@ $side-padding: 1/2 * $ca-grid;
   border: none;
   text-align: left;
   padding: 8px $side-padding;
-  margin: 0 4px;
+  margin: 0 $gutter;
   min-height: 1.75 * $ca-grid;
   border-radius: 4px;
   font-family: $kz-typography-paragraph-body-font-family;


### PR DESCRIPTION
# ⚠️ (POTENTIAL) VISUAL BREAKING CHANGE

# Objective

- Replaces container padding with margin on content elements
- This allows the divider to bleed to the edges (and makes other custom full-bleed sections easier)
- Also uses flexbox on the main container (with `flex-direction: column`) instead of relying on menu items to make themselves 100% width

⚠️  (This message is also in a commit body) This includes a potential visual breaking change, since it restructures the way margins and padding work. If any consumers are using the Menu in non-standard ways, such as creating a section at the top of the dropdown that bleeds all the way to the edges by using a negative margin to override the dropdown container's padding, those could break.

Under the new model, instead of the container using padding to add space, the *content* is responsible for setting its own margins. (This is handled within the component, so consumers don't have to do anything - but as mentioned above, they could run into problems if they had been overriding either the margin or padding.)

# Motivation and Context

A recent design review of the new navigation bar in Team Unify included a request for the dividers on all Menus to bleed to the edges.

# Screenshot
![image](https://user-images.githubusercontent.com/6406263/107590794-2bf27380-6c5d-11eb-95e6-aff386ac63a7.png)


# Checklist
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] If this contains visual changes, has it been reviewed by a designer?
- [ ] If this introduces either a new component or a breaking change to an existing component, has it been reviewed by an advocate? (Ask in #prod_design_systems)
- [ ] I have considered likely risks of these changes and got someone else to QA as appropriate
- [x] I have or will communicate these changes to the front end practice