### PR TITLE
fix: unpin draft-button dependency in zen-title-block

### DIFF
--- a/draft-packages/button/KaizenDraft/Button/components/GenericButton.tsx
+++ b/draft-packages/button/KaizenDraft/Button/components/GenericButton.tsx
@@ -55,19 +55,13 @@ type LabelPropsGeneric = {
   reverseColor?: "cluny" | "peach" | "seedling" | "wisteria" | "yuzu"
 }
 
-type WorkingUndefinedProps = {
-  working?: undefined
-  workingLabel?: undefined
-}
-
 type WorkingProps = {
-  working: boolean
-  workingLabel: string
+  working?: boolean
+  workingLabel?: string
   workingLabelHidden?: boolean
 }
 
-export type LabelProps = LabelPropsGeneric &
-  (WorkingProps | WorkingUndefinedProps)
+export type LabelProps = LabelPropsGeneric & WorkingProps
 
 export type IconButtonProps = GenericProps
 export type ButtonProps = GenericProps & LabelProps

--- a/draft-packages/button/KaizenDraft/Button/components/GenericButton.tsx
+++ b/draft-packages/button/KaizenDraft/Button/components/GenericButton.tsx
@@ -56,12 +56,17 @@ type LabelPropsGeneric = {
 }
 
 type WorkingProps = {
-  working?: boolean
-  workingLabel?: string
+  working: true
+  workingLabel: string
   workingLabelHidden?: boolean
 }
 
-export type LabelProps = LabelPropsGeneric & WorkingProps
+type WorkingUndefinedProps = {
+  working?: false
+}
+
+export type LabelProps = LabelPropsGeneric &
+  (WorkingProps | WorkingUndefinedProps)
 
 export type IconButtonProps = GenericProps
 export type ButtonProps = GenericProps & LabelProps
@@ -247,7 +252,7 @@ const renderLoadingSpinner = () => (
   </div>
 )
 
-const renderWorkingContent = props => {
+const renderWorkingContent = (props: Extract<Props, { working: true }>) => {
   if (props.workingLabelHidden) {
     return (
       <>
@@ -276,7 +281,7 @@ const renderWorkingContent = props => {
   )
 }
 
-const renderDefaultContent = props => (
+const renderDefaultContent = (props: Props) => (
   <>
     {props.icon && props.iconPosition !== "end" && renderIcon(props.icon)}
     {(!props.icon || !props.iconButton) && (

--- a/draft-packages/select/package.json
+++ b/draft-packages/select/package.json
@@ -37,7 +37,8 @@
     "@kaizen/draft-form": "^3.1.7",
     "@types/classnames": "^2.2.10",
     "classnames": "^2.2.6",
-    "react-select": "^3.1.0"
+    "react-select": "^3.1.0",
+    "@types/react-select": "3.0.22"
   },
   "devDependencies": {
     "@cultureamp/elm-storybook": "cultureamp/elm-storybook#0.2.1",

--- a/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/TitleBlockZen.tsx
+++ b/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/TitleBlockZen.tsx
@@ -20,6 +20,7 @@ import styles from "./TitleBlockZen.scss"
   thus you might lose the ability to access some fields that only exist conditionally based on another (e.g. discriminated unions).
   `T extends any ? Omit<T, K>` is a trick used to spread the action of Omit across every variant within the union or intersection.
   So, if T is something like `{foo: string} | {bar: string}`, it becomes `Omit<{foo: string}, K> | Omit<{bar: string}, K>
+  https://davidgomes.com/pick-omit-over-union-types-in-typescript/
 */
 type DistributiveOmit<T, K extends keyof any> = T extends any
   ? Omit<T, K>

--- a/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/TitleBlockZen.tsx
+++ b/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/TitleBlockZen.tsx
@@ -15,6 +15,16 @@ import NavigationTab, { NavigationTabProps } from "./NavigationTabs"
 import SecondaryActions from "./SecondaryActions"
 import styles from "./TitleBlockZen.scss"
 
+/*
+  This type exists to support omitting keys from a union or intersection type in a distributive manner. `Omit` out of the box will cause you to lose any union or intersection information about the type,
+  thus you might lose the ability to access some fields that only exist conditionally based on another (e.g. discriminated unions).
+  `T extends any ? Omit<T, K>` is a trick used to spread the action of Omit across every variant within the union or intersection.
+  So, if T is something like `{foo: string} | {bar: string}`, it becomes `Omit<{foo: string}, K> | Omit<{bar: string}, K>
+*/
+type DistributiveOmit<T, K extends keyof any> = T extends any
+  ? Omit<T, K>
+  : never
+
 export const NON_REVERSED_VARIANTS = ["education", "admin"]
 
 /**
@@ -60,7 +70,7 @@ export type BadgeProps = {
   animateChange?: boolean
 }
 
-export type TitleBlockButtonProps = Omit<ButtonProps, "onClick"> & {
+export type TitleBlockButtonProps = DistributiveOmit<ButtonProps, "onClick"> & {
   onClick?: (e: any) => void
 }
 
@@ -68,8 +78,11 @@ export type TitleBlockMenuItemProps = Omit<MenuItemProps, "action"> & {
   action: ((e: any) => void) | string
 }
 
-export type ButtonWithHrefNotOnClick = Omit<ButtonProps, "onClick">
-export type ButtonWithOnClickNotHref = Omit<TitleBlockButtonProps, "href">
+export type ButtonWithHrefNotOnClick = DistributiveOmit<ButtonProps, "onClick">
+export type ButtonWithOnClickNotHref = DistributiveOmit<
+  TitleBlockButtonProps,
+  "href"
+>
 
 export type MenuGroup = {
   label: string

--- a/draft-packages/title-block-zen/package.json
+++ b/draft-packages/title-block-zen/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "@kaizen/component-library": "^8.3.0",
     "@kaizen/draft-badge": "^1.2.4",
-    "@kaizen/draft-button": "^1.7.4",
+    "@kaizen/draft-button": "^3.0.13",
     "@kaizen/draft-menu": "^3.0.0",
     "@kaizen/draft-select": "^1.11.43",
     "@kaizen/draft-tag": "^1.7.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1058,7 +1058,7 @@
     core-js "^2.5.7"
     regenerator-runtime "^0.11.1"
 
-"@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.10.0", "@babel/runtime@^7.10.2", "@babel/runtime@^7.11.2", "@babel/runtime@^7.12.5", "@babel/runtime@^7.2.0", "@babel/runtime@^7.3.1", "@babel/runtime@^7.4.4", "@babel/runtime@^7.5.0", "@babel/runtime@^7.5.5", "@babel/runtime@^7.7.2", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7", "@babel/runtime@^7.9.2":
+"@babel/runtime@^7.0.0", "@babel/runtime@^7.10.0", "@babel/runtime@^7.10.2", "@babel/runtime@^7.11.2", "@babel/runtime@^7.12.5", "@babel/runtime@^7.2.0", "@babel/runtime@^7.3.1", "@babel/runtime@^7.4.4", "@babel/runtime@^7.5.0", "@babel/runtime@^7.5.5", "@babel/runtime@^7.7.2", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7", "@babel/runtime@^7.9.2":
   version "7.12.5"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.12.5.tgz#410e7e487441e1b360c29be715d870d9b985882e"
   integrity sha512-plcc+hbExy3McchJCEQG3knOsuh3HH+Prx1P6cLIkET/0dLuQDEnrT+s27Axgc9bqfsmNUNHfscgMUdBpC9xfg==
@@ -4185,14 +4185,21 @@
     "@types/react" "*"
     "@types/reactcss" "*"
 
-"@types/react-dom@*", "@types/react-dom@^16.9.0":
+"@types/react-dom@*":
+  version "17.0.0"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-17.0.0.tgz#b3b691eb956c4b3401777ee67b900cb28415d95a"
+  integrity sha512-lUqY7OlkF/RbNtD5nIq7ot8NquXrdFrjSOR6+w9a9RFQevGi1oZO1dcJbXMeONAPKtZ2UrZOEJ5UOCVsxbLk/g==
+  dependencies:
+    "@types/react" "*"
+
+"@types/react-dom@^16.9.0":
   version "16.9.8"
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-16.9.8.tgz#fe4c1e11dfc67155733dfa6aa65108b4971cb423"
   integrity sha512-ykkPQ+5nFknnlU6lDd947WbQ6TE3NNzbQAkInC2EKY1qeYdTKp7onFusmYZb+ityzx2YviqT6BXSu+LyWWJwcA==
   dependencies:
     "@types/react" "*"
 
-"@types/react-select@^3.0.5":
+"@types/react-select@3.0.22":
   version "3.0.22"
   resolved "https://registry.yarnpkg.com/@types/react-select/-/react-select-3.0.22.tgz#b88306365e99fa86809a5c0ce0f1b4e8d0b626bf"
   integrity sha512-fqgmC979JPr/6476Pau6QnmI9zVV664R7Q92Ld1rgTn+umtUXT5X3+PO/x6O4imCZnh7XCqZcouabWAlAQJNpQ==
@@ -8773,13 +8780,6 @@ dom-converter@^0.2:
   integrity sha512-gd3ypIPfOMr9h5jIKq8E3sHOTCjeirnl0WK5ZdS1AW0Odt0b1PaWaHdJ4Qk4klv+YB9aJBS7mESXjFoDQPu6DA==
   dependencies:
     utila "~0.4"
-
-dom-helpers@^3.4.0:
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-3.4.0.tgz#e9b369700f959f62ecde5a6babde4bccd9169af8"
-  integrity sha512-LnuPJ+dwqKDIyotW1VzmOZ5TONUN7CwkCR5hrgawTUbkBGYdeoNLZo6nNfGkCrjtE1nXXaj7iMMpDa8/d9WoIA==
-  dependencies:
-    "@babel/runtime" "^7.1.2"
 
 dom-helpers@^5.0.1:
   version "5.2.0"
@@ -19886,16 +19886,6 @@ react-tooltip@^4.2.6:
   dependencies:
     prop-types "^15.7.2"
     uuid "^7.0.3"
-
-react-transition-group@^2.9.0:
-  version "2.9.0"
-  resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-2.9.0.tgz#df9cdb025796211151a436c69a8f3b97b5b07c8d"
-  integrity sha512-+HzNTCHpeQyl4MJ/bdE0u6XRMe9+XG/+aL4mCxVN4DnPBQ0/5bfHWPDuOZUzYdMj94daZaZdCCc1Dzt9R/xSSg==
-  dependencies:
-    dom-helpers "^3.4.0"
-    loose-envify "^1.4.0"
-    prop-types "^15.6.2"
-    react-lifecycles-compat "^3.0.4"
 
 react-transition-group@^4.3.0, react-transition-group@^4.4.1:
   version "4.4.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1945,44 +1945,6 @@
     "@types/yargs" "^15.0.0"
     chalk "^4.0.0"
 
-"@kaizen/component-library@^7.30.4":
-  version "7.33.1"
-  resolved "https://registry.yarnpkg.com/@kaizen/component-library/-/component-library-7.33.1.tgz#2573fec05c77136bca28ee2f44e5e9e7e171d53d"
-  integrity sha512-ITNTiP09Vb57xkK+4IjgSYOYFHvcfAsN25MlFRRQ98puvAkFDdqv75pY+Y9gQC0VcGTRDbfBWjNybz6Bbamy5A==
-  dependencies:
-    "@kaizen/deprecated-component-library-helpers" "^1.6.13"
-    "@kaizen/hosted-assets" "^1.0.2"
-    "@types/classnames" "^2.2.6"
-    "@types/lodash" "^4.14.132"
-    "@types/react-select" "^3.0.5"
-    "@types/uuid" "^3.4.4"
-    classnames "^2.2.6"
-    lodash "^4.17.11"
-    motion-ui cultureamp/motion-ui
-    react-animate-height "^2.0.15"
-    react-focus-lock "^1.19.1"
-    react-media "^1.9.2"
-    react-select "^3.1.0"
-    react-tooltip "^4.2.6"
-    react-transition-group "^2.9.0"
-    uuid "^3.3.2"
-
-"@kaizen/deprecated-component-library-helpers@^1.6.13":
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/@kaizen/deprecated-component-library-helpers/-/deprecated-component-library-helpers-1.8.0.tgz#6e93e8a92e93376badafd330d290541e568ae21f"
-  integrity sha512-uqo0OEjpRAtkDY/iSNYCbRKJdXrbxBbiicn/bBqFHYAFAfYIStmv111pjemzFvu1RtHtvCyUpLUICgPYEVIjtw==
-  dependencies:
-    "@kaizen/design-tokens" "^2.1.3"
-
-"@kaizen/draft-button@^1.7.4":
-  version "1.13.12"
-  resolved "https://registry.yarnpkg.com/@kaizen/draft-button/-/draft-button-1.13.12.tgz#b6478a3e1922101d7eb2591250395d146f2bc1a6"
-  integrity sha512-aUIGmoUKKkZdvLSzWywvnksB9MWP7P7SBO2OJZ/cnUSr9Wmt8yHkrhBh+QkAZXAw+Pt7VT5wtHyfnXsAPwoIww==
-  dependencies:
-    "@kaizen/component-library" "^7.30.4"
-    "@types/classnames" "^2.2.10"
-    classnames "^2.2.6"
-
 "@lerna/add@3.21.0":
   version "3.21.0"
   resolved "https://registry.yarnpkg.com/@lerna/add/-/add-3.21.0.tgz#27007bde71cc7b0a2969ab3c2f0ae41578b4577b"
@@ -4341,11 +4303,6 @@
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/@types/unist/-/unist-2.0.3.tgz#9c088679876f374eb5983f150d4787aa6fb32d7e"
   integrity sha512-FvUupuM3rlRsRtCN+fDudtmytGO6iHJuuRKS1Ss0pG5z8oX0diNEw94UEL7hgDbpN94rgaK5R7sWm6RrSkZuAQ==
-
-"@types/uuid@^3.4.4":
-  version "3.4.9"
-  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-3.4.9.tgz#fcf01997bbc9f7c09ae5f91383af076d466594e1"
-  integrity sha512-XDwyIlt/47l2kWLTzw/mtrpLdB+GPSskR2n/PIcPn+VYhVO77rGhRncIR5GPU0KRzXuqkDO+J5qqrG0Y8P6jzQ==
 
 "@types/uuid@^8.3.0":
   version "8.3.0"


### PR DESCRIPTION
# Objective
Upgrades the draft-button dependency in title-block-zen, and solves any consequential issues, such as adding `@types/react-select@3.0.22` to draft-select

# Motivation and Context
We just love dependency upgrades ❤️

# Screenshots (if appropriate)

# Checklist
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] If this contains visual changes, has it been reviewed by a designer?
- [ ] If this introduces either a new component or a breaking change to an existing component, has it been reviewed by an advocate? (Ask in #prod_design_systems)
- [ ] I have considered likely risks of these changes and got someone else to QA as appropriate
- [ ] I have or will communicate these changes to the front end practice

# Additional Considerations
- Does there need to be right-to-left (RTL) options for localization and internationalization?
- Has the test suite been updated?
- Have you done cross-browser testing for our [supported browsers](https://academy.cultureamp.com/hc/en-us/articles/204539569-Supported-browsers-for-Participants)?
- Have you updated any relevant documentation or left useful comments in the code?
- Have you reviewed Culture Amp's Web Accessibility guide [Current Compliance, Going Forward, Statement and Answers for Customers](https://cultureamp.atlassian.net/wiki/spaces/Prod/pages/428572998/Web+Accessibility)?
- If this contains substantial visual changes, especially far reaching ones, have you unlocked the Chromatic step in the pipeline?
- Have Storybook stories been updated?

**If you're new to Kaizen, please ask #prod_design_systems to set up an onboarding session to get you up to speed.** If you have an urgent PR to merge before that happens, it is safest to ask in #prod_design_systems to have a design system advocate review the PR to catch any issues.
