### PR TITLE
fix: Center text on Confirmation/ Roadblock Modals

### DIFF
--- a/draft-packages/modal/KaizenDraft/Modal/Presets/ConfirmationModal.scss
+++ b/draft-packages/modal/KaizenDraft/Modal/Presets/ConfirmationModal.scss
@@ -46,6 +46,7 @@
 
 .body {
   padding: $kz-spacing-md $kz-spacing-xxxxl $kz-spacing-sm;
+  text-align: center;
 }
 
 .iconContainer {

--- a/draft-packages/modal/KaizenDraft/Modal/Presets/RoadblockModal.scss
+++ b/draft-packages/modal/KaizenDraft/Modal/Presets/RoadblockModal.scss
@@ -30,6 +30,7 @@
 
 .body {
   padding: $kz-spacing-md $kz-spacing-xxxxl $kz-spacing-sm;
+  text-align: center;
 }
 
 .iconContainer {


### PR DESCRIPTION
# Objective

This centres text on the body of the Confirmation and Roadblock Modals.

# Motivation and Context

Other modals such as the Input-Edit Modal often have form elements in them, and if we use `text-align: center` on the body of those, it will introduce visual bugs by centering form labels. We may want to leave these cases up to the consumer to handle any text centering (see #971 for more details).

# Checklist
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] If this contains visual changes, has it been reviewed by a designer?
- [ ] If this introduces either a new component or a breaking change to an existing component, has it been reviewed by an advocate? (Ask in #prod_design_systems)
- [ ] I have considered likely risks of these changes and got someone else to QA as appropriate
- [ ] I have or will communicate these changes to the front end practice
