### PR TITLE
feat: align breakpoints to mobile design token to make rollout of new title block and navigation easier

### DIFF
--- a/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/_styles.scss
+++ b/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/_styles.scss
@@ -25,18 +25,18 @@ $navbar-breakpoint-extended-large-up: 1350px;
 $navbar-breakpoint-condensed-large-up: 1150px;
 
 :export {
-  caBreakpointMobileMax: #{$ca-breakpoint-tablet - 1};
+  caBreakpointMobileMax: #{$kz-layout-breakpoints-large - 1};
   navbarBreakpointExtendedMin: $navbar-breakpoint-extended-large-up;
 }
 
 @mixin navbar-mobile-only {
-  @media (max-width: #{$ca-breakpoint-tablet - 1px}) {
+  @media (max-width: #{$kz-layout-breakpoints-large - 1px}) {
     @content;
   }
 }
 
 @mixin navbar-tablet-up {
-  @media (min-width: $ca-breakpoint-tablet) {
+  @media (min-width: $kz-layout-breakpoints-large) {
     @content;
   }
 }

--- a/legacy-packages/title-block/KaizenDraft/TitleBlock/TitleBlock.scss
+++ b/legacy-packages/title-block/KaizenDraft/TitleBlock/TitleBlock.scss
@@ -1,5 +1,6 @@
 @import "~@kaizen/design-tokens/sass/color";
 @import "~@kaizen/design-tokens/sass/shadow";
+@import "~@kaizen/design-tokens/sass/layout";
 @import "~@kaizen/deprecated-component-library-helpers/styles/type";
 @import "~@kaizen/deprecated-component-library-helpers/styles/color";
 @import "~@kaizen/component-library/styles/border";
@@ -7,6 +8,12 @@
 @import "~@kaizen/component-library/styles/layout";
 @import "~@kaizen/component-library/styles/responsive";
 @import "~@kaizen/component-library/styles/animation";
+
+@mixin title-block-mobile {
+  @media (max-width: $kz-layout-breakpoints-large - 1px) {
+    @content;
+  }
+}
 
 .titleBlockContainer {
   color: $kz-color-wisteria-800;
@@ -38,7 +45,7 @@
     height: $ca-layout-title-block-tablet-height;
   }
 
-  @include ca-media-mobile {
+  @include title-block-mobile {
     height: $ca-layout-title-block-mobile-height;
     padding-left: $ca-grid;
     padding-right: $ca-grid;
@@ -80,7 +87,7 @@
     top: $ca-layout-title-block-tablet-height / 2;
   }
 
-  @include ca-media-mobile {
+  @include title-block-mobile {
     display: none;
   }
 }
@@ -142,7 +149,7 @@
     opacity: 0;
   }
 
-  @include ca-media-mobile {
+  @include title-block-mobile {
     justify-content: center;
   }
 }
@@ -152,7 +159,7 @@
   flex-direction: row;
   align-items: center;
 
-  @include ca-media-mobile {
+  @include title-block-mobile {
     justify-content: center;
   }
 }
@@ -167,7 +174,7 @@
     @include ca-inherit-baseline;
   }
 
-  @include ca-media-mobile {
+  @include title-block-mobile {
     @include kz-typography-heading-3;
     @include ca-inherit-baseline;
   }
@@ -185,7 +192,7 @@
   @include ca-margin($start: $ca-grid);
   transform: translateY(-1px);
 
-  @include ca-media-mobile {
+  @include title-block-mobile {
     display: none;
   }
 }
@@ -202,7 +209,7 @@
   flex: 0 0 auto;
   align-items: center;
 
-  @include ca-media-mobile {
+  @include title-block-mobile {
     display: none;
   }
 }
@@ -263,7 +270,7 @@
   color: $kz-color-wisteria-800;
   @include ca-margin($start: $ca-grid * 1.5);
 
-  @include ca-media-mobile {
+  @include title-block-mobile {
     display: flex;
     margin: 0;
     border-bottom: 1px solid $ca-border-color;
@@ -274,7 +281,7 @@
   .navButtonsContainer {
     display: flex;
 
-    @include ca-media-mobile {
+    @include title-block-mobile {
       @include ca-padding($start: $ca-grid, $top: $ca-grid * 0.5);
     }
   }
@@ -282,7 +289,7 @@
 
 // Some hackiness to make mobile nav work in Elm 0.18:
 .nonMobileNav {
-  @include ca-media-mobile {
+  @include title-block-mobile {
     display: none;
   }
 }
@@ -330,7 +337,7 @@
   .navContainer {
     background-color: transparent;
 
-    @include ca-media-mobile {
+    @include title-block-mobile {
       border-bottom: 1px solid white;
     }
   }
@@ -342,7 +349,7 @@
       background-color: $kz-color-wisteria-800;
     }
   }
-  @include ca-media-mobile {
+  @include title-block-mobile {
     .navContainer {
       background-color: $kz-color-wisteria-800;
     }
@@ -355,7 +362,7 @@
       background-color: $kz-color-cluny-500;
     }
   }
-  @include ca-media-mobile {
+  @include title-block-mobile {
     .navContainer {
       background-color: $kz-color-cluny-500;
     }
@@ -368,7 +375,7 @@
       background-color: $kz-color-peach-500;
     }
   }
-  @include ca-media-mobile {
+  @include title-block-mobile {
     .navContainer {
       background-color: $kz-color-peach-500;
     }
@@ -381,7 +388,7 @@
       background-color: $kz-color-seedling-500;
     }
   }
-  @include ca-media-mobile {
+  @include title-block-mobile {
     .navContainer {
       background-color: $kz-color-seedling-500;
     }
@@ -394,7 +401,7 @@
       background-color: $kz-color-wisteria-700;
     }
   }
-  @include ca-media-mobile {
+  @include title-block-mobile {
     .navContainer {
       background-color: $kz-color-wisteria-500;
     }
@@ -407,7 +414,7 @@
       background-color: $kz-color-yuzu-500;
     }
   }
-  @include ca-media-mobile {
+  @include title-block-mobile {
     .navContainer {
       background-color: $kz-color-yuzu-500;
     }
@@ -420,7 +427,7 @@
       background-color: transparent;
     }
   }
-  @include ca-media-mobile {
+  @include title-block-mobile {
     .navContainer {
       background-color: transparent;
     }
@@ -468,7 +475,7 @@
       background-color: $kz-color-wisteria-600;
     }
   }
-  @include ca-media-mobile {
+  @include title-block-mobile {
     .navContainer {
       background-color: $kz-color-wisteria-600;
     }
@@ -481,7 +488,7 @@
       background-color: $kz-color-cluny-500;
     }
   }
-  @include ca-media-mobile {
+  @include title-block-mobile {
     .navContainer {
       background-color: $kz-color-cluny-500;
     }
@@ -494,7 +501,7 @@
       background-color: $kz-color-peach-400;
     }
   }
-  @include ca-media-mobile {
+  @include title-block-mobile {
     .navContainer {
       background-color: $kz-color-peach-400;
     }
@@ -507,7 +514,7 @@
       background-color: $kz-color-seedling-400;
     }
   }
-  @include ca-media-mobile {
+  @include title-block-mobile {
     .navContainer {
       background-color: $kz-color-seedling-400;
     }
@@ -520,7 +527,7 @@
       background-color: $kz-color-wisteria-700;
     }
   }
-  @include ca-media-mobile {
+  @include title-block-mobile {
     .navContainer {
       background-color: $kz-color-wisteria-700;
     }
@@ -533,7 +540,7 @@
       background-color: $kz-color-yuzu-500;
     }
   }
-  @include ca-media-mobile {
+  @include title-block-mobile {
     .navContainer {
       background-color: $kz-color-yuzu-500;
     }
@@ -546,7 +553,7 @@
       background-color: transparent;
     }
   }
-  @include ca-media-mobile {
+  @include title-block-mobile {
     .navContainer {
       background-color: transparent;
     }

--- a/legacy-packages/title-block/KaizenDraft/TitleBlock/TitleBlock.scss
+++ b/legacy-packages/title-block/KaizenDraft/TitleBlock/TitleBlock.scss
@@ -15,14 +15,8 @@
   }
 }
 
-@mixin title-block-tablet-up {
+@mixin title-block-desktop {
   @media (min-width: $kz-layout-breakpoints-large) {
-    @content;
-  }
-}
-
-@mixin title-block-tablet {
-  @media (min-width: $kz-layout-breakpoints-large) and (max-width: #{$ca-breakpoint-tablet - 1px}) {
     @content;
   }
 }
@@ -52,10 +46,6 @@
   margin: 0 auto;
   // Specifying this explicity in case the consuming app don't have this specified by default
   box-sizing: border-box;
-
-  @include title-block-tablet {
-    height: $ca-layout-title-block-tablet-height;
-  }
 
   @include title-block-mobile {
     height: $ca-layout-title-block-mobile-height;
@@ -93,10 +83,6 @@
     [dir="rtl"] & {
       right: 0;
     }
-  }
-
-  @include title-block-tablet {
-    top: $ca-layout-title-block-tablet-height / 2;
   }
 
   @include title-block-mobile {
@@ -180,11 +166,6 @@
   @include kz-typography-heading-1;
   display: inline-block;
   top: auto;
-
-  @include title-block-tablet {
-    @include kz-typography-heading-2;
-    @include ca-inherit-baseline;
-  }
 
   @include title-block-mobile {
     @include kz-typography-heading-3;
@@ -307,7 +288,7 @@
 }
 
 .mobileNav {
-  @include title-block-tablet-up {
+  @include title-block-desktop {
     display: none;
   }
 }
@@ -317,7 +298,7 @@
 .reversed {
   color: white;
 
-  @include title-block-tablet-up {
+  @include title-block-desktop {
     .title {
       color: white;
     }
@@ -356,7 +337,7 @@
 }
 
 .reverseColorLapis {
-  @include title-block-tablet-up {
+  @include title-block-desktop {
     .titleBlock {
       background-color: $kz-color-wisteria-800;
     }
@@ -369,7 +350,7 @@
 }
 
 .reverseColorOcean {
-  @include title-block-tablet-up {
+  @include title-block-desktop {
     .titleBlock {
       background-color: $kz-color-cluny-500;
     }
@@ -382,7 +363,7 @@
 }
 
 .reverseColorPeach {
-  @include title-block-tablet-up {
+  @include title-block-desktop {
     .titleBlock {
       background-color: $kz-color-peach-500;
     }
@@ -395,7 +376,7 @@
 }
 
 .reverseColorSeedling {
-  @include title-block-tablet-up {
+  @include title-block-desktop {
     .titleBlock {
       background-color: $kz-color-seedling-500;
     }
@@ -408,7 +389,7 @@
 }
 
 .reverseColorWisteria {
-  @include title-block-tablet-up {
+  @include title-block-desktop {
     .titleBlock {
       background-color: $kz-color-wisteria-700;
     }
@@ -421,7 +402,7 @@
 }
 
 .reverseColorYuzu {
-  @include title-block-tablet-up {
+  @include title-block-desktop {
     .titleBlock {
       background-color: $kz-color-yuzu-500;
     }
@@ -434,7 +415,7 @@
 }
 
 .reverseColorTransparent {
-  @include title-block-tablet-up {
+  @include title-block-desktop {
     .titleBlock {
       background-color: transparent;
     }
@@ -457,7 +438,7 @@
 }
 
 .compact {
-  @include title-block-tablet-up {
+  @include title-block-desktop {
     box-shadow: $kz-shadow-large-box-shadow;
 
     .titleBlockInner {
@@ -467,7 +448,7 @@
 }
 
 .sticky {
-  @include title-block-tablet-up {
+  @include title-block-desktop {
     position: fixed;
     z-index: $ca-z-index-sticky;
   }
@@ -482,7 +463,7 @@
 }
 
 .stickyColorLapis {
-  @include title-block-tablet-up {
+  @include title-block-desktop {
     .titleBlock {
       background-color: $kz-color-wisteria-600;
     }
@@ -495,7 +476,7 @@
 }
 
 .stickyColorOcean {
-  @include title-block-tablet-up {
+  @include title-block-desktop {
     .titleBlock {
       background-color: $kz-color-cluny-500;
     }
@@ -508,7 +489,7 @@
 }
 
 .stickyColorPeach {
-  @include title-block-tablet-up {
+  @include title-block-desktop {
     .titleBlock {
       background-color: $kz-color-peach-400;
     }
@@ -521,7 +502,7 @@
 }
 
 .stickyColorSeedling {
-  @include title-block-tablet-up {
+  @include title-block-desktop {
     .titleBlock {
       background-color: $kz-color-seedling-400;
     }
@@ -534,7 +515,7 @@
 }
 
 .stickyColorWisteria {
-  @include title-block-tablet-up {
+  @include title-block-desktop {
     .titleBlock {
       background-color: $kz-color-wisteria-700;
     }
@@ -547,7 +528,7 @@
 }
 
 .stickyColorYuzu {
-  @include title-block-tablet-up {
+  @include title-block-desktop {
     .titleBlock {
       background-color: $kz-color-yuzu-500;
     }
@@ -560,7 +541,7 @@
 }
 
 .stickyColorTransparent {
-  @include title-block-tablet-up {
+  @include title-block-desktop {
     .titleBlock {
       background-color: transparent;
     }

--- a/legacy-packages/title-block/KaizenDraft/TitleBlock/TitleBlock.scss
+++ b/legacy-packages/title-block/KaizenDraft/TitleBlock/TitleBlock.scss
@@ -15,6 +15,18 @@
   }
 }
 
+@mixin title-block-tablet-up {
+  @media (min-width: $kz-layout-breakpoints-large) {
+    @content;
+  }
+}
+
+@mixin title-block-tablet {
+  @media (min-width: $kz-layout-breakpoints-large) and (max-width: #{$ca-breakpoint-tablet - 1px}) {
+    @content;
+  }
+}
+
 .titleBlockContainer {
   color: $kz-color-wisteria-800;
   width: 100%;
@@ -41,7 +53,7 @@
   // Specifying this explicity in case the consuming app don't have this specified by default
   box-sizing: border-box;
 
-  @include ca-media-tablet {
+  @include title-block-tablet {
     height: $ca-layout-title-block-tablet-height;
   }
 
@@ -83,7 +95,7 @@
     }
   }
 
-  @include ca-media-tablet {
+  @include title-block-tablet {
     top: $ca-layout-title-block-tablet-height / 2;
   }
 
@@ -169,7 +181,7 @@
   display: inline-block;
   top: auto;
 
-  @include ca-media-tablet {
+  @include title-block-tablet {
     @include kz-typography-heading-2;
     @include ca-inherit-baseline;
   }
@@ -295,7 +307,7 @@
 }
 
 .mobileNav {
-  @include ca-media-tablet-and-up {
+  @include title-block-tablet-up {
     display: none;
   }
 }
@@ -305,7 +317,7 @@
 .reversed {
   color: white;
 
-  @include ca-media-tablet-and-up {
+  @include title-block-tablet-up {
     .title {
       color: white;
     }
@@ -344,7 +356,7 @@
 }
 
 .reverseColorLapis {
-  @include ca-media-tablet-and-up {
+  @include title-block-tablet-up {
     .titleBlock {
       background-color: $kz-color-wisteria-800;
     }
@@ -357,7 +369,7 @@
 }
 
 .reverseColorOcean {
-  @include ca-media-tablet-and-up {
+  @include title-block-tablet-up {
     .titleBlock {
       background-color: $kz-color-cluny-500;
     }
@@ -370,7 +382,7 @@
 }
 
 .reverseColorPeach {
-  @include ca-media-tablet-and-up {
+  @include title-block-tablet-up {
     .titleBlock {
       background-color: $kz-color-peach-500;
     }
@@ -383,7 +395,7 @@
 }
 
 .reverseColorSeedling {
-  @include ca-media-tablet-and-up {
+  @include title-block-tablet-up {
     .titleBlock {
       background-color: $kz-color-seedling-500;
     }
@@ -396,7 +408,7 @@
 }
 
 .reverseColorWisteria {
-  @include ca-media-tablet-and-up {
+  @include title-block-tablet-up {
     .titleBlock {
       background-color: $kz-color-wisteria-700;
     }
@@ -409,7 +421,7 @@
 }
 
 .reverseColorYuzu {
-  @include ca-media-tablet-and-up {
+  @include title-block-tablet-up {
     .titleBlock {
       background-color: $kz-color-yuzu-500;
     }
@@ -422,7 +434,7 @@
 }
 
 .reverseColorTransparent {
-  @include ca-media-tablet-and-up {
+  @include title-block-tablet-up {
     .titleBlock {
       background-color: transparent;
     }
@@ -445,7 +457,7 @@
 }
 
 .compact {
-  @include ca-media-tablet-and-up {
+  @include title-block-tablet-up {
     box-shadow: $kz-shadow-large-box-shadow;
 
     .titleBlockInner {
@@ -455,7 +467,7 @@
 }
 
 .sticky {
-  @include ca-media-tablet-and-up {
+  @include title-block-tablet-up {
     position: fixed;
     z-index: $ca-z-index-sticky;
   }
@@ -470,7 +482,7 @@
 }
 
 .stickyColorLapis {
-  @include ca-media-tablet-and-up {
+  @include title-block-tablet-up {
     .titleBlock {
       background-color: $kz-color-wisteria-600;
     }
@@ -483,7 +495,7 @@
 }
 
 .stickyColorOcean {
-  @include ca-media-tablet-and-up {
+  @include title-block-tablet-up {
     .titleBlock {
       background-color: $kz-color-cluny-500;
     }
@@ -496,7 +508,7 @@
 }
 
 .stickyColorPeach {
-  @include ca-media-tablet-and-up {
+  @include title-block-tablet-up {
     .titleBlock {
       background-color: $kz-color-peach-400;
     }
@@ -509,7 +521,7 @@
 }
 
 .stickyColorSeedling {
-  @include ca-media-tablet-and-up {
+  @include title-block-tablet-up {
     .titleBlock {
       background-color: $kz-color-seedling-400;
     }
@@ -522,7 +534,7 @@
 }
 
 .stickyColorWisteria {
-  @include ca-media-tablet-and-up {
+  @include title-block-tablet-up {
     .titleBlock {
       background-color: $kz-color-wisteria-700;
     }
@@ -535,7 +547,7 @@
 }
 
 .stickyColorYuzu {
-  @include ca-media-tablet-and-up {
+  @include title-block-tablet-up {
     .titleBlock {
       background-color: $kz-color-yuzu-500;
     }
@@ -548,7 +560,7 @@
 }
 
 .stickyColorTransparent {
-  @include ca-media-tablet-and-up {
+  @include title-block-tablet-up {
     .titleBlock {
       background-color: transparent;
     }

--- a/legacy-packages/title-block/KaizenDraft/TitleBlock/TitleBlock.tsx
+++ b/legacy-packages/title-block/KaizenDraft/TitleBlock/TitleBlock.tsx
@@ -6,6 +6,7 @@ import { withDeprecatedComponent } from "@kaizen/react-deprecate-warning"
 
 import Icon from "@kaizen/component-library/components/Icon/Icon"
 import { MOBILE_QUERY } from "@kaizen/component-library/components/NavigationBar/constants"
+import { kz as layoutTokens } from "@kaizen/design-tokens/tokens/layout.json"
 import { Tag } from "@kaizen/draft-tag"
 import backIcon from "@kaizen/component-library/icons/arrow-backward.icon.svg"
 
@@ -196,9 +197,11 @@ class TitleBlock extends React.Component<Props, State> {
                   {this.renderSubtitle()}
                 </div>
               </div>
-              <Media query={MOBILE_QUERY}>
+              <Media
+                query={{ minWidth: layoutTokens.layout.breakpoints.large }}
+              >
                 {(matches: boolean) =>
-                  !matches && (
+                  matches && (
                     <React.Fragment>{this.renderNavigation()}</React.Fragment>
                   )
                 }
@@ -212,9 +215,9 @@ class TitleBlock extends React.Component<Props, State> {
             </div>
           </div>
         </div>
-        <Media query={MOBILE_QUERY}>
+        <Media query={{ minWidth: layoutTokens.layout.breakpoints.large }}>
           {(matches: boolean) =>
-            matches && (
+            !matches && (
               <React.Fragment>{this.renderNavigation()}</React.Fragment>
             )
           }

--- a/legacy-packages/title-block/KaizenDraft/TitleBlock/TitleBlock.tsx
+++ b/legacy-packages/title-block/KaizenDraft/TitleBlock/TitleBlock.tsx
@@ -5,7 +5,6 @@ import Media from "react-media"
 import { withDeprecatedComponent } from "@kaizen/react-deprecate-warning"
 
 import Icon from "@kaizen/component-library/components/Icon/Icon"
-import { MOBILE_QUERY } from "@kaizen/component-library/components/NavigationBar/constants"
 import { kz as layoutTokens } from "@kaizen/design-tokens/tokens/layout.json"
 import { Tag } from "@kaizen/draft-tag"
 import backIcon from "@kaizen/component-library/icons/arrow-backward.icon.svg"


### PR DESCRIPTION
# Objective, Motivation and Context
<!-- Describe what this change achieves, and the details of how it works. -->

One legacy, and one soon-to-be legacy component, have different breakpoints for mobile. Specifically the Legacy Title Block and the Current Navigation.

We will be rolling out a new navigation with a mobile breakpoint defined design tokens. This will align the legacy components with their replacements. 

The problem exists because we will be rolling the new navigation out behind a feature flag, but we won't be upgrading the legacy title block as there is no new version in Elm. The title block needs to make space for the hamburger menu. And frankly it will just be 100x easier to work with.

This issue actually persists before this change so I guess I'm fixing a bug? IDK

![Screen Shot 2021-02-18 at 12 53 25 pm](https://user-images.githubusercontent.com/13988803/108292535-59549980-71e8-11eb-8273-c26b21cc5382.png)

