### PR TITLE
fix: Provide explicit text-transform on Headings

### DIFF
--- a/packages/component-library/components/Heading/Heading.module.scss
+++ b/packages/component-library/components/Heading/Heading.module.scss
@@ -61,6 +61,8 @@
   font-size: $kz-typography-heading-6-font-size;
   line-height: $kz-typography-heading-6-line-height;
   letter-spacing: $kz-typography-heading-6-letter-spacing;
+  // override Murmur global styles :(
+  text-transform: none;
 }
 
 .dark {


### PR DESCRIPTION
# BREAKING CHANGE: Any h6 elements that were relying on global h6 styles in the consuming repo for uppercase text could now break.

# Objective

Provide an explicit text-transform on h6 elements.

# Motivation and Context

Murmur has global h6 styles that mean that `<Heading variant="heading-6" />` has the wrong case when used there.

There are no similar rules that are overridden on other heading elements – only h6.

# Screenshots (if appropriate)

# Checklist
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] If this contains visual changes, has it been reviewed by a designer?
- [ ] If this introduces either a new component or a breaking change to an existing component, has it been reviewed by an advocate? (Ask in #prod_design_systems)
- [ ] I have considered likely risks of these changes and got someone else to QA as appropriate
- [x] I have or will communicate these changes to the front end practice
