### PR TITLE
feat: Update navigation bar to support Heart

### DIFF
--- a/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/NavigationBar.module.scss
+++ b/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/NavigationBar.module.scss
@@ -40,7 +40,7 @@
         transform: translate(-50%, -50%);
         height: 36px;
         width: 3px;
-        background-color: rgba($white, 0.1);
+        background-color: rgba($kz-var-color-white-rgb-params, 0.1);
         border-radius: 3px;
 
         .admin & {

--- a/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/NavigationBar.module.scss
+++ b/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/NavigationBar.module.scss
@@ -1,4 +1,4 @@
-@import "~@kaizen/design-tokens/sass/color";
+@import "~@kaizen/design-tokens/sass/color-vars";
 @import "~@kaizen/design-tokens/sass/border";
 @import "~@kaizen/component-library/styles/color";
 @import "~@kaizen/component-library/styles/type";
@@ -42,6 +42,10 @@
         width: 3px;
         background-color: rgba($white, 0.1);
         border-radius: 3px;
+
+        .admin & {
+          background-color: rgba($kz-var-color-slate-rgb-params, 0.1);
+        }
       }
     }
 
@@ -51,7 +55,7 @@
 
     // Bit of a hack selector, but because of module scoping this is the easiest way
     .content & span::before {
-      background-color: $kz-color-cluny-500;
+      background-color: $dt-color-background-color-content-link;
       height: 5px;
       border-radius: 0 0 $kz-border-solid-border-radius
         $kz-border-solid-border-radius;

--- a/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/_styles.scss
+++ b/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/_styles.scss
@@ -1,4 +1,4 @@
-@import "~@kaizen/design-tokens/sass/color";
+@import "~@kaizen/design-tokens/sass/color-vars";
 @import "~@kaizen/design-tokens/sass/border";
 @import "~@kaizen/design-tokens/sass/typography";
 @import "~@kaizen/design-tokens/sass/layout";
@@ -7,6 +7,7 @@
 @import "~@kaizen/component-library/styles/color";
 @import "~@kaizen/component-library/styles/type";
 @import "~@kaizen/component-library/styles/responsive";
+@import "./decision-tokens.scss";
 
 $ca-navigation-bar__spacer: $ca-grid / 2;
 $ca-navigation-bar__child-height: $ca-grid * 2;
@@ -88,7 +89,7 @@ $navbar-breakpoint-condensed-large-up: 1150px;
 
   align-items: center;
   border-radius: $kz-border-solid-border-radius;
-  color: rgba($kz-color-white, 0.8);
+  color: rgba($kz-var-color-white-rgb-params, 0.8);
   display: flex;
   height: 100%;
   justify-content: center;
@@ -109,7 +110,7 @@ $navbar-breakpoint-condensed-large-up: 1150px;
       position: absolute;
       top: -100%;
       left: 0;
-      background-color: $kz-color-white;
+      background-color: $kz-var-color-white;
       transition: top $ca-navigation-bar__animation-ease
         $ca-navigation-bar__animation-timing;
       border-radius: 0 0 $kz-border-borderless-border-radius
@@ -120,7 +121,7 @@ $navbar-breakpoint-condensed-large-up: 1150px;
   &.active {
     outline: none; // override native focus styles
     text-decoration: none;
-    color: $kz-color-white;
+    color: $kz-var-color-white;
 
     &::before {
       top: 0;
@@ -151,10 +152,10 @@ $navbar-breakpoint-condensed-large-up: 1150px;
   &.menuOpen,
   &:focus {
     text-decoration: none;
-    color: $kz-color-white; // override hyperlink hover color
+    color: $kz-var-color-white; // override hyperlink hover color
 
     .hoverArea {
-      background-color: rgba($kz-color-white, 0.1);
+      background-color: rgba($kz-var-color-white-rgb-params, 0.1);
     }
 
     .linkText::before {
@@ -202,25 +203,25 @@ $navbar-breakpoint-condensed-large-up: 1150px;
     border-radius: $ca-grid;
     &.badgeNew {
       @include ca-padding($start: $ca-grid * 0.5, $end: $ca-grid * 0.5);
-      background-color: $kz-color-seedling-200;
-      color: $kz-color-wisteria-800;
+      background-color: $dt-color-badge-background-color-new;
+      color: $dt-color-text;
     }
     &.badgeNotification {
       @include ca-padding($start: $ca-grid / 3, $end: $ca-grid / 3);
-      background-color: $kz-color-white;
-      color: $kz-color-wisteria-800;
+      background-color: $kz-var-color-white;
+      color: $dt-color-text;
 
       @include navbar-mobile-only {
-        background-color: $kz-color-coral-500;
-        color: $kz-color-white;
+        background-color: $dt-color-badge-background-color;
+        color: $kz-var-color-white;
       }
     }
   }
 
   &.admin .badge {
     &.badgeNotification {
-      background-color: $kz-color-wisteria-800;
-      color: $kz-color-white;
+      background-color: $kz-var-color-wisteria-800;
+      color: $kz-var-color-white;
     }
   }
 
@@ -236,7 +237,7 @@ $navbar-breakpoint-condensed-large-up: 1150px;
   }
 
   &.opaque {
-    color: $kz-color-white;
+    color: $kz-var-color-white;
 
     @include navbar-tablet-up {
       .linkIcon {
@@ -256,13 +257,13 @@ $navbar-breakpoint-condensed-large-up: 1150px;
       &:hover,
       &:focus {
         .hoverArea {
-          background-color: rgba($kz-color-white, 0.1);
+          background-color: rgba($kz-var-color-white-rgb-params, 0.1);
         }
       }
 
       &:active {
         .hoverArea {
-          background-color: rgba($kz-color-white, 0.2);
+          background-color: rgba($kz-var-color-white-rgb-params, 0.2);
         }
       }
     }
@@ -301,36 +302,36 @@ $navbar-breakpoint-condensed-large-up: 1150px;
   @include navbar-tablet-up {
     &.admin,
     &.content {
-      color: rgba($kz-color-wisteria-800, 0.7);
+      color: rgba($kz-var-color-wisteria-800-rgb-params, 0.7);
 
       &.opaque,
       &.menuOpen {
-        color: $kz-color-wisteria-800;
+        color: $kz-var-color-wisteria-800;
       }
 
       &.small {
-        color: $kz-color-cluny-500;
+        color: $kz-var-color-cluny-500;
 
         &.opaque {
-          color: $kz-color-cluny-500;
+          color: $kz-var-color-cluny-500;
         }
       }
 
       &.active {
-        color: $kz-color-cluny-500;
+        color: $kz-var-color-cluny-500;
       }
 
       &:hover,
       &:focus,
       &.menuOpen {
-        color: $kz-color-cluny-500;
+        color: $kz-var-color-cluny-500;
         .hoverArea {
-          background-color: rgba($kz-color-white, 0.5);
+          background-color: rgba($kz-var-color-white-rgb-params, 0.5);
         }
       }
 
       &::before {
-        background-color: $kz-color-cluny-500;
+        background-color: $kz-var-color-cluny-500;
       }
     }
   }
@@ -338,7 +339,7 @@ $navbar-breakpoint-condensed-large-up: 1150px;
   @include navbar-mobile-only {
     justify-content: flex-start;
     align-items: center;
-    color: $kz-color-wisteria-700;
+    color: $dt-color-background-color-default;
     transition: none;
     margin: 0 $ca-navigation-bar__link-item-margin-mobile;
 
@@ -346,8 +347,8 @@ $navbar-breakpoint-condensed-large-up: 1150px;
     &:hover,
     &:focus {
       .hoverArea {
-        color: $kz-color-cluny-500;
-        background-color: $kz-color-cluny-100;
+        color: $kz-var-color-cluny-500;
+        background-color: $kz-var-color-cluny-100;
 
         .menuIcon {
           opacity: 1;
@@ -367,7 +368,7 @@ $navbar-breakpoint-condensed-large-up: 1150px;
   display: flex;
   flex-direction: row;
   align-items: center;
-  background-color: $kz-color-wisteria-700;
+  background-color: $dt-color-background-color-default;
   height: $kz-layout-navigation-bar-height;
   max-height: $kz-layout-navigation-bar-height;
   width: 100%;
@@ -380,11 +381,11 @@ $navbar-breakpoint-condensed-large-up: 1150px;
   transition: background-color $ca-duration-slow $ca-ease-in-out;
 
   &.content {
-    background-color: $kz-color-cluny-200;
+    background-color: $dt-color-background-color-content;
   }
 
   &.admin {
-    background-color: $kz-color-white;
+    background-color: $kz-var-color-white;
   }
 }
 
@@ -398,7 +399,7 @@ $navbar-breakpoint-condensed-large-up: 1150px;
     // show custom focus ring when :focus-visible
     &:global(.focus-visible) {
       color: white;
-      outline: 2px solid $kz-color-cluny-500;
+      outline: 2px solid $kz-var-color-cluny-500;
     }
   }
 }

--- a/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/components/Badge.module.scss
+++ b/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/components/Badge.module.scss
@@ -1,12 +1,11 @@
-@import "~@kaizen/design-tokens/sass/color";
-@import "~@kaizen/component-library/styles/color";
 @import "~@kaizen/component-library/styles/layout";
 @import "~@kaizen/component-library/styles/type";
 @import "../styles";
+@import "../decision-tokens.scss";
 
 .badge {
-  background-color: $kz-color-coral-500;
-  color: $kz-color-white;
+  background-color: $dt-color-badge-background-color;
+  color: $kz-var-color-white;
   font-weight: $ca-weight-medium;
   text-decoration: none;
   text-transform: uppercase;
@@ -36,24 +35,24 @@
   }
 
   &.staging {
-    background-color: $kz-color-peach-500;
+    background-color: $dt-color-badge-background-color-staging;
   }
 
   &.named {
-    background-color: $kz-color-seedling-400;
+    background-color: $dt-color-badge-background-color-named;
   }
 
   &.test {
-    background-color: $kz-color-wisteria-400;
+    background-color: $dt-color-badge-background-color-test;
   }
 
   &.local {
-    background-color: $kz-color-cluny-300;
+    background-color: $dt-color-badge-background-color-local;
   }
 
   &.content {
-    background-color: $kz-color-cluny-200;
-    color: $kz-color-wisteria-800;
+    background-color: $dt-color-background-color-content;
+    color: $dt-color-text;
   }
 
   @include navbar-mobile-only {

--- a/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/components/Dropdown.module.scss
+++ b/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/components/Dropdown.module.scss
@@ -1,4 +1,4 @@
-@import "~@kaizen/design-tokens/sass/color";
+@import "~@kaizen/design-tokens/sass/color-vars";
 @import "~@kaizen/component-library/styles/type";
 @import "~@kaizen/component-library/styles/layout";
 @import "../styles";
@@ -8,8 +8,8 @@
   align-items: center;
   position: absolute;
   z-index: $ca-z-index-dropdown;
-  background-color: $kz-color-white;
-  box-shadow: 0 0 ($ca-grid / 2) rgba($kz-color-wisteria-800, 0.3);
+  background-color: $kz-var-color-white;
+  box-shadow: 0 0 ($ca-grid / 2) rgba($kz-var-color-wisteria-800, 0.3);
   border-radius: $kz-border-solid-border-radius;
   overflow: hidden;
   padding: 4px 0 0;

--- a/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/components/Dropdown.module.scss
+++ b/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/components/Dropdown.module.scss
@@ -9,7 +9,8 @@
   position: absolute;
   z-index: $ca-z-index-dropdown;
   background-color: $kz-var-color-white;
-  box-shadow: 0 0 ($ca-grid / 2) rgba($kz-var-color-wisteria-800, 0.3);
+  box-shadow: 0 0 ($ca-grid / 2)
+    rgba($kz-var-color-wisteria-800-rgb-params, 0.3);
   border-radius: $kz-border-solid-border-radius;
   overflow: hidden;
   padding: 4px 0 0;

--- a/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/components/Indicator.module.scss
+++ b/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/components/Indicator.module.scss
@@ -1,9 +1,9 @@
-@import "~@kaizen/design-tokens/sass/color";
+@import "~@kaizen/design-tokens/sass/color-vars";
 @import "~@kaizen/design-tokens/sass/spacing";
 @import "~@kaizen/component-library/styles/layout";
 
 .container {
   @include ca-margin($end: 4px);
   width: $kz-spacing-sm;
-  color: $kz-color-seedling-400;
+  color: $kz-var-color-seedling-400;
 }

--- a/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/components/MenuGroup.module.scss
+++ b/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/components/MenuGroup.module.scss
@@ -5,7 +5,7 @@
 .container {
   @include ca-padding($start: 0);
 
-  border-top: 1px solid rgba($kz-var-color-wisteria-800, 0.1);
+  border-top: 1px solid rgba($kz-var-color-wisteria-800-rgb-params, 0.1);
   list-style: none;
 
   &:first-child {
@@ -22,7 +22,7 @@
     width: 100%;
 
     &:first-child {
-      border-top: 1px solid rgba($kz-var-color-wisteria-800, 0.1);
+      border-top: 1px solid rgba($kz-var-color-wisteria-800-rgb-params, 0.1);
     }
 
     // Required because of the way this is nested
@@ -48,7 +48,7 @@
   margin: 0;
   white-space: nowrap;
 
-  color: rgba($kz-var-color-wisteria-800, 0.8);
+  color: rgba($kz-var-color-wisteria-800-rgb-params, 0.8);
 
   .offCanvas & {
     @include ca-padding($top: 10px, $bottom: 4px, $start: 12px, $end: 12px);

--- a/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/components/MenuGroup.module.scss
+++ b/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/components/MenuGroup.module.scss
@@ -1,11 +1,11 @@
-@import "~@kaizen/design-tokens/sass/color";
+@import "~@kaizen/design-tokens/sass/color-vars";
 @import "~@kaizen/component-library/styles/layout";
 @import "../styles";
 
 .container {
   @include ca-padding($start: 0);
 
-  border-top: 1px solid rgba($kz-color-wisteria-800, 0.1);
+  border-top: 1px solid rgba($kz-var-color-wisteria-800, 0.1);
   list-style: none;
 
   &:first-child {
@@ -22,7 +22,7 @@
     width: 100%;
 
     &:first-child {
-      border-top: 1px solid rgba($kz-color-wisteria-800, 0.1);
+      border-top: 1px solid rgba($kz-var-color-wisteria-800, 0.1);
     }
 
     // Required because of the way this is nested
@@ -48,13 +48,13 @@
   margin: 0;
   white-space: nowrap;
 
-  color: rgba($kz-color-wisteria-800, 0.8);
+  color: rgba($kz-var-color-wisteria-800, 0.8);
 
   .offCanvas & {
     @include ca-padding($top: 10px, $bottom: 4px, $start: 12px, $end: 12px);
     @include font-heading-6;
 
     margin: 0 10px;
-    color: $kz-color-wisteria-800;
+    color: $kz-var-color-wisteria-800;
   }
 }

--- a/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/components/MenuItem.module.scss
+++ b/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/components/MenuItem.module.scss
@@ -34,7 +34,7 @@ $menuItem__margin: 4px;
   @include ca-margin($start: $kz-spacing-md / 2);
 
   display: flex;
-  color: rgba($kz-var-color-wisteria-800, 0.5);
+  color: rgba($kz-var-color-wisteria-800-rgb-params, 0.5);
   transition: color $ca-ease $ca-duration-immediate;
 }
 

--- a/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/components/MenuItem.module.scss
+++ b/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/components/MenuItem.module.scss
@@ -1,4 +1,4 @@
-@import "~@kaizen/design-tokens/sass/color";
+@import "~@kaizen/design-tokens/sass/color-vars";
 @import "~@kaizen/component-library/styles/layout";
 @import "~@kaizen/component-library/styles/type";
 @import "~@kaizen/component-library/styles/animation";
@@ -34,7 +34,7 @@ $menuItem__margin: 4px;
   @include ca-margin($start: $kz-spacing-md / 2);
 
   display: flex;
-  color: rgba($kz-color-wisteria-800, 0.5);
+  color: rgba($kz-var-color-wisteria-800, 0.5);
   transition: color $ca-ease $ca-duration-immediate;
 }
 
@@ -56,7 +56,7 @@ $menuItem__margin: 4px;
   min-width: 150px;
   padding: 0 $menuItem__padding;
   text-align: left;
-  color: $kz-color-wisteria-800;
+  color: $kz-var-color-wisteria-800;
 
   transition-property: background-color, color;
   transition-duration: $ca-duration-immediate;
@@ -65,12 +65,12 @@ $menuItem__margin: 4px;
   &:hover,
   &:focus,
   .active & {
-    background-color: $kz-color-cluny-100;
-    color: $kz-color-cluny-500;
+    background-color: $kz-var-color-cluny-100;
+    color: $kz-var-color-cluny-500;
     text-decoration: none;
 
     .arrowIcon {
-      color: $kz-color-cluny-500;
+      color: $kz-var-color-cluny-500;
     }
   }
 }
@@ -100,16 +100,16 @@ $menuItem__margin: 4px;
       $start: $kz-spacing-md * 0.5,
       $end: $kz-spacing-md * 0.5
     );
-    background-color: $kz-color-seedling-200;
+    background-color: $kz-var-color-seedling-200;
   }
 
   &.badgeNotification {
     @include ca-padding($start: $kz-spacing-md / 3, $end: $kz-spacing-md / 3);
-    background-color: $kz-color-wisteria-800;
+    background-color: $kz-var-color-wisteria-800;
 
     @include navbar-mobile-only {
-      background-color: $kz-color-coral-500;
-      color: $kz-color-white;
+      background-color: $kz-var-color-coral-500;
+      color: $kz-var-color-white;
     }
   }
 }

--- a/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/decision-tokens.scss
+++ b/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/decision-tokens.scss
@@ -1,6 +1,7 @@
 @import "~@kaizen/design-tokens/sass/color-vars";
 
 $dt-color-text: $kz-var-color-wisteria-800;
+$dt-color-text-reversed: $kz-var-color-white;
 $dt-color-background-color-default: var(
   --kz-var-color-wisteria-600,
   $kz-var-color-wisteria-700

--- a/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/helpers/OffCanvas.module.scss
+++ b/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/helpers/OffCanvas.module.scss
@@ -1,4 +1,4 @@
-@import "~@kaizen/design-tokens/sass/color";
+@import "~@kaizen/design-tokens/sass/color-vars";
 @import "~@kaizen/design-tokens/sass/shadow";
 @import "~@kaizen/component-library/styles/color";
 @import "~@kaizen/component-library/styles/type";
@@ -20,8 +20,8 @@ $menu-footer-height: 80px;
   top: 0;
   left: 0;
   transform: translate3d(-120%, 0, 0);
-  background-color: $kz-color-white;
-  color: $kz-color-wisteria-800;
+  background-color: $kz-var-color-white;
+  color: $kz-var-color-wisteria-800;
   transition: transform $ca-duration-fast $ca-ease-out;
   box-shadow: $kz-shadow-small-box-shadow;
 }
@@ -38,7 +38,7 @@ $menu-footer-height: 80px;
   position: absolute;
   top: $ca-grid / 2;
   left: $ca-grid / 2;
-  color: $kz-color-cluny-500;
+  color: $kz-var-color-cluny-500;
   height: $hamburger-width;
   width: $hamburger-width;
   padding-bottom: $hamburger-layer-height;
@@ -51,7 +51,7 @@ $menu-footer-height: 80px;
 .hamburger {
   width: $hamburger-width;
   height: $hamburger-layer-height;
-  background-color: $kz-color-cluny-500;
+  background-color: $kz-var-color-cluny-500;
   position: relative;
   display: block;
 
@@ -62,7 +62,7 @@ $menu-footer-height: 80px;
     position: absolute;
     top: $hamburger-layer-height + $hamburger-layer-spacing;
     left: 0;
-    background-color: $kz-color-cluny-500;
+    background-color: $kz-var-color-cluny-500;
   }
 
   &::after {
@@ -72,7 +72,7 @@ $menu-footer-height: 80px;
     position: absolute;
     top: ($hamburger-layer-height + $hamburger-layer-spacing) * 2;
     left: 0;
-    background-color: $kz-color-cluny-500;
+    background-color: $kz-var-color-cluny-500;
   }
 }
 
@@ -94,7 +94,7 @@ $menu-footer-height: 80px;
   display: flex;
   align-items: center;
   justify-content: center;
-  color: $kz-color-white;
+  color: $kz-var-color-white;
   width: 22px;
   height: 22px;
 }

--- a/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/helpers/components/Header.module.scss
+++ b/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/helpers/components/Header.module.scss
@@ -1,9 +1,10 @@
-@import "~@kaizen/design-tokens/sass/color";
+@import "~@kaizen/design-tokens/sass/color-vars";
 @import "~@kaizen/component-library/styles/type";
 @import "~@kaizen/component-library/styles/layout";
 @import "~@kaizen/component-library/styles/color";
 @import "~@kaizen/component-library/styles/responsive";
 @import "~@kaizen/draft-zen-navigation-bar/KaizenDraft/ZenNavigationBar/_styles";
+@import "../../decision-tokens.scss";
 
 .root {
   @include ca-padding($end: $ca-grid / 2);
@@ -13,21 +14,20 @@
   align-items: center;
   justify-content: space-between;
   height: 60px;
-  background-color: $kz-color-wisteria-700;
+  background-color: $kz-var-color-wisteria-700;
   box-sizing: border-box;
 
   &.content {
-    background-color: $kz-color-cluny-200;
-    color: $kz-color-wisteria-800;
+    background-color: $dt-color-background-color-content;
+    color: $dt-color-text;
   }
 }
 
 .heading {
   @include font-heading-3;
-
-  color: $kz-color-white;
+  color: $kz-var-color-white;
 
   .content & {
-    color: $kz-color-wisteria-800;
+    color: $dt-color-text;
   }
 }

--- a/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/helpers/components/Menu.module.scss
+++ b/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/helpers/components/Menu.module.scss
@@ -1,4 +1,4 @@
-@import "~@kaizen/design-tokens/sass/color";
+@import "~@kaizen/design-tokens/sass/color-vars";
 @import "~@kaizen/component-library/styles/color";
 @import "~@kaizen/component-library/styles/type";
 @import "~@kaizen/component-library/styles/border";
@@ -9,12 +9,12 @@
   list-style-type: none;
 
   &.final {
-    border-top: 1px solid rgba($kz-color-wisteria-700, 0.1);
+    border-top: 1px solid rgba($kz-var-color-wisteria-700, 0.1);
     padding-top: 20px;
     margin-top: 20px;
   }
 }
 
 .active {
-  background-color: $kz-color-wisteria-700;
+  background-color: $kz-var-color-wisteria-700;
 }

--- a/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/helpers/components/Menu.module.scss
+++ b/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/helpers/components/Menu.module.scss
@@ -9,7 +9,7 @@
   list-style-type: none;
 
   &.final {
-    border-top: 1px solid rgba($kz-var-color-wisteria-700, 0.1);
+    border-top: 1px solid rgba($kz-var-color-wisteria-700-rgb-params, 0.1);
     padding-top: 20px;
     margin-top: 20px;
   }

--- a/packages/component-library/components/NavigationBar/NavigationBar.module.scss
+++ b/packages/component-library/components/NavigationBar/NavigationBar.module.scss
@@ -1,7 +1,6 @@
-@import "~@kaizen/design-tokens/sass/color";
 @import "~@kaizen/design-tokens/sass/border";
 @import "./styles";
-@import "../../styles/color";
+@import "./decision-tokens.scss";
 @import "../../styles/type";
 @import "../../styles/layout";
 @import "../../styles/responsive";
@@ -10,7 +9,7 @@
   @extend %ca-navigation-bar;
 
   &.kaizen {
-    background: $kz-color-wisteria-700;
+    background: $dt-color-background-color-default;
 
     a {
       color: white;
@@ -18,16 +17,16 @@
   }
 
   &.content {
-    background: $kz-color-cluny-200;
+    background: $dt-color-background-color-content;
 
     .links {
       a {
-        color: $kz-color-wisteria-800;
+        color: $dt-color-link;
         font-weight: 500;
       }
 
       .active a {
-        color: $kz-color-cluny-500;
+        color: $dt-color-link-active;
       }
     }
   }
@@ -58,7 +57,7 @@
 
     // Bit of a hack selector, but because of module scoping this is the easiest way
     .content & span::before {
-      background-color: $kz-color-cluny-500;
+      background-color: $dt-color-background-color-content-link;
       height: 5px;
       border-radius: 0 0 $kz-border-solid-border-radius
         $kz-border-solid-border-radius;
@@ -83,5 +82,5 @@
 }
 
 .kaizen .active {
-  background-color: $kz-color-wisteria-700;
+  background-color: $dt-color-background-color-default;
 }

--- a/packages/component-library/components/NavigationBar/_styles.scss
+++ b/packages/component-library/components/NavigationBar/_styles.scss
@@ -2,6 +2,7 @@
 @import "../../styles/color";
 @import "../../styles/type";
 @import "../../styles/responsive";
+@import "./decision-tokens.scss";
 
 $ca-navigation-bar__height: 2.5 * $ca-grid;
 
@@ -141,7 +142,7 @@ $link-margin: $ca-grid / 4;
 %ca-navigation-bar {
   display: flex;
   flex-direction: row;
-  background-color: $kz-color-wisteria-700;
+  background-color: $dt-color-background-color-default;
   height: $ca-navigation-bar__height;
   width: 100%;
   position: fixed;
@@ -161,7 +162,7 @@ $link-margin: $ca-grid / 4;
     // show custom focus ring when :focus-visible
     &:global(.focus-visible) {
       color: white;
-      outline: 2px solid $kz-color-cluny-500;
+      outline: 2px solid $kz-var-color-cluny-500;
     }
   }
 }

--- a/packages/component-library/components/NavigationBar/components/Badge.module.scss
+++ b/packages/component-library/components/NavigationBar/components/Badge.module.scss
@@ -1,10 +1,9 @@
-@import "~@kaizen/design-tokens/sass/color";
-@import "../../../styles/color";
 @import "../../../styles/type";
 @import "../styles";
+@import "../decision-tokens.scss";
 
 .badge {
-  background-color: $kz-color-coral-500;
+  background-color: $dt-color-badge-background-color;
   color: white;
   font-weight: $ca-weight-medium;
   text-decoration: none;
@@ -40,23 +39,23 @@
   }
 
   &.staging {
-    background-color: $kz-color-peach-500;
+    background-color: $dt-color-badge-background-color-staging;
   }
 
   &.named {
-    background-color: $kz-color-seedling-400;
+    background-color: $dt-color-badge-background-color-named;
   }
 
   &.test {
-    background-color: $kz-color-wisteria-400;
+    background-color: $dt-color-badge-background-color-test;
   }
 
   &.local {
-    background-color: $kz-color-cluny-300;
+    background-color: $dt-color-badge-background-color-local;
   }
 
   &.content {
-    background-color: $kz-color-cluny-200;
-    color: $kz-color-wisteria-800;
+    background-color: $dt-color-background-color-content;
+    color: $dt-color-badge-color-content;
   }
 }

--- a/packages/component-library/components/NavigationBar/components/Badge.module.scss
+++ b/packages/component-library/components/NavigationBar/components/Badge.module.scss
@@ -56,6 +56,6 @@
 
   &.content {
     background-color: $dt-color-background-color-content;
-    color: $dt-color-badge-color-content;
+    color: $dt-color-text;
   }
 }

--- a/packages/component-library/components/NavigationBar/components/Indicator.module.scss
+++ b/packages/component-library/components/NavigationBar/components/Indicator.module.scss
@@ -1,9 +1,9 @@
-@import "~@kaizen/design-tokens/sass/color";
 @import "~@kaizen/design-tokens/sass/spacing";
 @import "~@kaizen/component-library/styles/layout";
+@import "../decision-tokens.scss";
 
 .container {
   @include ca-margin($end: 4px);
   width: $kz-spacing-sm;
-  color: $kz-color-seedling-400;
+  color: $dt-color-indicator-color;
 }

--- a/packages/component-library/components/NavigationBar/components/Link.module.scss
+++ b/packages/component-library/components/NavigationBar/components/Link.module.scss
@@ -1,11 +1,12 @@
 @import "~@kaizen/design-tokens/sass/color";
 @import "~@kaizen/design-tokens/sass/border";
+@import "~@kaizen/deprecated-component-library-helpers/styles/type";
 @import "../styles";
 @import "../../../styles/border";
-@import "~@kaizen/deprecated-component-library-helpers/styles/type";
 @import "../../../styles/layout";
 @import "../../../styles/grid";
 @import "../../../styles/responsive";
+@import "../decision-tokens.scss";
 
 $nav-ease: cubic-bezier(0.55, 0.085, 0.68, 0.53);
 $nav-timing: 150ms;
@@ -62,12 +63,12 @@ $indicator-height: 3px;
   border-radius: $ca-grid;
   &.badgeNew {
     @include ca-padding($start: $ca-grid * 0.5, $end: $ca-grid * 0.5);
-    background-color: $kz-color-seedling-200;
-    color: $kz-color-wisteria-800;
+    background-color: $dt-color-badge-background-color-new;
+    color: $kz-var-color-wisteria-800;
   }
   &.badgeNotification {
     @include ca-padding($start: $ca-grid / 3, $end: $ca-grid / 3);
-    background-color: $kz-color-coral-500;
-    color: $kz-color-white;
+    background-color: $dt-color-badge-background-color;
+    color: $kz-var-color-white;
   }
 }

--- a/packages/component-library/components/NavigationBar/components/Menu.module.scss
+++ b/packages/component-library/components/NavigationBar/components/Menu.module.scss
@@ -1,12 +1,13 @@
 @import "~@kaizen/design-tokens/sass/color";
 @import "~@kaizen/design-tokens/sass/border";
+@import "~@kaizen/deprecated-component-library-helpers/styles/type";
 @import "../styles";
 @import "../../../styles/border";
 @import "../../../styles/color";
-@import "~@kaizen/deprecated-component-library-helpers/styles/type";
 @import "../../../styles/layers";
 @import "../../../styles/layout";
 @import "../../../styles/grid";
+@import "../decision-tokens.scss";
 
 $menu__square-size: $ca-grid * 2;
 
@@ -82,7 +83,7 @@ $menu__square-size: $ca-grid * 2;
     right: calc(#{$menu__square-size / 2} - #{$menu__arrow-size});
     border: $menu__arrow-size solid transparent;
     border-top-width: 0;
-    border-bottom-color: $kz-color-wisteria-800;
+    border-bottom-color: $dt-color-menu-background-color;
   }
 
   [dir="rtl"] &::before {
@@ -92,7 +93,7 @@ $menu__square-size: $ca-grid * 2;
 
   > * {
     color: white;
-    background-color: $kz-color-wisteria-800;
+    background-color: $dt-color-menu-background-color;
     border-radius: $kz-border-solid-border-radius;
     padding: 3px 0; // @TODO-DST - No magic padding
     white-space: nowrap;
@@ -137,12 +138,12 @@ $menu__square-size: $ca-grid * 2;
 
   &:hover,
   &.menuItemActive {
-    background-color: $kz-color-wisteria-700;
+    background-color: $dt-color-menu-background-color-active;
   }
 }
 
 .menuGroup {
-  border-top: 1px solid $kz-color-wisteria-700;
+  border-top: 1px solid $dt-color-menu-background-color-active;
   margin-top: $ca-grid / 2;
 
   &:first-child {
@@ -166,7 +167,7 @@ $menu__square-size: $ca-grid * 2;
 .offCanvasMenuGroupTitle {
   @extend .menuGroupTitle;
   font-size: 18px;
-  color: $kz-color-white;
+  color: $kz-var-color-white;
   padding: ($ca-grid / 2) $ca-grid;
 }
 
@@ -178,12 +179,12 @@ $menu__square-size: $ca-grid * 2;
   border-radius: $ca-grid;
   &.badgeNew {
     @include ca-padding($start: $ca-grid * 0.5, $end: $ca-grid * 0.5);
-    background-color: $kz-color-seedling-200;
-    color: $kz-color-wisteria-800;
+    background-color: $dt-color-badge-background-color-new;
+    color: $kz-var-color-wisteria-800;
   }
   &.badgeNotification {
     @include ca-padding($start: $ca-grid / 3, $end: $ca-grid / 3);
-    background-color: $kz-color-coral-500;
-    color: $kz-color-white;
+    background-color: $dt-color-badge-background-color;
+    color: $kz-var-color-white;
   }
 }

--- a/packages/component-library/components/NavigationBar/decision-tokens.scss
+++ b/packages/component-library/components/NavigationBar/decision-tokens.scss
@@ -1,0 +1,31 @@
+@import "~@kaizen/design-tokens/sass/color-vars";
+
+$dt-color-background-color-default: var(
+  --kz-var-color-wisteria-600,
+  $kz-var-color-wisteria-700
+);
+$dt-color-background-color-content: var(
+  --kz-var-color-cluny-100,
+  $kz-var-color-cluny-200
+);
+$dt-color-link: $kz-var-color-wisteria-800;
+$dt-color-link-active: $kz-var-color-cluny-500;
+$dt-color-background-color-content-link: $kz-var-color-cluny-500;
+
+$dt-color-badge-background-color: $kz-var-color-coral-500;
+$dt-color-badge-background-color-staging: $kz-var-color-peach-500;
+$dt-color-badge-background-color-named: $kz-var-color-seedling-400;
+$dt-color-badge-background-color-test: $kz-var-color-wisteria-400;
+$dt-color-badge-background-color-local: $kz-var-color-cluny-300;
+$dt-color-badge-background-color-new: $kz-var-color-seedling-200;
+$dt-color-badge-color-content: $kz-var-color-wisteria-800;
+$dt-color-indicator-color: $kz-var-color-seedling-400;
+
+$dt-color-menu-background-color: var(
+  --kz-var-color-wisteria-700,
+  $kz-var-color-wisteria-800
+);
+$dt-color-menu-background-color-active: var(
+  --kz-var-color-wisteria-600,
+  $kz-var-color-wisteria-700
+);

--- a/packages/component-library/stories/NavigationBar.stories.tsx
+++ b/packages/component-library/stories/NavigationBar.stories.tsx
@@ -3,13 +3,11 @@ import * as React from "react"
 import { Icon, Link, Menu, NavigationBar } from "@kaizen/component-library"
 
 import academyIcon from "@kaizen/component-library/icons/academy.icon.svg"
-
 import caMonogramIcon from "@kaizen/component-library/icons/ca-monogram.icon.svg"
-
 import supportIcon from "@kaizen/component-library/icons/support.icon.svg"
 
 export default {
-  title: "NavigationBar (React)",
+  title: "NavigationBar (deprecated) (React)",
   component: NavigationBar,
   parameters: {
     info: {


### PR DESCRIPTION
# Objective
Update navigation bar (both the component library and Zen packages) to support Heart. The changes here are: 
* Update to use the new `kz-var` variables
* Change default navigation bar  to be wisteria-600 on Heart, and keep wisteria-700 on Zen
* Change content navigation bar to be cluny-200 on Heart, and keep cluny-100 on Zen
* Add a separator on content and admin variants 

Related stories:
https://dev.cultureamp.design/ally/heart-navigation/storybook/?path=/story/zennavigationbar-react--admin-colours
https://dev.cultureamp.design/ally/heart-navigation/storybook/?path=/story/navigationbar-deprecated-react--content-colors

# Screenshots (if appropriate)
![Screen Shot 2021-02-23 at 11 05 56 am](https://user-images.githubusercontent.com/1621182/108786186-2be06500-75c7-11eb-8458-2a1992364303.png)
![Screen Shot 2021-02-23 at 11 05 47 am](https://user-images.githubusercontent.com/1621182/108786190-2d119200-75c7-11eb-813a-8b1cf5cbc5b5.png)
![Screen Shot 2021-02-23 at 11 07 18 am](https://user-images.githubusercontent.com/1621182/108786262-4fa3ab00-75c7-11eb-9405-469f26263839.png)
![Screen Shot 2021-02-23 at 11 07 10 am](https://user-images.githubusercontent.com/1621182/108786264-516d6e80-75c7-11eb-81cb-ffcde8081142.png)
![Screen Shot 2021-02-23 at 11 07 58 am](https://user-images.githubusercontent.com/1621182/108786304-6813c580-75c7-11eb-8c8f-f0a69f0adaf8.png)
![Screen Shot 2021-02-23 at 11 07 50 am](https://user-images.githubusercontent.com/1621182/108786308-6944f280-75c7-11eb-9a2a-b76c73c31dcf.png)

# Checklist
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] If this contains visual changes, has it been reviewed by a designer?
- [ ] If this introduces either a new component or a breaking change to an existing component, has it been reviewed by an advocate? (Ask in #prod_design_systems)
- [ ] I have considered likely risks of these changes and got someone else to QA as appropriate
- [ ] I have or will communicate these changes to the front end practice

# Additional Considerations
- Does there need to be right-to-left (RTL) options for localization and internationalization?
- Has the test suite been updated?
- Have you done cross-browser testing for our [supported browsers](https://academy.cultureamp.com/hc/en-us/articles/204539569-Supported-browsers-for-Participants)?
- Have you updated any relevant documentation or left useful comments in the code?
- Have you reviewed Culture Amp's Web Accessibility guide [Current Compliance, Going Forward, Statement and Answers for Customers](https://cultureamp.atlassian.net/wiki/spaces/Prod/pages/428572998/Web+Accessibility)?
- If this contains substantial visual changes, especially far-reaching ones, have you unlocked the Chromatic step in the pipeline?
- Have Storybook stories been updated?

**If you're new to Kaizen, please ask #prod_design_systems to set up an onboarding session to get you up to speed.** If you have an urgent PR to merge before that happens, it is safest to ask in #prod_design_systems to have a design system advocate review the PR to catch any issues.
