### PR TITLE
feat: Add automatic positioning for the Menu component, using popper

### DIFF
--- a/draft-packages/menu/KaizenDraft/Menu/MenuDropdown.tsx
+++ b/draft-packages/menu/KaizenDraft/Menu/MenuDropdown.tsx
@@ -40,7 +40,7 @@ const MenuDropdown = ({
         {
           name: "offset",
           options: {
-            offset: [0, parseInt(spacing.kz.spacing.xs, 10)],
+            offset: [0, parseInt(spacing?.kz.spacing.xs, 10)],
           },
         },
         {

--- a/draft-packages/menu/KaizenDraft/Menu/MenuDropdown.tsx
+++ b/draft-packages/menu/KaizenDraft/Menu/MenuDropdown.tsx
@@ -1,6 +1,5 @@
 import classnames from "classnames"
-import * as React from "react"
-
+import React, { useEffect, useRef } from "react"
 import styles from "./styles.scss"
 
 type MenuDropdownProps = {
@@ -15,68 +14,37 @@ type MenuDropdownProps = {
   align?: "left" | "right"
   width?: "default" | "contain"
   autoHide?: "on" | "outside-click-only" | "off"
+  children: React.ReactNode
 }
 
-class MenuDropdown extends React.Component<MenuDropdownProps> {
-  static displayName = "MenuDropdown"
+const MenuDropdown = ({
+  children,
+  position,
+  id,
+  hideMenuDropdown,
+  autoHide = "on",
+  align = "left",
+  width = "default",
+}: MenuDropdownProps) => {
+  const menu = useRef<HTMLDivElement | null>(null)
 
-  static defaultProps = {
-    autoHide: "on",
-  }
-
-  menu = React.createRef<HTMLDivElement>()
-
-  componentDidMount() {
-    const { autoHide } = this.props
-    if (autoHide !== "off") {
-      document.addEventListener(
-        "click",
-        this.handleDocumentClickForAutoHide,
-        false
-      )
-    }
-    window.addEventListener("resize", this.handleDocumentResize, false)
-    this.positionMenu()
-  }
-
-  componentWillUnmount() {
-    const { autoHide } = this.props
-    if (autoHide !== "off") {
-      document.removeEventListener(
-        "click",
-        this.handleDocumentClickForAutoHide,
-        false
-      )
-    }
-    window.removeEventListener("resize", this.handleDocumentResize, false)
-  }
-
-  componentWillUpdate(newProps) {
-    // Hm, I don't like hooks, but in this situation they would have been handy
-    if (this.props.autoHide === "off" && newProps.autoHide !== "off") {
-      document.addEventListener(
-        "click",
-        this.handleDocumentClickForAutoHide,
-        false
-      )
-    } else if (this.props.autoHide !== "off" && newProps.autoHide === "off") {
-      document.removeEventListener(
-        "click",
-        this.handleDocumentClickForAutoHide,
-        false
-      )
+  // This callback handler will not run when autoHide === "off"
+  const handleDocumentClickForAutoHide = (e: MouseEvent) => {
+    if (
+      menu?.current &&
+      e.target instanceof Node &&
+      !menu.current.contains(e.target)
+    ) {
+      hideMenuDropdown()
     }
   }
 
-  positionMenu() {
-    const menu = this.menu
-
-    if (!this.props.position || !menu) {
+  const positionMenu = () => {
+    if (!position || !menu) {
       return
     }
 
     if (menu.current) {
-      const pos = this.props.position
       const { innerHeight } = window
       const rect = menu.current.getBoundingClientRect()
       const offsetParentRect = menu.current.offsetParent?.getBoundingClientRect()
@@ -86,7 +54,7 @@ class MenuDropdown extends React.Component<MenuDropdownProps> {
       menu.current.style.bottom =
         // If the menu won't fit below the the menu button, show it above instead.
         // For some reason, a 5px buffer was needed.
-        pos.bottom + 5 > innerHeight - rect.height &&
+        position.bottom + 5 > innerHeight - rect.height &&
         // ...but, do not display it above the menu button, if there's not enough
         // room, otherwise the user won't even be able to scroll high enough to
         // see the menu items!
@@ -96,45 +64,49 @@ class MenuDropdown extends React.Component<MenuDropdownProps> {
     }
   }
 
-  // This callback handler will not run when autoHide === "off"
-  handleDocumentClickForAutoHide = (e: MouseEvent) => {
-    if (
-      this.menu?.current &&
-      e.target instanceof Node &&
-      !this.menu.current.contains(e.target)
-    ) {
-      this.props.hideMenuDropdown()
-    }
+  const handleDocumentResize = () => {
+    hideMenuDropdown()
   }
 
-  handleDocumentResize = () => {
-    this.props.hideMenuDropdown()
-  }
-
-  handleRootClick = (): void => {
-    const { autoHide, hideMenuDropdown } = this.props
+  const handleRootClick = (): void => {
     if (autoHide === "on") {
       // ie. is not equal to "off" | "outside-click-only"
       hideMenuDropdown()
     }
   }
 
-  render(): JSX.Element {
-    const { children, align = "left", width = "default" } = this.props
+  useEffect(() => {
+    if (autoHide !== "off") {
+      document.addEventListener("click", handleDocumentClickForAutoHide, false)
+    }
+    window.addEventListener("resize", handleDocumentResize, false)
+    positionMenu()
 
-    return (
-      <div
-        id={this.props.id}
-        className={classnames(styles.menuContainer, {
-          [styles.defaultWidth]: width == "default",
-          [styles.alignRight]: align == "right",
-        })}
-        ref={this.menu}
-        onClick={this.handleRootClick}
-      >
-        {children}
-      </div>
-    )
-  }
+    return () => {
+      if (autoHide !== "off") {
+        document.removeEventListener(
+          "click",
+          handleDocumentClickForAutoHide,
+          false
+        )
+      }
+      window.removeEventListener("resize", handleDocumentResize, false)
+    }
+  }, [autoHide])
+
+  return (
+    <div
+      id={id}
+      className={classnames(styles.menuContainer, {
+        [styles.defaultWidth]: width == "default",
+        [styles.alignRight]: align == "right",
+      })}
+      ref={menu}
+      onClick={handleRootClick}
+    >
+      {children}
+    </div>
+  )
 }
+
 export default MenuDropdown

--- a/draft-packages/menu/KaizenDraft/Menu/MenuDropdown.tsx
+++ b/draft-packages/menu/KaizenDraft/Menu/MenuDropdown.tsx
@@ -1,5 +1,6 @@
 import classnames from "classnames"
-import React, { useCallback, useEffect, useRef, useState } from "react"
+import { spacing } from "@kaizen/design-tokens/tokens/spacing"
+import React, { useCallback, useEffect, useState } from "react"
 import { usePopper } from "react-popper"
 import styles from "./styles.scss"
 
@@ -39,7 +40,7 @@ const MenuDropdown = ({
         {
           name: "offset",
           options: {
-            offset: [0, 6], // value used from the $kz-spacing-xs scss variable
+            offset: [0, parseInt(spacing.kz.spacing.xs, 10)],
           },
         },
         {

--- a/draft-packages/menu/KaizenDraft/Menu/StatelessMenu.tsx
+++ b/draft-packages/menu/KaizenDraft/Menu/StatelessMenu.tsx
@@ -32,7 +32,7 @@ export type StatelessMenuProps = {
    */
   children: React.ReactNode
   /**
-   * Render the tooltip inside a react portal, given the ccs selector.
+   * Render the tooltip inside a react portal, given the CSS selector.
    * This is typically used for instances where the menu is a descendant of an
    * `overflow: scroll` or `overflow: hidden` element.
    */

--- a/draft-packages/menu/KaizenDraft/Menu/StatelessMenu.tsx
+++ b/draft-packages/menu/KaizenDraft/Menu/StatelessMenu.tsx
@@ -1,31 +1,111 @@
-import { default as React, ReactElement, useRef } from "react"
-
-import { GenericMenuProps, render } from "./Menu"
+import { default as React, useEffect, useState } from "react"
+import ReactDOM from "react-dom"
 import styles from "./styles.scss"
+import MenuDropdown from "./MenuDropdown"
 
 export type StatelessMenuProps = {
+  /**
+   * Whether the menu is to be used on the left or right
+   * side of the viewport. If left, the left of the dropdown
+   * is aligned to the left of the button (and vice versa)
+   * @default "left"
+   */
+  align?: "left" | "right"
+
+  /**
+   * The width of the dropdown.
+   * "default": a fixed width of 248px
+   * "contain": contain the children's width (will be same width as children)
+   * @default "default"
+   */
+  dropdownWidth?: "default" | "contain"
+
+  automationId?: string
+  dropdownId?: string
+  /**
+   * Determines when the menu should automatically hide.
+   * @default: "on"
+   */
+  autoHide?: "on" | "outside-click-only" | "off"
+  /**
+   * The content to appear inside the dropdown when it is open
+   */
+  children: React.ReactNode
+  portalSelector?: string
   isMenuVisible: boolean
   toggleMenuDropdown: () => void
   hideMenuDropdown: () => void
   renderButton: (args: {
     onClick: (e: any) => void
     onMouseDown: (e: any) => void
+    "aria-haspopup": boolean
+    "aria-expanded": boolean
   }) => React.ReactElement
 }
 
-export type Props = StatelessMenuProps & GenericMenuProps
+export const StatelessMenu: React.FunctionComponent<StatelessMenuProps> = ({
+  align = "left",
+  dropdownWidth = "default",
+  autoHide = "on",
+  automationId,
+  dropdownId,
+  children,
+  portalSelector,
+  isMenuVisible,
+  toggleMenuDropdown,
+  hideMenuDropdown,
+  renderButton,
+}) => {
+  const [
+    referenceElement,
+    setReferenceElement,
+  ] = useState<HTMLSpanElement | null>(null)
+  const portalSelectorElement: Element | null = portalSelector
+    ? document.querySelector(portalSelector)
+    : null
 
-export const StatelessMenu: React.FunctionComponent<Props> = (props: Props) => {
-  const dropdownButtonContainer = useRef(null)
-
-  const menuButton = props.renderButton({
-    onMouseDown: (e: any) => e.preventDefault(),
+  const menuButton = renderButton({
     onClick: (e: any) => {
       e.stopPropagation()
-      props.toggleMenuDropdown()
+      toggleMenuDropdown()
     },
+    onMouseDown: (e: any) => e.preventDefault(),
+    "aria-haspopup": true,
+    "aria-expanded": isMenuVisible,
   })
-  return render({ ...props, dropdownButtonContainer, menuButton })
+
+  useEffect(() => {
+    if (portalSelector && !portalSelectorElement) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        "The portal could not be created using the selector: " + portalSelector
+      )
+    }
+  }, [portalSelectorElement, portalSelector])
+
+  const menu = isMenuVisible ? (
+    <MenuDropdown
+      referenceElement={referenceElement}
+      align={align}
+      hideMenuDropdown={hideMenuDropdown}
+      width={dropdownWidth}
+      id={dropdownId}
+      autoHide={autoHide}
+    >
+      {children}
+    </MenuDropdown>
+  ) : null
+
+  return (
+    <div data-automation-id={automationId}>
+      <div className={styles.buttonWrapper} ref={setReferenceElement}>
+        {menuButton}
+      </div>
+      {portalSelector && portalSelectorElement
+        ? ReactDOM.createPortal(menu, portalSelectorElement)
+        : menu}
+    </div>
+  )
 }
 
 export default StatelessMenu

--- a/draft-packages/menu/KaizenDraft/Menu/StatelessMenu.tsx
+++ b/draft-packages/menu/KaizenDraft/Menu/StatelessMenu.tsx
@@ -31,6 +31,11 @@ export type StatelessMenuProps = {
    * The content to appear inside the dropdown when it is open
    */
   children: React.ReactNode
+  /**
+   * Render the tooltip inside a react portal, given the ccs selector.
+   * This is typically used for instances where the menu is a descendant of an
+   * `overflow: scroll` or `overflow: hidden` element.
+   */
   portalSelector?: string
   isMenuVisible: boolean
   toggleMenuDropdown: () => void

--- a/draft-packages/menu/KaizenDraft/Menu/__snapshots__/Menu.spec.tsx.snap
+++ b/draft-packages/menu/KaizenDraft/Menu/__snapshots__/Menu.spec.tsx.snap
@@ -1,28 +1,30 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Dropdown renders default view 1`] = `
-<div
-  class="dropdown"
->
-  <span
-    class="container"
+<div>
+  <div
+    class="buttonWrapper"
   >
-    <button
-      aria-expanded="false"
-      aria-haspopup="true"
-      class="button"
-      type="button"
+    <span
+      class="container"
     >
-      <span
-        class="content"
+      <button
+        aria-expanded="false"
+        aria-haspopup="true"
+        class="button"
+        type="button"
       >
         <span
-          class="label"
+          class="content"
         >
-          Button
+          <span
+            class="label"
+          >
+            Button
+          </span>
         </span>
-      </span>
-    </button>
-  </span>
+      </button>
+    </span>
+  </div>
 </div>
 `;

--- a/draft-packages/menu/KaizenDraft/Menu/styles.scss
+++ b/draft-packages/menu/KaizenDraft/Menu/styles.scss
@@ -7,34 +7,17 @@
 
 $menu-container-width: 248px;
 
-.dropdown {
-  position: relative;
+.buttonWrapper {
+  display: inline-block;
 }
 
 .menuContainer {
-  margin-top: $kz-spacing-xs;
-  position: absolute;
   z-index: $ca-z-index-dropdown;
-  left: 0;
   width: auto;
-
-  [dir="rtl"] & {
-    left: auto;
-    right: 0;
-  }
 }
 
 .defaultWidth {
   width: $menu-container-width;
-}
-
-.alignRight {
-  right: 0;
-  left: auto;
-  [dir="rtl"] & {
-    right: auto;
-    left: 0;
-  }
 }
 
 .reversedColor {

--- a/draft-packages/menu/docs/Menu.stories.tsx
+++ b/draft-packages/menu/docs/Menu.stories.tsx
@@ -281,26 +281,71 @@ DropdownWidthContain.storyName = 'Label and Icon (dropdownWidth="contain")'
 
 export const MenuPositioning = () => (
   <StoryWrapper>
-    <Paragraph variant="body">
-      Note that this menu is near the top of page. Resize your browser so it's
-      about 300px high. Note that the menu still shows below the menu button.
-    </Paragraph>
-    <Menu
-      button={<Button label="Label" icon={chevronDown} iconPosition="end" />}
-    >
-      <MenuInstance />
-    </Menu>
     <div
       style={{
-        height: "500px",
-        display: "flex",
-        flexDirection: "column",
-        justifyContent: "flex-end",
+        position: "absolute",
+        top: "10px",
+        left: "10px",
+        width: "200px",
       }}
     >
       <Paragraph variant="body">
-        Note that this menu is near the bottom of the page. If there is no room
-        below, it will display above the menu button.
+        This menu is near the top of page. Resize your browser so it's about
+        300px high. Note that the menu still shows below the menu button.
+      </Paragraph>
+      <Menu
+        button={<Button label="Label" icon={chevronDown} iconPosition="end" />}
+      >
+        <MenuInstance />
+      </Menu>
+    </div>
+    <div
+      style={{
+        position: "absolute",
+        top: "10px",
+        right: "10px",
+        width: "200px",
+      }}
+    >
+      <Paragraph variant="body">
+        This menu is near right of the page. If there is no room to the right,
+        it push the menu to the left.
+      </Paragraph>
+      <Menu
+        button={<Button label="Label" icon={chevronDown} iconPosition="end" />}
+      >
+        <MenuInstance />
+      </Menu>
+    </div>
+    <div
+      style={{
+        position: "absolute",
+        bottom: "10px",
+        left: "10px",
+        width: "200px",
+      }}
+    >
+      <Paragraph variant="body">
+        This menu is near the bottom of the page. If there is no room below, it
+        will display above the menu button.
+      </Paragraph>
+      <Menu
+        button={<Button label="Label" icon={chevronDown} iconPosition="end" />}
+      >
+        <MenuInstance />
+      </Menu>
+    </div>
+    <div
+      style={{
+        position: "absolute",
+        bottom: "10px",
+        right: "10px",
+        width: "200px",
+      }}
+    >
+      <Paragraph variant="body">
+        This menu is near the bottom right of the page. If there is no room to
+        the right or bottom, it push the menu to the left and above.
       </Paragraph>
       <Menu
         button={<Button label="Label" icon={chevronDown} iconPosition="end" />}
@@ -341,3 +386,28 @@ export const MenuWithActiveItem = () => (
 )
 
 MenuWithActiveItem.storyName = "Menu with active item"
+
+export const OverflowScroll = () => (
+  <StoryWrapper>
+    <div style={{ overflowX: "scroll", width: "200px", height: "100px" }}>
+      <div style={{ width: "500px", textAlign: "center" }}>
+        <Menu
+          button={
+            <Button label="Label" icon={chevronDown} iconPosition="end" />
+          }
+          // Normally, you'd specify a div by ID, but since this is only in storybook,
+          // using `body` is fine (I think). DO NOT USE "BODY" AS A VALUE IN PRODUCTION.
+          portalSelector="body"
+        >
+          <MenuInstance />
+        </Menu>
+      </div>
+    </div>
+    <p>
+      Scroll the panel above, and open the menu. Notice that the dropdown does
+      not get cropped.
+    </p>
+  </StoryWrapper>
+)
+
+OverflowScroll.storyName = "overflow: scroll"

--- a/draft-packages/menu/package.json
+++ b/draft-packages/menu/package.json
@@ -35,13 +35,16 @@
     "@kaizen/component-library": "^9.1.0",
     "@kaizen/draft-button": "^3.1.9",
     "@types/classnames": "^2.2.10",
-    "classnames": "^2.2.6"
+    "@popperjs/core": "^2.6.0",
+    "classnames": "^2.2.6",
+    "react-popper": "^2.2.4"
   },
   "devDependencies": {
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
     "@kaizen/design-tokens": "1.6.0 || ^2",
-    "react": "^16.9.0"
+    "react": "^16.9.0",
+    "react-dom": "^16.9.0"
   }
 }

--- a/draft-packages/tooltip/KaizenDraft/Tooltip/Tooltip.tsx
+++ b/draft-packages/tooltip/KaizenDraft/Tooltip/Tooltip.tsx
@@ -1,5 +1,5 @@
 import { usePopper } from "react-popper"
-import React, { useState } from "react"
+import React, { useEffect, useState } from "react"
 import ReactDOM from "react-dom"
 import classnames from "classnames"
 import styles from "./Tooltip.scss"
@@ -129,6 +129,15 @@ const Tooltip = ({
   const portalSelectorElement: Element | null = portalSelector
     ? document.querySelector(portalSelector)
     : null
+
+  useEffect(() => {
+    if (portalSelector && !portalSelectorElement) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        "The portal could not be created using the selector: " + portalSelector
+      )
+    }
+  }, [portalSelectorElement, portalSelector])
 
   return (
     <>

--- a/draft-packages/tooltip/KaizenDraft/Tooltip/Tooltip.tsx
+++ b/draft-packages/tooltip/KaizenDraft/Tooltip/Tooltip.tsx
@@ -31,6 +31,8 @@ export type TooltipProps = {
   classNameAndIHaveSpokenToDST?: string
   /**
    * Render the tooltip inside a react portal, given the ccs selector.
+   * This is typically used for instances where the menu is a descendant of an
+   * `overflow: scroll` or `overflow: hidden` element.
    */
   portalSelector?: string
 }

--- a/draft-packages/tooltip/KaizenDraft/Tooltip/Tooltip.tsx
+++ b/draft-packages/tooltip/KaizenDraft/Tooltip/Tooltip.tsx
@@ -64,6 +64,14 @@ const TooltipContent = ({ position, text, referenceElement, tooltipId }) => {
             offset: [0, arrowHeight],
           },
         },
+        {
+          name: "preventOverflow",
+          options: {
+            // Makes sure that the tooltip isn't flush up against the end of the
+            // viewport
+            padding: 4,
+          },
+        },
       ],
       placement: position === "below" ? "bottom" : "top",
     }

--- a/draft-packages/tooltip/docs/Tooltip.stories.tsx
+++ b/draft-packages/tooltip/docs/Tooltip.stories.tsx
@@ -126,7 +126,7 @@ export const OverflowScroll = () => (
           display="inline-block"
           text="This should not get cropped"
           // Normally, you'd specify a div by ID, but since this is only in storybook,
-          // using `body` is fine (I think).
+          // using `body` is fine (I think). DO NOT USE "BODY" AS A VALUE IN PRODUCTION.
           portalSelector="body"
         >
           <Button label="Bottom" />
@@ -141,4 +141,4 @@ export const OverflowScroll = () => (
   </div>
 )
 
-OverflowScroll.storyName = "OverflowScroll"
+OverflowScroll.storyName = "overflow: scroll"


### PR DESCRIPTION
Add automatic positioning for the Menu component, using popper. This is similar to what was recently implemented for `Tooltip` ([PR 1](https://github.com/cultureamp/kaizen-design-system/pull/1041), [PR 2](https://github.com/cultureamp/kaizen-design-system/pull/1058)). It's basically so we can display a dropdown menu, even when inside a scrollable element. It will also automatically detect when a menu will go outside the viewport, and find the next best position for it. - 196973b, 6c9b00b

![image](https://user-images.githubusercontent.com/4495057/108950533-7c84ba80-76ba-11eb-9f45-7bf03b51a353.png)

![image](https://user-images.githubusercontent.com/4495057/108950552-85758c00-76ba-11eb-8ab9-c1eff9e40fa4.png)

# ⚠️  Contains BREAKING CHANGE
* `popper` has been integrated into the `Menu` components. Although I've tried to avoid adding breaking changes, I can't provide guarantees. Please test your dropdown menus after upgrading this package.

# Side tasks
* Convert `MenuItem` to a functional component - 1d58ba7
* Move code from the `Menu.render` function, into `StatelessMenu`. This was because I can't use hooks inside a regular function (well...you can, but the linter will complain). The other benefit is that it removes some of the duplicated code. - 229a711
* Fix to the tooltips, so they don't display flush up against the viewport - 196973b

Before:
![image](https://user-images.githubusercontent.com/4495057/108950956-3e3bcb00-76bb-11eb-9f77-8d1b30476f17.png)

After:
![image](https://user-images.githubusercontent.com/4495057/108950920-2ebc8200-76bb-11eb-8d10-93156186c9ae.png)

* Add a warning for tooltips if the portal selector does not find anything. This is to help developers, just in case there's a typo. Before it was failing silently. - ba5a136

![image](https://user-images.githubusercontent.com/4495057/108951019-57dd1280-76bb-11eb-877e-a9f4de5d167c.png)

# Checklist
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] If this contains visual changes, has it been reviewed by a designer?
- [x] If this introduces either a new component or a breaking change to an existing component, has it been reviewed by an advocate? (Ask in #prod_design_systems)
- [ ] I have considered likely risks of these changes and got someone else to QA as appropriate
- [ ] I have or will communicate these changes to the front end practice
