### PR TITLE
feat: Make LoadingSpinner inherit color

### DIFF
--- a/draft-packages/loading-spinner/KaizenDraft/LoadingSpinner/LoadingSpinner.tsx
+++ b/draft-packages/loading-spinner/KaizenDraft/LoadingSpinner/LoadingSpinner.tsx
@@ -39,13 +39,14 @@ export const LoadingSpinner = ({
           cx="24"
           cy="24"
           r="22.5"
-          stroke={colorTokens.kz.color.wisteria[200]}
+          stroke="currentColor"
           strokeWidth="3"
+          stroke-opacity="0.3"
         />
         <path
           fillRule="evenodd"
           clipRule="evenodd"
-          fill={colorTokens.kz.color.seedling[400]}
+          fill="currentColor"
           /* eslint-disable max-len */
           d="M46.5 24c.8284 0 1.5049-.6734 1.4539-1.5002C47.21 10.44 37.5601.789989 25.5003.0461639 24.6734-.004835 24 .671607 24 1.50003c0 .82843.6738 1.49444 1.5002 1.55277 10.4023.73424 18.7128 9.0447 19.447 19.447C45.0056 23.3262 45.6716 24 46.5 24z"
         />
@@ -63,13 +64,14 @@ export const LoadingSpinner = ({
           cx="12"
           cy="12"
           r="9"
-          stroke={colorTokens.kz.color.wisteria[200]}
+          stroke="currentColor"
+          stroke-opacity="0.3"
           strokeWidth="2"
         />
         <path
           fillRule="evenodd"
           clipRule="evenodd"
-          fill={colorTokens.kz.color.seedling[400]}
+          fill="currentColor"
           /* eslint-disable max-len */
           d="M21.0564 13c.5076 0 .9377-.3851.9431-.8926.0004-.0358.0005-.0716.0005-.1074 0-5.52285-4.4771-10-10-10-.0359 0-.0718.00019-.1076.00057-.5076.00535-.8926.43552-.8926.94308v.11543C10.9998 3.59163 11.4675 4 12 4c4.4183 0 8 3.58172 8 8 0 .5324.4083 1 .9407 1h.1157z"
         />

--- a/draft-packages/loading-spinner/docs/LoadingSpinner.stories.tsx
+++ b/draft-packages/loading-spinner/docs/LoadingSpinner.stories.tsx
@@ -1,7 +1,9 @@
 import * as React from "react"
 
 import { LoadingSpinner } from "@kaizen/draft-loading-spinner"
+import { Paragraph } from "@kaizen/component-library"
 import { withDesign } from "storybook-addon-designs"
+import colorTokens from "@kaizen/design-tokens/tokens/color.json"
 import { figmaEmbed } from "../../../storybook/helpers"
 
 export default {
@@ -20,12 +22,26 @@ export const DefaultStory = () => (
       alignItems: "center",
       display: "flex",
       justifyContent: "center",
+      flexDirection: "column",
+      color: colorTokens.kz.color.seedling["400"],
     }}
   >
-    <LoadingSpinner
-      accessibilityLabel="Loading comments"
-      size="md"
-    ></LoadingSpinner>
+    <div style={{ marginBottom: "3rem" }}>
+      <LoadingSpinner
+        accessibilityLabel="Loading comments"
+        size="md"
+      ></LoadingSpinner>
+    </div>
+    <Paragraph variant="body">
+      LoadingSpinner will inherit its color from the parent's <code>color</code>{" "}
+      property.
+      <br />
+      That color will become the foreground, and the background will be the same
+      color with 10% opacity.
+      <br />
+      When inside a button, it is intended to have the same color as the label
+      text.
+    </Paragraph>
   </div>
 )
 
@@ -37,6 +53,7 @@ export const SizeStory = () => (
       alignItems: "center",
       display: "flex",
       justifyContent: "center",
+      color: colorTokens.kz.color.wisteria["800"],
     }}
   >
     <LoadingSpinner


### PR DESCRIPTION
# ⚠️ BREAKING CHANGE: Consumers will now have to make sure that they are using LoadingSpinner in a context that provides the correct color property, since LoadingSpinner now no longer sets its own color but inherits it instead.

# Objective

Modifies the LoadingSpinner component to inherit its color rather than setting it.

# Motivation and Context

We needed this as part of the work required for the [secondary destructive variant of the Button](https://github.com/cultureamp/kaizen-design-system/pull/1109) (and it had to be done at some point anyway).

# Checklist
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] If this contains visual changes, has it been reviewed by a designer?
- [ ] If this introduces either a new component or a breaking change to an existing component, has it been reviewed by an advocate? (Ask in #prod_design_systems)
- [ ] I have considered likely risks of these changes and got someone else to QA as appropriate
- [x] I have or will communicate these changes to the front end practice