### PR TITLE
fix: export the ThemeContext

### DIFF
--- a/packages/design-tokens/react/ThemeProvider.tsx
+++ b/packages/design-tokens/react/ThemeProvider.tsx
@@ -1,7 +1,7 @@
 import React from "react"
 import { ThemeManager, defaultTheme, Theme } from "../"
 
-const ThemeContext = React.createContext<Theme>(defaultTheme)
+export const ThemeContext = React.createContext<Theme>(defaultTheme)
 
 /**
  * Wrap your application in this provider using a ThemeManager, to synchronise it with a react context.


### PR DESCRIPTION
Export the ThemeContext so that we can use the ThemeContext.Consumer element in a class component

Wanted to use it in a react class like so... 

```
        <ThemeContext.Consumer>
          {({ typography }) => ( ... ) }
        </ThemeContext.Consumer>
```

(if that's not the correct way to use a HoC please tell me)