### PR TITLE
feat: revert feat/menu-popper because is breaking Menu component

### DIFF
--- a/draft-packages/menu/KaizenDraft/Menu/Menu.tsx
+++ b/draft-packages/menu/KaizenDraft/Menu/Menu.tsx
@@ -1,30 +1,68 @@
 import { ButtonProps } from "@kaizen/draft-button"
-import React, { useState } from "react"
-import StatelessMenu, { StatelessMenuProps } from "./StatelessMenu"
+import React, { useRef, useState } from "react"
+import MenuDropdown from "./MenuDropdown"
 
-type ButtonPropsWithOptionalAria = ButtonProps & {
-  "aria-haspopup"?: boolean
-  "aria-expanded"?: boolean
-}
+import styles from "./styles.scss"
 
-export type MenuProps = Omit<
-  StatelessMenuProps,
-  "renderButton" | "hideMenuDropdown" | "toggleMenuDropdown" | "isMenuVisible"
-> & {
+export type GenericMenuProps = {
+  /**
+   * Whether the menu is to be used on the left or right
+   * side of the viewport. If left, the left of the dropdown
+   * is aligned to the left of the button (and vice versa)
+   * @default "left"
+   */
+  align?: "left" | "right"
+
+  /**
+   * The width of the dropdown.
+   * "default": a fixed width of 248px
+   * "contain": contain the children's width (will be same width as children)
+   * @default "default"
+   */
+  dropdownWidth?: "default" | "contain"
+
   /**
    * The initial state of the dropdown. Once initalised, further changes to this
    * prop will not have any affect, as the state is handled internally to the component.
    * @default: false
    */
   menuVisible?: boolean
+  automationId?: string
+  dropdownId?: string
+  /**
+   * Determines when the menu should automatically hide.
+   * @default: "on"
+   */
+  autoHide?: "on" | "outside-click-only" | "off"
+  /**
+   * The content to appear inside the dropdown when it is open
+   */
+  children: React.ReactNode
+}
+
+type ButtonPropsWithOptionalAria = ButtonProps & {
+  "aria-haspopup"?: boolean
+  "aria-expanded"?: boolean
+}
+
+type StatefulMenuProps = {
   button: React.ReactElement<ButtonPropsWithOptionalAria>
 }
 
-const Menu: React.FunctionComponent<MenuProps> = ({
-  button,
-  menuVisible = false,
-  ...rest
-}) => {
+export type MenuProps = GenericMenuProps & StatefulMenuProps
+
+type Menu = React.FunctionComponent<MenuProps>
+
+const Menu: Menu = props => {
+  const {
+    align = "left",
+    dropdownWidth = "default",
+    autoHide = "on",
+    menuVisible = false,
+  } = props
+
+  const dropdownButtonContainer: React.RefObject<HTMLDivElement> = useRef(null)
+
   const [isMenuVisible, setIsMenuVisible] = useState<boolean>(menuVisible)
 
   const toggleMenuDropdown = () => {
@@ -35,21 +73,64 @@ const Menu: React.FunctionComponent<MenuProps> = ({
     setIsMenuVisible(false)
   }
 
+  const { button } = props
+
+  return render({
+    ...props,
+    align,
+    autoHide,
+    isMenuVisible,
+    dropdownButtonContainer,
+    hideMenuDropdown,
+    menuButton: React.cloneElement(button, {
+      onClick: (e: any) => {
+        e.stopPropagation()
+        toggleMenuDropdown()
+      },
+      onMouseDown: (e: any) => e.preventDefault(),
+      "aria-haspopup": true,
+      "aria-expanded": isMenuVisible,
+    }),
+  })
+}
+
+type RenderProps = {
+  menuButton: React.ReactElement
+  isMenuVisible: boolean
+  dropdownButtonContainer: React.RefObject<HTMLDivElement>
+  hideMenuDropdown: () => void
+}
+
+export const render = (props: GenericMenuProps & RenderProps) => {
+  const menu = (
+    <MenuDropdown
+      position={getPosition(props.dropdownButtonContainer)}
+      align={props.align}
+      hideMenuDropdown={props.hideMenuDropdown}
+      width={props.dropdownWidth}
+      id={props.dropdownId}
+      autoHide={props.autoHide}
+    >
+      {props.children}
+    </MenuDropdown>
+  )
   return (
-    <StatelessMenu
-      {...rest}
-      isMenuVisible={isMenuVisible}
-      toggleMenuDropdown={toggleMenuDropdown}
-      hideMenuDropdown={hideMenuDropdown}
-      // `StatelessMenu` is one of the newer components, so it uses a render function,
-      // as opposed to `React.cloneElement`.
-      // `cloneElement` has its problems, mainly because it's somewhat magical, can lead
-      // to unexpected behaviour, and it doesn't self document. Hence, the switch
-      // to the render function. It would be nice if the `Menu` component also
-      // used this pattern, but it's probably not worth the time and effort.
-      renderButton={props => React.cloneElement(button, props)}
-    />
+    <div
+      className={styles.dropdown}
+      data-automation-id={props.automationId}
+      ref={props.dropdownButtonContainer}
+    >
+      {props.menuButton}
+      {props.isMenuVisible ? menu : null}
+    </div>
   )
 }
+
+const getPosition = (
+  dropdownButtonContainer: React.RefObject<HTMLDivElement>
+) =>
+  dropdownButtonContainer && dropdownButtonContainer.current
+    ? dropdownButtonContainer.current.getBoundingClientRect()
+    : null
 
 export default Menu

--- a/draft-packages/menu/KaizenDraft/Menu/MenuDropdown.tsx
+++ b/draft-packages/menu/KaizenDraft/Menu/MenuDropdown.tsx
@@ -1,7 +1,6 @@
 import classnames from "classnames"
-import { spacing } from "@kaizen/design-tokens/tokens/spacing"
-import React, { useCallback, useEffect, useState } from "react"
-import { usePopper } from "react-popper"
+import * as React from "react"
+
 import styles from "./styles.scss"
 
 type MenuDropdownProps = {
@@ -16,102 +15,126 @@ type MenuDropdownProps = {
   align?: "left" | "right"
   width?: "default" | "contain"
   autoHide?: "on" | "outside-click-only" | "off"
-  children: React.ReactNode
-  referenceElement: HTMLElement | null
 }
 
-const MenuDropdown = ({
-  children,
-  referenceElement,
-  id,
-  hideMenuDropdown,
-  autoHide = "on",
-  align = "left",
-  width = "default",
-}: MenuDropdownProps) => {
-  const [popperElement, setPopperElement] = useState<HTMLDivElement | null>(
-    null
-  )
-  const { styles: popperStyles, attributes } = usePopper(
-    referenceElement,
-    popperElement,
-    {
-      modifiers: [
-        {
-          name: "offset",
-          options: {
-            offset: [0, parseInt(spacing?.kz.spacing.xs, 10)],
-          },
-        },
-        {
-          name: "preventOverflow",
-          options: {
-            // Gives some room so the menu shadow doesn't get clipped if near the edge of the viewport.
-            padding: 8,
-          },
-        },
-      ],
-      placement: align === "left" ? "bottom-start" : "bottom-end",
+class MenuDropdown extends React.Component<MenuDropdownProps> {
+  static displayName = "MenuDropdown"
+
+  static defaultProps = {
+    autoHide: "on",
+  }
+
+  menu = React.createRef<HTMLDivElement>()
+
+  componentDidMount() {
+    const { autoHide } = this.props
+    if (autoHide !== "off") {
+      document.addEventListener(
+        "click",
+        this.handleDocumentClickForAutoHide,
+        false
+      )
     }
-  )
+    window.addEventListener("resize", this.handleDocumentResize, false)
+    this.positionMenu()
+  }
+
+  componentWillUnmount() {
+    const { autoHide } = this.props
+    if (autoHide !== "off") {
+      document.removeEventListener(
+        "click",
+        this.handleDocumentClickForAutoHide,
+        false
+      )
+    }
+    window.removeEventListener("resize", this.handleDocumentResize, false)
+  }
+
+  componentWillUpdate(newProps) {
+    // Hm, I don't like hooks, but in this situation they would have been handy
+    if (this.props.autoHide === "off" && newProps.autoHide !== "off") {
+      document.addEventListener(
+        "click",
+        this.handleDocumentClickForAutoHide,
+        false
+      )
+    } else if (this.props.autoHide !== "off" && newProps.autoHide === "off") {
+      document.removeEventListener(
+        "click",
+        this.handleDocumentClickForAutoHide,
+        false
+      )
+    }
+  }
+
+  positionMenu() {
+    const menu = this.menu
+
+    if (!this.props.position || !menu) {
+      return
+    }
+
+    if (menu.current) {
+      const pos = this.props.position
+      const { innerHeight } = window
+      const rect = menu.current.getBoundingClientRect()
+      const offsetParentRect = menu.current.offsetParent?.getBoundingClientRect()
+
+      const offsetParentHeight = offsetParentRect?.height || 0
+
+      menu.current.style.bottom =
+        // If the menu won't fit below the the menu button, show it above instead.
+        // For some reason, a 5px buffer was needed.
+        pos.bottom + 5 > innerHeight - rect.height &&
+        // ...but, do not display it above the menu button, if there's not enough
+        // room, otherwise the user won't even be able to scroll high enough to
+        // see the menu items!
+        rect.top - rect.height - offsetParentHeight - 10 >= 0
+          ? `${offsetParentHeight + 5}px`
+          : "auto"
+    }
+  }
 
   // This callback handler will not run when autoHide === "off"
-  const handleDocumentClickForAutoHide = useCallback(
-    (e: MouseEvent) => {
-      if (
-        popperElement &&
-        e.target instanceof Node &&
-        !popperElement.contains(e.target)
-      ) {
-        hideMenuDropdown()
-      }
-    },
-    [popperElement, hideMenuDropdown]
-  )
+  handleDocumentClickForAutoHide = (e: MouseEvent) => {
+    if (
+      this.menu?.current &&
+      e.target instanceof Node &&
+      !this.menu.current.contains(e.target)
+    ) {
+      this.props.hideMenuDropdown()
+    }
+  }
 
-  const handleDocumentResize = useCallback(() => {
-    hideMenuDropdown()
-  }, [hideMenuDropdown])
+  handleDocumentResize = () => {
+    this.props.hideMenuDropdown()
+  }
 
-  const handleRootClick = (): void => {
+  handleRootClick = (): void => {
+    const { autoHide, hideMenuDropdown } = this.props
     if (autoHide === "on") {
       // ie. is not equal to "off" | "outside-click-only"
       hideMenuDropdown()
     }
   }
 
-  useEffect(() => {
-    if (autoHide !== "off") {
-      document.addEventListener("click", handleDocumentClickForAutoHide, false)
-    }
-    window.addEventListener("resize", handleDocumentResize, false)
+  render(): JSX.Element {
+    const { children, align = "left", width = "default" } = this.props
 
-    return () => {
-      if (autoHide !== "off") {
-        document.removeEventListener(
-          "click",
-          handleDocumentClickForAutoHide,
-          false
-        )
-      }
-      window.removeEventListener("resize", handleDocumentResize, false)
-    }
-  }, [autoHide, handleDocumentClickForAutoHide, handleDocumentResize])
-
-  return (
-    <div
-      id={id}
-      ref={setPopperElement}
-      {...attributes.popper}
-      style={popperStyles.popper}
-      className={classnames(styles.menuContainer, {
-        [styles.defaultWidth]: width == "default",
-      })}
-      onClick={handleRootClick}
-    >
-      {children}
-    </div>
-  )
+    return (
+      <div
+        id={this.props.id}
+        className={classnames(styles.menuContainer, {
+          [styles.defaultWidth]: width == "default",
+          [styles.alignRight]: align == "right",
+        })}
+        ref={this.menu}
+        onClick={this.handleRootClick}
+      >
+        {children}
+      </div>
+    )
+  }
 }
-
 export default MenuDropdown

--- a/draft-packages/menu/KaizenDraft/Menu/StatelessMenu.tsx
+++ b/draft-packages/menu/KaizenDraft/Menu/StatelessMenu.tsx
@@ -1,116 +1,31 @@
-import { default as React, useEffect, useState } from "react"
-import ReactDOM from "react-dom"
+import { default as React, ReactElement, useRef } from "react"
+
+import { GenericMenuProps, render } from "./Menu"
 import styles from "./styles.scss"
-import MenuDropdown from "./MenuDropdown"
 
 export type StatelessMenuProps = {
-  /**
-   * Whether the menu is to be used on the left or right
-   * side of the viewport. If left, the left of the dropdown
-   * is aligned to the left of the button (and vice versa)
-   * @default "left"
-   */
-  align?: "left" | "right"
-
-  /**
-   * The width of the dropdown.
-   * "default": a fixed width of 248px
-   * "contain": contain the children's width (will be same width as children)
-   * @default "default"
-   */
-  dropdownWidth?: "default" | "contain"
-
-  automationId?: string
-  dropdownId?: string
-  /**
-   * Determines when the menu should automatically hide.
-   * @default: "on"
-   */
-  autoHide?: "on" | "outside-click-only" | "off"
-  /**
-   * The content to appear inside the dropdown when it is open
-   */
-  children: React.ReactNode
-  /**
-   * Render the tooltip inside a react portal, given the CSS selector.
-   * This is typically used for instances where the menu is a descendant of an
-   * `overflow: scroll` or `overflow: hidden` element.
-   */
-  portalSelector?: string
   isMenuVisible: boolean
   toggleMenuDropdown: () => void
   hideMenuDropdown: () => void
   renderButton: (args: {
     onClick: (e: any) => void
     onMouseDown: (e: any) => void
-    "aria-haspopup": boolean
-    "aria-expanded": boolean
   }) => React.ReactElement
 }
 
-export const StatelessMenu: React.FunctionComponent<StatelessMenuProps> = ({
-  align = "left",
-  dropdownWidth = "default",
-  autoHide = "on",
-  automationId,
-  dropdownId,
-  children,
-  portalSelector,
-  isMenuVisible,
-  toggleMenuDropdown,
-  hideMenuDropdown,
-  renderButton,
-}) => {
-  const [
-    referenceElement,
-    setReferenceElement,
-  ] = useState<HTMLSpanElement | null>(null)
-  const portalSelectorElement: Element | null = portalSelector
-    ? document.querySelector(portalSelector)
-    : null
+export type Props = StatelessMenuProps & GenericMenuProps
 
-  const menuButton = renderButton({
+export const StatelessMenu: React.FunctionComponent<Props> = (props: Props) => {
+  const dropdownButtonContainer = useRef(null)
+
+  const menuButton = props.renderButton({
+    onMouseDown: (e: any) => e.preventDefault(),
     onClick: (e: any) => {
       e.stopPropagation()
-      toggleMenuDropdown()
+      props.toggleMenuDropdown()
     },
-    onMouseDown: (e: any) => e.preventDefault(),
-    "aria-haspopup": true,
-    "aria-expanded": isMenuVisible,
   })
-
-  useEffect(() => {
-    if (portalSelector && !portalSelectorElement) {
-      // eslint-disable-next-line no-console
-      console.warn(
-        "The portal could not be created using the selector: " + portalSelector
-      )
-    }
-  }, [portalSelectorElement, portalSelector])
-
-  const menu = isMenuVisible ? (
-    <MenuDropdown
-      referenceElement={referenceElement}
-      align={align}
-      hideMenuDropdown={hideMenuDropdown}
-      width={dropdownWidth}
-      id={dropdownId}
-      autoHide={autoHide}
-    >
-      {children}
-    </MenuDropdown>
-  ) : null
-
-  return (
-    <div data-automation-id={automationId}>
-      <div className={styles.buttonWrapper} ref={setReferenceElement}>
-        {menuButton}
-      </div>
-      {portalSelector && portalSelectorElement
-        ? ReactDOM.createPortal(menu, portalSelectorElement)
-        : menu}
-    </div>
-  )
+  return render({ ...props, dropdownButtonContainer, menuButton })
 }
 
 export default StatelessMenu

--- a/draft-packages/menu/KaizenDraft/Menu/__snapshots__/Menu.spec.tsx.snap
+++ b/draft-packages/menu/KaizenDraft/Menu/__snapshots__/Menu.spec.tsx.snap
@@ -1,30 +1,28 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Dropdown renders default view 1`] = `
-<div>
-  <div
-    class="buttonWrapper"
+<div
+  class="dropdown"
+>
+  <span
+    class="container"
   >
-    <span
-      class="container"
+    <button
+      aria-expanded="false"
+      aria-haspopup="true"
+      class="button"
+      type="button"
     >
-      <button
-        aria-expanded="false"
-        aria-haspopup="true"
-        class="button"
-        type="button"
+      <span
+        class="content"
       >
         <span
-          class="content"
+          class="label"
         >
-          <span
-            class="label"
-          >
-            Button
-          </span>
+          Button
         </span>
-      </button>
-    </span>
-  </div>
+      </span>
+    </button>
+  </span>
 </div>
 `;

--- a/draft-packages/menu/KaizenDraft/Menu/styles.scss
+++ b/draft-packages/menu/KaizenDraft/Menu/styles.scss
@@ -7,17 +7,34 @@
 
 $menu-container-width: 248px;
 
-.buttonWrapper {
-  display: inline-block;
+.dropdown {
+  position: relative;
 }
 
 .menuContainer {
+  margin-top: $kz-spacing-xs;
+  position: absolute;
   z-index: $ca-z-index-dropdown;
+  left: 0;
   width: auto;
+
+  [dir="rtl"] & {
+    left: auto;
+    right: 0;
+  }
 }
 
 .defaultWidth {
   width: $menu-container-width;
+}
+
+.alignRight {
+  right: 0;
+  left: auto;
+  [dir="rtl"] & {
+    right: auto;
+    left: 0;
+  }
 }
 
 .reversedColor {

--- a/draft-packages/menu/docs/Menu.stories.tsx
+++ b/draft-packages/menu/docs/Menu.stories.tsx
@@ -281,71 +281,26 @@ DropdownWidthContain.storyName = 'Label and Icon (dropdownWidth="contain")'
 
 export const MenuPositioning = () => (
   <StoryWrapper>
+    <Paragraph variant="body">
+      Note that this menu is near the top of page. Resize your browser so it's
+      about 300px high. Note that the menu still shows below the menu button.
+    </Paragraph>
+    <Menu
+      button={<Button label="Label" icon={chevronDown} iconPosition="end" />}
+    >
+      <MenuInstance />
+    </Menu>
     <div
       style={{
-        position: "absolute",
-        top: "10px",
-        left: "10px",
-        width: "200px",
+        height: "500px",
+        display: "flex",
+        flexDirection: "column",
+        justifyContent: "flex-end",
       }}
     >
       <Paragraph variant="body">
-        This menu is near the top of page. Resize your browser so it's about
-        300px high. Note that the menu still shows below the menu button.
-      </Paragraph>
-      <Menu
-        button={<Button label="Label" icon={chevronDown} iconPosition="end" />}
-      >
-        <MenuInstance />
-      </Menu>
-    </div>
-    <div
-      style={{
-        position: "absolute",
-        top: "10px",
-        right: "10px",
-        width: "200px",
-      }}
-    >
-      <Paragraph variant="body">
-        This menu is near right of the page. If there is no room to the right,
-        it push the menu to the left.
-      </Paragraph>
-      <Menu
-        button={<Button label="Label" icon={chevronDown} iconPosition="end" />}
-      >
-        <MenuInstance />
-      </Menu>
-    </div>
-    <div
-      style={{
-        position: "absolute",
-        bottom: "10px",
-        left: "10px",
-        width: "200px",
-      }}
-    >
-      <Paragraph variant="body">
-        This menu is near the bottom of the page. If there is no room below, it
-        will display above the menu button.
-      </Paragraph>
-      <Menu
-        button={<Button label="Label" icon={chevronDown} iconPosition="end" />}
-      >
-        <MenuInstance />
-      </Menu>
-    </div>
-    <div
-      style={{
-        position: "absolute",
-        bottom: "10px",
-        right: "10px",
-        width: "200px",
-      }}
-    >
-      <Paragraph variant="body">
-        This menu is near the bottom right of the page. If there is no room to
-        the right or bottom, it push the menu to the left and above.
+        Note that this menu is near the bottom of the page. If there is no room
+        below, it will display above the menu button.
       </Paragraph>
       <Menu
         button={<Button label="Label" icon={chevronDown} iconPosition="end" />}
@@ -386,28 +341,3 @@ export const MenuWithActiveItem = () => (
 )
 
 MenuWithActiveItem.storyName = "Menu with active item"
-
-export const OverflowScroll = () => (
-  <StoryWrapper>
-    <div style={{ overflowX: "scroll", width: "200px", height: "100px" }}>
-      <div style={{ width: "500px", textAlign: "center" }}>
-        <Menu
-          button={
-            <Button label="Label" icon={chevronDown} iconPosition="end" />
-          }
-          // Normally, you'd specify a div by ID, but since this is only in storybook,
-          // using `body` is fine (I think). DO NOT USE "BODY" AS A VALUE IN PRODUCTION.
-          portalSelector="body"
-        >
-          <MenuInstance />
-        </Menu>
-      </div>
-    </div>
-    <p>
-      Scroll the panel above, and open the menu. Notice that the dropdown does
-      not get cropped.
-    </p>
-  </StoryWrapper>
-)
-
-OverflowScroll.storyName = "overflow: scroll"

--- a/draft-packages/menu/package.json
+++ b/draft-packages/menu/package.json
@@ -34,17 +34,14 @@
   "dependencies": {
     "@kaizen/component-library": "^9.1.2",
     "@kaizen/draft-button": "^3.2.1",
-    "@popperjs/core": "^2.6.0",
     "@types/classnames": "^2.2.10",
-    "classnames": "^2.2.6",
-    "react-popper": "^2.2.4"
+    "classnames": "^2.2.6"
   },
   "devDependencies": {
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
     "@kaizen/design-tokens": "^2.5.0",
-    "react": "^16.9.0",
-    "react-dom": "^16.9.0"
+    "react": "^16.9.0"
   }
 }

--- a/draft-packages/tooltip/KaizenDraft/Tooltip/Tooltip.tsx
+++ b/draft-packages/tooltip/KaizenDraft/Tooltip/Tooltip.tsx
@@ -1,5 +1,5 @@
 import { usePopper } from "react-popper"
-import React, { useEffect, useState } from "react"
+import React, { useState } from "react"
 import ReactDOM from "react-dom"
 import classnames from "classnames"
 import styles from "./Tooltip.scss"
@@ -31,8 +31,6 @@ export type TooltipProps = {
   classNameAndIHaveSpokenToDST?: string
   /**
    * Render the tooltip inside a react portal, given the ccs selector.
-   * This is typically used for instances where the menu is a descendant of an
-   * `overflow: scroll` or `overflow: hidden` element.
    */
   portalSelector?: string
 }
@@ -64,14 +62,6 @@ const TooltipContent = ({ position, text, referenceElement, tooltipId }) => {
           name: "offset",
           options: {
             offset: [0, arrowHeight],
-          },
-        },
-        {
-          name: "preventOverflow",
-          options: {
-            // Makes sure that the tooltip isn't flush up against the end of the
-            // viewport
-            padding: 4,
           },
         },
       ],
@@ -139,15 +129,6 @@ const Tooltip = ({
   const portalSelectorElement: Element | null = portalSelector
     ? document.querySelector(portalSelector)
     : null
-
-  useEffect(() => {
-    if (portalSelector && !portalSelectorElement) {
-      // eslint-disable-next-line no-console
-      console.warn(
-        "The portal could not be created using the selector: " + portalSelector
-      )
-    }
-  }, [portalSelectorElement, portalSelector])
 
   return (
     <>

--- a/draft-packages/tooltip/docs/Tooltip.stories.tsx
+++ b/draft-packages/tooltip/docs/Tooltip.stories.tsx
@@ -126,7 +126,7 @@ export const OverflowScroll = () => (
           display="inline-block"
           text="This should not get cropped"
           // Normally, you'd specify a div by ID, but since this is only in storybook,
-          // using `body` is fine (I think). DO NOT USE "BODY" AS A VALUE IN PRODUCTION.
+          // using `body` is fine (I think).
           portalSelector="body"
         >
           <Button label="Bottom" />
@@ -141,4 +141,4 @@ export const OverflowScroll = () => (
   </div>
 )
 
-OverflowScroll.storyName = "overflow: scroll"
+OverflowScroll.storyName = "OverflowScroll"


### PR DESCRIPTION
# Objective
Revert https://github.com/cultureamp/kaizen-design-system/pull/1110. 

# Motivation and Context
That last PR introduced a bug on `Menu` component exactly in one of the last commits --> https://github.com/cultureamp/kaizen-design-system/pull/1110/commits/ae49d577661fe2910aaaf8a960523009567f0eb5
When importing `spacing` from kaizen tokens
