### PR TITLE
fix: Menu crashing fix

### DIFF
--- a/draft-packages/menu/KaizenDraft/Menu/MenuDropdown.tsx
+++ b/draft-packages/menu/KaizenDraft/Menu/MenuDropdown.tsx
@@ -1,5 +1,4 @@
 import classnames from "classnames"
-import { spacing } from "@kaizen/design-tokens/tokens/spacing"
 import React, { useCallback, useEffect, useState } from "react"
 import { usePopper } from "react-popper"
 import styles from "./styles.scss"
@@ -40,7 +39,7 @@ const MenuDropdown = ({
         {
           name: "offset",
           options: {
-            offset: [0, parseInt(spacing?.kz.spacing.xs, 10)],
+            offset: [0, 6], // value used from the $kz-spacing-xs scss variable,
           },
         },
         {


### PR DESCRIPTION
# Objective
Fix an issue introduced in this PR https://github.com/cultureamp/kaizen-design-system/pull/1110 and more specific this commit --> https://github.com/cultureamp/kaizen-design-system/commit/ae49d577661fe2910aaaf8a960523009567f0eb5

# Motivation and Context
The problem introduced is that when importing `spacing` from `@kaizen/design-tokens/tokens/spacing` it was undefined and made crash the Menu component.
Use the value instead. This value was already used in the PR in this commit https://github.com/cultureamp/kaizen-design-system/pull/1110/commits/37e5223308559d554443c6d5b9910ab52814a42a so is ok.
