### PR TITLE
fix: error in useResizeObserver in Storybook

### DIFF
--- a/draft-packages/page-layout/KaizenDraft/useResizeObserver.ts
+++ b/draft-packages/page-layout/KaizenDraft/useResizeObserver.ts
@@ -36,7 +36,7 @@ export const useResizeObserver = <T, E extends Element = HTMLElement>(
 
   const ref: Ref<E> = useCallback(
     (node: E) => {
-      if (node !== undefined) {
+      if (node) {
         const resizeObserver = new ResizeObserver(
           (entries: ResizeObserverEntry[]) => {
             for (const entry of entries) {


### PR DESCRIPTION
# Objective
Fix error that happens sometimes in storybook when navigating between 2 stories. 


# Motivation and Context
It is happening because `node === null` instead of undefined. Not sure why is it happening, but this fixes that reliably.

```
useResizeObserver.js:35 Uncaught TypeError: Failed to execute 'observe' on 'ResizeObserver': parameter 1 is not of type 'Element'.
    at useResizeObserver.js:35
    at HTMLUnknownElement.callCallback (react-dom.development.js:188)
    at Object.invokeGuardedCallbackDev (react-dom.development.js:237)
    at invokeGuardedCallback (react-dom.development.js:292)
    at safelyDetachRef (react-dom.development.js:19602)
    at commitUnmount (react-dom.development.js:20118)
    at commitNestedUnmounts (react-dom.development.js:20163)
    at unmountHostComponents (react-dom.development.js:20443)
    at commitDeletion (react-dom.development.js:20500)
    at commitMutationEffects (react-dom.development.js:22782)
```


# Screenshots (if appropriate)

# Checklist
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] If this contains visual changes, has it been reviewed by a designer?
- [ ] If this introduces either a new component or a breaking change to an existing component, has it been reviewed by an advocate? (Ask in #prod_design_systems)
- [ ] I have considered likely risks of these changes and got someone else to QA as appropriate
- [ ] I have or will communicate these changes to the front end practice

# Additional Considerations
- Does there need to be right-to-left (RTL) options for localization and internationalization?
- Has the test suite been updated?
- Have you done cross-browser testing for our [supported browsers](https://academy.cultureamp.com/hc/en-us/articles/204539569-Supported-browsers-for-Participants)?
- Have you updated any relevant documentation or left useful comments in the code?
- Have you reviewed Culture Amp's Web Accessibility guide [Current Compliance, Going Forward, Statement and Answers for Customers](https://cultureamp.atlassian.net/wiki/spaces/Prod/pages/428572998/Web+Accessibility)?
- If this contains substantial visual changes, especially far reaching ones, have you unlocked the Chromatic step in the pipeline?
- Have Storybook stories been updated?

**If you're new to Kaizen, please ask #prod_design_systems to set up an onboarding session to get you up to speed.** If you have an urgent PR to merge before that happens, it is safest to ask in #prod_design_systems to have a design system advocate review the PR to catch any issues.
