### PR TITLE
feat: update LoadingPlaceholder to support Heart theme

### DIFF
--- a/draft-packages/loading-placeholder/KaizenDraft/LoadingPlaceholder/decision-tokens.scss
+++ b/draft-packages/loading-placeholder/KaizenDraft/LoadingPlaceholder/decision-tokens.scss
@@ -1,0 +1,29 @@
+@import "~@kaizen/design-tokens/sass/color-vars";
+@import "~@kaizen/design-tokens/sass/variable-identifiers";
+
+// Setting these variables on our container allows us to use rgba() while allowing cascading fallbacks.
+// If the `--kz-var-*` variables exist, then our `--loading-placeholder--*` variables will use these colours with alpha added.
+// If the `--kz-var-*` variables do not exist, then our `--loading-placeholder--*` variables will also be invalid.
+// Therefore when we use `--loading-placeholder--*` they will either correctly have alpha added, or trigger a fallback.
+@mixin loading-placeholder-theme-switching-tokens() {
+  --loading-placeholder--color-background-default: rgba(
+    var(#{$kz-var-id-color-slate-rgb-params}),
+    0.1
+  );
+  --loading-placeholder--color-background-reversed: rgba(
+    var(#{$kz-var-id-color-white-rgb-params}),
+    0.1
+  );
+}
+
+// Decision tokens for background colours based on presence of CSS variables.
+// If the `--kz-var-*` variable is missing, our `--loading-placeholder--*` variables will be invalid, and the Zen tokens are used as a fallback.
+$dt-color-background-default: var(
+  --loading-placeholder--color-background-default,
+  $kz-color-wisteria-200
+);
+
+$dt-color-background-reversed: var(
+  --loading-placeholder--color-background-reversed,
+  rgba($kz-color-white, 0.65)
+);

--- a/draft-packages/loading-placeholder/KaizenDraft/LoadingPlaceholder/styles.scss
+++ b/draft-packages/loading-placeholder/KaizenDraft/LoadingPlaceholder/styles.scss
@@ -45,7 +45,7 @@
 }
 
 .reversedOcean {
-  background-color: $kz-var-color-cluny-300;
+  background-color: var($kz-var-id-color-cluny-200, $kz-var-color-cluny-300);
 }
 
 .normal {

--- a/draft-packages/loading-placeholder/KaizenDraft/LoadingPlaceholder/styles.scss
+++ b/draft-packages/loading-placeholder/KaizenDraft/LoadingPlaceholder/styles.scss
@@ -1,7 +1,7 @@
 @import "~@kaizen/design-tokens/sass/color-vars";
 @import "~@kaizen/design-tokens/sass/border-vars";
-@import "~@kaizen/component-library/styles/animation";
-@import "~@kaizen/deprecated-component-library-helpers/styles/color";
+@import "~@kaizen/design-tokens/sass/animation-vars";
+@import "~@kaizen/design-tokens/sass/spacing-vars";
 @import "~@kaizen/deprecated-component-library-helpers/styles/layout";
 @import "~@kaizen/deprecated-component-library-helpers/styles/type";
 @import "./decision-tokens";
@@ -13,8 +13,8 @@
   background-color: $dt-color-background-default;
   border-radius: calc(#{$kz-var-border-solid-border-radius} * 3);
   position: relative;
-  top: $ca-grid * 0.175;
-  margin-bottom: $ca-grid * 0.5;
+  top: calc(#{$kz-var-spacing-md} * 0.175);
+  margin-bottom: calc(#{$kz-var-spacing-md} * 0.5);
 }
 
 @keyframes fadeInOut {
@@ -31,7 +31,7 @@
 
 .animated {
   animation-name: fadeInOut;
-  animation-duration: $ca-duration-deliberate * 2;
+  animation-duration: calc(#{$kz-var-animation-duration-deliberate} * 2);
   animation-iteration-count: infinite;
 }
 
@@ -49,21 +49,21 @@
 }
 
 .normal {
-  height: $ca-grid * 0.625;
+  height: calc(#{$kz-var-spacing-md} * 0.625);
 }
 
 .tall {
-  top: $ca-grid * 0.25;
-  height: $ca-grid * 0.725;
+  top: calc(#{$kz-var-spacing-md} * 0.25);
+  height: calc(#{$kz-var-spacing-md} * 0.725);
 }
 
 .inline {
   display: inline-block;
-  margin-bottom: $ca-grid * 0.35;
+  margin-bottom: calc(#{$kz-var-spacing-md} * 0.35);
 }
 
 .inline + .inline {
-  @include ca-margin($start: $ca-grid);
+  @include ca-margin($start: $kz-var-spacing-md);
 }
 
 .noBottomMargin {

--- a/draft-packages/loading-placeholder/KaizenDraft/LoadingPlaceholder/styles.scss
+++ b/draft-packages/loading-placeholder/KaizenDraft/LoadingPlaceholder/styles.scss
@@ -1,15 +1,17 @@
-@import "~@kaizen/design-tokens/sass/color";
 @import "~@kaizen/design-tokens/sass/color-vars";
-@import "~@kaizen/design-tokens/sass/border";
+@import "~@kaizen/design-tokens/sass/border-vars";
 @import "~@kaizen/component-library/styles/animation";
-@import "~@kaizen/component-library/styles/border";
 @import "~@kaizen/deprecated-component-library-helpers/styles/color";
 @import "~@kaizen/deprecated-component-library-helpers/styles/layout";
 @import "~@kaizen/deprecated-component-library-helpers/styles/type";
+@import "./decision-tokens";
 
 .base {
-  background-color: $kz-color-wisteria-100;
-  border-radius: $kz-border-solid-border-radius * 3;
+  // We need to set some CSS Custom Properties on our container for theme switching to work.
+  @include loading-placeholder-theme-switching-tokens;
+
+  background-color: $dt-color-background-default;
+  border-radius: calc(#{$kz-var-border-solid-border-radius} * 3);
   position: relative;
   top: $ca-grid * 0.175;
   margin-bottom: $ca-grid * 0.5;
@@ -39,11 +41,11 @@
 }
 
 .reversedDefault {
-  background-color: rgba($kz-var-color-white-rgb-params, 0.5);
+  background-color: $dt-color-background-reversed;
 }
 
 .reversedOcean {
-  background-color: $kz-color-cluny-300;
+  background-color: $kz-var-color-cluny-300;
 }
 
 .normal {


### PR DESCRIPTION
Note about Zen fallback:
- The "Zen" fallbacks are actually updated in this PR to match the Zen UI Kit.
- Zen default bg was Wisteria 100, now Wisteria 200
- Zen reversed bg was white 50% opacity, now white 65% opacity

The pattern I've used to add alpha to the token _only if using the custom property_
relies on cascading fallbacks in CSS Custom Properties.

I did a codepen to demonstrate how this works:
https://codepen.io/jasononeil/pen/vYyjzMz?editors=1100

Alternatively, I could use React Context to get the theme, but that won't work with the Elm version.

:shrug:

# Objective
<!-- Describe what this change achieves, and the details of how it works. -->

# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

# Screenshots (if appropriate)

# Checklist
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] If this contains visual changes, has it been reviewed by a designer?
- [ ] If this introduces either a new component or a breaking change to an existing component, has it been reviewed by an advocate? (Ask in #prod_design_systems)
- [ ] I have considered likely risks of these changes and got someone else to QA as appropriate
- [ ] I have or will communicate these changes to the front end practice

# Additional Considerations
- Does there need to be right-to-left (RTL) options for localization and internationalization?
- Has the test suite been updated?
- Have you done cross-browser testing for our [supported browsers](https://academy.cultureamp.com/hc/en-us/articles/204539569-Supported-browsers-for-Participants)?
- Have you updated any relevant documentation or left useful comments in the code?
- Have you reviewed Culture Amp's Web Accessibility guide [Current Compliance, Going Forward, Statement and Answers for Customers](https://cultureamp.atlassian.net/wiki/spaces/Prod/pages/428572998/Web+Accessibility)?
- If this contains substantial visual changes, especially far reaching ones, have you unlocked the Chromatic step in the pipeline?
- Have Storybook stories been updated?

**If you're new to Kaizen, please ask #prod_design_systems to set up an onboarding session to get you up to speed.** If you have an urgent PR to merge before that happens, it is safest to ask in #prod_design_systems to have a design system advocate review the PR to catch any issues.
