### PR TITLE
feat: Add popper layout engine to `Popover`

### DIFF
--- a/draft-packages/popover/KaizenDraft/Popover/Popover.elm
+++ b/draft-packages/popover/KaizenDraft/Popover/Popover.elm
@@ -209,13 +209,17 @@ view (Config config) =
             ]
         , div
             [ styles.classList
-                [ ( mapArrowVariantToClass config.variant, True )
-                , ( mapArrowSideToClass side, True )
+                [ ( mapArrowSideToClass side, True )
                 , ( mapArrowPositionToClass position, True )
+                ], styles.class .arrowWrapper
+            ] [
+              div
+                [ styles.classList
+                  [ ( mapArrowVariantToClass config.variant, True ) ]
+                , styles.class .arrow
                 ]
-            , getArrowStyle side
+                []
             ]
-            []
         ]
 
 
@@ -230,6 +234,8 @@ styles =
         , cautionaryBox = "cautionaryBox"
         , header = "header"
         , icon = "icon"
+        , arrow = "arrow"
+        , arrowWrapper = "arrowWrapper"
         , close = "close"
         , informativeArrow = "informativeArrow"
         , positiveArrow = "positiveArrow"
@@ -274,17 +280,6 @@ mapVariantToBoxClass variant =
 
         Cautionary ->
             .cautionaryBox
-
-
-getArrowStyle : Side -> Attribute msg
-getArrowStyle side =
-    case side of
-        Top ->
-            style "transform" "rotate(180deg)"
-
-        Bottom ->
-            style "" ""
-
 
 mapVariantToIconClass : Variant -> { b | informativeIcon : a, positiveIcon : a, negativeIcon : a, cautionaryIcon : a } -> a
 mapVariantToIconClass variant =
@@ -371,6 +366,10 @@ mapArrowPositionToClass position =
 mapArrowSideToClass : Side -> { b | arrowSideTop : a, arrowSideBottom : a } -> a
 mapArrowSideToClass side =
     case side of
+        -- In the legacy popover, the "side" described the location of the arrow.
+        -- In the modern popover, the "side" describes the location of the popover
+        -- relative to the reference element.
+        -- This elm component is the legacy type.
         Bottom ->
             .arrowSideBottom
 

--- a/draft-packages/popover/KaizenDraft/Popover/PopoverLegacy.tsx
+++ b/draft-packages/popover/KaizenDraft/Popover/PopoverLegacy.tsx
@@ -1,0 +1,146 @@
+import { Icon } from "@kaizen/component-library"
+import closeIcon from "@kaizen/component-library/icons/close.icon.svg"
+
+import classNames from "classnames"
+import * as React from "react"
+
+import styles from "./styles.scss"
+import { Size, Variant } from "./types"
+import {
+  mapArrowVariantToClass,
+  mapLineVariant,
+  mapSizeToClass,
+  mapVariantToBoxClass,
+  mapVariantToIcon,
+  mapVariantToIconClass,
+} from "./classMappers"
+
+export type Side = "top" | "bottom"
+
+export type Position = "start" | "center" | "end"
+
+export type PopoverLegacyProps = {
+  readonly automationId?: string
+  readonly visible?: boolean
+  readonly onClose?: (event: React.MouseEvent<HTMLButtonElement>) => any
+  readonly variant?: Variant
+  readonly side?: Side
+  readonly size?: Size
+  readonly position?: Position
+  readonly heading?: string
+  readonly dismissible?: boolean
+  readonly singleLine?: boolean
+  readonly children: React.ReactNode
+  /** For almost all intents and purposes, you should be using a pre-defined variant.
+   Please avoid using a custom icon unless you have a very good reason to do so. **/
+  readonly customIcon?: React.SVGAttributes<SVGSymbolElement>
+}
+
+/**
+ * Used for the legacy popover only. For the new popover, the position of the
+ * arrow is determined by popper.
+ */
+const mapArrowPositionToClass = (position: Position): string => {
+  switch (position) {
+    case "start":
+      return styles.arrowPositionStart
+    case "end":
+      return styles.arrowPositionEnd
+    case "center":
+      return styles.arrowPositionCenter
+    default:
+      return ""
+  }
+}
+
+/**
+ * Used for the legacy popover only.
+ * In the legacy popover, the "side" described the location of the arrow.
+ * In the modern popover, the "side" describes the location of the popover
+ * relative to the reference element.
+ */
+const mapArrowSideToClass = (side: Side): string => {
+  switch (side) {
+    case "top":
+      return styles.arrowSideTop
+    default:
+      return styles.arrowSideBottom
+  }
+}
+
+type PopoverLegacy = React.FunctionComponent<PopoverLegacyProps>
+
+/**
+ * Please use `usePopover` or `Popover` instead
+ * @deprecated
+ */
+export const PopoverLegacy: PopoverLegacy = React.forwardRef<
+  HTMLDivElement,
+  PopoverLegacyProps
+>(
+  (
+    {
+      automationId,
+      children,
+      variant = "default",
+      side = "bottom",
+      size = "small",
+      position = "center",
+      heading,
+      dismissible = false,
+      onClose,
+      singleLine = false,
+      customIcon,
+    },
+    ref
+  ) => (
+    <div
+      className={classNames(styles.root, mapSizeToClass(size))}
+      style={{ transform: "translateX(-50%)" }}
+      ref={ref}
+      data-automation-id={automationId}
+    >
+      <div className={mapVariantToBoxClass(variant)}>
+        {heading && (
+          <div className={styles.header}>
+            {variant !== "default" && (
+              <span
+                className={classNames(
+                  styles.icon,
+                  mapVariantToIconClass(variant)
+                )}
+              >
+                <Icon
+                  role="presentation"
+                  icon={customIcon ? customIcon : mapVariantToIcon(variant)}
+                />
+              </span>
+            )}
+            <div className={styles.singleLine}>{heading}</div>
+            {dismissible && (
+              <button className={styles.close} onClick={onClose}>
+                <Icon role="presentation" icon={closeIcon} />
+              </button>
+            )}
+          </div>
+        )}
+        <div
+          className={classNames(styles.container, mapLineVariant(singleLine))}
+        >
+          {children}
+        </div>
+      </div>
+      <div
+        className={classNames(
+          styles.arrowWrapper,
+          mapArrowSideToClass(side),
+          mapArrowPositionToClass(position)
+        )}
+      >
+        <div
+          className={classNames(styles.arrow, mapArrowVariantToClass(variant))}
+        />
+      </div>
+    </div>
+  )
+)

--- a/draft-packages/popover/KaizenDraft/Popover/classMappers.ts
+++ b/draft-packages/popover/KaizenDraft/Popover/classMappers.ts
@@ -1,0 +1,85 @@
+import * as React from "react"
+import informativeIcon from "@kaizen/component-library/icons/information.icon.svg"
+import positiveIcon from "@kaizen/component-library/icons/success.icon.svg"
+import negativeIcon from "@kaizen/component-library/icons/exclamation.icon.svg"
+import styles from "./styles.scss"
+import { Size, Variant } from "./types"
+
+export const mapVariantToBoxClass = (variant: Variant): string => {
+  switch (variant) {
+    case "informative":
+      return styles.informativeBox
+    case "positive":
+      return styles.positiveBox
+    case "negative":
+      return styles.negativeBox
+    case "cautionary":
+      return styles.cautionaryBox
+    default:
+      return styles.defaultBox
+  }
+}
+
+export const mapVariantToIconClass = (variant: Variant) => {
+  switch (variant) {
+    case "informative":
+      return styles.informativeIcon
+    case "positive":
+      return styles.positiveIcon
+    case "negative":
+      return styles.negativeIcon
+    case "cautionary":
+      return styles.cautionaryIcon
+    default:
+      return undefined
+  }
+}
+
+export const mapVariantToIcon = (
+  variant: Variant
+): React.SVGAttributes<SVGSymbolElement> => {
+  switch (variant) {
+    case "informative":
+      return informativeIcon
+    case "positive":
+      return positiveIcon
+    case "negative":
+      return negativeIcon
+    case "cautionary":
+      return negativeIcon
+    default:
+      return informativeIcon
+  }
+}
+
+export const mapArrowVariantToClass = (variant: Variant): string => {
+  switch (variant) {
+    case "informative":
+      return styles.informativeArrow
+    case "positive":
+      return styles.positiveArrow
+    case "negative":
+      return styles.negativeArrow
+    case "cautionary":
+      return styles.cautionaryArrow
+    default:
+      return styles.defaultArrow
+  }
+}
+
+export const mapSizeToClass = (size: Size): string => {
+  switch (size) {
+    case "large":
+      return styles.large
+    default:
+      return ""
+  }
+}
+
+export const mapLineVariant = (singleLine: boolean): string => {
+  if (singleLine === true) {
+    return styles.singleLine
+  } else {
+    return ""
+  }
+}

--- a/draft-packages/popover/KaizenDraft/Popover/index.ts
+++ b/draft-packages/popover/KaizenDraft/Popover/index.ts
@@ -1,1 +1,2 @@
-export { default as Popover, Props as PopoverProps } from "./Popover"
+export { usePopover, Popover, PopoverProps } from "./Popover"
+export { PopoverLegacy, PopoverLegacyProps } from "./PopoverLegacy"

--- a/draft-packages/popover/KaizenDraft/Popover/styles.scss
+++ b/draft-packages/popover/KaizenDraft/Popover/styles.scss
@@ -9,37 +9,34 @@
 @import "~@kaizen/component-library/components/Button/styles";
 @import "~@kaizen/deprecated-component-library-helpers/styles/type";
 
-/* The bordered part of the triangle */
-$default-size: 8px;
-$large: 450px;
+// Sync with PopoverModern.tsx
+$arrow-width: 16px;
+$arrow-height: 8px;
+
+$large-width: 450px;
 
 // Suggestion: with this implementation, the anchor point of the popover is at the base of the triangle. But,
 // we would ideally want it at the tip of the triangle. Otherwise, when using the popover, the consumer needs to manually
 // add something like a `margin-top: 8px` to get the popover properly positioned.
 // I didn't update this, as I didn't want to introduce a breaking change.
-@mixin arrow($background-color, $border-color, $size: $default-size) {
-  position: absolute;
-  top: 100%;
-  left: 50%;
-
+@mixin arrow($background-color, $border-color) {
   &::before,
   &::after {
     content: "";
     position: absolute;
-    border-left: $size solid transparent;
-    border-right: $size solid transparent;
+    border-left: ($arrow-width / 2) solid transparent;
+    border-right: ($arrow-width / 2) solid transparent;
     top: 0;
     left: 0;
-    margin-left: -$size;
   }
 
   &::before {
-    border-top: $size solid $border-color;
+    border-top: $arrow-height solid $border-color;
   }
 
   /* The white fill of the triangle */
   &::after {
-    border-top: $size solid $background-color;
+    border-top: $arrow-height solid $background-color;
     margin-top: -2px;
     z-index: 1;
   }
@@ -155,32 +152,56 @@ $large: 450px;
   color: rgba(black, 0.5);
 }
 
-.arrowSideBottom {
-  // This is just an empty class to satisfy Elm's case statement
-  // (we were in a rush and the linter wouldn't let an empty class through.)
-  // Can be refactored out!
-  visibility: visible;
+.arrowWrapper {
+  position: absolute;
+  // Needed by popper, so it measures the size of the arrow correctly
+  width: $arrow-width;
+  height: $arrow-height;
 }
 
-.arrowSideTop {
-  top: initial;
+.arrow {
+  // Needed by popper, so it measures the size of the arrow correctly
+  width: $arrow-width;
+  height: $arrow-height;
+}
+
+/**
+ * In the legacy popover, the "side" described the location of the arrow, and
+ * we use css classes to determine the placement.
+ * In the modern popover, the "side" describes the location of the popover
+ * relative to the reference element, and we use data attributes to determine
+ * the placement.
+ * Hence, the confusion below.
+ */
+.arrowSideTop,
+[data-popper-placement^="bottom"] .arrowWrapper {
   bottom: 100%;
-  margin-top: 1px;
-  // Also see getArrowStyle in the component file, which will rotate the arrow 180 degrees
+  left: 50%;
+  margin-top: -$arrow-height;
+
+  .arrow {
+    transform: rotate(180deg);
+  }
 }
 
+.arrowSideBottom,
+[data-popper-placement^="top"] .arrowWrapper {
+  top: 100%;
+  left: 50%;
+}
+
+// Legacy component only
 .arrowPositionCenter {
-  // This is just an empty class to satisfy Elm's case statement
-  // (we were in a rush and the linter wouldn't let an empty class through.)
-  // Can be refactored out!
-  visibility: visible;
+  transform: translateX(-50%);
 }
 
+// Legacy component only
 .arrowPositionStart {
   left: $ca-grid;
   right: auto;
 }
 
+// Legacy component only
 .arrowPositionEnd {
   right: $ca-grid;
   left: auto;
@@ -188,7 +209,7 @@ $large: 450px;
 
 .large {
   width: auto;
-  max-width: $large;
+  max-width: $large-width;
 }
 
 .singleLine {

--- a/draft-packages/popover/KaizenDraft/Popover/types.ts
+++ b/draft-packages/popover/KaizenDraft/Popover/types.ts
@@ -1,0 +1,8 @@
+export type Variant =
+  | "default"
+  | "informative"
+  | "positive"
+  | "negative"
+  | "cautionary"
+
+export type Size = "small" | "large"

--- a/draft-packages/popover/docs/Popover.stories.tsx
+++ b/draft-packages/popover/docs/Popover.stories.tsx
@@ -1,18 +1,20 @@
-import { DismissiblePositiveAutohide } from "@kaizen/component-library/stories/InlineNotification.stories"
-import { Popover } from "@kaizen/draft-popover"
+import {
+  PopoverLegacy,
+  usePopover,
+  Popover as PopoverRaw,
+} from "@kaizen/draft-popover"
 import * as React from "react"
 import guidanceIcon from "@kaizen/component-library/icons/guidance.icon.svg"
-import { Avatar } from "@kaizen/draft-avatar"
 import { withDesign } from "storybook-addon-designs"
 import { figmaEmbed } from "../../../storybook/helpers"
 
 export default {
   title: "Popover (React)",
-  component: Popover,
+  component: PopoverRaw,
   parameters: {
     info: {
       text: `
-      import { Popover } from "@kaizen/draft-popover"
+      import { usePopover } from "@kaizen/draft-popover"
       `,
     },
     ...figmaEmbed(
@@ -26,212 +28,276 @@ const Container = ({ children }: { children: React.ReactNode }) => (
   <div style={{ minHeight: "150px" }}>{children}</div>
 )
 
-export const DefaultKaizenSiteDemo = () => (
-  <Container>
-    <Popover heading="Default">
-      Popover body that explains something useful, is optional, and not critical
-      to completing a task.
-    </Popover>
-  </Container>
+const TargetElement = ({
+  referenceElementRef,
+}: {
+  referenceElementRef: (element: HTMLElement | null) => void
+}) => (
+  <div style={{ textAlign: "center" }}>
+    <div
+      ref={referenceElementRef}
+      style={{
+        display: "inline-block",
+        background: "#888",
+        padding: "8px",
+      }}
+    >
+      Target element
+    </div>
+  </div>
 )
+
+export const DefaultKaizenSiteDemo = () => {
+  const [referenceElementRef, Popover] = usePopover()
+  return (
+    <Container>
+      <TargetElement referenceElementRef={referenceElementRef} />
+      <Popover heading="Default">
+        Popover body that explains something useful, is optional, and not
+        critical to completing a task.
+      </Popover>
+    </Container>
+  )
+}
 
 DefaultKaizenSiteDemo.storyName = "Default (Kaizen Site Demo)"
 
-export const DefaultWithoutHeading = () => (
-  <Container>
-    <Popover>
-      Popover body that explains something useful, is optional, and not critical
-      to completing a task.
-    </Popover>
-  </Container>
-)
+export const DefaultWithoutHeading = () => {
+  const [referenceElementRef, Popover] = usePopover()
+  return (
+    <Container>
+      <TargetElement referenceElementRef={referenceElementRef} />
+      <Popover>
+        Popover body that explains something useful, is optional, and not
+        critical to completing a task.
+      </Popover>
+    </Container>
+  )
+}
 
 DefaultWithoutHeading.storyName = "Default without heading"
 
-export const Informative = () => (
-  <Container>
-    <Popover heading="Informative" variant="informative">
-      Popover body that explains something useful, is optional, and not critical
-      to completing a task.
-    </Popover>
-  </Container>
-)
+export const Informative = () => {
+  const [referenceElementRef, Popover] = usePopover()
+  return (
+    <Container>
+      <TargetElement referenceElementRef={referenceElementRef} />
+      <Popover heading="Informative" variant="informative">
+        Popover body that explains something useful, is optional, and not
+        critical to completing a task.
+      </Popover>
+    </Container>
+  )
+}
 
-export const InformativeWithSingleLine = () => (
-  <Container>
-    <Popover
-      heading="Informative-default-with-single-line"
-      variant="informative"
-      singleLine
-    >
-      {"http://employee-data.integrations.eu.cultureamp.com/iamaverylongurl/" +
-        "iamaverylongurl/iamaverylongurl/iamaverylongurl"}
-    </Popover>
-  </Container>
-)
+export const InformativeWithSingleLine = () => {
+  const [referenceElementRef, Popover] = usePopover()
+  return (
+    <Container>
+      <TargetElement referenceElementRef={referenceElementRef} />
+      <Popover
+        heading="Informative-default-with-single-line"
+        variant="informative"
+        singleLine
+      >
+        {"http://employee-data.integrations.eu.cultureamp.com/iamaverylongurl/" +
+          "iamaverylongurl/iamaverylongurl/iamaverylongurl"}
+      </Popover>
+    </Container>
+  )
+}
 
 InformativeWithSingleLine.storyName = "Informative with singleLine"
 
-export const InformativeLarge = () => (
-  <Container>
-    <Popover
-      heading="Informative-large-with-multi-line"
-      variant="informative"
-      size="large"
-    >
-      Popover body that explains something useful, is optional, and not critical
-      to completing a task.
-    </Popover>
-  </Container>
-)
+export const InformativeLarge = () => {
+  const [referenceElementRef, Popover] = usePopover()
+  return (
+    <Container>
+      <TargetElement referenceElementRef={referenceElementRef} />
+      <Popover
+        heading="Informative-large-with-multi-line"
+        variant="informative"
+        size="large"
+      >
+        Popover body that explains something useful, is optional, and not
+        critical to completing a task.
+      </Popover>
+    </Container>
+  )
+}
 
-export const InformativeLargeWithSingleLine = () => (
-  <Container>
-    <Popover
-      heading="Informative-large-with-single-line"
-      variant="informative"
-      size="large"
-      singleLine
-    >
-      {"http://employee-data.integrations.eu.cultureamp.com/iamaverylongurl/" +
-        "iamaverylongurl/iamaverylongurl/iamaverylongurl"}
-    </Popover>
-  </Container>
-)
+export const InformativeLargeWithSingleLine = () => {
+  const [referenceElementRef, Popover] = usePopover()
+  return (
+    <Container>
+      <TargetElement referenceElementRef={referenceElementRef} />
+      <Popover
+        heading="Informative-large-with-single-line"
+        variant="informative"
+        size="large"
+        singleLine
+      >
+        {"http://employee-data.integrations.eu.cultureamp.com/iamaverylongurl/" +
+          "iamaverylongurl/iamaverylongurl/iamaverylongurl"}
+      </Popover>
+    </Container>
+  )
+}
 
 InformativeLargeWithSingleLine.storyName = "Informative Large with singleLine"
 
-export const InformativeWithCustomIcon = () => (
-  <Container>
-    <Popover
-      heading="Informative"
-      variant="informative"
-      customIcon={guidanceIcon}
-    >
-      Popover body that explains something useful, is optional, and not critical
-      to completing a task.
-    </Popover>
-  </Container>
-)
+export const InformativeWithCustomIcon = () => {
+  const [referenceElementRef, Popover] = usePopover()
+  return (
+    <Container>
+      <TargetElement referenceElementRef={referenceElementRef} />
+      <Popover
+        heading="Informative"
+        variant="informative"
+        customIcon={guidanceIcon}
+      >
+        Popover body that explains something useful, is optional, and not
+        critical to completing a task.
+      </Popover>
+    </Container>
+  )
+}
 
 InformativeWithCustomIcon.storyName = "Informative with a custom icon"
 
-export const Positive = () => (
-  <Container>
-    <Popover heading="Positive" variant="positive">
-      Popover body that explains something useful, is optional, and not critical
-      to completing a task.
-    </Popover>
-  </Container>
-)
-
-export const Negative = () => (
-  <Container>
-    <Popover heading="Negative" variant="negative">
-      Popover body that explains something useful, is optional, and not critical
-      to completing a task.
-    </Popover>
-  </Container>
-)
-
-export const Cautionary = () => (
-  <Container>
-    <Popover heading="Cautionary" variant="cautionary">
-      Popover body that explains something useful, is optional, and not critical
-      to completing a task.
-    </Popover>
-  </Container>
-)
-
-export const Dismissible = () => (
-  <Container>
-    <Popover heading="Dismissible" dismissible>
-      Popover body that explains something useful, is optional, and not critical
-      to completing a task.
-    </Popover>
-  </Container>
-)
-
-export const ArrowAbove = () => (
-  <Container>
-    <div style={{ marginTop: "1.5rem" }}>
-      <Popover heading="Arrow above" side="top">
+export const Positive = () => {
+  const [referenceElementRef, Popover] = usePopover()
+  return (
+    <Container>
+      <TargetElement referenceElementRef={referenceElementRef} />
+      <Popover heading="Positive" variant="positive">
         Popover body that explains something useful, is optional, and not
         critical to completing a task.
       </Popover>
-    </div>
-  </Container>
-)
+    </Container>
+  )
+}
 
-ArrowAbove.storyName = "Arrow above"
-
-export const ArrowStart = () => (
-  <Container>
-    <div style={{ marginTop: "1.5rem" }}>
-      <Popover heading="Arrow start" position="start">
+export const Negative = () => {
+  const [referenceElementRef, Popover] = usePopover()
+  return (
+    <Container>
+      <TargetElement referenceElementRef={referenceElementRef} />
+      <Popover heading="Negative" variant="negative">
         Popover body that explains something useful, is optional, and not
         critical to completing a task.
       </Popover>
-    </div>
-  </Container>
-)
+    </Container>
+  )
+}
 
-ArrowStart.storyName = "Arrow start"
-
-export const ArrowEnd = () => (
-  <Container>
-    <div style={{ marginTop: "1.5rem" }}>
-      <Popover heading="Arrow end" position="end" side="top">
+export const Cautionary = () => {
+  const [referenceElementRef, Popover] = usePopover()
+  return (
+    <Container>
+      <TargetElement referenceElementRef={referenceElementRef} />
+      <Popover heading="Cautionary" variant="cautionary">
         Popover body that explains something useful, is optional, and not
         critical to completing a task.
       </Popover>
-    </div>
-  </Container>
-)
+    </Container>
+  )
+}
 
-ArrowEnd.storyName = "Arrow end"
+export const Dismissible = () => {
+  const [referenceElementRef, Popover] = usePopover()
+  return (
+    <Container>
+      <TargetElement referenceElementRef={referenceElementRef} />
+      <Popover heading="Dismissible" dismissible>
+        Popover body that explains something useful, is optional, and not
+        critical to completing a task.
+      </Popover>
+    </Container>
+  )
+}
 
-export const BoxOffset = () => (
-  <Container>
-    <>
-      <div style={{ marginTop: "1.5rem", height: 200 }}>
-        <Popover
-          heading="Box offset"
-          position="center"
-          side="top"
-          boxOffset={-50}
-        >
+export const PlacementTop = () => {
+  const [referenceElementRef, Popover] = usePopover()
+  return (
+    <Container>
+      <div style={{ marginTop: "200px" }}>
+        <TargetElement referenceElementRef={referenceElementRef} />
+        <Popover heading="Placement top" placement="top">
           Popover body that explains something useful, is optional, and not
           critical to completing a task.
         </Popover>
       </div>
-      <div style={{ marginTop: "1.5rem", height: 200 }}>
-        <Popover
-          heading="Box offset"
-          position="center"
-          side="bottom"
-          boxOffset={50}
-        >
+    </Container>
+  )
+}
+
+PlacementTop.storyName = "Placement top"
+
+export const PlacementStart = () => {
+  const [referenceElementRef, Popover] = usePopover()
+  return (
+    <Container>
+      <div style={{ marginTop: "1.5rem" }}>
+        <TargetElement referenceElementRef={referenceElementRef} />
+        <Popover heading="Placement start" placement="bottom-start">
           Popover body that explains something useful, is optional, and not
           critical to completing a task.
         </Popover>
       </div>
-    </>
-  </Container>
-)
+    </Container>
+  )
+}
 
-BoxOffset.storyName = "Box offset"
+PlacementStart.storyName = "Placement start"
 
-export const BoxWithYOffset = () => (
+export const PlacementEnd = () => {
+  const [referenceElementRef, Popover] = usePopover()
+  return (
+    <Container>
+      <div style={{ marginTop: "1.5rem" }}>
+        <TargetElement referenceElementRef={referenceElementRef} />
+        <Popover heading="Placement end" placement="bottom-end">
+          Popover body that explains something useful, is optional, and not
+          critical to completing a task.
+        </Popover>
+      </div>
+    </Container>
+  )
+}
+
+PlacementEnd.storyName = "Placement end"
+
+export const LegacyPopover = () => (
   <Container>
-    <Popover heading="Default" boxOffset={{ yOffset: "calc(-100% + -12px)" }}>
-      Popover body that explains something useful, is optional, and not critical
-      to completing a task.
-    </Popover>
-    <div style={{ margin: "200px auto auto", width: "fit-content" }}>
-      <Avatar fullName="Test user"></Avatar>
+    <div
+      style={{
+        position: "relative",
+        height: "200px",
+      }}
+    >
+      <PopoverLegacy heading="Arrow top end" position="end" side="top">
+        The legacy popover gets used when the referenceElement prop is not
+        included.
+      </PopoverLegacy>
+    </div>
+
+    <div
+      style={{
+        position: "relative",
+        height: "200px",
+      }}
+    >
+      <PopoverLegacy
+        heading="Arrow bottom start"
+        position="start"
+        side="bottom"
+      >
+        The legacy popover gets used when the referenceElement prop is not
+        included.
+      </PopoverLegacy>
     </div>
   </Container>
 )
 
-BoxWithYOffset.storyName = "Popover with Y offset positioning"
+LegacyPopover.storyName = "Legacy Popover"

--- a/draft-packages/popover/package.json
+++ b/draft-packages/popover/package.json
@@ -34,8 +34,10 @@
   "dependencies": {
     "@kaizen/component-library": "^9.2.0",
     "@kaizen/deprecated-component-library-helpers": "^2.1.1",
+    "@popperjs/core": "^2.6.0",
     "@types/classnames": "^2.2.10",
-    "classnames": "^2.2.6"
+    "classnames": "^2.2.6",
+    "react-popper": "^2.2.4"
   },
   "devDependencies": {
     "@cultureamp/elm-storybook": "cultureamp/elm-storybook#0.2.1",


### PR DESCRIPTION
* Add the popper layout engine to `Popover`. This will allow the popover to automatically change

![image](https://user-images.githubusercontent.com/4495057/109476289-d62a2200-7aca-11eb-9eaf-574deb8fc3ca.png)

For the sake of backwards compatibility, internally I created `PopoverLegacy`, which gets used if the `referenceElement` prop has not been included. Keeping this up to date is going to be a problem. I'm tempted to go "No, you must go through every `Popover` component in your codebase, and update the props accordingly". I'm happy to fix all the existing code in perf-ui. LMK if you'd like to go down this path.

Contrary to the Tooltip and Menu components, I did not add a `portalSelector` prop. It will be the consumer's responsibility to wrap the popover in a portal if needed. This is due to a difference in the component design. The Popover doesn't wrap around an element, you pass it the reference.

# Breaking changes

BREAKING CHANGE: To quickly fix all breaking changes, simply import `PopoverLegacy` instead of `Popover` from `@kaizen/draft-popover`. Codemod:

```
codemod -m -d ./src --extensions tsx,jsx 'import \{([\,\w\s]*)Popover([\w\W]*)\} from "@kaizen\/draft-popover"' 'import {\1PopoverLegacy\2} from "@kaizen/draft-popover"'
codemod -m -d ./src --extensions tsx,jsx '<Popover([\w\W]*)<\/Popover>' '<PopoverLegacy\1</PopoverLegacy>'
```

With that said, it is recommended that you start using the `usePopover` hook (see the stories for more examples), or the new `Popover` component if you are using a class component (see the `usePopover` hook to see how this needs to be wired up).

BREAKING CHANGE: The `boxOffset` property has been removed. Now that the new `Popover` uses popper, it will automatically determine the offset. This property was also being overloaded with two types of offsets, depending on the value type, which was confusing.

BREAKING CHANGE: With the new version of `Popover`, the `side` and `position` props are no longer used. Use `placement` instead. Also note, the `placement` describes the position of the popover, relative to the referenceElement, which is unlike the legacy popover, where it describes the placement of the arrow.

BREAKING CHANGE: We now use popper as the positioning engine, which shouldn't cause any breaking change, but please test your popovers when upgrading this package.

# Side updates
* Fix the `automationId` prop not getting added to the root div element
* Remove the `id` prop, which wasn't getting used.