### PR TITLE
fix: Remove max-width to prevent bugs outside grid

### DIFF
--- a/draft-packages/tile/KaizenDraft/Tile/TileGrid.scss
+++ b/draft-packages/tile/KaizenDraft/Tile/TileGrid.scss
@@ -1,10 +1,8 @@
 @import "~@kaizen/design-tokens/sass/spacing";
 @import "~@kaizen/design-tokens/sass/layout";
-@import "~@kaizen/component-library/styles/layout";
 @import "~@kaizen/component-library/styles/responsive";
 
 .grid {
-  max-width: $kz-layout-content-max-width;
   display: grid;
   grid-template-columns: repeat(auto-fit, 330px);
   grid-gap: $kz-spacing-md;


### PR DESCRIPTION
# ⚠️ VISUAL BREAKING CHANGE: Because TileGrid no longer sets its own max-width, the surrounding container or page must take on this responsibility of constraining its width. If this is not already the case on a page that is affected by this update, the TileGrid will be wider than it should be.

# Motivation and Context

The `max-width` rule on TileGrid was the source of a confusing bug in a consuming repo owned by Team Unify. It was causing margins to not be respected on a containing element a few layers up.

Since
- turning it off solves the problem, and
- the TileGrid should not be responsible for constraining its own width anyway (that is the page's responsibility),

I decided to remove it.

# Checklist
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] If this contains visual changes, has it been reviewed by a designer?
- [x] If this introduces either a new component or a breaking change to an existing component, has it been reviewed by an advocate? (Ask in #prod_design_systems)
- [ ] I have considered likely risks of these changes and got someone else to QA as appropriate
- [x] I have or will communicate these changes to the front end practice