### PR TITLE
fix: Fix styling bugs in TitleBlockZen

### DIFF
--- a/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/MobileActions.scss
+++ b/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/MobileActions.scss
@@ -64,6 +64,7 @@ $mobile-actions-split-select-square-width: 64px;
 .mobileActionsPrimaryLabel {
   @include ca-padding($start: $ca-grid * 0.75);
   text-align: left;
+  text-decoration: none;
 
   color: $kz-color-white;
   font-family: $kz-typography-button-primary-font-family;

--- a/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/TitleBlockZen.scss
+++ b/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/TitleBlockZen.scss
@@ -27,6 +27,7 @@ $tab-container-height-medium-and-small-collapsed: $ca-grid * 0.75;
   display: flex;
   justify-content: center;
   flex-direction: column;
+  overflow-x: hidden;
 
   &.educationVariant {
     background-color: $dt-color-background-color-eduction;

--- a/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/TitleBlockZen.scss
+++ b/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/TitleBlockZen.scss
@@ -586,6 +586,7 @@ $tab-container-height-medium-and-small-collapsed: $ca-grid * 0.75;
   @include ca-position($start: -2 * $ca-grid);
   top: $ca-grid * 3/4;
   align-items: center;
+  text-decoration: none;
 
   @include title-block-under-1645 {
     @include ca-position($start: $ca-grid);

--- a/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/TitleBlockZen.tsx
+++ b/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/TitleBlockZen.tsx
@@ -297,7 +297,7 @@ const renderNavigationTabs = (
         [styles.navigationTabsContainerCollapsed]: collapse,
       })}
     >
-      {!collapse && (
+      {!collapse && navigationTabs !== undefined && (
         <>
           <span className={styles.navigationTabEdgeShadowLeft} />
           {navigationTabs}


### PR DESCRIPTION
# Objective

This solves a few minor miscellaneous visual bugs:
- Hides `overflow-x` on the Title Block to prevent the scroll bar overlay from pushing the Title Block's width beyond the viewport, which was creating a scrollbar on mobile
- Removes the underline from the text used in the "back" button when the button is hovered (text gains an underline on hover still)
- Removes the mobile navigation tab section's scroll overlay (the translucent gradient) when there are no navigation tabs
- Removes text underline on the link in the mobile actions drawer


# Screenshots
These bugs are fixed in this PR:
![image](https://user-images.githubusercontent.com/6406263/110741139-4b92b100-8288-11eb-94b9-09966464b169.png)
![image](https://user-images.githubusercontent.com/6406263/110741088-34ec5a00-8288-11eb-9238-df8b3c500a72.png)


# Checklist
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] If this contains visual changes, has it been reviewed by a designer?
- [ ] If this introduces either a new component or a breaking change to an existing component, has it been reviewed by an advocate? (Ask in #prod_design_systems)
- [ ] I have considered likely risks of these changes and got someone else to QA as appropriate
- [x] I have or will communicate these changes to the front end practice
