### PR TITLE
feat: Update Menu component to support Heart

### DIFF
--- a/draft-packages/menu/KaizenDraft/Menu/components/MenuContent.module.scss
+++ b/draft-packages/menu/KaizenDraft/Menu/components/MenuContent.module.scss
@@ -5,9 +5,9 @@
 @import "~@kaizen/deprecated-component-library-helpers/styles/layout";
 @import "~@kaizen/component-library/styles/layers";
 
-$side-padding: calc(1 / 2 * #{$kz-var-spacing-md});
+$side-padding: $kz-var-spacing-sm;
 $gutter: calc(#{$kz-var-spacing-md} * 1 / 6);
-$padding: calc(#{$kz-var-spacing-md} * 1 / 4);
+$padding: $kz-var-spacing-xs;
 
 .menuContent {
   display: flex;

--- a/draft-packages/menu/KaizenDraft/Menu/components/MenuContent.module.scss
+++ b/draft-packages/menu/KaizenDraft/Menu/components/MenuContent.module.scss
@@ -1,8 +1,6 @@
-@import "~@kaizen/design-tokens/sass/color";
-@import "~@kaizen/design-tokens/sass/color-vars";
-@import "~@kaizen/design-tokens/sass/border";
-@import "~@kaizen/design-tokens/sass/shadow";
-@import "~@kaizen/design-tokens/sass/typography";
+@import "~@kaizen/design-tokens/sass/border-vars";
+@import "~@kaizen/design-tokens/sass/shadow-vars";
+@import "~@kaizen/design-tokens/sass/typography-vars";
 @import "~@kaizen/deprecated-component-library-helpers/styles/layout";
 @import "~@kaizen/component-library/styles/layers";
 
@@ -13,10 +11,10 @@ $gutter: 4px;
   display: flex;
   flex-direction: column;
   box-sizing: border-box;
-  background: $kz-color-white;
-  color: $kz-color-wisteria-800;
-  border-radius: $kz-border-solid-border-radius;
-  box-shadow: $kz-shadow-large-box-shadow;
+  background: $kz-var-color-white;
+  color: $kz-var-color-wisteria-800;
+  border-radius: $kz-var-border-solid-border-radius;
+  box-shadow: $kz-var-shadow-large-box-shadow;
   padding: ($gutter + 2px) 0;
   text-align: left;
   width: 100%;
@@ -28,16 +26,16 @@ $gutter: 4px;
 
 .header {
   padding: 10px $side-padding 5px;
-  color: $kz-color-wisteria-800;
+  color: $kz-var-color-wisteria-800;
   margin: 0 $gutter;
 }
 
 .header__title {
-  font-family: $kz-typography-heading-6-font-family;
-  font-weight: $kz-typography-heading-6-font-weight;
-  font-size: $kz-typography-heading-6-font-size;
-  line-height: $kz-typography-heading-6-line-height;
-  letter-spacing: $kz-typography-heading-6-letter-spacing;
+  font-family: $kz-var-typography-heading-6-font-family;
+  font-weight: $kz-var-typography-heading-6-font-weight;
+  font-size: $kz-var-typography-heading-6-font-size;
+  line-height: $kz-var-typography-heading-6-line-height;
+  letter-spacing: $kz-var-typography-heading-6-letter-spacing;
   display: block;
 }
 
@@ -50,16 +48,16 @@ $gutter: 4px;
   border: none;
   text-align: left;
   padding: 8px $side-padding;
-  margin: 0 $gutter;
+  margin: 0 $gutter + 2px;
   min-height: 1.75 * $ca-grid;
   border-radius: 4px;
-  font-family: $kz-typography-paragraph-body-font-family;
-  font-weight: $kz-typography-paragraph-body-font-weight;
-  font-size: $kz-typography-paragraph-body-font-size;
-  line-height: $kz-typography-paragraph-body-line-height;
-  letter-spacing: $kz-typography-paragraph-body-letter-spacing;
+  font-family: $kz-var-typography-paragraph-body-font-family;
+  font-weight: $kz-var-typography-paragraph-body-font-weight;
+  font-size: $kz-var-typography-paragraph-body-font-size;
+  line-height: $kz-var-typography-paragraph-body-line-height;
+  letter-spacing: $kz-var-typography-paragraph-body-letter-spacing;
   text-decoration: none;
-  color: $kz-color-wisteria-800;
+  color: $kz-var-color-wisteria-800;
 
   cursor: default;
 
@@ -73,19 +71,19 @@ $gutter: 4px;
 
   &:not(.menuItem--disabled):hover,
   &:focus {
-    background: $kz-color-cluny-100;
-    color: $kz-color-cluny-500;
+    background: $kz-var-color-cluny-100;
+    color: $kz-var-color-cluny-500;
 
     .menuItem__Icon {
-      color: $kz-color-cluny-500;
+      color: $kz-var-color-cluny-500;
     }
 
     &.menuItem--destructive {
-      background: $kz-color-coral-100;
-      color: $kz-color-coral-600;
+      background: $kz-var-color-coral-100;
+      color: $kz-var-color-coral-600;
 
       .menuItem__Icon {
-        color: $kz-color-coral-600;
+        color: $kz-var-color-coral-600;
       }
     }
   }
@@ -100,14 +98,14 @@ $gutter: 4px;
 }
 
 .menuItem--active {
-  color: $kz-color-cluny-500;
-  font-weight: $kz-typography-paragraph-bold-font-weight;
+  color: $kz-var-color-cluny-500;
+  font-weight: $kz-var-typography-paragraph-bold-font-weight;
 }
 
 .menuItem--destructive {
-  color: $kz-color-coral-600;
+  color: $kz-var-color-coral-600;
   .menuItem__Icon {
-    color: $kz-color-coral-600;
+    color: $kz-var-color-coral-600;
   }
 }
 
@@ -122,13 +120,4 @@ $gutter: 4px;
   align-self: flex-start;
   transform: translateY(0.2em);
   color: rgba($kz-var-color-wisteria-800-rgb-params, 0.75);
-}
-
-.separator {
-  height: 1px;
-  width: 100%;
-  border: 0;
-  background: $kz-color-wisteria-200;
-  visibility: visible;
-  margin: 5px 0;
 }

--- a/draft-packages/menu/KaizenDraft/Menu/components/MenuContent.module.scss
+++ b/draft-packages/menu/KaizenDraft/Menu/components/MenuContent.module.scss
@@ -1,11 +1,13 @@
 @import "~@kaizen/design-tokens/sass/border-vars";
 @import "~@kaizen/design-tokens/sass/shadow-vars";
+@import "~@kaizen/design-tokens/sass/spacing-vars";
 @import "~@kaizen/design-tokens/sass/typography-vars";
 @import "~@kaizen/deprecated-component-library-helpers/styles/layout";
 @import "~@kaizen/component-library/styles/layers";
 
-$side-padding: 1/2 * $ca-grid;
-$gutter: 4px;
+$side-padding: calc(1 / 2 * #{$kz-var-spacing-md});
+$gutter: calc(#{$kz-var-spacing-md} * 1 / 6);
+$padding: calc(#{$kz-var-spacing-md} * 1 / 4);
 
 .menuContent {
   display: flex;
@@ -15,7 +17,7 @@ $gutter: 4px;
   color: $kz-var-color-wisteria-800;
   border-radius: $kz-var-border-solid-border-radius;
   box-shadow: $kz-var-shadow-large-box-shadow;
-  padding: ($gutter + 2px) 0;
+  padding: $padding 0;
   text-align: left;
   width: 100%;
 
@@ -48,8 +50,8 @@ $gutter: 4px;
   border: none;
   text-align: left;
   padding: 8px $side-padding;
-  margin: 0 $gutter + 2px;
-  min-height: 1.75 * $ca-grid;
+  margin: 0 $padding;
+  min-height: calc(1.75 * #{$kz-var-spacing-md});
   border-radius: 4px;
   font-family: $kz-var-typography-paragraph-body-font-family;
   font-weight: $kz-var-typography-paragraph-body-font-weight;
@@ -114,7 +116,7 @@ $gutter: 4px;
 }
 
 .menuItem__Icon {
-  @include ca-margin($end: $ca-grid / 3);
+  @include ca-margin($end: calc(#{$kz-var-spacing-md} / 3));
 
   display: flex;
   align-self: flex-start;

--- a/draft-packages/menu/KaizenDraft/Menu/components/MenuContent.module.scss
+++ b/draft-packages/menu/KaizenDraft/Menu/components/MenuContent.module.scss
@@ -1,9 +1,9 @@
 @import "~@kaizen/design-tokens/sass/border-vars";
 @import "~@kaizen/design-tokens/sass/shadow-vars";
+@import "~@kaizen/design-tokens/sass/color-vars";
 @import "~@kaizen/design-tokens/sass/spacing-vars";
 @import "~@kaizen/design-tokens/sass/typography-vars";
 @import "~@kaizen/deprecated-component-library-helpers/styles/layout";
-@import "~@kaizen/component-library/styles/layers";
 
 $side-padding: $kz-var-spacing-sm;
 $gutter: calc(#{$kz-var-spacing-md} * 1 / 6);

--- a/draft-packages/menu/KaizenDraft/Menu/components/MenuSeparator.tsx
+++ b/draft-packages/menu/KaizenDraft/Menu/components/MenuSeparator.tsx
@@ -1,8 +1,7 @@
+import { Divider } from "@kaizen/draft-divider"
 import * as React from "react"
 
-import styles from "./MenuContent.module.scss"
-
-const MenuSeparator = () => <hr className={styles.separator} />
+const MenuSeparator = () => <Divider variant="menuSeparator" />
 MenuSeparator.displayName = "MenuSeparator"
 
 export default MenuSeparator

--- a/draft-packages/menu/package.json
+++ b/draft-packages/menu/package.json
@@ -40,9 +40,11 @@
     "react-popper": "^2.2.4"
   },
   "devDependencies": {
+    "@kaizen/draft-divider": "^1.3.0",
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
+    "@kaizen/draft-divider": "^1.3.0",
     "@kaizen/design-tokens": "^2.5.0",
     "react": "^16.9.0",
     "react-dom": "^16.9.0"

--- a/draft-packages/menu/package.json
+++ b/draft-packages/menu/package.json
@@ -34,17 +34,16 @@
   "dependencies": {
     "@kaizen/component-library": "^9.3.1",
     "@kaizen/draft-button": "^3.2.7",
+    "@kaizen/draft-divider": "^1.4.0",
     "@popperjs/core": "^2.6.0",
     "@types/classnames": "^2.2.10",
     "classnames": "^2.2.6",
     "react-popper": "^2.2.4"
   },
   "devDependencies": {
-    "@kaizen/draft-divider": "^1.3.0",
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/draft-divider": "^1.3.0",
     "@kaizen/design-tokens": "^2.5.0",
     "react": "^16.9.0",
     "react-dom": "^16.9.0"


### PR DESCRIPTION
Update Menu for Heart theme. This is a simple old -> new token change with no decision tokens.

Also:
* MenuSeparator component now using the Divider component with the menuSeparator variant
* Slight margin fix on the Menu container.

# Screenshots (if appropriate)

# Checklist
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] If this contains visual changes, has it been reviewed by a designer?
- [ ] If this introduces either a new component or a breaking change to an existing component, has it been reviewed by an advocate? (Ask in #prod_design_systems)
- [ ] I have considered likely risks of these changes and got someone else to QA as appropriate
- [ ] I have or will communicate these changes to the front end practice

# Additional Considerations
- Does there need to be right-to-left (RTL) options for localization and internationalization?
- Has the test suite been updated?
- Have you done cross-browser testing for our [supported browsers](https://academy.cultureamp.com/hc/en-us/articles/204539569-Supported-browsers-for-Participants)?
- Have you updated any relevant documentation or left useful comments in the code?
- Have you reviewed Culture Amp's Web Accessibility guide [Current Compliance, Going Forward, Statement and Answers for Customers](https://cultureamp.atlassian.net/wiki/spaces/Prod/pages/428572998/Web+Accessibility)?
- If this contains substantial visual changes, especially far reaching ones, have you unlocked the Chromatic step in the pipeline?
- Have Storybook stories been updated?

**If you're new to Kaizen, please ask #prod_design_systems to set up an onboarding session to get you up to speed.** If you have an urgent PR to merge before that happens, it is safest to ask in #prod_design_systems to have a design system advocate review the PR to catch any issues.
