### PR TITLE
fix: Remove hover border on tag

### DIFF
--- a/draft-packages/tag/KaizenDraft/Tag/Tag.scss
+++ b/draft-packages/tag/KaizenDraft/Tag/Tag.scss
@@ -99,51 +99,27 @@ $small: $ca-grid;
 
 .default {
   background-color: $kz-color-wisteria-200;
-
-  &.dismissible:hover {
-    border-color: $kz-color-wisteria-300;
-  }
 }
 
 .sentimentPositive {
   background-color: $kz-color-seedling-100;
-
-  &.dismissible:hover {
-    border-color: $kz-color-seedling-200;
-  }
 }
 
 .sentimentNeutral {
   background-color: $kz-color-ash;
-
-  &.dismissible:hover {
-    border-color: $kz-color-wisteria-200;
-  }
 }
 
 .sentimentNegative {
   background-color: $kz-color-coral-100;
-
-  &.dismissible:hover {
-    border-color: $kz-color-coral-200;
-  }
 }
 
 .sentimentNone {
   background-color: $kz-color-white;
   border-color: $kz-color-wisteria-300;
-
-  &:hover {
-    border-color: $kz-color-wisteria-500;
-  }
 }
 
 .validationPositive {
   background-color: $kz-color-seedling-100;
-
-  &.dismissible:hover {
-    border-color: $kz-color-seedling-200;
-  }
 
   .validationIcon {
     color: $kz-color-seedling-300;
@@ -153,10 +129,6 @@ $small: $ca-grid;
 .validationInformative {
   background-color: $kz-color-cluny-100;
 
-  &.dismissible:hover {
-    border-color: $kz-color-cluny-300;
-  }
-
   .validationIcon {
     color: $kz-color-cluny-500;
   }
@@ -165,10 +137,6 @@ $small: $ca-grid;
 .validationNegative {
   background-color: $kz-color-coral-100;
 
-  &.dismissible:hover {
-    border-color: $kz-color-coral-200;
-  }
-
   .validationIcon {
     color: $kz-color-coral-500;
   }
@@ -176,10 +144,6 @@ $small: $ca-grid;
 
 .validationCautionary {
   background-color: $kz-color-yuzu-100;
-
-  &.dismissible:hover {
-    border-color: $kz-color-yuzu-300;
-  }
 
   .validationIcon {
     color: $kz-color-yuzu-500;


### PR DESCRIPTION
Updates the Tag component to not show a border when a user hovers over one - as per design reviews and the UI kit https://www.figma.com/file/eZKEE5kXbEMY3lx84oz8iN/%E2%9D%A4%EF%B8%8F-UI-Kit-Heart?node-id=1929%3A29917

# Screenshots (if appropriate)

# Checklist
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] If this contains visual changes, has it been reviewed by a designer?
- [ ] If this introduces either a new component or a breaking change to an existing component, has it been reviewed by an advocate? (Ask in #prod_design_systems)
- [ ] I have considered likely risks of these changes and got someone else to QA as appropriate
- [ ] I have or will communicate these changes to the front end practice

# Additional Considerations
- Does there need to be right-to-left (RTL) options for localization and internationalization?
- Has the test suite been updated?
- Have you done cross-browser testing for our [supported browsers](https://academy.cultureamp.com/hc/en-us/articles/204539569-Supported-browsers-for-Participants)?
- Have you updated any relevant documentation or left useful comments in the code?
- Have you reviewed Culture Amp's Web Accessibility guide [Current Compliance, Going Forward, Statement and Answers for Customers](https://cultureamp.atlassian.net/wiki/spaces/Prod/pages/428572998/Web+Accessibility)?
- If this contains substantial visual changes, especially far reaching ones, have you unlocked the Chromatic step in the pipeline?
- Have Storybook stories been updated?

**If you're new to Kaizen, please ask #prod_design_systems to set up an onboarding session to get you up to speed.** If you have an urgent PR to merge before that happens, it is safest to ask in #prod_design_systems to have a design system advocate review the PR to catch any issues.
