### PR TITLE
fix: Adjust padding and sizing within inline notifications

### DIFF
--- a/packages/component-library/components/Notification/InlineNotification.tsx
+++ b/packages/component-library/components/Notification/InlineNotification.tsx
@@ -6,7 +6,7 @@ import GenericNotification, {
 type Props = {
   type: NotificationType
   title: string
-  children: React.ReactNode
+  children?: React.ReactNode
   autohide?: boolean
   autohideDelay?: "short" | "long"
   persistent: boolean

--- a/packages/component-library/components/Notification/_styles.scss
+++ b/packages/component-library/components/Notification/_styles.scss
@@ -15,7 +15,7 @@ $ca-notification-border-width: $kz-border-solid-border-width;
 $ca-notification-vertical-padding: calc(
   #{$ca-grid / 4} - #{$ca-notification-border-width}
 );
-$ca-notification-inline-horizontal-padding: 20px;
+$ca-notification-inline-horizontal-padding: $kz-spacing-sm;
 $ca-notification-toast-horizontal-padding: 10px;
 $ca-notification-fade-out: opacity $ca-duration-slow ease;
 $ca-notification-collapse-height: margin-top $ca-duration-slow ease,
@@ -40,6 +40,7 @@ $ca-notification-slide-right: transform $ca-duration-slow ease-out;
 
   &%ca-notification---inline {
     width: 100%;
+    min-height: 46px;
     padding: $ca-notification-vertical-padding
       $ca-notification-inline-horizontal-padding;
     transition: $ca-notification-fade-out,
@@ -156,8 +157,8 @@ $ca-notification-slide-right: transform $ca-duration-slow ease-out;
 
   %ca-notification---inline &,
   %ca-notification---toast & {
-    width: $ca-grid;
-    height: $ca-grid;
+    width: 22px;
+    height: 22px;
     margin-top: $ca-grid / 4;
   }
 
@@ -178,7 +179,7 @@ $ca-notification-slide-right: transform $ca-duration-slow ease-out;
 
   %ca-notification---inline &,
   %ca-notification---toast & {
-    margin-left: 10px;
+    margin-left: 6px;
   }
 
   %ca-notification---global & {
@@ -195,10 +196,11 @@ $ca-notification-slide-right: transform $ca-duration-slow ease-out;
 %ca-notification__title {
   @include kz-typography-heading-6;
   margin: 0;
-  padding-right: $ca-grid / 2;
+  padding-right: 6px;
   // overriding Bootstrap style that changes h6s to text-transform: uppercase
   text-transform: none;
   color: inherit;
+  top: 0.37em;
 }
 
 %ca-notification__text {
@@ -214,6 +216,7 @@ $ca-notification-slide-right: transform $ca-duration-slow ease-out;
     margin-top: $ca-grid / 4;
     flex: 0 1 auto;
     padding-bottom: 0.75rem;
+    top: 0.21em;
   }
 
   %ca-notification---global & {

--- a/packages/component-library/components/Notification/components/GenericNotification.tsx
+++ b/packages/component-library/components/Notification/components/GenericNotification.tsx
@@ -18,7 +18,7 @@ export type NotificationType =
 type Props = {
   type: NotificationType
   style: "global" | "inline" | "toast"
-  children: React.ReactNode
+  children?: React.ReactNode
   title?: string
   persistent: boolean
   autohide: boolean
@@ -95,7 +95,9 @@ class GenericNotification extends React.Component<Props, State> {
           {this.props.title && (
             <h6 className={styles.title}>{this.props.title}</h6>
           )}
-          <p className={styles.text}>{this.props.children}</p>
+          {this.props.children && (
+            <p className={styles.text}>{this.props.children}</p>
+          )}
         </div>
         {!this.props.persistent && <CancelButton onClick={this.hide} />}
       </div>

--- a/packages/component-library/stories/InlineNotification.stories.tsx
+++ b/packages/component-library/stories/InlineNotification.stories.tsx
@@ -249,3 +249,7 @@ export const MultipleNotification = () => (
     </InlineNotification>
   </div>
 )
+
+export const NoChildren = () => (
+  <InlineNotification title="No children" type="affirmative" persistent />
+)


### PR DESCRIPTION
# Objective
<!-- Describe what this change achieves, and the details of how it works. -->
Inline notifications do not always need children. This PR makes them non-mandatory and remove padding issues that occur when notifications have no children.

This PR also makes other slight padding adjustments to inline notification.

# Screenshots (if appropriate)
Padding issue when no children:
<img width="664" alt="Screen Shot 2021-03-18 at 2 40 28 pm" src="https://user-images.githubusercontent.com/22196200/111735488-37763180-88d0-11eb-8afe-18b094edcaac.png">

# Checklist
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] If this contains visual changes, has it been reviewed by a designer?
- [ ] If this introduces either a new component or a breaking change to an existing component, has it been reviewed by an advocate? (Ask in #prod_design_systems)
- [x] I have considered likely risks of these changes and got someone else to QA as appropriate
- [ ] I have or will communicate these changes to the front end practice

# Additional Considerations
- Does there need to be right-to-left (RTL) options for localization and internationalization?
- Has the test suite been updated?
- Have you done cross-browser testing for our [supported browsers](https://academy.cultureamp.com/hc/en-us/articles/204539569-Supported-browsers-for-Participants)?
- Have you updated any relevant documentation or left useful comments in the code?
- Have you reviewed Culture Amp's Web Accessibility guide [Current Compliance, Going Forward, Statement and Answers for Customers](https://cultureamp.atlassian.net/wiki/spaces/Prod/pages/428572998/Web+Accessibility)?
- If this contains substantial visual changes, especially far reaching ones, have you unlocked the Chromatic step in the pipeline?
- Have Storybook stories been updated?

**If you're new to Kaizen, please ask #prod_design_systems to set up an onboarding session to get you up to speed.** If you have an urgent PR to merge before that happens, it is safest to ask in #prod_design_systems to have a design system advocate review the PR to catch any issues.
