### PR TITLE
fix: React 17 fix - replace react-transition-group in draft-modal

### DIFF
--- a/draft-packages/modal/KaizenDraft/Modal/Modal.elm
+++ b/draft-packages/modal/KaizenDraft/Modal/Modal.elm
@@ -241,7 +241,7 @@ viewContent (Config modalConfig) =
                     [ ( .animatingElmEnter, True ) ]
 
                 Closing_ ->
-                    [ ( .animatingElmExit, True ) ]
+                    [ ( .animatingElmLeave, True ) ]
 
                 _ ->
                     []
@@ -505,7 +505,7 @@ styles =
         { backdropLayer = "backdropLayer"
         , animatingElmEnter = "animatingElmEnter"
         , elmUnscrollable = "elmUnscrollable"
-        , animatingElmExit = "animatingElmExit"
+        , animatingElmLeave = "animatingElmLeave"
         , elmGenericModal = "elmGenericModal"
         , hide = "hide"
         }

--- a/draft-packages/modal/KaizenDraft/Modal/Presets/ConfirmationModal.spec.tsx
+++ b/draft-packages/modal/KaizenDraft/Modal/Presets/ConfirmationModal.spec.tsx
@@ -19,9 +19,7 @@ const ConfirmationModalWrapper = (props: Partial<ConfirmationModalProps>) => (
 describe("<ConfirmationModal />", () => {
   it("renders an open modal with the provided content", () => {
     const { getByText } = render(
-      <ConfirmationModalWrapper>
-          Example modal body
-      </ConfirmationModalWrapper>
+      <ConfirmationModalWrapper>Example modal body</ConfirmationModalWrapper>
     )
     expect(getByText("Example modal body")).toBeTruthy()
 
@@ -30,14 +28,15 @@ describe("<ConfirmationModal />", () => {
     expect(getByText("Cancel")).toBeTruthy()
   })
 
-  it("renders a modal in a \"working\" state", () => {
+  it('renders a modal in a "working" state', () => {
     const { getByText, queryByText } = render(
       <ConfirmationModalWrapper
         confirmWorking={{
           label: "Submitting",
-          labelHidden: false
-        }}>
-          Example modal body
+          labelHidden: false,
+        }}
+      >
+        Example modal body
       </ConfirmationModalWrapper>
     )
     expect(getByText("Example modal body")).toBeTruthy()
@@ -56,8 +55,9 @@ describe("<ConfirmationModal />", () => {
     const document = render(
       <ConfirmationModalWrapper
         onDismiss={handleDismiss}
-        onConfirm={handleConfirm}>
-          Example modal body
+        onConfirm={handleConfirm}
+      >
+        Example modal body
       </ConfirmationModalWrapper>
     )
     fireEvent.keyUp(document.container, { key: "Escape", code: "Escape" })
@@ -71,8 +71,9 @@ describe("<ConfirmationModal />", () => {
     const { getByText } = render(
       <ConfirmationModalWrapper
         onDismiss={handleDismiss}
-        onConfirm={handleConfirm}>
-          Example modal body
+        onConfirm={handleConfirm}
+      >
+        Example modal body
       </ConfirmationModalWrapper>
     )
     fireEvent.click(getByText(/Cancel/i))
@@ -86,8 +87,9 @@ describe("<ConfirmationModal />", () => {
     const { getByText } = render(
       <ConfirmationModalWrapper
         onDismiss={handleDismiss}
-        onConfirm={handleConfirm}>
-          Example modal body
+        onConfirm={handleConfirm}
+      >
+        Example modal body
       </ConfirmationModalWrapper>
     )
     fireEvent.click(getByText(/Confirm/i))

--- a/draft-packages/modal/KaizenDraft/Modal/Presets/ConfirmationModal.spec.tsx
+++ b/draft-packages/modal/KaizenDraft/Modal/Presets/ConfirmationModal.spec.tsx
@@ -49,7 +49,7 @@ describe("<ConfirmationModal />", () => {
     expect(queryByText("Confirm")).toBeNull()
   })
 
-  it("closes the modal when escape key pressed", () => {
+  it("supports a dismiss action when escape key is pressed", () => {
     const handleConfirm = jest.fn()
     const handleDismiss = jest.fn()
     const document = render(
@@ -65,7 +65,23 @@ describe("<ConfirmationModal />", () => {
     expect(handleConfirm).toHaveBeenCalledTimes(0)
   })
 
-  it("closes the modal when cancel button is pressed", () => {
+  it("supports a dismiss action when dismiss button is pressed", () => {
+    const handleConfirm = jest.fn()
+    const handleDismiss = jest.fn()
+    const { getByTitle } = render(
+      <ConfirmationModalWrapper
+        onConfirm={handleConfirm}
+        onDismiss={handleDismiss}
+      >
+        Example modal body
+      </ConfirmationModalWrapper>
+    )
+    fireEvent.click(getByTitle(/Dismiss/i))
+    expect(handleConfirm).toHaveBeenCalledTimes(0)
+    expect(handleDismiss).toHaveBeenCalledTimes(1)
+  })
+
+  it("supports a dismiss action when cancel button is pressed", () => {
     const handleConfirm = jest.fn()
     const handleDismiss = jest.fn()
     const { getByText } = render(
@@ -81,7 +97,7 @@ describe("<ConfirmationModal />", () => {
     expect(handleDismiss).toHaveBeenCalledTimes(1)
   })
 
-  it("closes the modal when confirm button is pressed", () => {
+  it("supports a confirm action when confirm button is pressed", () => {
     const handleConfirm = jest.fn()
     const handleDismiss = jest.fn()
     const { getByText } = render(

--- a/draft-packages/modal/KaizenDraft/Modal/Presets/ConfirmationModal.spec.tsx
+++ b/draft-packages/modal/KaizenDraft/Modal/Presets/ConfirmationModal.spec.tsx
@@ -1,0 +1,97 @@
+import { cleanup, render, fireEvent } from "@testing-library/react"
+import * as React from "react"
+import ConfirmationModal, { ConfirmationModalProps } from "./ConfirmationModal"
+
+afterEach(cleanup)
+
+const ConfirmationModalWrapper = (props: Partial<ConfirmationModalProps>) => (
+  <ConfirmationModal
+    type="informative"
+    isOpen={true}
+    title="Example Modal Title"
+    onDismiss={() => undefined}
+    onConfirm={() => undefined}
+    children="Example Modal body"
+    {...props}
+  />
+)
+
+describe("<ConfirmationModal />", () => {
+  it("renders an open modal with the provided content", () => {
+    const { getByText } = render(
+      <ConfirmationModalWrapper>
+          Example modal body
+      </ConfirmationModalWrapper>
+    )
+    expect(getByText("Example modal body")).toBeTruthy()
+
+    // Confirm/Cancel are modal footer CTAs
+    expect(getByText("Confirm")).toBeTruthy()
+    expect(getByText("Cancel")).toBeTruthy()
+  })
+
+  it("renders a modal in a \"working\" state", () => {
+    const { getByText, queryByText } = render(
+      <ConfirmationModalWrapper
+        confirmWorking={{
+          label: "Submitting",
+          labelHidden: false
+        }}>
+          Example modal body
+      </ConfirmationModalWrapper>
+    )
+    expect(getByText("Example modal body")).toBeTruthy()
+
+    // Replaced by the user-submitted prop
+    expect(getByText("Submitting")).toBeTruthy()
+    expect(getByText("Cancel")).toBeTruthy()
+
+    // default "confirm" CTA should not be replaced by the above working state label
+    expect(queryByText("Confirm")).toBeNull()
+  })
+
+  it("closes the modal when escape key pressed", () => {
+    const handleConfirm = jest.fn()
+    const handleDismiss = jest.fn()
+    const document = render(
+      <ConfirmationModalWrapper
+        onDismiss={handleDismiss}
+        onConfirm={handleConfirm}>
+          Example modal body
+      </ConfirmationModalWrapper>
+    )
+    fireEvent.keyUp(document.container, { key: "Escape", code: "Escape" })
+    expect(handleDismiss).toHaveBeenCalledTimes(1)
+    expect(handleConfirm).toHaveBeenCalledTimes(0)
+  })
+
+  it("closes the modal when cancel button is pressed", () => {
+    const handleConfirm = jest.fn()
+    const handleDismiss = jest.fn()
+    const { getByText } = render(
+      <ConfirmationModalWrapper
+        onDismiss={handleDismiss}
+        onConfirm={handleConfirm}>
+          Example modal body
+      </ConfirmationModalWrapper>
+    )
+    fireEvent.click(getByText(/Cancel/i))
+    expect(handleConfirm).toHaveBeenCalledTimes(0)
+    expect(handleDismiss).toHaveBeenCalledTimes(1)
+  })
+
+  it("closes the modal when confirm button is pressed", () => {
+    const handleConfirm = jest.fn()
+    const handleDismiss = jest.fn()
+    const { getByText } = render(
+      <ConfirmationModalWrapper
+        onDismiss={handleDismiss}
+        onConfirm={handleConfirm}>
+          Example modal body
+      </ConfirmationModalWrapper>
+    )
+    fireEvent.click(getByText(/Confirm/i))
+    expect(handleConfirm).toHaveBeenCalledTimes(1)
+    expect(handleDismiss).toHaveBeenCalledTimes(0)
+  })
+})

--- a/draft-packages/modal/KaizenDraft/Modal/Presets/InformationModal.spec.tsx
+++ b/draft-packages/modal/KaizenDraft/Modal/Presets/InformationModal.spec.tsx
@@ -1,0 +1,89 @@
+import { cleanup, render, fireEvent } from "@testing-library/react"
+import * as React from "react"
+import InformationModal, { InformationModalProps } from "./InformationModal"
+
+afterEach(cleanup)
+
+const InformationModalWrapper = (props: Partial<InformationModalProps>) => (
+  <InformationModal
+    isOpen={true}
+    title="Example modal title"
+    onConfirm={() => undefined}
+    onDismiss={() => undefined}
+    children="Example modal body"
+    secondaryLabel="Example secondary"
+    onSecondaryAction={() => undefined}
+    {...props}
+  />
+)
+
+describe("<InformationModal />", () => {
+  it("renders an open modal with the provided content", () => {
+    const { getByText } = render(
+      <InformationModalWrapper>Example modal body</InformationModalWrapper>
+    )
+    expect(getByText("Example modal body")).toBeTruthy()
+  })
+
+  it("supports a dismiss action when escape key is pressed", () => {
+    const handleDismiss = jest.fn()
+    const document = render(
+      <InformationModalWrapper onDismiss={handleDismiss}>
+        Example modal body
+      </InformationModalWrapper>
+    )
+    fireEvent.keyUp(document.container, { key: "Escape", code: "Escape" })
+    expect(handleDismiss).toHaveBeenCalledTimes(1)
+  })
+
+  it("supports a dismiss action when dismiss button is pressed", () => {
+    const handleConfirm = jest.fn()
+    const handleDismiss = jest.fn()
+    const { getByTitle } = render(
+      <InformationModalWrapper
+        onConfirm={handleConfirm}
+        onDismiss={handleDismiss}
+      >
+        Example modal body
+      </InformationModalWrapper>
+    )
+    fireEvent.click(getByTitle(/Dismiss/i))
+    expect(handleConfirm).toHaveBeenCalledTimes(0)
+    expect(handleDismiss).toHaveBeenCalledTimes(1)
+  })
+
+  it("supports a confirm action when confirm button is pressed", () => {
+    const handleConfirm = jest.fn()
+    const handleDismiss = jest.fn()
+    const { getByText } = render(
+      <InformationModalWrapper
+        onConfirm={handleConfirm}
+        onDismiss={handleDismiss}
+      >
+        Example modal body
+      </InformationModalWrapper>
+    )
+    fireEvent.click(getByText(/Confirm/i))
+    expect(handleConfirm).toHaveBeenCalledTimes(1)
+    expect(handleDismiss).toHaveBeenCalledTimes(0)
+  })
+
+  it("supports a secondary action when secondary button is pressed", () => {
+    const handleConfirm = jest.fn()
+    const handleSecondary = jest.fn()
+    const handleDismiss = jest.fn()
+    const { getByText } = render(
+      <InformationModalWrapper
+        onConfirm={handleConfirm}
+        onDismiss={handleDismiss}
+        onSecondaryAction={handleSecondary}
+      >
+        Example modal body
+      </InformationModalWrapper>
+    )
+    fireEvent.click(getByText(/Example secondary/i))
+    expect(handleSecondary).toHaveBeenCalledTimes(1)
+    expect(handleConfirm).toHaveBeenCalledTimes(0)
+    expect(handleDismiss).toHaveBeenCalledTimes(0)
+  })
+})

--- a/draft-packages/modal/KaizenDraft/Modal/Presets/InputEditModal.spec.tsx
+++ b/draft-packages/modal/KaizenDraft/Modal/Presets/InputEditModal.spec.tsx
@@ -1,0 +1,76 @@
+import { cleanup, render, fireEvent } from "@testing-library/react"
+import * as React from "react"
+import InputEditModal, { InputEditModalProps } from "./InputEditModal"
+
+afterEach(cleanup)
+
+const InputEditModalWrapper = (props: Partial<InputEditModalProps>) => (
+  <InputEditModal
+    isOpen={true}
+    type="positive"
+    title="Example modal title"
+    onSubmit={() => undefined}
+    onDismiss={() => undefined}
+    children="Example modal body"
+    {...props}
+  />
+)
+
+describe("<InputEditModal />", () => {
+  it("renders an open modal with the provided content", () => {
+    const { getByText } = render(
+      <InputEditModalWrapper>Example modal body</InputEditModalWrapper>
+    )
+    expect(getByText("Example modal body")).toBeTruthy()
+  })
+
+  it("supports a dismiss action when escape key is pressed", () => {
+    const handleDismiss = jest.fn()
+    const document = render(
+      <InputEditModalWrapper onDismiss={handleDismiss}>
+        Example modal body
+      </InputEditModalWrapper>
+    )
+    fireEvent.keyUp(document.container, { key: "Escape", code: "Escape" })
+    expect(handleDismiss).toHaveBeenCalledTimes(1)
+  })
+
+  it("supports a dismiss action when dismiss button is pressed", () => {
+    const handleSubmit = jest.fn()
+    const handleDismiss = jest.fn()
+    const { getByTitle } = render(
+      <InputEditModalWrapper onSubmit={handleSubmit} onDismiss={handleDismiss}>
+        Example modal body
+      </InputEditModalWrapper>
+    )
+    fireEvent.click(getByTitle(/Dismiss/i))
+    expect(handleSubmit).toHaveBeenCalledTimes(0)
+    expect(handleDismiss).toHaveBeenCalledTimes(1)
+  })
+
+  it("supports a dismiss action when cancel button is pressed", () => {
+    const handleSubmit = jest.fn()
+    const handleDismiss = jest.fn()
+    const { getByText } = render(
+      <InputEditModalWrapper onSubmit={handleSubmit} onDismiss={handleDismiss}>
+        Example modal body
+      </InputEditModalWrapper>
+    )
+    fireEvent.click(getByText(/Cancel/i))
+    expect(handleSubmit).toHaveBeenCalledTimes(0)
+    expect(handleDismiss).toHaveBeenCalledTimes(1)
+  })
+
+  it("supports a submit action when submit button is pressed", () => {
+    const handleSubmit = jest.fn()
+    const handleDismiss = jest.fn()
+    const { getByText } = render(
+      <InputEditModalWrapper onSubmit={handleSubmit} onDismiss={handleDismiss}>
+        Example modal body
+      </InputEditModalWrapper>
+    )
+    fireEvent.click(getByText(/Submit/i))
+    expect(handleSubmit).toHaveBeenCalledTimes(1)
+    expect(handleDismiss).toHaveBeenCalledTimes(0)
+  })
+})

--- a/draft-packages/modal/KaizenDraft/Modal/Presets/RoadblockModal.spec.tsx
+++ b/draft-packages/modal/KaizenDraft/Modal/Presets/RoadblockModal.spec.tsx
@@ -1,0 +1,57 @@
+import { cleanup, render, fireEvent } from "@testing-library/react"
+import * as React from "react"
+import RoadblockModal, { RoadblockModalProps } from "./RoadblockModal"
+
+afterEach(cleanup)
+
+const RoadblockModalWrapper = (props: Partial<RoadblockModalProps>) => (
+  <RoadblockModal
+    isOpen={true}
+    title="Example modal title"
+    onDismiss={() => undefined}
+    children="Example modal body"
+    {...props}
+  />
+)
+
+describe("<RoadblockModal />", () => {
+  it("renders an open modal with the provided content", () => {
+    const { getByText } = render(
+      <RoadblockModalWrapper>Example modal body</RoadblockModalWrapper>
+    )
+    expect(getByText("Example modal body")).toBeTruthy()
+  })
+
+  it("supports a dismiss action when escape key is pressed", () => {
+    const handleDismiss = jest.fn()
+    const document = render(
+      <RoadblockModalWrapper onDismiss={handleDismiss}>
+        Example modal body
+      </RoadblockModalWrapper>
+    )
+    fireEvent.keyUp(document.container, { key: "Escape", code: "Escape" })
+    expect(handleDismiss).toHaveBeenCalledTimes(1)
+  })
+
+  it("supports a dismiss action when dismiss button is pressed", () => {
+    const handleDismiss = jest.fn()
+    const { getByTitle } = render(
+      <RoadblockModalWrapper onDismiss={handleDismiss}>
+        Example modal body
+      </RoadblockModalWrapper>
+    )
+    fireEvent.click(getByTitle(/Dismiss/i))
+    expect(handleDismiss).toHaveBeenCalledTimes(1)
+  })
+
+  it("supports a dismiss action when back button is pressed", () => {
+    const handleDismiss = jest.fn()
+    const { getByText } = render(
+      <RoadblockModalWrapper onDismiss={handleDismiss}>
+        Example modal body
+      </RoadblockModalWrapper>
+    )
+    fireEvent.click(getByText(/Back/i))
+    expect(handleDismiss).toHaveBeenCalledTimes(1)
+  })
+})

--- a/draft-packages/modal/KaizenDraft/Modal/Primitives/GenericModal.scss
+++ b/draft-packages/modal/KaizenDraft/Modal/Primitives/GenericModal.scss
@@ -87,7 +87,7 @@
   }
 }
 
-.aniamtingLeave,
+.animatingLeave,
 .animatingElmLeave {
   transition-duration: $ca-duration-rapid;
 

--- a/draft-packages/modal/KaizenDraft/Modal/Primitives/GenericModal.scss
+++ b/draft-packages/modal/KaizenDraft/Modal/Primitives/GenericModal.scss
@@ -66,9 +66,10 @@
   z-index: $ca-z-index-modal + 1;
 }
 
-:global(.animating-enter),
-:global(.animating-appear),
+.animatingEnter,
 .animatingElmEnter {
+  transition-duration: $ca-duration-fast;
+
   .backdropLayer {
     @include ca-animation-fade(
       $duration: $ca-duration-rapid,
@@ -86,8 +87,10 @@
   }
 }
 
-:global(.animating-exit),
-.animatingElmExit {
+.aniamtingLeave,
+.animatingElmLeave {
+  transition-duration: $ca-duration-rapid;
+
   .backdropLayer {
     @include ca-animation-fade(
       $duration: $ca-duration-rapid,

--- a/draft-packages/modal/KaizenDraft/Modal/Primitives/GenericModal.spec.tsx
+++ b/draft-packages/modal/KaizenDraft/Modal/Primitives/GenericModal.spec.tsx
@@ -1,0 +1,14 @@
+import { cleanup, render } from "@testing-library/react"
+import * as React from "react"
+import GenericModal from "./GenericModal"
+
+afterEach(cleanup)
+
+describe("<GenericModal />", () => {
+  it("renders the provided content", () => {
+    const { getByText } = render(
+      <GenericModal isOpen={true}>Example</GenericModal>
+    )
+    expect(() => getByText("Example")).not.toThrow()
+  })
+})

--- a/draft-packages/modal/KaizenDraft/Modal/Primitives/GenericModal.spec.tsx
+++ b/draft-packages/modal/KaizenDraft/Modal/Primitives/GenericModal.spec.tsx
@@ -1,14 +1,49 @@
-import { cleanup, render } from "@testing-library/react"
+import { cleanup, render, fireEvent, configure } from "@testing-library/react"
 import * as React from "react"
 import GenericModal from "./GenericModal"
+
+configure({ testIdAttribute: "data-automation-id" })
 
 afterEach(cleanup)
 
 describe("<GenericModal />", () => {
-  it("renders the provided content", () => {
+  it("renders an open modal with the provided content", () => {
     const { getByText } = render(
       <GenericModal isOpen={true}>Example</GenericModal>
     )
-    expect(() => getByText("Example")).not.toThrow()
+    expect(getByText("Example")).toBeTruthy()
+  })
+
+  it("does not render a closed modal with the provided content", () => {
+    const { getByText } = render(
+      <GenericModal isOpen={false}>Example</GenericModal>
+    )
+    expect(() => getByText("Example")).toThrow()
+  })
+
+  it("closes the modal when the escape key is pressed", () => {
+    const handleDismiss = jest.fn()
+    const document = render(
+      <GenericModal isOpen={true} onEscapeKeyup={handleDismiss}>
+        Example
+      </GenericModal>
+    )
+    fireEvent.keyUp(document.container, { key: "Escape", code: "Escape" })
+    expect(handleDismiss).toHaveBeenCalledTimes(1)
+  })
+
+  it("closes the modal when a click is outside of the modal content", () => {
+    const handleDismiss = jest.fn()
+    const { getByTestId } = render(
+      <GenericModal
+        isOpen={true}
+        onOutsideModalClick={handleDismiss}
+        automationId="GenericModalAutomationId"
+      >
+        Example
+      </GenericModal>
+    )
+    fireEvent.click(getByTestId("GenericModalAutomationId-scrollLayer"))
+    expect(handleDismiss).toHaveBeenCalledTimes(1)
   })
 })

--- a/draft-packages/modal/KaizenDraft/Modal/Primitives/GenericModal.spec.tsx
+++ b/draft-packages/modal/KaizenDraft/Modal/Primitives/GenericModal.spec.tsx
@@ -21,7 +21,7 @@ describe("<GenericModal />", () => {
     expect(() => getByText("Example")).toThrow()
   })
 
-  it("closes the modal when the escape key is pressed", () => {
+  it("closes the modal when escape key is pressed", () => {
     const handleDismiss = jest.fn()
     const document = render(
       <GenericModal isOpen={true} onEscapeKeyup={handleDismiss}>

--- a/draft-packages/modal/KaizenDraft/Modal/Primitives/GenericModal.tsx
+++ b/draft-packages/modal/KaizenDraft/Modal/Primitives/GenericModal.tsx
@@ -3,13 +3,13 @@ import { createPortal } from "react-dom"
 import FocusLock from "react-focus-lock"
 import uuid from "uuid/v4"
 import { warn } from "@kaizen/component-library/util/console"
+import { Transition } from "@headlessui/react"
 import {
   ModalAccessibleContext,
   ModalAccessibleContextType,
 } from "./ModalAccessibleContext"
 
 import styles from "./GenericModal.scss"
-const { CSSTransition } = require("react-transition-group")
 
 export interface GenericModalContainerProps {
   readonly isOpen: boolean
@@ -167,42 +167,38 @@ class GenericModal extends React.Component<GenericModalProps> {
     } = this.props
 
     return createPortal(
-      <CSSTransition
-        in={isOpen}
-        timeout={MODAL_TRANSITION_TIMEOUT}
-        classNames="animating"
+      <Transition
         appear={true}
-        unmountOnExit
+        show={isOpen}
+        enter={styles.animatingEnter}
+        leave={styles.animatingLeave}
       >
-        {/* This is not an unused div. It will receive `animating-` classes from react-transition-group */}
-        <div>
-          <FocusLock
-            disabled={focusLockDisabled}
-            returnFocus={true}
-            autoFocus={false}
+        <FocusLock
+          disabled={focusLockDisabled}
+          returnFocus={true}
+          autoFocus={false}
+        >
+          <div className={styles.backdropLayer} />
+          <div
+            className={styles.scrollLayer}
+            ref={scrollLayer => (this.scrollLayer = scrollLayer)}
+            onClick={
+              this.props.onOutsideModalClick && this.outsideModalClickHandler
+            }
           >
-            <div className={styles.backdropLayer} />
             <div
-              className={styles.scrollLayer}
-              ref={scrollLayer => (this.scrollLayer = scrollLayer)}
-              onClick={
-                this.props.onOutsideModalClick && this.outsideModalClickHandler
-              }
+              role="dialog"
+              aria-labelledby={this.props.labelledByID}
+              aria-describedby={this.props.describedByID}
+              className={styles.modalLayer}
+              ref={modalLayer => (this.modalLayer = modalLayer)}
+              data-automation-id={automationId}
             >
-              <div
-                role="dialog"
-                aria-labelledby={this.props.labelledByID}
-                aria-describedby={this.props.describedByID}
-                className={styles.modalLayer}
-                ref={modalLayer => (this.modalLayer = modalLayer)}
-                data-automation-id={automationId}
-              >
-                {children}
-              </div>
+              {children}
             </div>
-          </FocusLock>
-        </div>
-      </CSSTransition>,
+          </div>
+        </FocusLock>
+      </Transition>,
       document.body
     )
   }

--- a/draft-packages/modal/KaizenDraft/Modal/Primitives/GenericModal.tsx
+++ b/draft-packages/modal/KaizenDraft/Modal/Primitives/GenericModal.tsx
@@ -185,6 +185,7 @@ class GenericModal extends React.Component<GenericModalProps> {
             onClick={
               this.props.onOutsideModalClick && this.outsideModalClickHandler
             }
+            data-automation-id={`${automationId}-scrollLayer`}
           >
             <div
               role="dialog"

--- a/draft-packages/modal/package.json
+++ b/draft-packages/modal/package.json
@@ -33,6 +33,7 @@
   "license": "MIT",
   "dependencies": {
     "@kaizen/component-library": "^9.5.3",
+    "@headlessui/react": "^0.3.1",
     "@kaizen/deprecated-component-library-helpers": "^2.1.2",
     "@kaizen/draft-button": "^3.2.15",
     "@kaizen/draft-divider": "^1.4.1",
@@ -42,7 +43,6 @@
     "classnames": "^2.2.6",
     "react-dom": "^16.13.1",
     "react-focus-lock": "1.19.1",
-    "react-transition-group": "^4.4.1",
     "uuid": "^3.3.2"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1443,6 +1443,11 @@
   dependencies:
     "@hapi/hoek" "^9.0.0"
 
+"@headlessui/react@^0.3.1":
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/@headlessui/react/-/react-0.3.1.tgz#62d8df3b49f7e212f81f7fa4ba3cefb8945720ec"
+  integrity sha512-GnAVXCLmDs3CFvmvYo4Iu/LqAWVIoS+bGo+eMADnbWgF8BeMX13sWMyb8eOdj7N9nqY9QA2AsMzqYdAIbbsRIw==
+
 "@icons/material@^0.2.4":
   version "0.2.4"
   resolved "https://registry.yarnpkg.com/@icons/material/-/material-0.2.4.tgz#e90c9f71768b3736e76d7dd6783fc6c2afa88bc8"


### PR DESCRIPTION
# Objective
Replace CSSTransition from react-transition-group with Transition from headlessui/react. The API is very close making it a near drop-in replacement.

For this PR, the relevant change happens in `GenericModal.scss` and `GenericModal.tsx`. There is also a minor change to `Modal.elm` to make the CSS class names consistent.

The rest of the PR is adding tests to GenericModal and the presets we have (ConfirmationModal, InformationModal, InputEditModal, RoadblockModal) to hopefully catch issues like this in the future.

# Motivation and Context
react-transition-group is not actively maintained (https://github.com/reactjs/react-transition-group/issues/630#issuecomment-797733168) and is not fully compatible with React 17 (https://github.com/cultureamp/kaizen-design-system/issues/1184).

# Checklist
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] If this contains visual changes, has it been reviewed by a designer? N/A
- [x] If this introduces either a new component or a breaking change to an existing component, has it been reviewed by an advocate? (Ask in #prod_design_systems)
- [x] I have considered likely risks of these changes and got someone else to QA as appropriate
- [x] I have or will communicate these changes to the front end practice

# Additional Considerations
- Has the test suite been updated?
A basic test case has been added for GenericModal, however, we would like to have the test suite running in both React 16 and React 17 to catch issues such as this.