### PR TITLE
fix: InlineNotification issue from Heart update

### DIFF
--- a/packages/component-library/components/Notification/_styles.scss
+++ b/packages/component-library/components/Notification/_styles.scss
@@ -301,7 +301,7 @@ $ca-notification-slide-right: transform $ca-duration-slow ease-out;
   }
 
   %ca-notification---inline & {
-    margin-right: -$ca-notification-inline-horizontal-padding;
+    margin-right: calc(-1 * #{$ca-notification-inline-horizontal-padding});
   }
 
   %ca-notification---toast & {


### PR DESCRIPTION
# Objective
Fixes the negative margin on InlineNotification's cancel button (needed a `calc()` function to negate a CSS variable; silently failed)
