### PR TITLE
feat: add additional background colors to HeroCard component

### DIFF
--- a/draft-packages/hero-card/KaizenDraft/HeroCard/HeroCard.scss
+++ b/draft-packages/hero-card/KaizenDraft/HeroCard/HeroCard.scss
@@ -26,7 +26,6 @@ $left-content__width: 221px;
   display: flex;
   border-radius: $kz-border-solid-border-radius 0 0
     $kz-border-solid-border-radius;
-  background-color: $kz-color-wisteria-700;
   color: $kz-color-white;
   padding: ($ca-grid / 2) ($ca-grid * 2);
   flex-direction: column;
@@ -38,6 +37,22 @@ $left-content__width: 221px;
   .fullWidth & {
     width: 33%;
     max-width: 450px;
+  }
+
+  &.wisteria700 {
+    background-color: $kz-color-wisteria-700;
+  }
+
+  &.wisteria200 {
+    background-color: $kz-color-wisteria-200;
+  }
+
+  &.cluny200 {
+    background-color: $kz-color-cluny-200;
+  }
+
+  &.seedling200 {
+    background-color: $kz-color-seedling-200;
   }
 }
 

--- a/draft-packages/hero-card/KaizenDraft/HeroCard/HeroCard.tsx
+++ b/draft-packages/hero-card/KaizenDraft/HeroCard/HeroCard.tsx
@@ -3,6 +3,12 @@ import * as React from "react"
 
 import styles from "./HeroCard.scss"
 
+type BackgroundColors =
+  | "wisteria700"
+  | "wisteria200"
+  | "cluny200"
+  | "seedling200"
+
 export interface HeroCardProps {
   readonly leftContent?: React.ReactNode
   readonly children: React.ReactNode
@@ -11,6 +17,7 @@ export interface HeroCardProps {
   readonly badge?: React.ReactNode
   readonly fullWidth?: boolean
   readonly minHeight?: string
+  readonly leftBackgroundColor?: BackgroundColors
 }
 
 type HeroCard = React.FunctionComponent<HeroCardProps>
@@ -23,13 +30,17 @@ const HeroCard: HeroCard = ({
   badge,
   minHeight = "none",
   fullWidth = false,
+  leftBackgroundColor = "wisteria700",
 }: HeroCardProps) => (
   <div
     className={classnames(styles.root, {
       [styles.fullWidth]: fullWidth,
     })}
   >
-    <div style={{ minHeight }} className={styles.left}>
+    <div
+      style={{ minHeight }}
+      className={classnames(styles.left, styles[leftBackgroundColor])}
+    >
       {badge && <div className={styles.badge}>{badge}</div>}
       {leftContent && (
         <div

--- a/draft-packages/hero-card/docs/HeroCard.stories.tsx
+++ b/draft-packages/hero-card/docs/HeroCard.stories.tsx
@@ -132,3 +132,19 @@ export const FullWidth = () => (
 )
 
 FullWidth.storyName = "Full width"
+
+export const BackgroundColors = ({ leftBackgroundColor }) => (
+  <Container>
+    <HeroCard
+      title={<h1>Preview the survey questions</h1>}
+      leftBackgroundColor={leftBackgroundColor}
+    >
+      {renderContent()}
+    </HeroCard>
+  </Container>
+)
+
+BackgroundColors.storyName = "Background colors"
+BackgroundColors.args = {
+  leftBackgroundColor: "cluny200",
+}

--- a/draft-packages/hero-card/docs/HeroCard.stories.tsx
+++ b/draft-packages/hero-card/docs/HeroCard.stories.tsx
@@ -133,11 +133,11 @@ export const FullWidth = () => (
 
 FullWidth.storyName = "Full width"
 
-export const BackgroundColors = ({ leftBackgroundColor }) => (
+export const BackgroundColors = () => (
   <Container>
     <HeroCard
       title={<h1>Preview the survey questions</h1>}
-      leftBackgroundColor={leftBackgroundColor}
+      leftBackgroundColor="cluny200"
     >
       {renderContent()}
     </HeroCard>
@@ -145,6 +145,3 @@ export const BackgroundColors = ({ leftBackgroundColor }) => (
 )
 
 BackgroundColors.storyName = "Background colors"
-BackgroundColors.args = {
-  leftBackgroundColor: "cluny200",
-}


### PR DESCRIPTION
# Objective
<!-- Describe what this change achieves, and the details of how it works. -->

Adding the ability to change the background color of the left hand side of the HeroCard component. Now several options are available including the default background colour, currently set to wisteria700.

I thought about adding a transparent background, and then controlling the background color in a child element, but there was too much absolute positioning and/or negative margins involved for it to feel like a clean solution.

This is still not a very extensible way to define variations, but I think a larger conversation needs to happen before dynamic styling is included in any components.


# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Previously the HeroCard component used wisteria700 as a hardcoded background color, this change allows variations to the background color, allowing the new survey summary page to use it and match the current designs.

# Screenshots (if appropriate)

<img width="1016" alt="Mar 26 11-35-11" src="https://user-images.githubusercontent.com/899827/112560466-61c37400-8e27-11eb-8d63-0250337090f8.png">

