### PR TITLE
fix: Deprecate ToastNotification component

### DIFF
--- a/packages/component-library/components/Notification/ToastNotification.tsx
+++ b/packages/component-library/components/Notification/ToastNotification.tsx
@@ -1,5 +1,6 @@
 import * as React from "react"
 import { v4 } from "uuid"
+import { withDeprecatedComponent } from "@kaizen/react-deprecate-warning"
 import { addToastNotification } from "./ToastNotificationManager"
 import { ToastNotificationWithOptionals } from "./types"
 
@@ -32,4 +33,7 @@ const ToastNotification = ({
   return null
 }
 
-export default ToastNotification
+export default withDeprecatedComponent(ToastNotification, {
+  warning:
+    "ToastNotification component API is deprecated. Use addToastNotification from @kaizen/component-library instead.",
+})

--- a/packages/component-library/package.json
+++ b/packages/component-library/package.json
@@ -34,6 +34,7 @@
   "dependencies": {
     "@kaizen/deprecated-component-library-helpers": "^2.1.1",
     "@kaizen/hosted-assets": "^1.1.0",
+    "@kaizen/react-deprecate-warning": "^1.1.3",
     "@types/classnames": "^2.2.6",
     "@types/lodash": "^4.14.132",
     "@types/uuid": "^3.3.2",


### PR DESCRIPTION
Deprecate the `<ToastNotification>` component API in favour of the imperative API introduced in: https://github.com/cultureamp/kaizen-design-system/pull/758

The component itself remains for backwards compatibility, and the stories et al have already all been updated in the linked PR above.