### PR TITLE
feat: add mixins to create accessible stripes on colour blocks

### DIFF
--- a/packages/design-tokens/sass/accessibility.scss
+++ b/packages/design-tokens/sass/accessibility.scss
@@ -3,7 +3,7 @@ $default-stripe-angle: 45deg;
 $default-lighten-percent: 50%;
 $default-darken-percent: 50%;
 
-@mixin accessibility-stripe($base-color, $stripe-color, $angle, $width) {
+@mixin kz-accessibility-stripe($base-color, $stripe-color, $angle, $width) {
   background: repeating-linear-gradient(
     $angle,
     $base-color,
@@ -13,7 +13,7 @@ $default-darken-percent: 50%;
   );
 }
 
-@mixin accessibility-stripe-dark(
+@mixin kz-accessibility-stripe-dark(
   $base-color,
   $angle: $default-stripe-angle,
   $width: $default-stripe-width,
@@ -23,7 +23,7 @@ $default-darken-percent: 50%;
   @include accessibility-stripe($base-color, $stripe-color, $angle, $width);
 }
 
-@mixin accessibility-stripe-light(
+@mixin kz-accessibility-stripe-light(
   $base-color,
   $angle: $default-stripe-angle,
   $width: $default-stripe-width,

--- a/packages/design-tokens/sass/accessibility.scss
+++ b/packages/design-tokens/sass/accessibility.scss
@@ -1,46 +1,111 @@
-$default-stripe-width: 5px;
-$default-stripe-angle: 45deg;
-$default-lighten-percent: 50%;
-$default-darken-percent: 50%;
+$default-stripe-width-thin: 5px;
+$default-stripe-width-thick: 10px;
+$default-stripe-angle: -45deg;
+$default-stripe-lighten-percent: 50%;
+$default-stripe-darken-percent: 50%;
+$default-stripe-ratio: 0.5;
+$default-striped-row-background-size: 10px;
+$default-stripe-width-multiplier: 1;
 
-@mixin accessibility-stripe($base-color, $stripe-color, $angle, $width) {
+@function generate-stripes($base-color, $stripe-color, $stripe-to-base-ratio) {
+  @if (unit($stripe-to-base-ratio) == "%") {
+    $stripe-to-base-ratio: $stripe-to-base-ratio / 100%;
+  }
+  $base-color-percent: ceil(50% * $stripe-to-base-ratio);
+
+  $stripes: (
+    $stripe-color $base-color-percent,
+    $base-color $base-color-percent,
+    $base-color 50%,
+    $stripe-color 50%,
+    $stripe-color 50% + ($base-color-percent),
+    $base-color 50% + ($base-color-percent),
+    $base-color 100%
+  );
+
+  @return $stripes;
+}
+
+@mixin kz-accessibility-stripe(
+  $base-color,
+  $stripe-color,
+  $angle,
+  $width: $default-stripe-width-thick,
+  $stripe-to-base-ratio: $default-stripe-ratio,
+  $stripe-width-multiplier: $default-stripe-width-multiplier
+) {
   background: linear-gradient(
     $angle,
-    $base-color 25%,
-    $stripe-color 25%,
-    $stripe-color 50%,
-    $base-color 50%,
-    $base-color 75%,
-    $stripe-color 75%,
-    $stripe-color 100%
+    generate-stripes($base-color, $stripe-color, $stripe-to-base-ratio)
   );
-  background-size: $width $width;
+  background-size: (
+      $default-striped-row-background-size * $stripe-width-multiplier
+    )
+    ($default-striped-row-background-size * $stripe-width-multiplier);
 }
 
 @mixin kz-accessibility-stripe-dark(
   $base-color,
   $angle: $default-stripe-angle,
-  $width: $default-stripe-width,
-  $lightness: $default-darken-percent
+  $lightness: $default-stripe-darken-percent,
+  $stripe-width-multiplier: $default-stripe-width-multiplier
 ) {
   $stripe-color: scale-color($base-color, $lightness: -75%);
-  @include accessibility-stripe($base-color, $stripe-color, $angle, $width);
+  @include kz-accessibility-stripe(
+    $base-color,
+    $stripe-color,
+    $angle,
+    $stripe-width-multiplier
+  );
 }
 
 @mixin kz-accessibility-stripe-light(
   $base-color,
   $angle: $default-stripe-angle,
-  $width: $default-stripe-width,
-  $lightness: $default-lighten-percent
+  $lightness: $default-stripe-lighten-percent,
+  $stripe-width-multiplier: $default-stripe-width-multiplier
 ) {
   $stripe-color: scale-color($base-color, $lightness: 75%);
-  @include accessibility-stripe($base-color, $stripe-color, $angle, $width);
+  @include kz-accessibility-stripe(
+    $base-color,
+    $stripe-color,
+    $angle,
+    $stripe-width-multiplier
+  );
 }
 
 .kz-blue-stripe {
-  @include kz-accessibility-stripe(
+  @include accessibility-stripe(
     var(--kz-var-color-cluny-300, #73c0e8),
     var(--kz-var-color-cluny-500, #0168b3),
-    $width: 1px
+    $angle: $default-stripe-angle,
+    $width: $default-stripe-width-thin
+  );
+}
+
+.kz-grey-stripe {
+  @include accessibility-stripe(
+    var(--kz-var-color-ash, #ececef),
+    var(--kz-var-color-iron, #8c8c97),
+    $angle: $default-stripe-angle,
+    $width: $default-stripe-width-thin
+  );
+}
+
+.kz-green-stripe {
+  @include accessibility-stripe(
+    var(--kz-var-color-seedling-400, #5dcbad),
+    var(--kz-var-color-seedling-500, #3caf90),
+    $angle: $default-stripe-angle,
+    $width: $default-stripe-width-thick
+  );
+}
+
+.kz-red-stripe {
+  @include accessibility-stripe(
+    var(--kz-var-color-coral-400, #e0707d),
+    var(--kz-var-color-coral-600, #a82433),
+    $angle: $default-stripe-angle,
+    $width: $default-stripe-width-thick
   );
 }

--- a/packages/design-tokens/sass/accessibility.scss
+++ b/packages/design-tokens/sass/accessibility.scss
@@ -1,3 +1,8 @@
+$default-stripe-width: 5px;
+$default-stripe-angle: 45deg;
+$default-lighten-percent: 50%;
+$default-darken-percent: 50%;
+
 @mixin accessibility-stripe($base-color, $stripe-color, $angle, $width) {
   background: repeating-linear-gradient(
     $angle,
@@ -8,12 +13,22 @@
   );
 }
 
-@mixin accessibility-stripe-dark($base-color, $angle: 45deg, $width: 2px) {
+@mixin accessibility-stripe-dark(
+  $base-color,
+  $angle: $default-stripe-angle,
+  $width: $default-stripe-width,
+  $lightness: $default-darken-percent
+) {
   $stripe-color: scale-color($base-color, $lightness: -75%);
   @include accessibility-stripe($base-color, $stripe-color, $angle, $width);
 }
 
-@mixin accessibility-stripe-light($base-color, $angle: 45deg, $width: 2px) {
+@mixin accessibility-stripe-light(
+  $base-color,
+  $angle: $default-stripe-angle,
+  $width: $default-stripe-width,
+  $lightness: $default-lighten-percent
+) {
   $stripe-color: scale-color($base-color, $lightness: 75%);
   @include accessibility-stripe($base-color, $stripe-color, $angle, $width);
 }

--- a/packages/design-tokens/sass/accessibility.scss
+++ b/packages/design-tokens/sass/accessibility.scss
@@ -3,14 +3,18 @@ $default-stripe-angle: 45deg;
 $default-lighten-percent: 50%;
 $default-darken-percent: 50%;
 
-@mixin kz-accessibility-stripe($base-color, $stripe-color, $angle, $width) {
-  background: repeating-linear-gradient(
+@mixin accessibility-stripe($base-color, $stripe-color, $angle, $width) {
+  background: linear-gradient(
     $angle,
-    $base-color,
-    $base-color $width,
-    $stripe-color $width,
-    $stripe-color $width * 2
+    $base-color 25%,
+    $stripe-color 25%,
+    $stripe-color 50%,
+    $base-color 50%,
+    $base-color 75%,
+    $stripe-color 75%,
+    $stripe-color 100%
   );
+  background-size: $width $width;
 }
 
 @mixin kz-accessibility-stripe-dark(
@@ -31,4 +35,12 @@ $default-darken-percent: 50%;
 ) {
   $stripe-color: scale-color($base-color, $lightness: 75%);
   @include accessibility-stripe($base-color, $stripe-color, $angle, $width);
+}
+
+.kz-blue-stripe {
+  @include kz-accessibility-stripe(
+    var(--kz-var-color-cluny-300, #73c0e8),
+    var(--kz-var-color-cluny-500, #0168b3),
+    $width: 1px
+  );
 }

--- a/packages/design-tokens/sass/accessibility.scss
+++ b/packages/design-tokens/sass/accessibility.scss
@@ -74,37 +74,37 @@ $default-stripe-width-multiplier: 1;
   );
 }
 
-.kz-blue-stripe {
+.kz-cluny-stripe {
   @include accessibility-stripe(
-    var(--kz-var-color-cluny-300, #73c0e8),
-    var(--kz-var-color-cluny-500, #0168b3),
+    var(--kz-var-color-cluny-300),
+    var(--kz-var-color-cluny-500),
     $angle: $default-stripe-angle,
     $width: $default-stripe-width-thin
   );
 }
 
-.kz-grey-stripe {
+.kz-ash-stripe {
   @include accessibility-stripe(
-    var(--kz-var-color-ash, #ececef),
-    var(--kz-var-color-iron, #8c8c97),
+    var(--kz-var-color-ash),
+    var(--kz-var-color-iron),
     $angle: $default-stripe-angle,
     $width: $default-stripe-width-thin
   );
 }
 
-.kz-green-stripe {
+.kz-favorable-with-stripe {
   @include accessibility-stripe(
-    var(--kz-var-color-seedling-400, #5dcbad),
-    var(--kz-var-color-seedling-500, #3caf90),
+    var(--kz-var-data-viz-favorable),
+    var(--kz-var-color-seedling-500),
     $angle: $default-stripe-angle,
     $width: $default-stripe-width-thick
   );
 }
 
-.kz-red-stripe {
+.kz-unfavorable-with-stripe {
   @include accessibility-stripe(
-    var(--kz-var-color-coral-400, #e0707d),
-    var(--kz-var-color-coral-600, #a82433),
+    var(--kz-var-data-viz-unfavorable),
+    var(--kz-var-color-coral-600),
     $angle: $default-stripe-angle,
     $width: $default-stripe-width-thick
   );

--- a/packages/design-tokens/sass/accessibility.scss
+++ b/packages/design-tokens/sass/accessibility.scss
@@ -1,0 +1,19 @@
+@mixin accessibility-stripe($base-color, $stripe-color, $angle, $width) {
+  background: repeating-linear-gradient(
+    $angle,
+    $base-color,
+    $base-color $width,
+    $stripe-color $width,
+    $stripe-color $width * 2
+  );
+}
+
+@mixin accessibility-stripe-dark($base-color, $angle: 45deg, $width: 2px) {
+  $stripe-color: scale-color($base-color, $lightness: -75%);
+  @include accessibility-stripe($base-color, $stripe-color, $angle, $width);
+}
+
+@mixin accessibility-stripe-light($base-color, $angle: 45deg, $width: 2px) {
+  $stripe-color: scale-color($base-color, $lightness: 75%);
+  @include accessibility-stripe($base-color, $stripe-color, $angle, $width);
+}

--- a/site/docs/guidelines/color.mdx
+++ b/site/docs/guidelines/color.mdx
@@ -19,6 +19,7 @@ import ZenSeedling from "docs-components/color/ZenSeedling"
 import ZenYuzu from "docs-components/color/ZenYuzu"
 import ZenPeach from "docs-components/color/ZenPeach"
 import ZenCoral from "docs-components/color/ZenCoral"
+import HeartAccessibilityHelpers from "docs-components/color/HeartAccessibilityHelpers"
 
 ## Zen palette
 
@@ -88,6 +89,14 @@ For the most important action on a page, use Cluny (or Seedling on dark backgrou
 
 See [data visualization](/guidelines/data-visualization) for details.
 
+### Accessibility tools
+
+The preferred option for handling accessibility in relation to colors is to use contrasting colors that won't cause confusion as our defaults. Sometimes this isn't possible, and in that case other indicators such as stripes over data colors can help create this distinction.
+
+Some defaults and helper methods are available for scss.
+
+<HeartAccessibilityHelpers />
+
 ## When to use and when not to use
 
 <WhenToUseAndWhenNotToUse>
@@ -121,4 +130,3 @@ Here are some examples of existing design system colors:
 - [Bootstrap: colors](https://getbootstrap.com/docs/4.3/utilities/colors/)
 - [Element: color](https://element.eleme.io/#/en-US/component/color)
 - [Spectre: color](https://picturepan2.github.io/spectre/utilities/colors.html)
-

--- a/site/docs/guidelines/data-visualization.mdx
+++ b/site/docs/guidelines/data-visualization.mdx
@@ -36,6 +36,7 @@ For nearly all charts, you must consider the following:
 - Text color must have sufficient contrast with the background. See our [color guidelines](/guidelines/color) for details.
 - Color must not used as the only visual means of conveying information. Consider using changes in contrast and patterns in bars or lines.
 - Ensure SVG elements have a `<title>` element that provides an accessible, short-text description.
+- Where color-blind versions of visualisations can be made available, there is some guidance and scss helpers available. See our [color guidelines](/guidelines/color) for details.
 
 Where applicable, you might consider the following:
 

--- a/site/src/docs-components/color/HeartAccessibilityHelpers.tsx
+++ b/site/src/docs-components/color/HeartAccessibilityHelpers.tsx
@@ -1,6 +1,6 @@
-import accessibilityHelpers from "!raw-loader!@kaizen/design-tokens/sass/accessibility.scss"
 import * as React from "react"
 import Code from "../Code"
+import accessibilityHelpers from "!raw-loader!@kaizen/design-tokens/sass/accessibility.scss"
 
 class HeartAccessibilityHelpers extends React.PureComponent {
   render() {

--- a/site/src/docs-components/color/HeartAccessibilityHelpers.tsx
+++ b/site/src/docs-components/color/HeartAccessibilityHelpers.tsx
@@ -1,0 +1,11 @@
+import accessibilityHelpers from "!raw-loader!@kaizen/design-tokens/sass/accessibility.scss"
+import * as React from "react"
+import Code from "../Code"
+
+class HeartAccessibilityHelpers extends React.PureComponent {
+  render() {
+    return <Code language="scss">{accessibilityHelpers}</Code>
+  }
+}
+
+export default HeartAccessibilityHelpers


### PR DESCRIPTION
# Objective
Add some easy accessibility scss mixins so we can use them in our codebases!

# Motivation and Context
We currently only have colour to define different values in a number of our graphs. This is not okay for some colour-blind users. These are some mixins to allow for stripes to be added to those colours.

# Screenshots (if appropriate)
Colours are just examples, but this is what it may look like on our reports page:
![Screen Shot 2021-03-31 at 6 37 56 pm](https://user-images.githubusercontent.com/6839317/113108344-9cc30e80-9250-11eb-967e-cf2e6bab2a99.png)

Some defaults I've added (class name ideas welcomed!) based on the rebranded Heart theme in the [UI kit](https://www.figma.com/file/eZKEE5kXbEMY3lx84oz8iN/?node-id=10516%3A4269):
![Screen Shot 2021-04-01 at 12 36 35 pm](https://user-images.githubusercontent.com/6839317/113231414-e9f1bf80-92e6-11eb-856b-90c1af07d36d.png)


# Checklist
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] If this contains visual changes, has it been reviewed by a designer?
- [ ] If this introduces either a new component or a breaking change to an existing component, has it been reviewed by an advocate? (Ask in #prod_design_systems)
- [ ] I have considered likely risks of these changes and got someone else to QA as appropriate
- [ ] I have or will communicate these changes to the front end practice

# Additional Considerations
- Does there need to be right-to-left (RTL) options for localization and internationalization?
- Has the test suite been updated?
- Have you done cross-browser testing for our [supported browsers](https://academy.cultureamp.com/hc/en-us/articles/204539569-Supported-browsers-for-Participants)?
- Have you updated any relevant documentation or left useful comments in the code?
- Have you reviewed Culture Amp's Web Accessibility guide [Current Compliance, Going Forward, Statement and Answers for Customers](https://cultureamp.atlassian.net/wiki/spaces/Prod/pages/428572998/Web+Accessibility)?
- If this contains substantial visual changes, especially far reaching ones, have you unlocked the Chromatic step in the pipeline?
- Have Storybook stories been updated?

**If you're new to Kaizen, please ask #prod_design_systems to set up an onboarding session to get you up to speed.** If you have an urgent PR to merge before that happens, it is safest to ask in #prod_design_systems to have a design system advocate review the PR to catch any issues.
