### PR TITLE
feat: add clearable option for SelectField.elm

### DIFF
--- a/draft-packages/form/KaizenDraft/Form/SelectField/SelectField.elm
+++ b/draft-packages/form/KaizenDraft/Form/SelectField/SelectField.elm
@@ -48,6 +48,7 @@ type alias ConfigValue msg item =
     , placeholder : ( String, Select.Style )
     , menuItems : List (Select.MenuItem item)
     , searchable : Bool
+    , clearable : Bool
     , toMsg : ToMsg msg item
     , labelText : Label.LabelProp msg
     , description : Maybe (List (Html msg))
@@ -71,6 +72,7 @@ defaults toMsg =
     , placeholder = Select.defaults.placeholder
     , menuItems = Select.defaults.menuItems
     , searchable = Select.defaults.searchable
+    , clearable = Select.defaults.clearable
     , toMsg = toMsg
     , labelText = Label.LabelString ""
     , description = Nothing
@@ -143,6 +145,11 @@ placeholder plc (Config config) =
 searchable : Bool -> Config msg item -> Config msg item
 searchable searchable_ (Config config) =
     Config { config | searchable = searchable_ }
+
+
+clearable : Bool -> Config msg item -> Config msg item
+clearable predicate (Config config) =
+    Config { config | clearable = predicate }
 
 
 
@@ -269,6 +276,7 @@ view (Config config) =
                 |> Select.placeholder config.placeholder
                 |> Select.menuItems config.menuItems
                 |> Select.searchable config.searchable
+                |> Select.clearable config.clearable
 
         selectInputId =
             config.id ++ "-field-input"


### PR DESCRIPTION
# Objective
This is a follow up to https://github.com/cultureamp/kaizen-design-system/pull/1351, but also adds the clearable option to SelectField (not just Select, I forgot to do this)

# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

# Screenshots (if appropriate)

# Checklist
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] If this contains visual changes, has it been reviewed by a designer?
- [ ] If this introduces either a new component or a breaking change to an existing component, has it been reviewed by an advocate? (Ask in #prod_design_systems)
- [ ] I have considered likely risks of these changes and got someone else to QA as appropriate
- [ ] I have or will communicate these changes to the front end practice

# Additional Considerations
- Does there need to be right-to-left (RTL) options for localization and internationalization?
- Has the test suite been updated?
- Have you done cross-browser testing for our [supported browsers](https://academy.cultureamp.com/hc/en-us/articles/204539569-Supported-browsers-for-Participants)?
- Have you updated any relevant documentation or left useful comments in the code?
- Have you reviewed Culture Amp's Web Accessibility guide [Current Compliance, Going Forward, Statement and Answers for Customers](https://cultureamp.atlassian.net/wiki/spaces/Prod/pages/428572998/Web+Accessibility)?
- If this contains substantial visual changes, especially far reaching ones, have you unlocked the Chromatic step in the pipeline?
- Have Storybook stories been updated?

**If you're new to Kaizen, please ask #prod_design_systems to set up an onboarding session to get you up to speed.** If you have an urgent PR to merge before that happens, it is safest to ask in #prod_design_systems to have a design system advocate review the PR to catch any issues.
