### PR TITLE
fix: export elm select field clearable

### DIFF
--- a/draft-packages/form/KaizenDraft/Form/SelectField/SelectField.elm
+++ b/draft-packages/form/KaizenDraft/Form/SelectField/SelectField.elm
@@ -1,6 +1,7 @@
 module KaizenDraft.Form.SelectField.SelectField exposing
     ( Config
     , Status(..)
+    , clearable
     , description
     , disabled
     , id


### PR DESCRIPTION
Export the `clearable` config option of the Elm SelectField so it can actually be used!

