### PR TITLE
fix: Update environment check to not use optional chaining

### DIFF
--- a/packages/react-deprecate-warning/src/util.ts
+++ b/packages/react-deprecate-warning/src/util.ts
@@ -1,5 +1,12 @@
+/**
+ * All our consumers use Webpack's DefinePlugin to emulate process.env
+ * This either generates a string, "process.env.NODE_ENV", or an object
+ * process.env with properties such that they can be referenced like so
+ * process.env["NODE_ENV"]. This makes it safe to not need to check if
+ * process.env is a valid object.
+ */
 export const shouldWarn =
-  process.env?.NODE_ENV !== undefined && process.env?.NODE_ENV !== "production"
+  process.env.NODE_ENV !== undefined && process.env.NODE_ENV !== "production"
 
 const log = (deprecatedType: "component" | "prop") => (
   name: string,


### PR DESCRIPTION
# Objective
All our consumers use Webpack's DefinePlugin to emulate process.env. This either generates a string, "process.env.NODE_ENV", or an object process.env with properties such that they can be referenced like so process.env["NODE_ENV"]. This makes it safe to not need to check if process.env is a valid object.

# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

# Screenshots (if appropriate)

# Checklist
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] If this contains visual changes, has it been reviewed by a designer?
- [ ] If this introduces either a new component or a breaking change to an existing component, has it been reviewed by an advocate? (Ask in #prod_design_systems)
- [ ] I have considered likely risks of these changes and got someone else to QA as appropriate
- [ ] I have or will communicate these changes to the front end practice

# Additional Considerations
- Does there need to be right-to-left (RTL) options for localization and internationalization?
- Has the test suite been updated?
- Have you done cross-browser testing for our [supported browsers](https://academy.cultureamp.com/hc/en-us/articles/204539569-Supported-browsers-for-Participants)?
- Have you updated any relevant documentation or left useful comments in the code?
- Have you reviewed Culture Amp's Web Accessibility guide [Current Compliance, Going Forward, Statement and Answers for Customers](https://cultureamp.atlassian.net/wiki/spaces/Prod/pages/428572998/Web+Accessibility)?
- If this contains substantial visual changes, especially far reaching ones, have you unlocked the Chromatic step in the pipeline?
- Have Storybook stories been updated?

**If you're new to Kaizen, please ask #prod_design_systems to set up an onboarding session to get you up to speed.** If you have an urgent PR to merge before that happens, it is safest to ask in #prod_design_systems to have a design system advocate review the PR to catch any issues.
