### PR TITLE
feat: Add clear variant to Collapsible component

### DIFF
--- a/draft-packages/collapsible/KaizenDraft/Collapsible/Collapsible.spec.tsx
+++ b/draft-packages/collapsible/KaizenDraft/Collapsible/Collapsible.spec.tsx
@@ -198,3 +198,37 @@ it("respects controlled mode (stays open after click)", () => {
   fireEvent.click(button)
   expect(section.style.height).toEqual("auto")
 })
+
+it("clear variant has correct class", () => {
+  const { getByTestId } = render(
+    <CollapsibleGroup>
+      <Collapsible variant="clear" id="1" open title="First panel">
+        First panel content
+      </Collapsible>
+      <Collapsible variant="clear" id="2" title="Second panel">
+        Second panel content
+      </Collapsible>
+    </CollapsibleGroup>
+  )
+
+  const collapsibleContainer = getByTestId("collapsible-button-1")
+
+  expect(collapsibleContainer.classList.contains("clearVariant")).toBeTruthy()
+})
+
+it("default variant has correct class", () => {
+  const { getByTestId } = render(
+    <CollapsibleGroup>
+      <Collapsible id="1" open title="First panel">
+        First panel content
+      </Collapsible>
+      <Collapsible id="2" title="Second panel">
+        Second panel content
+      </Collapsible>
+    </CollapsibleGroup>
+  )
+
+  const collapsibleContainer = getByTestId("collapsible-button-1")
+
+  expect(collapsibleContainer.classList.contains("defaultVariant")).toBeTruthy()
+})

--- a/draft-packages/collapsible/KaizenDraft/Collapsible/Collapsible.stories.tsx
+++ b/draft-packages/collapsible/KaizenDraft/Collapsible/Collapsible.stories.tsx
@@ -74,7 +74,7 @@ export const SingleCollapsibleCustomHeader = () => (
       id="collapsible-single"
       open
       title="Custom header"
-      highlightOpen={false}
+      variant="default"
       renderHeader={title => (
         <>
           <Icon icon={translationIcon} />
@@ -131,6 +131,39 @@ export const _CollapsibleGroup = () => (
 )
 
 _CollapsibleGroup.storyName = "Collapsible group"
+SingleCollapsibleLazyLoad.storyName = "Single collapsible (lazy load)"
+
+// eslint-disable-next-line no-underscore-dangle
+export const _CollapsibleClearVariantGroup = () => (
+  <div style={{ margin: "1rem", width: "40rem" }}>
+    <CollapsibleGroup>
+      <Collapsible
+        variant="clear"
+        id="collapsible-separate-1"
+        open
+        title="First panel"
+      >
+        <Paragraph variant="body">{lipsum}</Paragraph>
+      </Collapsible>
+      <Collapsible
+        variant="clear"
+        id="collapsible-separate-2"
+        title="Second panel"
+      >
+        <Paragraph variant="body">{lipsum}</Paragraph>
+      </Collapsible>
+      <Collapsible
+        variant="clear"
+        id="collapsible-separate-3"
+        title="Third panel"
+      >
+        <Paragraph variant="body">{lipsum}</Paragraph>
+      </Collapsible>
+    </CollapsibleGroup>
+  </div>
+)
+
+_CollapsibleClearVariantGroup.storyName = "Collapsible group (clear variant)"
 
 export const CollapsibleGroupSeparated = () => (
   <div style={{ margin: "1rem", width: "40rem" }}>

--- a/draft-packages/collapsible/KaizenDraft/Collapsible/Collapsible.tsx
+++ b/draft-packages/collapsible/KaizenDraft/Collapsible/Collapsible.tsx
@@ -9,6 +9,8 @@ import { Sticky } from "./CollapsibleGroup"
 
 import styles from "./styles.scss"
 
+type Variant = "default" | "clear"
+
 export type Props = {
   id: string
   children: JSX.Element | JSX.Element[] | string
@@ -23,7 +25,7 @@ export type Props = {
   onToggle?: (open: boolean, id: string) => void
 
   /* Highlights the header when open by changing the background color */
-  highlightOpen?: boolean
+  variant?: Variant
 
   /* Will avoid rendering the content until required (especially important when you have queries inside sections).
   Removes animation. */
@@ -54,7 +56,7 @@ class Collapsible extends React.Component<Props, State> {
       automationId,
       children,
       lazyLoad,
-      highlightOpen = true,
+      variant = "default",
     } = this.props
     const buttonId = `${this.props.id}-button`
     const sectionId = `${this.props.id}-section`
@@ -74,7 +76,8 @@ class Collapsible extends React.Component<Props, State> {
         <button
           id={buttonId}
           className={classnames(styles.button, {
-            [styles.highlightOpen]: open && highlightOpen,
+            [styles.defaultVariant]: open && variant === "default",
+            [styles.clearVariant]: open && variant === "clear",
             [styles.sticky]: sticky,
           })}
           style={sticky && { top: sticky.top }}

--- a/draft-packages/collapsible/KaizenDraft/Collapsible/Collapsible.tsx
+++ b/draft-packages/collapsible/KaizenDraft/Collapsible/Collapsible.tsx
@@ -24,7 +24,11 @@ export type Props = {
   automationId?: string
   onToggle?: (open: boolean, id: string) => void
 
-  /* Highlights the header when open by changing the background color */
+  /**
+   * By default, the header will change background colour when open. When the variant
+    is set to 'clear', it will not have a background but a border-bottom will appear
+    to separate the heading from the content.
+   */
   variant?: Variant
 
   /* Will avoid rendering the content until required (especially important when you have queries inside sections).

--- a/draft-packages/collapsible/KaizenDraft/Collapsible/__snapshots__/Collapsible.spec.tsx.snap
+++ b/draft-packages/collapsible/KaizenDraft/Collapsible/__snapshots__/Collapsible.spec.tsx.snap
@@ -61,7 +61,7 @@ exports[`matches snapshot with everything enabled 1`] = `
       <button
         aria-controls="2-section"
         aria-expanded="true"
-        class="button highlightOpen sticky"
+        class="button defaultVariant sticky"
         data-automation-id="collapsible-button-2"
         id="2-button"
         style="top: 20px;"

--- a/draft-packages/collapsible/KaizenDraft/Collapsible/styles.scss
+++ b/draft-packages/collapsible/KaizenDraft/Collapsible/styles.scss
@@ -63,8 +63,12 @@ $heading-active-color: $kz-var-color-wisteria-100;
   flex: 1 1 auto;
 }
 
-.highlightOpen {
+.defaultVariant {
   background-color: $heading-active-color;
+}
+
+.clearVariant {
+  border-bottom: 1px solid $kz-var-color-wisteria-200;
 }
 
 .sticky {


### PR DESCRIPTION
# Objective
- Update the Collapsible component to have a clear variant, that when open, will have a border on the bottom of it. This change is also keeping the default the way it is and tests/snapshots have been updated.

# Motivation and Context
- This has been updated so we can reflect the new designs for the survey overview page. Where a collapsible component can be open with a border bottom on it.
- Closes this: https://cultureamp.atlassian.net/secure/RapidBoard.jspa?rapidView=186&projectKey=EARTH&modal=detail&selectedIssue=EARTH-307&quickFilter=194

# Screenshots
## Designs
<img width="739" alt="Screen Shot 2021-04-15 at 11 14 47 am" src="https://user-images.githubusercontent.com/18339250/114799786-cc8b1e00-9ddb-11eb-874c-0a7773d77d4f.png">

## Storybook
<img width="995" alt="Screen Shot 2021-04-15 at 11 15 25 am" src="https://user-images.githubusercontent.com/18339250/114799825-e2004800-9ddb-11eb-8847-9d3cf98c82dd.png">


# Checklist
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] If this contains visual changes, has it been reviewed by a designer?
- [ ] If this introduces either a new component or a breaking change to an existing component, has it been reviewed by an advocate? (Ask in #prod_design_systems)
- [ ] I have considered likely risks of these changes and got someone else to QA as appropriate
- [ ] I have or will communicate these changes to the front end practice

# Additional Considerations
- Does there need to be right-to-left (RTL) options for localization and internationalization?
- Has the test suite been updated?
- Have you done cross-browser testing for our [supported browsers](https://academy.cultureamp.com/hc/en-us/articles/204539569-Supported-browsers-for-Participants)?
- Have you updated any relevant documentation or left useful comments in the code?
- Have you reviewed Culture Amp's Web Accessibility guide [Current Compliance, Going Forward, Statement and Answers for Customers](https://cultureamp.atlassian.net/wiki/spaces/Prod/pages/428572998/Web+Accessibility)?
- If this contains substantial visual changes, especially far reaching ones, have you unlocked the Chromatic step in the pipeline?
- Have Storybook stories been updated?

**If you're new to Kaizen, please ask #prod_design_systems to set up an onboarding session to get you up to speed.** If you have an urgent PR to merge before that happens, it is safest to ask in #prod_design_systems to have a design system advocate review the PR to catch any issues.
