### PR TITLE
fix: Stop shadow from overflowing and remove overflow-x:hidden

### DIFF
--- a/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/TitleBlockZen.scss
+++ b/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/TitleBlockZen.scss
@@ -12,7 +12,7 @@ $title-block-margin-width-on-medium-and-small: 12px;
 $breadcrumb-circle-width: 48px;
 $breadcrumb-breakpoint-width: $kz-layout-content-max-width +
   $kz-layout-content-side-margin * 2 + $breadcrumb-circle-width * 2.25;
-$title-block-separator-height: 3px;
+$title-block-separator-height: 0.1875rem;
 $tab-container-height-default: $ca-grid * 3;
 $tab-container-height-small: $ca-grid * 2.5;
 $tab-container-height-default-collapsed: $ca-grid + 0.1875rem;
@@ -27,7 +27,6 @@ $tab-container-height-medium-and-small-collapsed: $ca-grid * 0.75;
   display: flex;
   justify-content: center;
   flex-direction: column;
-  overflow-x: hidden;
 
   &.educationVariant {
     background-color: $dt-color-background-color-eduction;
@@ -457,8 +456,8 @@ $tab-container-height-medium-and-small-collapsed: $ca-grid * 0.75;
   @include title-block-small {
     display: block;
     position: absolute;
-    top: 63px;
-    width: $ca-grid * 2;
+    top: $tab-container-height-small - $title-block-separator-height;
+    width: $tab-container-height-small;
     height: $tab-container-height-small;
     background: linear-gradient(
       0,


### PR DESCRIPTION
# Objective, Motivation and Context
In https://github.com/cultureamp/kaizen-design-system/pull/1232 there was an `overflow-x: hidden` added to the Title Block in order to avoid a scroll bar appearing on smaller viewports. This created a new bug:

https://user-images.githubusercontent.com/1811583/115176603-c74a0e00-a110-11eb-8a5f-62c6e905e2c6.mov

This PR removes the `overflow-x: hidden` that was added, and fixes the root cause of the scroll bar. The scroll bar was caused by an element that adds a shadow to the tabs:
![image](https://user-images.githubusercontent.com/1811583/115176910-5f47f780-a111-11eb-91b3-0378547be7a9.png)

This element is rotated 270deg, which was causing a scroll bar to appear. We've fixed this by making this element square.


# Checklist
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] If this contains visual changes, has it been reviewed by a designer?
- [ ] If this introduces either a new component or a breaking change to an existing component, has it been reviewed by an advocate? (Ask in #prod_design_systems)
- [ ] I have considered likely risks of these changes and got someone else to QA as appropriate
- [ ] I have or will communicate these changes to the front end practice

# Additional Considerations
- Does there need to be right-to-left (RTL) options for localization and internationalization?
- Has the test suite been updated?
- Have you done cross-browser testing for our [supported browsers](https://academy.cultureamp.com/hc/en-us/articles/204539569-Supported-browsers-for-Participants)?
- Have you updated any relevant documentation or left useful comments in the code?
- Have you reviewed Culture Amp's Web Accessibility guide [Current Compliance, Going Forward, Statement and Answers for Customers](https://cultureamp.atlassian.net/wiki/spaces/Prod/pages/428572998/Web+Accessibility)?
- If this contains substantial visual changes, especially far reaching ones, have you unlocked the Chromatic step in the pipeline?
- Have Storybook stories been updated?

**If you're new to Kaizen, please ask #prod_design_systems to set up an onboarding session to get you up to speed.** If you have an urgent PR to merge before that happens, it is safest to ask in #prod_design_systems to have a design system advocate review the PR to catch any issues.
