### PR TITLE
feat: Add support for multiple fullwidth values for different breakpoints 

### DIFF
--- a/draft-packages/button/KaizenDraft/Button/components/GenericButton.module.scss
+++ b/draft-packages/button/KaizenDraft/Button/components/GenericButton.module.scss
@@ -64,7 +64,7 @@
   @extend %caButtonLabel;
 }
 
-.fullWidth {
+@mixin full-width {
   width: 100%;
 
   .button {
@@ -74,6 +74,28 @@
 
   .content {
     justify-content: center;
+  }
+}
+
+.fullWidth {
+  @include full-width;
+}
+
+@media (max-width: 768px) {
+  .smallFullWidth {
+    @include full-width;
+  }
+}
+
+@media (min-width: 768px) and (max-width: 1080px) {
+  .mediumFullWidth {
+    @include full-width;
+  }
+}
+
+@media (min-width: 1081px) {
+  .largeFullWidth {
+    @include full-width;
   }
 }
 

--- a/draft-packages/button/KaizenDraft/Button/components/GenericButton.tsx
+++ b/draft-packages/button/KaizenDraft/Button/components/GenericButton.tsx
@@ -13,6 +13,16 @@ import React, {
 
 import styles from "./GenericButton.module.scss"
 
+// Duplicated(ish?) from design-tokens/layout
+type Breakpoints = {
+  "small": 0,
+  "medium": 768,
+  "large": 1080
+}
+
+type BreakpointNames = keyof Breakpoints
+type BreakpointMap<N> = N | { [key in BreakpointNames]: N }
+
 export type CustomButtonProps = {
   id?: string
   className: string
@@ -37,7 +47,7 @@ export type GenericProps = {
   href?: string
   newTabAndIUnderstandTheAccessibilityImplications?: boolean
   type?: "submit" | "reset" | "button"
-  fullWidth?: boolean
+  fullWidth?: BreakpointMap<boolean>
   disableTabFocusAndIUnderstandTheAccessibilityImplications?: boolean
   onFocus?: (e: FocusEvent<HTMLElement>) => void
   onBlur?: (e: FocusEvent<HTMLElement>) => void
@@ -115,7 +125,10 @@ const GenericButton = forwardRef(
     return (
       <span
         className={classNames(styles.container, {
-          [styles.fullWidth]: props.fullWidth,
+          [styles.fullWidth]: typeof props.fullWidth !== "object" && props.fullWidth,
+          [styles.smallFullWidth]: typeof props.fullWidth !== "boolean" && props.fullWidth?.small,
+          [styles.mediumFullWidth]: typeof props.fullWidth !== "boolean" &&  props.fullWidth?.medium,
+          [styles.largeFullWidth]: typeof props.fullWidth !== "boolean" && props.fullWidth?.large,
         })}
       >
         {determineButtonRenderer()}

--- a/draft-packages/button/docs/Button.stories.tsx
+++ b/draft-packages/button/docs/Button.stories.tsx
@@ -715,3 +715,18 @@ CustomComponent.story = {
   name: "Custom Component",
   parameters: {},
 }
+
+export const FullWidthResponsiveButton = args => (
+  <div>
+    <Button
+      fullWidth={{ small: true, medium: true, large: false }}
+      label="Passez au rapport de synthèse"
+      data-automation-id="demo-button"
+      {...args}
+    />
+  </div>
+)
+FullWidthResponsiveButton.story = {
+  name: "Full width responsive",
+  parameters: {},
+}


### PR DESCRIPTION
# Objective
<!-- Describe what this change achieves, and the details of how it works. -->

# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

# Screenshots (if appropriate)

# Checklist
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] If this contains visual changes, has it been reviewed by a designer?
- [ ] If this introduces either a new component or a breaking change to an existing component, has it been reviewed by an advocate? (Ask in #prod_design_systems)
- [ ] I have considered likely risks of these changes and got someone else to QA as appropriate
- [ ] I have or will communicate these changes to the front end practice

# Additional Considerations
- Does there need to be right-to-left (RTL) options for localization and internationalization?
- Has the test suite been updated?
- Have you done cross-browser testing for our [supported browsers](https://academy.cultureamp.com/hc/en-us/articles/204539569-Supported-browsers-for-Participants)?
- Have you updated any relevant documentation or left useful comments in the code?
- Have you reviewed Culture Amp's Web Accessibility guide [Current Compliance, Going Forward, Statement and Answers for Customers](https://cultureamp.atlassian.net/wiki/spaces/Prod/pages/428572998/Web+Accessibility)?
- If this contains substantial visual changes, especially far reaching ones, have you unlocked the Chromatic step in the pipeline?
- Have Storybook stories been updated?

**If you're new to Kaizen, please ask #prod_design_systems to set up an onboarding session to get you up to speed.** If you have an urgent PR to merge before that happens, it is safest to ask in #prod_design_systems to have a design system advocate review the PR to catch any issues.
