### PR TITLE
feat: Add get started illustration to storybook and scene component

### DIFF
--- a/draft-packages/illustration/KaizenDraft/Illustration/Scene.tsx
+++ b/draft-packages/illustration/KaizenDraft/Illustration/Scene.tsx
@@ -291,3 +291,7 @@ export const KaizenSiteResourcesAlt = (props: SceneProps) => (
 export const SurveyOverviewClosed = (props: SceneProps) => (
   <Base {...props} name="illustrations/scene/survey-overview-closed.svg" />
 )
+
+export const SurveyGetStarted = (props: SceneProps) => (
+  <Base {...props} name="illustrations/scene/getting-started.svg" />
+)

--- a/draft-packages/illustration/docs/IllustrationScene.stories.tsx
+++ b/draft-packages/illustration/docs/IllustrationScene.stories.tsx
@@ -50,6 +50,7 @@ import {
   PerformanceTeamSummary,
   Programs,
   SurveyOverviewClosed,
+  SurveyGetStarted,
 } from ".."
 
 export default {
@@ -428,3 +429,10 @@ export const SurveyOverviewClosedStory = () => (
   </div>
 )
 SurveyOverviewClosedStory.storyName = "Survey Overview: Closed Survey"
+
+export const SurveyGetStartedStory = () => (
+  <div style={{ width: "500px" }}>
+    <SurveyGetStarted alt="" />
+  </div>
+)
+SurveyGetStartedStory.storyName = "Survey Overview: Get Started"


### PR DESCRIPTION
Work:
- Added an illustration here: https://github.com/cultureamp/kaizen-design-system-assets/pull/24
- Now added it to Kaizen for use

<img width="794" alt="Screen Shot 2021-04-20 at 2 25 16 pm" src="https://user-images.githubusercontent.com/18339250/115337559-8c190f00-a1e4-11eb-8182-6a71ecf41f67.png">
