### PR TITLE
fix: Update data-viz color values for Heart theme

### DIFF
--- a/packages/design-tokens/src/themes/heart.ts
+++ b/packages/design-tokens/src/themes/heart.ts
@@ -108,8 +108,8 @@ export const heartTheme: Theme = {
     slate: "#524e56",
   },
   dataViz: {
-    favorable: "#a5e2d2",
-    unfavorable: "#f7acb9",
+    favorable: "#7dd5bd",
+    unfavorable: "#e68d97",
   },
   DEPRECATED: {
     color: {


### PR DESCRIPTION
These were mis-calculated in passing them over originally. @katsambarcus has re-calced them for me.