### PR TITLE
feat: Added Heart spot illustrations

### DIFF
--- a/draft-packages/illustration/KaizenDraft/Illustration/Spot.tsx
+++ b/draft-packages/illustration/KaizenDraft/Illustration/Spot.tsx
@@ -6,7 +6,9 @@ export type SpotProps = Pick<BaseProps, "alt" | "classNameAndIHaveSpokenToDST">
 
 const noZenIllustrationWarning = (illustrationName: string) => {
   // eslint-disable-next-line no-console
-  console.warn(`Kaizen Illustration: No corresponding Zen illustration for ${illustrationName}. Displaying Heart illustration instead."`)
+  console.warn(
+    `Kaizen Illustration: No corresponding Zen illustration for ${illustrationName}. Displaying Heart illustration instead."`
+  )
 }
 
 /**
@@ -595,8 +597,8 @@ export const ManagerLearning = (props: SpotProps) => {
   const theme = useTheme()
   const illustrationPath =
     theme.themeKey === "zen"
-    ? "illustrations/spot/manager-learning-manager-learning.svg"
-     : "illustrations/heart/spot/skills-coach-manager-learning.svg"
+      ? "illustrations/spot/manager-learning-manager-learning.svg"
+      : "illustrations/heart/spot/skills-coach-manager-learning.svg"
 
   return <Base {...props} name={illustrationPath} />
 }
@@ -625,7 +627,7 @@ export const OneOnOne = (props: SpotProps) => {
   const theme = useTheme()
   const illustrationPath =
     theme.themeKey === "zen"
-    ? "illustrations/spot/manager-learning-1-on-1.svg"
+      ? "illustrations/spot/manager-learning-1-on-1.svg"
       : "illustrations/heart/spot/skills-coach-1-on-1.svg"
 
   return <Base {...props} name={illustrationPath} />
@@ -994,10 +996,6 @@ export const Recommendation = (props: SpotProps) => {
     noZenIllustrationWarning("Recommendation")
   }
   return (
-    <Base
-      {...props}
-      name="illustrations/heart/spot/miscellaneous-shield.svg"
-    />
+    <Base {...props} name="illustrations/heart/spot/miscellaneous-shield.svg" />
   )
 }
-

--- a/draft-packages/illustration/KaizenDraft/Illustration/Spot.tsx
+++ b/draft-packages/illustration/KaizenDraft/Illustration/Spot.tsx
@@ -1,361 +1,1003 @@
+import { useTheme } from "@kaizen/design-tokens"
 import * as React from "react"
 import { Base, BaseProps } from "./Base"
 
 export type SpotProps = Pick<BaseProps, "alt" | "classNameAndIHaveSpokenToDST">
 
-export const BenefitsSurvey = (props: SpotProps) => (
-  <Base
-    {...props}
-    name="illustrations/spot/template-library-benefits-survey.svg"
-  />
-)
-
-export const CustomSurvey = (props: SpotProps) => (
-  <Base
-    {...props}
-    name="illustrations/spot/template-library-custom-survey.svg"
-  />
-)
-
-export const CustomUnattributedSurvey = (props: SpotProps) => (
-  <Base
-    {...props}
-    name="illustrations/spot/template-library-custom-unattributed-survey.svg"
-  />
-)
-
-export const EngagementSurvey = (props: SpotProps) => (
-  <Base
-    {...props}
-    name="illustrations/spot/template-library-engagement-survey.svg"
-  />
-)
-
-export const InclusionSurvey = (props: SpotProps) => (
-  <Base
-    {...props}
-    name="illustrations/spot/template-library-inclusion-survey.svg"
-  />
-)
-
-export const QuickEngagementSurvey = (props: SpotProps) => (
-  <Base
-    {...props}
-    name="illustrations/spot/template-library-quick-engagement-survey.svg"
-  />
-)
-
-export const ValuesSurvey1 = (props: SpotProps) => (
-  <Base
-    {...props}
-    name="illustrations/spot/template-library-values-survey-1.svg"
-  />
-)
-
-export const ValuesSurvey2 = (props: SpotProps) => (
-  <Base
-    {...props}
-    name="illustrations/spot/template-library-values-survey-2.svg"
-  />
-)
-
-export const WellbeingSurvey1 = (props: SpotProps) => (
-  <Base
-    {...props}
-    name="illustrations/spot/template-library-wellbeing-survey-1.svg"
-  />
-)
-
-export const WellbeingSurvey2 = (props: SpotProps) => (
-  <Base
-    {...props}
-    name="illustrations/spot/template-library-wellbeing-survey-2.svg"
-  />
-)
-
-export const WellbeingSurvey3 = (props: SpotProps) => (
-  <Base
-    {...props}
-    name="illustrations/spot/template-library-wellbeing-survey-3.svg"
-  />
-)
-
-export const ChangeReadiness = (props: SpotProps) => (
-  <Base
-    {...props}
-    name="illustrations/spot/template-library-change-readiness.svg"
-  />
-)
-
-export const ChangeSuccess = (props: SpotProps) => (
-  <Base
-    {...props}
-    name="illustrations/spot/template-library-change-success.svg"
-  />
-)
-
-export const CandidateSurvey = (props: SpotProps) => (
-  <Base
-    {...props}
-    name="illustrations/spot/template-library-candidate-survey.svg"
-  />
-)
-
-export const CustomOnboardSurvey = (props: SpotProps) => (
-  <Base
-    {...props}
-    name="illustrations/spot/template-library-custom-onboard-survey.svg"
-  />
-)
-
-export const ExitSurvey = (props: SpotProps) => (
-  <Base {...props} name="illustrations/spot/template-library-exit-survey.svg" />
-)
-
-export const InternSurvey = (props: SpotProps) => (
-  <Base
-    {...props}
-    name="illustrations/spot/template-library-intern-survey.svg"
-  />
-)
-
-export const PhasedWeek1OnboardSurvey = (props: SpotProps) => (
-  <Base
-    {...props}
-    name="illustrations/spot/template-library-phased-week-1-onboard-survey.svg"
-  />
-)
-
-export const PhasedWeek5OnboardSurvey = (props: SpotProps) => (
-  <Base
-    {...props}
-    name="illustrations/spot/template-library-phased-week-5-onboard-survey.svg"
-  />
-)
-
-export const SinglePointOnboardSurvey = (props: SpotProps) => (
-  <Base
-    {...props}
-    name="illustrations/spot/template-library-single-point-onboard-survey.svg"
-  />
-)
-
-export const Individual360 = (props: SpotProps) => (
-  <Base
-    {...props}
-    name="illustrations/spot/template-library-individual-360.svg"
-  />
-)
-
-export const Leadership360 = (props: SpotProps) => (
-  <Base
-    {...props}
-    name="illustrations/spot/template-library-leadership-360.svg"
-  />
-)
-
-export const Manager360 = (props: SpotProps) => (
-  <Base {...props} name="illustrations/spot/template-library-manager-360.svg" />
-)
-
-export const TeamEffectiveness1 = (props: SpotProps) => (
-  <Base
-    {...props}
-    name="illustrations/spot/template-library-team-effectiveness-1.svg"
-  />
-)
-
-export const TeamEffectiveness2 = (props: SpotProps) => (
-  <Base
-    {...props}
-    name="illustrations/spot/template-library-team-effectiveness-2.svg"
-  />
-)
-
-export const AccountBasics = (props: SpotProps) => (
-  <Base {...props} name="illustrations/spot/new-account-account-basics.svg" />
-)
-
-export const CompanyDetails = (props: SpotProps) => (
-  <Base {...props} name="illustrations/spot/new-account-company-details.svg" />
-)
-
-export const EmployeeData = (props: SpotProps) => (
-  <Base {...props} name="illustrations/spot/new-account-employee-data.svg" />
-)
-
-export const Gdpr = (props: SpotProps) => (
-  <Base {...props} name="illustrations/spot/new-account-gdpr.svg" />
-)
-
-export const Timezone = (props: SpotProps) => (
-  <Base {...props} name="illustrations/spot/new-account-timezone.svg" />
-)
-
-export const AddUser = (props: SpotProps) => (
-  <Base {...props} name="illustrations/spot/new-account-add-user.svg" />
-)
-
-export const ViewReports = (props: SpotProps) => (
-  <Base {...props} name="illustrations/spot/miscellaneous-view-reports.svg" />
-)
-
-export const ReadArticle = (props: SpotProps) => (
-  <Base {...props} name="illustrations/spot/miscellaneous-read-article.svg" />
-)
-
-export const FastAction = (props: SpotProps) => (
-  <Base {...props} name="illustrations/spot/miscellaneous-fast-action.svg" />
-)
-
-export const BaselineSurvey = (props: SpotProps) => (
-  <Base
-    {...props}
-    name="illustrations/spot/miscellaneous-baseline-survey.svg"
-  />
-)
-
-export const SpreadsheetTemplate = (props: SpotProps) => (
-  <Base
-    {...props}
-    name="illustrations/spot/miscellaneous-spreadsheet-template.svg"
-  />
-)
-
-export const AddImage = (props: SpotProps) => (
-  <Base {...props} name="illustrations/spot/miscellaneous-add-image.svg" />
-)
-
-export const MeetingVoices = (props: SpotProps) => (
-  <Base {...props} name="illustrations/spot/miscellaneous-meeting-voices.svg" />
-)
-
-export const Workshop = (props: SpotProps) => (
-  <Base {...props} name="illustrations/spot/miscellaneous-workshop.svg" />
-)
-
-export const Video = (props: SpotProps) => (
-  <Base {...props} name="illustrations/spot/miscellaneous-video.svg" />
-)
-
-export const ReportSharing = (props: SpotProps) => (
-  <Base {...props} name="illustrations/spot/miscellaneous-report-sharing.svg" />
-)
-
-export const BlankSurvey = (props: SpotProps) => (
-  <Base {...props} name="illustrations/spot/miscellaneous-blank-survey.svg" />
-)
-
-export const TakeAim = (props: SpotProps) => (
-  <Base {...props} name="illustrations/spot/miscellaneous-take-aim.svg" />
-)
-
-export const Action = (props: SpotProps) => (
-  <Base {...props} name="illustrations/spot/miscellaneous-action.svg" />
-)
-
-export const Training1 = (props: SpotProps) => (
-  <Base {...props} name="illustrations/spot/miscellaneous-training-1.svg" />
-)
-
-export const Training2 = (props: SpotProps) => (
-  <Base {...props} name="illustrations/spot/miscellaneous-training-2.svg" />
-)
-
-export const Training3 = (props: SpotProps) => (
-  <Base {...props} name="illustrations/spot/miscellaneous-training-3.svg" />
-)
-
-export const ShareReport = (props: SpotProps) => (
-  <Base {...props} name="illustrations/spot/miscellaneous-share-report.svg" />
-)
-
-export const Team = (props: SpotProps) => (
-  <Base {...props} name="illustrations/spot/miscellaneous-team.svg" />
-)
-
-export const ExecutiveReportSharing = (props: SpotProps) => (
-  <Base
-    {...props}
-    name="illustrations/spot/miscellaneous-executive-report-sharing.svg"
-  />
-)
-
-export const ManagerReportSharing = (props: SpotProps) => (
-  <Base
-    {...props}
-    name="illustrations/spot/miscellaneous-manager-report-sharing.svg"
-  />
-)
-
-export const LeaderReportSharing = (props: SpotProps) => (
-  <Base
-    {...props}
-    name="illustrations/spot/miscellaneous-leader-report-sharing.svg"
-  />
-)
-
-export const Cautionary = (props: SpotProps) => (
-  <Base {...props} name="illustrations/spot/moods-cautionary.svg" />
-)
-
-export const Informative = (props: SpotProps) => (
-  <Base {...props} name="illustrations/spot/moods-informative.svg" />
-)
-
-export const Negative = (props: SpotProps) => (
-  <Base {...props} name="illustrations/spot/moods-negative.svg" />
-)
-
-export const PositiveMale = (props: SpotProps) => (
-  <Base {...props} name="illustrations/spot/moods-positive-male.svg" />
-)
-
-export const PositiveFemale = (props: SpotProps) => (
-  <Base {...props} name="illustrations/spot/moods-positive-female.svg" />
-)
-
-export const OneOnOne = (props: SpotProps) => (
-  <Base {...props} name="illustrations/spot/manager-learning-1-on-1.svg" />
-)
-
-export const Productivity = (props: SpotProps) => (
-  <Base
-    {...props}
-    name="illustrations/spot/manager-learning-productivity.svg"
-  />
-)
-
-export const Strategy = (props: SpotProps) => (
-  <Base {...props} name="illustrations/spot/manager-learning-strategy.svg" />
-)
-
-export const Resilience = (props: SpotProps) => (
-  <Base {...props} name="illustrations/spot/manager-learning-resilience.svg" />
-)
-
-export const Coaching = (props: SpotProps) => (
-  <Base {...props} name="illustrations/spot/manager-learning-coaching.svg" />
-)
-
-export const Feedback = (props: SpotProps) => (
-  <Base {...props} name="illustrations/spot/manager-learning-feedback.svg" />
-)
-
-export const RemoteManager = (props: SpotProps) => (
-  <Base
-    {...props}
-    name="illustrations/spot/manager-learning-remote-manager.svg"
-  />
-)
-
-export const ManagerLearning = (props: SpotProps) => (
-  <Base
-    {...props}
-    name="illustrations/spot/manager-learning-manager-learning.svg"
-  />
-)
-
-export const PerformanceDiagnostics = (props: SpotProps) => (
-  <Base {...props} name="illustrations/spot/template-library-diagnostics.svg" />
-)
+const noZenIllustrationWarning = (illustrationName: string) => {
+  // eslint-disable-next-line no-console
+  console.warn(`Kaizen Illustration: No corresponding Zen illustration for ${illustrationName}. Displaying Heart illustration instead."`)
+}
+
+/**
+ * Moods
+ */
+export const Cautionary = (props: SpotProps) => {
+  const theme = useTheme()
+  const illustrationPath =
+    theme.themeKey === "zen"
+      ? "illustrations/spot/moods-cautionary.svg"
+      : "illustrations/heart/spot/moods-cautionary.svg"
+
+  return <Base {...props} name={illustrationPath} />
+}
+
+export const Informative = (props: SpotProps) => {
+  const theme = useTheme()
+  const illustrationPath =
+    theme.themeKey === "zen"
+      ? "illustrations/spot/moods-informative.svg"
+      : "illustrations/heart/spot/moods-informative.svg"
+  return <Base {...props} name={illustrationPath} />
+}
+
+export const Negative = (props: SpotProps) => {
+  const theme = useTheme()
+  const illustrationPath =
+    theme.themeKey === "zen"
+      ? "illustrations/spot/moods-negative.svg"
+      : "illustrations/heart/spot/moods-negative.svg"
+
+  return <Base {...props} name={illustrationPath} />
+}
+
+/**
+ * @deprecated Use the non-gendered Positive illustration instead
+ */
+export const PositiveMale = (props: SpotProps) => {
+  const theme = useTheme()
+  const illustrationPath =
+    theme.themeKey === "zen"
+      ? "illustrations/spot/moods-positive-male.svg"
+      : "illustrations/heart/spot/moods-positive.svg"
+
+  return <Base {...props} name={illustrationPath} />
+}
+
+/**
+ * @deprecated Use the non-gendered Positive illustration instead
+ */
+export const PositiveFemale = (props: SpotProps) => {
+  const theme = useTheme()
+  const illustrationPath =
+    theme.themeKey === "zen"
+      ? "illustrations/spot/moods-positive-female.svg"
+      : "illustrations/heart/spot/moods-positive.svg"
+
+  return <Base {...props} name={illustrationPath} />
+}
+
+export const Positive = (props: SpotProps) => {
+  const theme = useTheme()
+  const illustrationPath =
+    theme.themeKey === "zen"
+      ? "illustrations/spot/moods-positive-female.svg"
+      : "illustrations/heart/spot/moods-positive.svg"
+
+  return <Base {...props} name={illustrationPath} />
+}
+
+export const Assertive = (props: SpotProps) => {
+  const theme = useTheme()
+  if (theme.themeKey === "zen") {
+    noZenIllustrationWarning("Assertive")
+  }
+
+  return <Base {...props} name="illustrations/heart/spot/moods-assertive.svg" />
+}
+
+/**
+ * Template Library / Engagement
+ */
+export const BenefitsSurvey = (props: SpotProps) => {
+  const theme = useTheme()
+  const illustrationPath =
+    theme.themeKey === "zen"
+      ? "illustrations/spot/template-library-benefits-survey.svg"
+      : "illustrations/heart/spot/template-library-benefits-survey.svg"
+
+  return <Base {...props} name={illustrationPath} />
+}
+
+export const CustomSurvey = (props: SpotProps) => {
+  const theme = useTheme()
+  const illustrationPath =
+    theme.themeKey === "zen"
+      ? "illustrations/spot/template-library-custom-survey.svg"
+      : "illustrations/heart/spot/template-library-custom-survey.svg"
+
+  return <Base {...props} name={illustrationPath} />
+}
+
+export const CustomUnattributedSurvey = (props: SpotProps) => {
+  const theme = useTheme()
+  const illustrationPath =
+    theme.themeKey === "zen"
+      ? "illustrations/spot/template-library-custom-unattributed-survey.svg"
+      : "illustrations/heart/spot/template-library-custom-unattributed-survey.svg"
+
+  return <Base {...props} name={illustrationPath} />
+}
+
+export const EngagementSurvey = (props: SpotProps) => {
+  const theme = useTheme()
+  const illustrationPath =
+    theme.themeKey === "zen"
+      ? "illustrations/spot/template-library-engagement-survey.svg"
+      : "illustrations/heart/spot/template-library-engagement-survey.svg"
+
+  return <Base {...props} name={illustrationPath} />
+}
+
+export const InclusionSurvey = (props: SpotProps) => {
+  const theme = useTheme()
+  const illustrationPath =
+    theme.themeKey === "zen"
+      ? "illustrations/spot/template-library-inclusion-survey.svg"
+      : "illustrations/heart/spot/template-library-inclusion-survey.svg"
+
+  return <Base {...props} name={illustrationPath} />
+}
+
+export const QuickEngagementSurvey = (props: SpotProps) => {
+  const theme = useTheme()
+  const illustrationPath =
+    theme.themeKey === "zen"
+      ? "illustrations/spot/template-library-quick-engagement-survey.svg"
+      : "illustrations/heart/spot/template-library-quick-engagement-survey.svg"
+
+  return <Base {...props} name={illustrationPath} />
+}
+
+export const ValuesSurvey1 = (props: SpotProps) => {
+  const theme = useTheme()
+  const illustrationPath =
+    theme.themeKey === "zen"
+      ? "illustrations/spot/template-library-values-survey-1.svg"
+      : "illustrations/heart/spot/template-library-values-survey-1.svg"
+
+  return <Base {...props} name={illustrationPath} />
+}
+
+export const ValuesSurvey2 = (props: SpotProps) => {
+  const theme = useTheme()
+  const illustrationPath =
+    theme.themeKey === "zen"
+      ? "illustrations/spot/template-library-values-survey-2.svg"
+      : "illustrations/heart/spot/template-library-values-survey-2.svg"
+
+  return <Base {...props} name={illustrationPath} />
+}
+
+export const WellbeingSurvey1 = (props: SpotProps) => {
+  const theme = useTheme()
+  const illustrationPath =
+    theme.themeKey === "zen"
+      ? "illustrations/spot/template-library-wellbeing-survey-1.svg"
+      : "illustrations/heart/spot/template-library-wellbeing-survey-1.svg"
+
+  return <Base {...props} name={illustrationPath} />
+}
+
+export const WellbeingSurvey2 = (props: SpotProps) => {
+  const theme = useTheme()
+  const illustrationPath =
+    theme.themeKey === "zen"
+      ? "illustrations/spot/template-library-wellbeing-survey-2.svg"
+      : "illustrations/heart/spot/template-library-wellbeing-survey-2.svg"
+
+  return <Base {...props} name={illustrationPath} />
+}
+
+export const WellbeingSurvey3 = (props: SpotProps) => {
+  const theme = useTheme()
+  const illustrationPath =
+    theme.themeKey === "zen"
+      ? "illustrations/spot/template-library-wellbeing-survey-3.svg"
+      : "illustrations/heart/spot/template-library-wellbeing-survey-3.svg"
+
+  return <Base {...props} name={illustrationPath} />
+}
+
+export const ChangeReadiness = (props: SpotProps) => {
+  const theme = useTheme()
+  const illustrationPath =
+    theme.themeKey === "zen"
+      ? "illustrations/spot/template-library-change-readiness.svg"
+      : "illustrations/heart/spot/template-library-change-readiness.svg"
+
+  return <Base {...props} name={illustrationPath} />
+}
+
+export const ChangeSuccess = (props: SpotProps) => {
+  const theme = useTheme()
+  const illustrationPath =
+    theme.themeKey === "zen"
+      ? "illustrations/spot/template-library-change-success.svg"
+      : "illustrations/heart/spot/template-library-change-success.svg"
+
+  return <Base {...props} name={illustrationPath} />
+}
+
+export const PerformanceDiagnostics = (props: SpotProps) => {
+  const theme = useTheme()
+  const illustrationPath =
+    theme.themeKey === "zen"
+      ? "illustrations/spot/template-library-diagnostics.svg"
+      : "illustrations/heart/spot/template-library-performance-diagnostics.svg"
+
+  return <Base {...props} name={illustrationPath} />
+}
+
+export const LeadingThroughCrisis = (props: SpotProps) => {
+  const theme = useTheme()
+  if (theme.themeKey === "zen") {
+    noZenIllustrationWarning("LeadingThroughCrisis")
+  }
+
+  return (
+    <Base
+      {...props}
+      name="illustrations/heart/spot/template-library-leading-through-crisis.svg"
+    />
+  )
+}
+
+export const EmergencyResponse = (props: SpotProps) => {
+  const theme = useTheme()
+  if (theme.themeKey === "zen") {
+    noZenIllustrationWarning("EmergencyResponse")
+  }
+
+  return (
+    <Base
+      {...props}
+      name="illustrations/heart/spot/template-library-emergency-response.svg"
+    />
+  )
+}
+
+/**
+ * Template Library / Experience
+ */
+export const CandidateSurvey = (props: SpotProps) => {
+  const theme = useTheme()
+  const illustrationPath =
+    theme.themeKey === "zen"
+      ? "illustrations/spot/template-library-candidate-survey.svg"
+      : "illustrations/heart/spot/template-library-candidate-survey.svg"
+
+  return <Base {...props} name={illustrationPath} />
+}
+
+export const CustomOnboardSurvey = (props: SpotProps) => {
+  const theme = useTheme()
+  const illustrationPath =
+    theme.themeKey === "zen"
+      ? "illustrations/spot/template-library-custom-onboard-survey.svg"
+      : "illustrations/heart/spot/template-library-custom-onboard-survey.svg"
+
+  return <Base {...props} name={illustrationPath} />
+}
+
+export const ExitSurvey = (props: SpotProps) => {
+  const theme = useTheme()
+  const illustrationPath =
+    theme.themeKey === "zen"
+      ? "illustrations/spot/template-library-exit-survey.svg"
+      : "illustrations/heart/spot/template-library-exit-survey.svg"
+
+  return <Base {...props} name={illustrationPath} />
+}
+
+export const InternSurvey = (props: SpotProps) => {
+  const theme = useTheme()
+  const illustrationPath =
+    theme.themeKey === "zen"
+      ? "illustrations/spot/template-library-intern-survey.svg"
+      : "illustrations/heart/spot/template-library-intern-survey.svg"
+
+  return <Base {...props} name={illustrationPath} />
+}
+
+export const PhasedWeek1OnboardSurvey = (props: SpotProps) => {
+  const theme = useTheme()
+  const illustrationPath =
+    theme.themeKey === "zen"
+      ? "illustrations/spot/template-library-phased-week-1-onboard-survey.svg"
+      : "illustrations/heart/spot/template-library-phased-week-1-onboard-survey.svg"
+
+  return <Base {...props} name={illustrationPath} />
+}
+
+export const PhasedWeek5OnboardSurvey = (props: SpotProps) => {
+  const theme = useTheme()
+  const illustrationPath =
+    theme.themeKey === "zen"
+      ? "illustrations/spot/template-library-phased-week-5-onboard-survey.svg"
+      : "illustrations/heart/spot/template-library-phased-week-5-onboard-survey.svg"
+
+  return <Base {...props} name={illustrationPath} />
+}
+
+export const SinglePointOnboardSurvey = (props: SpotProps) => {
+  const theme = useTheme()
+  const illustrationPath =
+    theme.themeKey === "zen"
+      ? "illustrations/spot/template-library-single-point-onboard-survey.svg"
+      : "illustrations/heart/spot/template-library-single-point-onboard-survey.svg"
+
+  return <Base {...props} name={illustrationPath} />
+}
+
+export const GeneralOnboardSurvey = (props: SpotProps) => {
+  const theme = useTheme()
+  if (theme.themeKey === "zen") {
+    noZenIllustrationWarning("GeneralOnboardSurvey")
+  }
+
+  return (
+    <Base
+      {...props}
+      name="illustrations/heart/spot/template-library-general-onboard-survey.svg"
+    />
+  )
+}
+
+export const RemoteOnboardSurvey = (props: SpotProps) => {
+  const theme = useTheme()
+  if (theme.themeKey === "zen") {
+    noZenIllustrationWarning("GeneralOnboardSurvey")
+  }
+
+  return (
+    <Base
+      {...props}
+      name="illustrations/heart/spot/template-library-remote-onboard-survey.svg"
+    />
+  )
+}
+
+/**
+ * Template Library / Performance
+ */
+export const Individual360 = (props: SpotProps) => {
+  const theme = useTheme()
+  const illustrationPath =
+    theme.themeKey === "zen"
+      ? "illustrations/spot/template-library-individual-360.svg"
+      : "illustrations/heart/spot/template-library-individual-360.svg"
+
+  return <Base {...props} name={illustrationPath} />
+}
+
+export const Leadership360 = (props: SpotProps) => {
+  const theme = useTheme()
+  const illustrationPath =
+    theme.themeKey === "zen"
+      ? "illustrations/spot/template-library-leadership-360.svg"
+      : "illustrations/heart/spot/template-library-leadership-360.svg"
+
+  return <Base {...props} name={illustrationPath} />
+}
+
+export const Manager360 = (props: SpotProps) => {
+  const theme = useTheme()
+  const illustrationPath =
+    theme.themeKey === "zen"
+      ? "illustrations/spot/template-library-manager-360.svg"
+      : "illustrations/heart/spot/template-library-manager-360.svg"
+
+  return <Base {...props} name={illustrationPath} />
+}
+
+export const TeamEffectiveness1 = (props: SpotProps) => {
+  const theme = useTheme()
+  const illustrationPath =
+    theme.themeKey === "zen"
+      ? "illustrations/spot/template-library-team-effectiveness-1.svg"
+      : "illustrations/heart/spot/template-library-team-effectiveness-1.svg"
+
+  return <Base {...props} name={illustrationPath} />
+}
+
+export const TeamEffectiveness2 = (props: SpotProps) => {
+  const theme = useTheme()
+  const illustrationPath =
+    theme.themeKey === "zen"
+      ? "illustrations/spot/template-library-team-effectiveness-2.svg"
+      : "illustrations/heart/spot/template-library-team-effectiveness-2.svg"
+
+  return <Base {...props} name={illustrationPath} />
+}
+
+/**
+ * Template Library / COVID-19
+ */
+
+export const WellbeingSurvey = (props: SpotProps) => {
+  const theme = useTheme()
+  if (theme.themeKey === "zen") {
+    noZenIllustrationWarning("WellbeingSurvey")
+  }
+
+  return (
+    <Base
+      {...props}
+      name="illustrations/heart/spot/template-library-wellbeing-survey.svg"
+    />
+  )
+}
+
+export const Response = (props: SpotProps) => {
+  const theme = useTheme()
+  if (theme.themeKey === "zen") {
+    noZenIllustrationWarning("Response")
+  }
+
+  return (
+    <Base
+      {...props}
+      name="illustrations/heart/spot/template-library-response.svg"
+    />
+  )
+}
+
+export const RemoteWorkQSet = (props: SpotProps) => {
+  const theme = useTheme()
+  if (theme.themeKey === "zen") {
+    noZenIllustrationWarning("RemoteWorkQSet")
+  }
+
+  return (
+    <Base
+      {...props}
+      name="illustrations/heart/spot/template-library-remote-work-q-set.svg"
+    />
+  )
+}
+
+export const ReturnToWorkplace = (props: SpotProps) => {
+  const theme = useTheme()
+  if (theme.themeKey === "zen") {
+    noZenIllustrationWarning("ReturnToWorkplace")
+  }
+
+  return (
+    <Base
+      {...props}
+      name="illustrations/heart/spot/template-library-return-to-workplace.svg"
+    />
+  )
+}
+
+export const PulseSurvey = (props: SpotProps) => {
+  const theme = useTheme()
+  if (theme.themeKey === "zen") {
+    noZenIllustrationWarning("PulseSurvey")
+  }
+
+  return (
+    <Base
+      {...props}
+      name="illustrations/heart/spot/template-library-pulse-survey.svg"
+    />
+  )
+}
+
+/**
+ * New Account
+ */
+export const AccountBasics = (props: SpotProps) => {
+  const theme = useTheme()
+  const illustrationPath =
+    theme.themeKey === "zen"
+      ? "illustrations/spot/new-account-account-basics.svg"
+      : "illustrations/heart/spot/new-account-account-basics.svg"
+
+  return <Base {...props} name={illustrationPath} />
+}
+
+export const CompanyDetails = (props: SpotProps) => {
+  const theme = useTheme()
+  const illustrationPath =
+    theme.themeKey === "zen"
+      ? "illustrations/spot/new-account-company-details.svg"
+      : "illustrations/heart/spot/new-account-company-details.svg"
+
+  return <Base {...props} name={illustrationPath} />
+}
+
+export const EmployeeData = (props: SpotProps) => {
+  const theme = useTheme()
+  const illustrationPath =
+    theme.themeKey === "zen"
+      ? "illustrations/spot/new-account-employee-data.svg"
+      : "illustrations/heart/spot/new-account-employee-data.svg"
+
+  return <Base {...props} name={illustrationPath} />
+}
+
+export const Gdpr = (props: SpotProps) => {
+  const theme = useTheme()
+  const illustrationPath =
+    theme.themeKey === "zen"
+      ? "illustrations/spot/new-account-gdpr.svg"
+      : "illustrations/heart/spot/new-account-gdpr.svg"
+
+  return <Base {...props} name={illustrationPath} />
+}
+
+export const Timezone = (props: SpotProps) => {
+  const theme = useTheme()
+  const illustrationPath =
+    theme.themeKey === "zen"
+      ? "illustrations/spot/new-account-timezone.svg"
+      : "illustrations/heart/spot/new-account-timezone.svg"
+
+  return <Base {...props} name={illustrationPath} />
+}
+
+export const AddUser = (props: SpotProps) => {
+  const theme = useTheme()
+  const illustrationPath =
+    theme.themeKey === "zen"
+      ? "illustrations/spot/new-account-add-user.svg"
+      : "illustrations/heart/spot/new-account-add-user.svg"
+
+  return <Base {...props} name={illustrationPath} />
+}
+
+/**
+ * Skills Coach (previously referred to as Manager Learning)
+ */
+export const Strategy = (props: SpotProps) => {
+  const theme = useTheme()
+  const illustrationPath =
+    theme.themeKey === "zen"
+      ? "illustrations/spot/manager-learning-strategy.svg"
+      : "illustrations/heart/spot/skills-coach-strategy.svg"
+
+  return <Base {...props} name={illustrationPath} />
+}
+
+export const Resilience = (props: SpotProps) => {
+  const theme = useTheme()
+  const illustrationPath =
+    theme.themeKey === "zen"
+      ? "illustrations/spot/manager-learning-resilience.svg"
+      : "illustrations/heart/spot/skills-coach-resilience.svg"
+
+  return <Base {...props} name={illustrationPath} />
+}
+
+export const RemoteManager = (props: SpotProps) => {
+  const theme = useTheme()
+  const illustrationPath =
+    theme.themeKey === "zen"
+      ? "illustrations/spot/manager-learning-remote-manager.svg"
+      : "illustrations/heart/spot/skills-coach-remote-manager.svg"
+
+  return <Base {...props} name={illustrationPath} />
+}
+
+export const Productivity = (props: SpotProps) => {
+  const theme = useTheme()
+  const illustrationPath =
+    theme.themeKey === "zen"
+      ? "illustrations/spot/manager-learning-productivity.svg"
+      : "illustrations/heart/spot/skills-coach-productivity.svg"
+
+  return <Base {...props} name={illustrationPath} />
+}
+
+export const ManagerLearning = (props: SpotProps) => {
+  const theme = useTheme()
+  const illustrationPath =
+    theme.themeKey === "zen"
+    ? "illustrations/spot/manager-learning-manager-learning.svg"
+     : "illustrations/heart/spot/skills-coach-manager-learning.svg"
+
+  return <Base {...props} name={illustrationPath} />
+}
+
+export const Feedback = (props: SpotProps) => {
+  const theme = useTheme()
+  const illustrationPath =
+    theme.themeKey === "zen"
+      ? "illustrations/spot/manager-learning-feedback.svg"
+      : "illustrations/heart/spot/skills-coach-feedback.svg"
+
+  return <Base {...props} name={illustrationPath} />
+}
+
+export const Coaching = (props: SpotProps) => {
+  const theme = useTheme()
+  const illustrationPath =
+    theme.themeKey === "zen"
+      ? "illustrations/spot/manager-learning-coaching.svg"
+      : "illustrations/heart/spot/skills-coach-coaching.svg"
+
+  return <Base {...props} name={illustrationPath} />
+}
+
+export const OneOnOne = (props: SpotProps) => {
+  const theme = useTheme()
+  const illustrationPath =
+    theme.themeKey === "zen"
+    ? "illustrations/spot/manager-learning-1-on-1.svg"
+      : "illustrations/heart/spot/skills-coach-1-on-1.svg"
+
+  return <Base {...props} name={illustrationPath} />
+}
+
+/**
+ * Miscellaneous
+ */
+export const ViewReports = (props: SpotProps) => {
+  const theme = useTheme()
+  const illustrationPath =
+    theme.themeKey === "zen"
+      ? "illustrations/spot/miscellaneous-view-reports.svg"
+      : "illustrations/heart/spot/miscellaneous-view-reports.svg"
+
+  return <Base {...props} name={illustrationPath} />
+}
+
+export const ReadArticle = (props: SpotProps) => {
+  const theme = useTheme()
+  const illustrationPath =
+    theme.themeKey === "zen"
+      ? "illustrations/spot/miscellaneous-read-article.svg"
+      : "illustrations/heart/spot/miscellaneous-read-article.svg"
+
+  return <Base {...props} name={illustrationPath} />
+}
+
+export const FastAction = (props: SpotProps) => {
+  const theme = useTheme()
+  const illustrationPath =
+    theme.themeKey === "zen"
+      ? "illustrations/spot/miscellaneous-fast-action.svg"
+      : "illustrations/heart/spot/miscellaneous-fast-action.svg"
+
+  return <Base {...props} name={illustrationPath} />
+}
+
+export const BaselineSurvey = (props: SpotProps) => {
+  const theme = useTheme()
+  const illustrationPath =
+    theme.themeKey === "zen"
+      ? "illustrations/spot/miscellaneous-baseline-survey.svg"
+      : "illustrations/heart/spot/miscellaneous-baseline-survey.svg"
+
+  return <Base {...props} name={illustrationPath} />
+}
+
+export const SpreadsheetTemplate = (props: SpotProps) => {
+  const theme = useTheme()
+  const illustrationPath =
+    theme.themeKey === "zen"
+      ? "illustrations/spot/miscellaneous-spreadsheet-template.svg"
+      : "illustrations/heart/spot/miscellaneous-spreadsheet-template.svg"
+
+  return <Base {...props} name={illustrationPath} />
+}
+
+export const AddImage = (props: SpotProps) => {
+  const theme = useTheme()
+  const illustrationPath =
+    theme.themeKey === "zen"
+      ? "illustrations/spot/miscellaneous-add-image.svg"
+      : "illustrations/heart/spot/miscellaneous-add-image.svg"
+
+  return <Base {...props} name={illustrationPath} />
+}
+
+export const MeetingVoices = (props: SpotProps) => {
+  const theme = useTheme()
+  const illustrationPath =
+    theme.themeKey === "zen"
+      ? "illustrations/spot/miscellaneous-meeting-voices.svg"
+      : "illustrations/heart/spot/miscellaneous-meeting-voices.svg"
+
+  return <Base {...props} name={illustrationPath} />
+}
+
+export const Workshop = (props: SpotProps) => {
+  const theme = useTheme()
+  const illustrationPath =
+    theme.themeKey === "zen"
+      ? "illustrations/spot/miscellaneous-workshop.svg"
+      : "illustrations/heart/spot/miscellaneous-workshop.svg"
+
+  return <Base {...props} name={illustrationPath} />
+}
+
+export const Video = (props: SpotProps) => {
+  const theme = useTheme()
+  const illustrationPath =
+    theme.themeKey === "zen"
+      ? "illustrations/spot/miscellaneous-video.svg"
+      : "illustrations/heart/spot/miscellaneous-video.svg"
+
+  return <Base {...props} name={illustrationPath} />
+}
+
+export const ReportSharing = (props: SpotProps) => {
+  const theme = useTheme()
+  const illustrationPath =
+    theme.themeKey === "zen"
+      ? "illustrations/spot/miscellaneous-report-sharing.svg"
+      : "illustrations/heart/spot/miscellaneous-report-sharing.svg"
+
+  return <Base {...props} name={illustrationPath} />
+}
+
+export const BlankSurvey = (props: SpotProps) => {
+  const theme = useTheme()
+  const illustrationPath =
+    theme.themeKey === "zen"
+      ? "illustrations/spot/miscellaneous-blank-survey.svg"
+      : "illustrations/heart/spot/miscellaneous-blank-survey.svg"
+
+  return <Base {...props} name={illustrationPath} />
+}
+
+export const TakeAim = (props: SpotProps) => {
+  const theme = useTheme()
+  const illustrationPath =
+    theme.themeKey === "zen"
+      ? "illustrations/spot/miscellaneous-take-aim.svg"
+      : "illustrations/heart/spot/miscellaneous-take-aim.svg"
+
+  return <Base {...props} name={illustrationPath} />
+}
+
+export const Action = (props: SpotProps) => {
+  const theme = useTheme()
+  const illustrationPath =
+    theme.themeKey === "zen"
+      ? "illustrations/spot/miscellaneous-action.svg"
+      : "illustrations/heart/spot/miscellaneous-action.svg"
+
+  return <Base {...props} name={illustrationPath} />
+}
+
+export const Training1 = (props: SpotProps) => {
+  const theme = useTheme()
+  const illustrationPath =
+    theme.themeKey === "zen"
+      ? "illustrations/spot/miscellaneous-training-1.svg"
+      : "illustrations/heart/spot/miscellaneous-training-1.svg"
+
+  return <Base {...props} name={illustrationPath} />
+}
+
+export const Training2 = (props: SpotProps) => {
+  const theme = useTheme()
+  const illustrationPath =
+    theme.themeKey === "zen"
+      ? "illustrations/spot/miscellaneous-training-2.svg"
+      : "illustrations/heart/spot/miscellaneous-training-2.svg"
+
+  return <Base {...props} name={illustrationPath} />
+}
+
+export const Training3 = (props: SpotProps) => {
+  const theme = useTheme()
+  const illustrationPath =
+    theme.themeKey === "zen"
+      ? "illustrations/spot/miscellaneous-training-3.svg"
+      : "illustrations/heart/spot/miscellaneous-training-3.svg"
+
+  return <Base {...props} name={illustrationPath} />
+}
+
+export const ShareReport = (props: SpotProps) => {
+  const theme = useTheme()
+  const illustrationPath =
+    theme.themeKey === "zen"
+      ? "illustrations/spot/miscellaneous-share-report.svg"
+      : "illustrations/heart/spot/miscellaneous-share-report.svg"
+
+  return <Base {...props} name={illustrationPath} />
+}
+
+export const Team = (props: SpotProps) => {
+  const theme = useTheme()
+  const illustrationPath =
+    theme.themeKey === "zen"
+      ? "illustrations/spot/miscellaneous-team.svg"
+      : "illustrations/heart/spot/miscellaneous-team.svg"
+
+  return <Base {...props} name={illustrationPath} />
+}
+
+export const ExecutiveReportSharing = (props: SpotProps) => {
+  const theme = useTheme()
+  const illustrationPath =
+    theme.themeKey === "zen"
+      ? "illustrations/spot/miscellaneous-executive-report-sharing.svg"
+      : "illustrations/heart/spot/miscellaneous-executive-report-sharing.svg"
+
+  return <Base {...props} name={illustrationPath} />
+}
+
+export const ManagerReportSharing = (props: SpotProps) => {
+  const theme = useTheme()
+  const illustrationPath =
+    theme.themeKey === "zen"
+      ? "illustrations/spot/miscellaneous-manager-report-sharing.svg"
+      : "illustrations/heart/spot/miscellaneous-manager-report-sharing.svg"
+
+  return <Base {...props} name={illustrationPath} />
+}
+
+export const LeaderReportSharing = (props: SpotProps) => {
+  const theme = useTheme()
+  const illustrationPath =
+    theme.themeKey === "zen"
+      ? "illustrations/spot/miscellaneous-leader-report-sharing.svg"
+      : "illustrations/heart/spot/miscellaneous-leader-report-sharing.svg"
+
+  return <Base {...props} name={illustrationPath} />
+}
+
+export const Alarm = (props: SpotProps) => {
+  const theme = useTheme()
+  if (theme.themeKey === "zen") {
+    noZenIllustrationWarning("Alarm")
+  }
+  return (
+    <Base {...props} name="illustrations/heart/spot/miscellaneous-alarm.svg" />
+  )
+}
+
+export const Fire = (props: SpotProps) => {
+  const theme = useTheme()
+  if (theme.themeKey === "zen") {
+    noZenIllustrationWarning("Fire")
+  }
+  return (
+    <Base {...props} name="illustrations/heart/spot/miscellaneous-fire.svg" />
+  )
+}
+
+export const Fireworks = (props: SpotProps) => {
+  const theme = useTheme()
+  if (theme.themeKey === "zen") {
+    noZenIllustrationWarning("Fireworks")
+  }
+  return (
+    <Base
+      {...props}
+      name="illustrations/heart/spot/miscellaneous-fireworks.svg"
+    />
+  )
+}
+
+export const FullImport = (props: SpotProps) => {
+  const theme = useTheme()
+  if (theme.themeKey === "zen") {
+    noZenIllustrationWarning("FullImport")
+  }
+  return (
+    <Base
+      {...props}
+      name="illustrations/heart/spot/miscellaneous-full-import.svg"
+    />
+  )
+}
+
+export const HrisImport = (props: SpotProps) => {
+  const theme = useTheme()
+  if (theme.themeKey === "zen") {
+    noZenIllustrationWarning("HrisImport")
+  }
+  return (
+    <Base
+      {...props}
+      name="illustrations/heart/spot/miscellaneous-hris-import.svg"
+    />
+  )
+}
+
+export const PartialImport = (props: SpotProps) => {
+  const theme = useTheme()
+  if (theme.themeKey === "zen") {
+    noZenIllustrationWarning("PartialImport")
+  }
+  return (
+    <Base
+      {...props}
+      name="illustrations/heart/spot/miscellaneous-partial-import.svg"
+    />
+  )
+}
+
+export const Starburst = (props: SpotProps) => {
+  const theme = useTheme()
+  if (theme.themeKey === "zen") {
+    noZenIllustrationWarning("Starburst")
+  }
+  return (
+    <Base
+      {...props}
+      name="illustrations/heart/spot/miscellaneous-starburst.svg"
+    />
+  )
+}
+
+export const Stop = (props: SpotProps) => {
+  const theme = useTheme()
+  if (theme.themeKey === "zen") {
+    noZenIllustrationWarning("Stop")
+  }
+  return (
+    <Base {...props} name="illustrations/heart/spot/miscellaneous-stop.svg" />
+  )
+}
+
+export const TrafficCone = (props: SpotProps) => {
+  const theme = useTheme()
+  if (theme.themeKey === "zen") {
+    noZenIllustrationWarning("TrafficCone")
+  }
+  return (
+    <Base
+      {...props}
+      name="illustrations/heart/spot/miscellaneous-traffic-cone.svg"
+    />
+  )
+}
+
+export const Trophy = (props: SpotProps) => {
+  const theme = useTheme()
+  if (theme.themeKey === "zen") {
+    noZenIllustrationWarning("Trophy")
+  }
+  return (
+    <Base {...props} name="illustrations/heart/spot/miscellaneous-trophy.svg" />
+  )
+}
+
+export const UnderConstruction = (props: SpotProps) => {
+  const theme = useTheme()
+  if (theme.themeKey === "zen") {
+    noZenIllustrationWarning("UnderConstruction")
+  }
+  return (
+    <Base
+      {...props}
+      name="illustrations/heart/spot/miscellaneous-under-construction.svg"
+    />
+  )
+}
+
+export const ValueAdd = (props: SpotProps) => {
+  const theme = useTheme()
+  if (theme.themeKey === "zen") {
+    noZenIllustrationWarning("ValueAdd")
+  }
+  return (
+    <Base
+      {...props}
+      name="illustrations/heart/spot/miscellaneous-value-add.svg"
+    />
+  )
+}
+
+export const Recommendation = (props: SpotProps) => {
+  const theme = useTheme()
+  if (theme.themeKey === "zen") {
+    noZenIllustrationWarning("Recommendation")
+  }
+  return (
+    <Base
+      {...props}
+      name="illustrations/heart/spot/miscellaneous-shield.svg"
+    />
+  )
+}
+

--- a/draft-packages/illustration/KaizenDraft/Illustration/__snapshots__/illustration.spec.tsx.snap
+++ b/draft-packages/illustration/KaizenDraft/Illustration/__snapshots__/illustration.spec.tsx.snap
@@ -1,0 +1,1411 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<Illustration /> Scene EmptyStatesAction should exist and render an alt tag 1`] = `
+<div>
+  <img
+    alt="My accessible title"
+    class=" wrapper"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/scene/empty-states-action.svg"
+  />
+</div>
+`;
+
+exports[`<Illustration /> Scene EmptyStatesInformative should exist and render an alt tag 1`] = `
+<div>
+  <img
+    alt="My accessible title"
+    class=" wrapper"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/scene/empty-states-informative.svg"
+  />
+</div>
+`;
+
+exports[`<Illustration /> Scene EmptyStatesNegative should exist and render an alt tag 1`] = `
+<div>
+  <img
+    alt="My accessible title"
+    class=" wrapper"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/scene/empty-states-negative.svg"
+  />
+</div>
+`;
+
+exports[`<Illustration /> Scene EmptyStatesNeutral should exist and render an alt tag 1`] = `
+<div>
+  <img
+    alt="My accessible title"
+    class=" wrapper"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/scene/empty-states-neutral.svg"
+  />
+</div>
+`;
+
+exports[`<Illustration /> Scene EmptyStatesPositive should exist and render an alt tag 1`] = `
+<div>
+  <img
+    alt="My accessible title"
+    class=" wrapper"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/scene/empty-states-positive.svg"
+  />
+</div>
+`;
+
+exports[`<Illustration /> Scene Information360Upgrade should exist and render an alt tag 1`] = `
+<div>
+  <img
+    alt="My accessible title"
+    class=" wrapper"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/scene/information-modals-360-upgrade.svg"
+  />
+</div>
+`;
+
+exports[`<Illustration /> Scene InformationDemographicFocus should exist and render an alt tag 1`] = `
+<div>
+  <img
+    alt="My accessible title"
+    class=" wrapper"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/scene/information-modals-demographic-focus.svg"
+  />
+</div>
+`;
+
+exports[`<Illustration /> Scene InformationEmergingTrends should exist and render an alt tag 1`] = `
+<div>
+  <img
+    alt="My accessible title"
+    class=" wrapper"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/scene/information-modals-emerging-trends.svg"
+  />
+</div>
+`;
+
+exports[`<Illustration /> Scene InformationEmployeeLifecycle should exist and render an alt tag 1`] = `
+<div>
+  <img
+    alt="My accessible title"
+    class=" wrapper"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/scene/information-modals-employee-lifecycle.svg"
+  />
+</div>
+`;
+
+exports[`<Illustration /> Scene InformationReportOwner should exist and render an alt tag 1`] = `
+<div>
+  <img
+    alt="My accessible title"
+    class=" wrapper"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/scene/information-modals-report-owner.svg"
+  />
+</div>
+`;
+
+exports[`<Illustration /> Scene InformationReportOwnerByRule should exist and render an alt tag 1`] = `
+<div>
+  <img
+    alt="My accessible title"
+    class=" wrapper"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/scene/information-modals-report-owner-by-rule.svg"
+  />
+</div>
+`;
+
+exports[`<Illustration /> Scene InformationTurnoverCalculator should exist and render an alt tag 1`] = `
+<div>
+  <img
+    alt="My accessible title"
+    class=" wrapper"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/scene/information-modals-turnover-calculator.svg"
+  />
+</div>
+`;
+
+exports[`<Illustration /> Scene InformationTurnoverForecast should exist and render an alt tag 1`] = `
+<div>
+  <img
+    alt="My accessible title"
+    class=" wrapper"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/scene/information-modals-turnover-forecast.svg"
+  />
+</div>
+`;
+
+exports[`<Illustration /> Scene IntroductionsCaptureIntro should exist and render an alt tag 1`] = `
+<div>
+  <img
+    alt="My accessible title"
+    class=" wrapper"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/scene/introductions-capture-intro.svg"
+  />
+</div>
+`;
+
+exports[`<Illustration /> Scene IntroductionsNewAccount should exist and render an alt tag 1`] = `
+<div>
+  <img
+    alt="My accessible title"
+    class=" wrapper"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/scene/introductions-new-account.svg"
+  />
+</div>
+`;
+
+exports[`<Illustration /> Scene IntroductionsNewAdmin should exist and render an alt tag 1`] = `
+<div>
+  <img
+    alt="My accessible title"
+    class=" wrapper"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/scene/introductions-new-admin.svg"
+  />
+</div>
+`;
+
+exports[`<Illustration /> Scene IntroductionsPerformance should exist and render an alt tag 1`] = `
+<div>
+  <img
+    alt="My accessible title"
+    class=" wrapper"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/scene/introductions-performance.svg"
+  />
+</div>
+`;
+
+exports[`<Illustration /> Scene KaizenSiteBrand should exist and render an alt tag 1`] = `
+<div>
+  <img
+    alt="My accessible title"
+    class=" wrapper"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/scene/kaizen-site-brand.svg"
+  />
+</div>
+`;
+
+exports[`<Illustration /> Scene KaizenSiteBrandAlt should exist and render an alt tag 1`] = `
+<div>
+  <img
+    alt="My accessible title"
+    class=" wrapper"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/scene/kaizen-site-brand-alt.svg"
+  />
+</div>
+`;
+
+exports[`<Illustration /> Scene KaizenSiteLanguage should exist and render an alt tag 1`] = `
+<div>
+  <img
+    alt="My accessible title"
+    class=" wrapper"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/scene/kaizen-site-language.svg"
+  />
+</div>
+`;
+
+exports[`<Illustration /> Scene KaizenSiteLanguageAlt should exist and render an alt tag 1`] = `
+<div>
+  <img
+    alt="My accessible title"
+    class=" wrapper"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/scene/kaizen-site-language-alt.svg"
+  />
+</div>
+`;
+
+exports[`<Illustration /> Scene KaizenSitePrinciples should exist and render an alt tag 1`] = `
+<div>
+  <img
+    alt="My accessible title"
+    class=" wrapper"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/scene/kaizen-site-principles.svg"
+  />
+</div>
+`;
+
+exports[`<Illustration /> Scene KaizenSitePrinciplesAlt should exist and render an alt tag 1`] = `
+<div>
+  <img
+    alt="My accessible title"
+    class=" wrapper"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/scene/kaizen-site-principles-alt.svg"
+  />
+</div>
+`;
+
+exports[`<Illustration /> Scene KaizenSiteProduct should exist and render an alt tag 1`] = `
+<div>
+  <img
+    alt="My accessible title"
+    class=" wrapper"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/scene/kaizen-site-product.svg"
+  />
+</div>
+`;
+
+exports[`<Illustration /> Scene KaizenSiteProductAlt should exist and render an alt tag 1`] = `
+<div>
+  <img
+    alt="My accessible title"
+    class=" wrapper"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/scene/kaizen-site-product-alt.svg"
+  />
+</div>
+`;
+
+exports[`<Illustration /> Scene KaizenSiteResources should exist and render an alt tag 1`] = `
+<div>
+  <img
+    alt="My accessible title"
+    class=" wrapper"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/scene/kaizen-site-resources.svg"
+  />
+</div>
+`;
+
+exports[`<Illustration /> Scene KaizenSiteResourcesAlt should exist and render an alt tag 1`] = `
+<div>
+  <img
+    alt="My accessible title"
+    class=" wrapper"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/scene/kaizen-site-resources-alt.svg"
+  />
+</div>
+`;
+
+exports[`<Illustration /> Scene ManagerLabFourWeekCycle should exist and render an alt tag 1`] = `
+<div>
+  <img
+    alt="My accessible title"
+    class=" wrapper"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/scene/manager-lab-4-week-cycle.svg"
+  />
+</div>
+`;
+
+exports[`<Illustration /> Scene ManagerLabScheduling should exist and render an alt tag 1`] = `
+<div>
+  <img
+    alt="My accessible title"
+    class=" wrapper"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/scene/manager-lab-scheduling.svg"
+  />
+</div>
+`;
+
+exports[`<Illustration /> Scene ManagerLearningCoaching should exist and render an alt tag 1`] = `
+<div>
+  <img
+    alt="My accessible title"
+    class=" wrapper"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/scene/manager-learning-coaching.svg"
+  />
+</div>
+`;
+
+exports[`<Illustration /> Scene ManagerLearningFeedback should exist and render an alt tag 1`] = `
+<div>
+  <img
+    alt="My accessible title"
+    class=" wrapper"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/scene/manager-learning-feedback.svg"
+  />
+</div>
+`;
+
+exports[`<Illustration /> Scene ManagerLearningManagerHub should exist and render an alt tag 1`] = `
+<div>
+  <img
+    alt="My accessible title"
+    class=" wrapper"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/scene/manager-learning-manager-hub.svg"
+  />
+</div>
+`;
+
+exports[`<Illustration /> Scene ManagerLearningOneOnOneMeetings should exist and render an alt tag 1`] = `
+<div>
+  <img
+    alt="My accessible title"
+    class=" wrapper"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/scene/manager-learning-1-on-1.svg"
+  />
+</div>
+`;
+
+exports[`<Illustration /> Scene ManagerLearningProductivity should exist and render an alt tag 1`] = `
+<div>
+  <img
+    alt="My accessible title"
+    class=" wrapper"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/scene/manager-learning-productivity.svg"
+  />
+</div>
+`;
+
+exports[`<Illustration /> Scene ManagerLearningRemoteManager should exist and render an alt tag 1`] = `
+<div>
+  <img
+    alt="My accessible title"
+    class=" wrapper"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/scene/manager-learning-remote-manager.svg"
+  />
+</div>
+`;
+
+exports[`<Illustration /> Scene ManagerLearningResilience should exist and render an alt tag 1`] = `
+<div>
+  <img
+    alt="My accessible title"
+    class=" wrapper"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/scene/manager-learning-resilience.svg"
+  />
+</div>
+`;
+
+exports[`<Illustration /> Scene ManagerLearningStrategy should exist and render an alt tag 1`] = `
+<div>
+  <img
+    alt="My accessible title"
+    class=" wrapper"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/scene/manager-learning-strategy.svg"
+  />
+</div>
+`;
+
+exports[`<Illustration /> Scene PerformanceCalibration should exist and render an alt tag 1`] = `
+<div>
+  <img
+    alt="My accessible title"
+    class=" wrapper"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/scene/performance-calibration.svg"
+  />
+</div>
+`;
+
+exports[`<Illustration /> Scene PerformanceCompanySettings should exist and render an alt tag 1`] = `
+<div>
+  <img
+    alt="My accessible title"
+    class=" wrapper"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/scene/performance-company-settings.svg"
+  />
+</div>
+`;
+
+exports[`<Illustration /> Scene PerformanceEvaluations should exist and render an alt tag 1`] = `
+<div>
+  <img
+    alt="My accessible title"
+    class=" wrapper"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/scene/performance-evaluations.svg"
+  />
+</div>
+`;
+
+exports[`<Illustration /> Scene PerformanceFaq should exist and render an alt tag 1`] = `
+<div>
+  <img
+    alt="My accessible title"
+    class=" wrapper"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/scene/performance-faq.svg"
+  />
+</div>
+`;
+
+exports[`<Illustration /> Scene PerformanceGoalStats should exist and render an alt tag 1`] = `
+<div>
+  <img
+    alt="My accessible title"
+    class=" wrapper"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/scene/performance-goal-stats.svg"
+  />
+</div>
+`;
+
+exports[`<Illustration /> Scene PerformanceGoals should exist and render an alt tag 1`] = `
+<div>
+  <img
+    alt="My accessible title"
+    class=" wrapper"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/scene/performance-goals.svg"
+  />
+</div>
+`;
+
+exports[`<Illustration /> Scene PerformancePeopleNetwork should exist and render an alt tag 1`] = `
+<div>
+  <img
+    alt="My accessible title"
+    class=" wrapper"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/scene/performance-people-network.svg"
+  />
+</div>
+`;
+
+exports[`<Illustration /> Scene PerformancePerformanceFeedback should exist and render an alt tag 1`] = `
+<div>
+  <img
+    alt="My accessible title"
+    class=" wrapper"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/scene/performance-feedback.svg"
+  />
+</div>
+`;
+
+exports[`<Illustration /> Scene PerformanceSelfReflections should exist and render an alt tag 1`] = `
+<div>
+  <img
+    alt="My accessible title"
+    class=" wrapper"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/scene/performance-self-reflections.svg"
+  />
+</div>
+`;
+
+exports[`<Illustration /> Scene PerformanceSupport should exist and render an alt tag 1`] = `
+<div>
+  <img
+    alt="My accessible title"
+    class=" wrapper"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/scene/performance-support.svg"
+  />
+</div>
+`;
+
+exports[`<Illustration /> Scene PerformanceTeamSummary should exist and render an alt tag 1`] = `
+<div>
+  <img
+    alt="My accessible title"
+    class=" wrapper"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/scene/performance-team-summary.svg"
+  />
+</div>
+`;
+
+exports[`<Illustration /> Scene Programs should exist and render an alt tag 1`] = `
+<div>
+  <img
+    alt="My accessible title"
+    class=" wrapper"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/scene/programs.svg"
+  />
+</div>
+`;
+
+exports[`<Illustration /> Scene SurveyGetStarted should exist and render an alt tag 1`] = `
+<div>
+  <img
+    alt="My accessible title"
+    class=" wrapper"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/scene/getting-started.svg"
+  />
+</div>
+`;
+
+exports[`<Illustration /> Scene SurveyOverviewClosed should exist and render an alt tag 1`] = `
+<div>
+  <img
+    alt="My accessible title"
+    class=" wrapper"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/scene/survey-overview-closed.svg"
+  />
+</div>
+`;
+
+exports[`<Illustration /> Spot AccountBasics should exist and render an alt tag 1`] = `
+<div>
+  <img
+    alt="My accessible title"
+    class=" wrapper"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/spot/new-account-account-basics.svg"
+  />
+</div>
+`;
+
+exports[`<Illustration /> Spot Action should exist and render an alt tag 1`] = `
+<div>
+  <img
+    alt="My accessible title"
+    class=" wrapper"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/spot/miscellaneous-action.svg"
+  />
+</div>
+`;
+
+exports[`<Illustration /> Spot AddImage should exist and render an alt tag 1`] = `
+<div>
+  <img
+    alt="My accessible title"
+    class=" wrapper"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/spot/miscellaneous-add-image.svg"
+  />
+</div>
+`;
+
+exports[`<Illustration /> Spot AddUser should exist and render an alt tag 1`] = `
+<div>
+  <img
+    alt="My accessible title"
+    class=" wrapper"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/spot/new-account-add-user.svg"
+  />
+</div>
+`;
+
+exports[`<Illustration /> Spot Alarm should exist and render an alt tag 1`] = `
+<div>
+  <img
+    alt="My accessible title"
+    class=" wrapper"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/heart/spot/miscellaneous-alarm.svg"
+  />
+</div>
+`;
+
+exports[`<Illustration /> Spot Assertive should exist and render an alt tag 1`] = `
+<div>
+  <img
+    alt="My accessible title"
+    class=" wrapper"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/heart/spot/moods-assertive.svg"
+  />
+</div>
+`;
+
+exports[`<Illustration /> Spot BaselineSurvey should exist and render an alt tag 1`] = `
+<div>
+  <img
+    alt="My accessible title"
+    class=" wrapper"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/spot/miscellaneous-baseline-survey.svg"
+  />
+</div>
+`;
+
+exports[`<Illustration /> Spot BenefitsSurvey should exist and render an alt tag 1`] = `
+<div>
+  <img
+    alt="My accessible title"
+    class=" wrapper"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/spot/template-library-benefits-survey.svg"
+  />
+</div>
+`;
+
+exports[`<Illustration /> Spot BlankSurvey should exist and render an alt tag 1`] = `
+<div>
+  <img
+    alt="My accessible title"
+    class=" wrapper"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/spot/miscellaneous-blank-survey.svg"
+  />
+</div>
+`;
+
+exports[`<Illustration /> Spot CandidateSurvey should exist and render an alt tag 1`] = `
+<div>
+  <img
+    alt="My accessible title"
+    class=" wrapper"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/spot/template-library-candidate-survey.svg"
+  />
+</div>
+`;
+
+exports[`<Illustration /> Spot Cautionary should exist and render an alt tag 1`] = `
+<div>
+  <img
+    alt="My accessible title"
+    class=" wrapper"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/spot/moods-cautionary.svg"
+  />
+</div>
+`;
+
+exports[`<Illustration /> Spot ChangeReadiness should exist and render an alt tag 1`] = `
+<div>
+  <img
+    alt="My accessible title"
+    class=" wrapper"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/spot/template-library-change-readiness.svg"
+  />
+</div>
+`;
+
+exports[`<Illustration /> Spot ChangeSuccess should exist and render an alt tag 1`] = `
+<div>
+  <img
+    alt="My accessible title"
+    class=" wrapper"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/spot/template-library-change-success.svg"
+  />
+</div>
+`;
+
+exports[`<Illustration /> Spot Coaching should exist and render an alt tag 1`] = `
+<div>
+  <img
+    alt="My accessible title"
+    class=" wrapper"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/spot/manager-learning-coaching.svg"
+  />
+</div>
+`;
+
+exports[`<Illustration /> Spot CompanyDetails should exist and render an alt tag 1`] = `
+<div>
+  <img
+    alt="My accessible title"
+    class=" wrapper"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/spot/new-account-company-details.svg"
+  />
+</div>
+`;
+
+exports[`<Illustration /> Spot CustomOnboardSurvey should exist and render an alt tag 1`] = `
+<div>
+  <img
+    alt="My accessible title"
+    class=" wrapper"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/spot/template-library-custom-onboard-survey.svg"
+  />
+</div>
+`;
+
+exports[`<Illustration /> Spot CustomSurvey should exist and render an alt tag 1`] = `
+<div>
+  <img
+    alt="My accessible title"
+    class=" wrapper"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/spot/template-library-custom-survey.svg"
+  />
+</div>
+`;
+
+exports[`<Illustration /> Spot CustomUnattributedSurvey should exist and render an alt tag 1`] = `
+<div>
+  <img
+    alt="My accessible title"
+    class=" wrapper"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/spot/template-library-custom-unattributed-survey.svg"
+  />
+</div>
+`;
+
+exports[`<Illustration /> Spot EmergencyResponse should exist and render an alt tag 1`] = `
+<div>
+  <img
+    alt="My accessible title"
+    class=" wrapper"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/heart/spot/template-library-emergency-response.svg"
+  />
+</div>
+`;
+
+exports[`<Illustration /> Spot EmployeeData should exist and render an alt tag 1`] = `
+<div>
+  <img
+    alt="My accessible title"
+    class=" wrapper"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/spot/new-account-employee-data.svg"
+  />
+</div>
+`;
+
+exports[`<Illustration /> Spot EngagementSurvey should exist and render an alt tag 1`] = `
+<div>
+  <img
+    alt="My accessible title"
+    class=" wrapper"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/spot/template-library-engagement-survey.svg"
+  />
+</div>
+`;
+
+exports[`<Illustration /> Spot ExecutiveReportSharing should exist and render an alt tag 1`] = `
+<div>
+  <img
+    alt="My accessible title"
+    class=" wrapper"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/spot/miscellaneous-executive-report-sharing.svg"
+  />
+</div>
+`;
+
+exports[`<Illustration /> Spot ExitSurvey should exist and render an alt tag 1`] = `
+<div>
+  <img
+    alt="My accessible title"
+    class=" wrapper"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/spot/template-library-exit-survey.svg"
+  />
+</div>
+`;
+
+exports[`<Illustration /> Spot FastAction should exist and render an alt tag 1`] = `
+<div>
+  <img
+    alt="My accessible title"
+    class=" wrapper"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/spot/miscellaneous-fast-action.svg"
+  />
+</div>
+`;
+
+exports[`<Illustration /> Spot Feedback should exist and render an alt tag 1`] = `
+<div>
+  <img
+    alt="My accessible title"
+    class=" wrapper"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/spot/manager-learning-feedback.svg"
+  />
+</div>
+`;
+
+exports[`<Illustration /> Spot Fire should exist and render an alt tag 1`] = `
+<div>
+  <img
+    alt="My accessible title"
+    class=" wrapper"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/heart/spot/miscellaneous-fire.svg"
+  />
+</div>
+`;
+
+exports[`<Illustration /> Spot Fireworks should exist and render an alt tag 1`] = `
+<div>
+  <img
+    alt="My accessible title"
+    class=" wrapper"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/heart/spot/miscellaneous-fireworks.svg"
+  />
+</div>
+`;
+
+exports[`<Illustration /> Spot FullImport should exist and render an alt tag 1`] = `
+<div>
+  <img
+    alt="My accessible title"
+    class=" wrapper"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/heart/spot/miscellaneous-full-import.svg"
+  />
+</div>
+`;
+
+exports[`<Illustration /> Spot Gdpr should exist and render an alt tag 1`] = `
+<div>
+  <img
+    alt="My accessible title"
+    class=" wrapper"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/spot/new-account-gdpr.svg"
+  />
+</div>
+`;
+
+exports[`<Illustration /> Spot GeneralOnboardSurvey should exist and render an alt tag 1`] = `
+<div>
+  <img
+    alt="My accessible title"
+    class=" wrapper"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/heart/spot/template-library-general-onboard-survey.svg"
+  />
+</div>
+`;
+
+exports[`<Illustration /> Spot HrisImport should exist and render an alt tag 1`] = `
+<div>
+  <img
+    alt="My accessible title"
+    class=" wrapper"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/heart/spot/miscellaneous-hris-import.svg"
+  />
+</div>
+`;
+
+exports[`<Illustration /> Spot InclusionSurvey should exist and render an alt tag 1`] = `
+<div>
+  <img
+    alt="My accessible title"
+    class=" wrapper"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/spot/template-library-inclusion-survey.svg"
+  />
+</div>
+`;
+
+exports[`<Illustration /> Spot Individual360 should exist and render an alt tag 1`] = `
+<div>
+  <img
+    alt="My accessible title"
+    class=" wrapper"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/spot/template-library-individual-360.svg"
+  />
+</div>
+`;
+
+exports[`<Illustration /> Spot Informative should exist and render an alt tag 1`] = `
+<div>
+  <img
+    alt="My accessible title"
+    class=" wrapper"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/spot/moods-informative.svg"
+  />
+</div>
+`;
+
+exports[`<Illustration /> Spot InternSurvey should exist and render an alt tag 1`] = `
+<div>
+  <img
+    alt="My accessible title"
+    class=" wrapper"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/spot/template-library-intern-survey.svg"
+  />
+</div>
+`;
+
+exports[`<Illustration /> Spot LeaderReportSharing should exist and render an alt tag 1`] = `
+<div>
+  <img
+    alt="My accessible title"
+    class=" wrapper"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/spot/miscellaneous-leader-report-sharing.svg"
+  />
+</div>
+`;
+
+exports[`<Illustration /> Spot Leadership360 should exist and render an alt tag 1`] = `
+<div>
+  <img
+    alt="My accessible title"
+    class=" wrapper"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/spot/template-library-leadership-360.svg"
+  />
+</div>
+`;
+
+exports[`<Illustration /> Spot LeadingThroughCrisis should exist and render an alt tag 1`] = `
+<div>
+  <img
+    alt="My accessible title"
+    class=" wrapper"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/heart/spot/template-library-leading-through-crisis.svg"
+  />
+</div>
+`;
+
+exports[`<Illustration /> Spot Manager360 should exist and render an alt tag 1`] = `
+<div>
+  <img
+    alt="My accessible title"
+    class=" wrapper"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/spot/template-library-manager-360.svg"
+  />
+</div>
+`;
+
+exports[`<Illustration /> Spot ManagerLearning should exist and render an alt tag 1`] = `
+<div>
+  <img
+    alt="My accessible title"
+    class=" wrapper"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/spot/manager-learning-manager-learning.svg"
+  />
+</div>
+`;
+
+exports[`<Illustration /> Spot ManagerReportSharing should exist and render an alt tag 1`] = `
+<div>
+  <img
+    alt="My accessible title"
+    class=" wrapper"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/spot/miscellaneous-manager-report-sharing.svg"
+  />
+</div>
+`;
+
+exports[`<Illustration /> Spot MeetingVoices should exist and render an alt tag 1`] = `
+<div>
+  <img
+    alt="My accessible title"
+    class=" wrapper"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/spot/miscellaneous-meeting-voices.svg"
+  />
+</div>
+`;
+
+exports[`<Illustration /> Spot Negative should exist and render an alt tag 1`] = `
+<div>
+  <img
+    alt="My accessible title"
+    class=" wrapper"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/spot/moods-negative.svg"
+  />
+</div>
+`;
+
+exports[`<Illustration /> Spot OneOnOne should exist and render an alt tag 1`] = `
+<div>
+  <img
+    alt="My accessible title"
+    class=" wrapper"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/spot/manager-learning-1-on-1.svg"
+  />
+</div>
+`;
+
+exports[`<Illustration /> Spot PartialImport should exist and render an alt tag 1`] = `
+<div>
+  <img
+    alt="My accessible title"
+    class=" wrapper"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/heart/spot/miscellaneous-partial-import.svg"
+  />
+</div>
+`;
+
+exports[`<Illustration /> Spot PerformanceDiagnostics should exist and render an alt tag 1`] = `
+<div>
+  <img
+    alt="My accessible title"
+    class=" wrapper"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/spot/template-library-diagnostics.svg"
+  />
+</div>
+`;
+
+exports[`<Illustration /> Spot PhasedWeek1OnboardSurvey should exist and render an alt tag 1`] = `
+<div>
+  <img
+    alt="My accessible title"
+    class=" wrapper"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/spot/template-library-phased-week-1-onboard-survey.svg"
+  />
+</div>
+`;
+
+exports[`<Illustration /> Spot PhasedWeek5OnboardSurvey should exist and render an alt tag 1`] = `
+<div>
+  <img
+    alt="My accessible title"
+    class=" wrapper"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/spot/template-library-phased-week-5-onboard-survey.svg"
+  />
+</div>
+`;
+
+exports[`<Illustration /> Spot Positive should exist and render an alt tag 1`] = `
+<div>
+  <img
+    alt="My accessible title"
+    class=" wrapper"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/spot/moods-positive-female.svg"
+  />
+</div>
+`;
+
+exports[`<Illustration /> Spot PositiveFemale should exist and render an alt tag 1`] = `
+<div>
+  <img
+    alt="My accessible title"
+    class=" wrapper"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/spot/moods-positive-female.svg"
+  />
+</div>
+`;
+
+exports[`<Illustration /> Spot PositiveMale should exist and render an alt tag 1`] = `
+<div>
+  <img
+    alt="My accessible title"
+    class=" wrapper"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/spot/moods-positive-male.svg"
+  />
+</div>
+`;
+
+exports[`<Illustration /> Spot Productivity should exist and render an alt tag 1`] = `
+<div>
+  <img
+    alt="My accessible title"
+    class=" wrapper"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/spot/manager-learning-productivity.svg"
+  />
+</div>
+`;
+
+exports[`<Illustration /> Spot PulseSurvey should exist and render an alt tag 1`] = `
+<div>
+  <img
+    alt="My accessible title"
+    class=" wrapper"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/heart/spot/template-library-pulse-survey.svg"
+  />
+</div>
+`;
+
+exports[`<Illustration /> Spot QuickEngagementSurvey should exist and render an alt tag 1`] = `
+<div>
+  <img
+    alt="My accessible title"
+    class=" wrapper"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/spot/template-library-quick-engagement-survey.svg"
+  />
+</div>
+`;
+
+exports[`<Illustration /> Spot ReadArticle should exist and render an alt tag 1`] = `
+<div>
+  <img
+    alt="My accessible title"
+    class=" wrapper"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/spot/miscellaneous-read-article.svg"
+  />
+</div>
+`;
+
+exports[`<Illustration /> Spot Recommendation should exist and render an alt tag 1`] = `
+<div>
+  <img
+    alt="My accessible title"
+    class=" wrapper"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/heart/spot/miscellaneous-shield.svg"
+  />
+</div>
+`;
+
+exports[`<Illustration /> Spot RemoteManager should exist and render an alt tag 1`] = `
+<div>
+  <img
+    alt="My accessible title"
+    class=" wrapper"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/spot/manager-learning-remote-manager.svg"
+  />
+</div>
+`;
+
+exports[`<Illustration /> Spot RemoteOnboardSurvey should exist and render an alt tag 1`] = `
+<div>
+  <img
+    alt="My accessible title"
+    class=" wrapper"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/heart/spot/template-library-remote-onboard-survey.svg"
+  />
+</div>
+`;
+
+exports[`<Illustration /> Spot RemoteWorkQSet should exist and render an alt tag 1`] = `
+<div>
+  <img
+    alt="My accessible title"
+    class=" wrapper"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/heart/spot/template-library-remote-work-q-set.svg"
+  />
+</div>
+`;
+
+exports[`<Illustration /> Spot ReportSharing should exist and render an alt tag 1`] = `
+<div>
+  <img
+    alt="My accessible title"
+    class=" wrapper"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/spot/miscellaneous-report-sharing.svg"
+  />
+</div>
+`;
+
+exports[`<Illustration /> Spot Resilience should exist and render an alt tag 1`] = `
+<div>
+  <img
+    alt="My accessible title"
+    class=" wrapper"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/spot/manager-learning-resilience.svg"
+  />
+</div>
+`;
+
+exports[`<Illustration /> Spot Response should exist and render an alt tag 1`] = `
+<div>
+  <img
+    alt="My accessible title"
+    class=" wrapper"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/heart/spot/template-library-response.svg"
+  />
+</div>
+`;
+
+exports[`<Illustration /> Spot ReturnToWorkplace should exist and render an alt tag 1`] = `
+<div>
+  <img
+    alt="My accessible title"
+    class=" wrapper"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/heart/spot/template-library-return-to-workplace.svg"
+  />
+</div>
+`;
+
+exports[`<Illustration /> Spot ShareReport should exist and render an alt tag 1`] = `
+<div>
+  <img
+    alt="My accessible title"
+    class=" wrapper"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/spot/miscellaneous-share-report.svg"
+  />
+</div>
+`;
+
+exports[`<Illustration /> Spot SinglePointOnboardSurvey should exist and render an alt tag 1`] = `
+<div>
+  <img
+    alt="My accessible title"
+    class=" wrapper"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/spot/template-library-single-point-onboard-survey.svg"
+  />
+</div>
+`;
+
+exports[`<Illustration /> Spot SpreadsheetTemplate should exist and render an alt tag 1`] = `
+<div>
+  <img
+    alt="My accessible title"
+    class=" wrapper"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/spot/miscellaneous-spreadsheet-template.svg"
+  />
+</div>
+`;
+
+exports[`<Illustration /> Spot Starburst should exist and render an alt tag 1`] = `
+<div>
+  <img
+    alt="My accessible title"
+    class=" wrapper"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/heart/spot/miscellaneous-starburst.svg"
+  />
+</div>
+`;
+
+exports[`<Illustration /> Spot Stop should exist and render an alt tag 1`] = `
+<div>
+  <img
+    alt="My accessible title"
+    class=" wrapper"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/heart/spot/miscellaneous-stop.svg"
+  />
+</div>
+`;
+
+exports[`<Illustration /> Spot Strategy should exist and render an alt tag 1`] = `
+<div>
+  <img
+    alt="My accessible title"
+    class=" wrapper"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/spot/manager-learning-strategy.svg"
+  />
+</div>
+`;
+
+exports[`<Illustration /> Spot TakeAim should exist and render an alt tag 1`] = `
+<div>
+  <img
+    alt="My accessible title"
+    class=" wrapper"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/spot/miscellaneous-take-aim.svg"
+  />
+</div>
+`;
+
+exports[`<Illustration /> Spot Team should exist and render an alt tag 1`] = `
+<div>
+  <img
+    alt="My accessible title"
+    class=" wrapper"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/spot/miscellaneous-team.svg"
+  />
+</div>
+`;
+
+exports[`<Illustration /> Spot TeamEffectiveness1 should exist and render an alt tag 1`] = `
+<div>
+  <img
+    alt="My accessible title"
+    class=" wrapper"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/spot/template-library-team-effectiveness-1.svg"
+  />
+</div>
+`;
+
+exports[`<Illustration /> Spot TeamEffectiveness2 should exist and render an alt tag 1`] = `
+<div>
+  <img
+    alt="My accessible title"
+    class=" wrapper"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/spot/template-library-team-effectiveness-2.svg"
+  />
+</div>
+`;
+
+exports[`<Illustration /> Spot Timezone should exist and render an alt tag 1`] = `
+<div>
+  <img
+    alt="My accessible title"
+    class=" wrapper"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/spot/new-account-timezone.svg"
+  />
+</div>
+`;
+
+exports[`<Illustration /> Spot TrafficCone should exist and render an alt tag 1`] = `
+<div>
+  <img
+    alt="My accessible title"
+    class=" wrapper"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/heart/spot/miscellaneous-traffic-cone.svg"
+  />
+</div>
+`;
+
+exports[`<Illustration /> Spot Training1 should exist and render an alt tag 1`] = `
+<div>
+  <img
+    alt="My accessible title"
+    class=" wrapper"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/spot/miscellaneous-training-1.svg"
+  />
+</div>
+`;
+
+exports[`<Illustration /> Spot Training2 should exist and render an alt tag 1`] = `
+<div>
+  <img
+    alt="My accessible title"
+    class=" wrapper"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/spot/miscellaneous-training-2.svg"
+  />
+</div>
+`;
+
+exports[`<Illustration /> Spot Training3 should exist and render an alt tag 1`] = `
+<div>
+  <img
+    alt="My accessible title"
+    class=" wrapper"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/spot/miscellaneous-training-3.svg"
+  />
+</div>
+`;
+
+exports[`<Illustration /> Spot Trophy should exist and render an alt tag 1`] = `
+<div>
+  <img
+    alt="My accessible title"
+    class=" wrapper"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/heart/spot/miscellaneous-trophy.svg"
+  />
+</div>
+`;
+
+exports[`<Illustration /> Spot UnderConstruction should exist and render an alt tag 1`] = `
+<div>
+  <img
+    alt="My accessible title"
+    class=" wrapper"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/heart/spot/miscellaneous-under-construction.svg"
+  />
+</div>
+`;
+
+exports[`<Illustration /> Spot ValueAdd should exist and render an alt tag 1`] = `
+<div>
+  <img
+    alt="My accessible title"
+    class=" wrapper"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/heart/spot/miscellaneous-value-add.svg"
+  />
+</div>
+`;
+
+exports[`<Illustration /> Spot ValuesSurvey1 should exist and render an alt tag 1`] = `
+<div>
+  <img
+    alt="My accessible title"
+    class=" wrapper"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/spot/template-library-values-survey-1.svg"
+  />
+</div>
+`;
+
+exports[`<Illustration /> Spot ValuesSurvey2 should exist and render an alt tag 1`] = `
+<div>
+  <img
+    alt="My accessible title"
+    class=" wrapper"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/spot/template-library-values-survey-2.svg"
+  />
+</div>
+`;
+
+exports[`<Illustration /> Spot Video should exist and render an alt tag 1`] = `
+<div>
+  <img
+    alt="My accessible title"
+    class=" wrapper"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/spot/miscellaneous-video.svg"
+  />
+</div>
+`;
+
+exports[`<Illustration /> Spot ViewReports should exist and render an alt tag 1`] = `
+<div>
+  <img
+    alt="My accessible title"
+    class=" wrapper"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/spot/miscellaneous-view-reports.svg"
+  />
+</div>
+`;
+
+exports[`<Illustration /> Spot WellbeingSurvey should exist and render an alt tag 1`] = `
+<div>
+  <img
+    alt="My accessible title"
+    class=" wrapper"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/heart/spot/template-library-wellbeing-survey.svg"
+  />
+</div>
+`;
+
+exports[`<Illustration /> Spot WellbeingSurvey1 should exist and render an alt tag 1`] = `
+<div>
+  <img
+    alt="My accessible title"
+    class=" wrapper"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/spot/template-library-wellbeing-survey-1.svg"
+  />
+</div>
+`;
+
+exports[`<Illustration /> Spot WellbeingSurvey2 should exist and render an alt tag 1`] = `
+<div>
+  <img
+    alt="My accessible title"
+    class=" wrapper"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/spot/template-library-wellbeing-survey-2.svg"
+  />
+</div>
+`;
+
+exports[`<Illustration /> Spot WellbeingSurvey3 should exist and render an alt tag 1`] = `
+<div>
+  <img
+    alt="My accessible title"
+    class=" wrapper"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/spot/template-library-wellbeing-survey-3.svg"
+  />
+</div>
+`;
+
+exports[`<Illustration /> Spot Workshop should exist and render an alt tag 1`] = `
+<div>
+  <img
+    alt="My accessible title"
+    class=" wrapper"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/spot/miscellaneous-workshop.svg"
+  />
+</div>
+`;

--- a/draft-packages/illustration/KaizenDraft/Illustration/illustration.spec.tsx
+++ b/draft-packages/illustration/KaizenDraft/Illustration/illustration.spec.tsx
@@ -1,0 +1,38 @@
+import { cleanup, render } from "@testing-library/react"
+import * as React from "react"
+import * as SpotIllustrations from "./Spot"
+import * as SceneIllustrations from "./Scene"
+
+afterEach(cleanup)
+
+describe("<Illustration />", () => {
+  describe("Spot", () => {
+    Object.keys(SpotIllustrations).forEach(componentName => {
+      const Component: (props: SpotIllustrations.SpotProps) => JSX.Element =
+        SpotIllustrations[componentName]
+
+      it(`${componentName} should exist and render an alt tag`, () => {
+        const altTitle = "My accessible title"
+        const wrapper = render(<Component alt={altTitle} />)
+
+        expect(wrapper.getByAltText(altTitle)).toBeTruthy()
+        expect(wrapper.container).toMatchSnapshot()
+      })
+    })
+  })
+
+  describe("Scene", () => {
+    Object.keys(SceneIllustrations).forEach(componentName => {
+      const Component: (props: SceneIllustrations.SceneProps) => JSX.Element =
+        SceneIllustrations[componentName]
+
+      it(`${componentName} should exist and render an alt tag`, () => {
+        const altTitle = "My accessible title"
+        const wrapper = render(<Component alt={altTitle} />)
+
+        expect(wrapper.getByAltText(altTitle)).toBeTruthy()
+        expect(wrapper.container).toMatchSnapshot()
+      })
+    })
+  })
+})

--- a/draft-packages/illustration/docs/IllustrationScene.stories.tsx
+++ b/draft-packages/illustration/docs/IllustrationScene.stories.tsx
@@ -57,10 +57,10 @@ export default {
   title: "Illustration, Scene (React)",
   component: ManagerLearningResilience,
   parameters: {
-    info: {
-      text: `
-        import { EmptyStatesAction, EmptyStatesInformative, EmptyStatesNegative } from "@kaizen/draft-illustration";
-      `,
+    docs: {
+      description: {
+        component: "Import { SurveyOverviewClosed } from \"@kaizen/draft-illustration\"",
+      },
     },
   },
 }

--- a/draft-packages/illustration/docs/IllustrationScene.stories.tsx
+++ b/draft-packages/illustration/docs/IllustrationScene.stories.tsx
@@ -59,7 +59,8 @@ export default {
   parameters: {
     docs: {
       description: {
-        component: "Import { SurveyOverviewClosed } from \"@kaizen/draft-illustration\"",
+        component:
+          'Import { SurveyOverviewClosed } from "@kaizen/draft-illustration"',
       },
     },
   },

--- a/draft-packages/illustration/docs/IllustrationSpot.stories.tsx
+++ b/draft-packages/illustration/docs/IllustrationSpot.stories.tsx
@@ -88,7 +88,7 @@ import {
   Trophy,
   UnderConstruction,
   ValueAdd,
-  Recommendation
+  Recommendation,
 } from ".."
 
 export default {
@@ -313,7 +313,7 @@ export const AllSpotIllustrations = () => {
     },
     {
       Component: Assertive,
-      name: "Assertive"
+      name: "Assertive",
     },
     {
       Component: Positive,

--- a/draft-packages/illustration/docs/IllustrationSpot.stories.tsx
+++ b/draft-packages/illustration/docs/IllustrationSpot.stories.tsx
@@ -1,21 +1,24 @@
 import * as React from "react"
+import { Paragraph } from "@kaizen/component-library"
 import {
   AccountBasics,
   Action,
   AddImage,
   AddUser,
+  Assertive,
   BaselineSurvey,
   BenefitsSurvey,
   BlankSurvey,
   CandidateSurvey,
   Cautionary,
+  CompanyDetails,
   ChangeReadiness,
   ChangeSuccess,
   Coaching,
-  CompanyDetails,
   CustomOnboardSurvey,
   CustomSurvey,
   CustomUnattributedSurvey,
+  EmergencyResponse,
   EmployeeData,
   EngagementSurvey,
   ExecutiveReportSharing,
@@ -23,12 +26,14 @@ import {
   FastAction,
   Feedback,
   Gdpr,
+  GeneralOnboardSurvey,
   InclusionSurvey,
   Individual360,
   Informative,
   InternSurvey,
   LeaderReportSharing,
   Leadership360,
+  LeadingThroughCrisis,
   Manager360,
   ManagerLearning,
   ManagerReportSharing,
@@ -38,12 +43,12 @@ import {
   PerformanceDiagnostics,
   PhasedWeek1OnboardSurvey,
   PhasedWeek5OnboardSurvey,
-  PositiveFemale,
-  PositiveMale,
+  Positive,
   Productivity,
   QuickEngagementSurvey,
   ReadArticle,
   RemoteManager,
+  RemoteOnboardSurvey,
   ReportSharing,
   Resilience,
   ShareReport,
@@ -66,490 +71,480 @@ import {
   WellbeingSurvey2,
   WellbeingSurvey3,
   Workshop,
+  WellbeingSurvey,
+  Response,
+  RemoteWorkQSet,
+  ReturnToWorkplace,
+  PulseSurvey,
+  Alarm,
+  Fire,
+  Fireworks,
+  FullImport,
+  HrisImport,
+  PartialImport,
+  Starburst,
+  Stop,
+  TrafficCone,
+  Trophy,
+  UnderConstruction,
+  ValueAdd,
+  Recommendation
 } from ".."
 
 export default {
   title: "Illustration, Spot (React)",
   component: AccountBasics,
   parameters: {
-    info: {
-      text: `
-        import { AccountBasics } from "@kaizen/draft-illustration";
-      `,
+    docs: {
+      description: {
+        component:
+          'import { AccountBasics } from "@kaizen/draft-illustration";',
+      },
     },
   },
 }
 
 export const SpotStoryForKaizenSite = () => (
-  <div style={{ width: "156px" }}>
-    <BenefitsSurvey alt="" />
+  <div style={{ width: "150px" }}>
+    <AccountBasics alt="" />
   </div>
 )
 SpotStoryForKaizenSite.storyName = "Spot (Kaizen Site Demo)"
 
-export const BenefitsSurveyStory = () => (
-  <div style={{ width: "156px" }}>
-    <BenefitsSurvey alt="" />
-  </div>
-)
-BenefitsSurveyStory.storyName = "Engagement: Benefits Survey"
-
-export const CustomSurveyStory = () => (
-  <div style={{ width: "156px" }}>
-    <CustomSurvey alt="" />
-  </div>
-)
-CustomSurveyStory.storyName = "Engagement: Custom Survey"
-
-export const CustomUnattributedSurveyStory = () => (
-  <div style={{ width: "156px" }}>
-    <CustomUnattributedSurvey alt="" />
-  </div>
-)
-CustomUnattributedSurveyStory.storyName =
-  "Engagement: Custom Unattributed Survey"
-
-export const EngagementSurveyStory = () => (
-  <div style={{ width: "156px" }}>
-    <EngagementSurvey alt="" />
-  </div>
-)
-EngagementSurveyStory.storyName = "Engagement: Engagement Survey"
-
-export const InclusionSurveyStory = () => (
-  <div style={{ width: "156px" }}>
-    <InclusionSurvey alt="" />
-  </div>
-)
-InclusionSurveyStory.storyName = "Engagement: Inclusion Survey"
-
-export const QuickEngagementSurveyStory = () => (
-  <div style={{ width: "156px" }}>
-    <QuickEngagementSurvey alt="" />
-  </div>
-)
-QuickEngagementSurveyStory.storyName = "Engagement: Quick Engagement Survey"
-
-export const ValuesSurvey1Story = () => (
-  <div style={{ width: "156px" }}>
-    <ValuesSurvey1 alt="" />
-  </div>
-)
-ValuesSurvey1Story.storyName = "Engagement: Values Survey 1"
-
-export const ValuesSurvey2Story = () => (
-  <div style={{ width: "156px" }}>
-    <ValuesSurvey2 alt="" />
-  </div>
-)
-ValuesSurvey2Story.storyName = "Engagement: Values Survey 2"
-
-export const WellbeingSurvey1Story = () => (
-  <div style={{ width: "156px" }}>
-    <WellbeingSurvey1 alt="" />
-  </div>
-)
-WellbeingSurvey1Story.storyName = "Engagement: Wellbeing Survey 1"
-
-export const WellbeingSurvey2Story = () => (
-  <div style={{ width: "156px" }}>
-    <WellbeingSurvey2 alt="" />
-  </div>
-)
-WellbeingSurvey2Story.storyName = "Engagement: Wellbeing Survey 2"
-
-export const WellbeingSurvey3Story = () => (
-  <div style={{ width: "156px" }}>
-    <WellbeingSurvey3 alt="" />
-  </div>
-)
-WellbeingSurvey3Story.storyName = "Engagement: Wellbeing Survey 3"
-
-export const ChangeReadinessStory = () => (
-  <div style={{ width: "156px" }}>
-    <ChangeReadiness alt="" />
-  </div>
-)
-ChangeReadinessStory.storyName = "Engagement: Change Readiness"
-
-export const ChangeSuccessStory = () => (
-  <div style={{ width: "156px" }}>
-    <ChangeSuccess alt="" />
-  </div>
-)
-ChangeSuccessStory.storyName = "Engagement: Change Success"
-
-export const PerformanceDiagnosticsStory = () => (
-  <div style={{ width: "156px" }}>
-    <PerformanceDiagnostics alt="" />
-  </div>
-)
-PerformanceDiagnosticsStory.storyName = "Engagement: Performance Diagnostics"
-
-export const CandidateSurveyStory = () => (
-  <div style={{ width: "156px" }}>
-    <CandidateSurvey alt="" />
-  </div>
-)
-CandidateSurveyStory.storyName = "Experience: Candidate Survey"
-
-export const CustomOnboardSurveyStory = () => (
-  <div style={{ width: "156px" }}>
-    <CustomOnboardSurvey alt="" />
-  </div>
-)
-CustomOnboardSurveyStory.storyName = "Experience: Custom Onboard Survey"
-
-export const ExitSurveyStory = () => (
-  <div style={{ width: "156px" }}>
-    <ExitSurvey alt="" />
-  </div>
-)
-ExitSurveyStory.storyName = "Experience: Exit Survey"
-
-export const InternSurveyStory = () => (
-  <div style={{ width: "156px" }}>
-    <InternSurvey alt="" />
-  </div>
-)
-InternSurveyStory.storyName = "Experience: Intern Survey"
-
-export const PhasedWeek1OnboardSurveyStory = () => (
-  <div style={{ width: "156px" }}>
-    <PhasedWeek1OnboardSurvey alt="" />
-  </div>
-)
-PhasedWeek1OnboardSurveyStory.storyName =
-  "Experience: Phased Week 1 Onboard Survey"
-
-export const PhasedWeek5OnboardSurveyStory = () => (
-  <div style={{ width: "156px" }}>
-    <PhasedWeek5OnboardSurvey alt="" />
-  </div>
-)
-PhasedWeek5OnboardSurveyStory.storyName =
-  "Experience: Phased Week 5 Onboard Survey"
-
-export const SinglePointOnboardSurveyStory = () => (
-  <div style={{ width: "156px" }}>
-    <SinglePointOnboardSurvey alt="" />
-  </div>
-)
-SinglePointOnboardSurveyStory.storyName =
-  "Experience: Single Point Onboard Survey"
-
-export const Individual360Story = () => (
-  <div style={{ width: "156px" }}>
-    <Individual360 alt="" />
-  </div>
-)
-Individual360Story.storyName = "Performance: Individual 360"
-
-export const Leadership360Story = () => (
-  <div style={{ width: "156px" }}>
-    <Leadership360 alt="" />
-  </div>
-)
-Leadership360Story.storyName = "Performance: Leadership 360"
-
-export const Manager360Story = () => (
-  <div style={{ width: "156px" }}>
-    <Manager360 alt="" />
-  </div>
-)
-Manager360Story.storyName = "Performance: Manager 360"
-
-export const TeamEffectiveness1Story = () => (
-  <div style={{ width: "156px" }}>
-    <TeamEffectiveness1 alt="" />
-  </div>
-)
-TeamEffectiveness1Story.storyName = "Performance: Team Effectiveness 1"
-
-export const TeamEffectiveness2Story = () => (
-  <div style={{ width: "156px" }}>
-    <TeamEffectiveness2 alt="" />
-  </div>
-)
-TeamEffectiveness2Story.storyName = "Performance: Team Effectiveness 2"
-
-export const AccountBasicsStory = () => (
-  <div style={{ width: "156px" }}>
-    <AccountBasics alt="" />
-  </div>
-)
-AccountBasicsStory.storyName = "New Account: Account Basics"
-
-export const CompanyDetailsStory = () => (
-  <div style={{ width: "156px" }}>
-    <CompanyDetails alt="" />
-  </div>
-)
-CompanyDetailsStory.storyName = "New Account: Company Details"
-
-export const EmployeeDataStory = () => (
-  <div style={{ width: "156px" }}>
-    <EmployeeData alt="" />
-  </div>
-)
-EmployeeDataStory.storyName = "New Account: Employee Data"
-
-export const GdprStory = () => (
-  <div style={{ width: "156px" }}>
-    <Gdpr alt="" />
-  </div>
-)
-GdprStory.storyName = "New Account: GDPR"
-
-export const TimezoneStory = () => (
-  <div style={{ width: "156px" }}>
-    <Timezone alt="" />
-  </div>
-)
-TimezoneStory.storyName = "New Account: Timezone"
-
-export const AddUserStory = () => (
-  <div style={{ width: "156px" }}>
-    <AddUser alt="" />
-  </div>
-)
-AddUserStory.storyName = "New Account: Add User"
-
-export const ViewReportsStory = () => (
-  <div style={{ width: "156px" }}>
-    <ViewReports alt="" />
-  </div>
-)
-ViewReportsStory.storyName = "Miscellaneous: View Reports"
-
-export const ReadArticleStory = () => (
-  <div style={{ width: "156px" }}>
-    <ReadArticle alt="" />
-  </div>
-)
-ReadArticleStory.storyName = "Miscellaneous: Read Article"
-
-export const FastActionStory = () => (
-  <div style={{ width: "156px" }}>
-    <FastAction alt="" />
-  </div>
-)
-FastActionStory.storyName = "Miscellaneous: Fast Action"
-
-export const BaselineSurveyStory = () => (
-  <div style={{ width: "156px" }}>
-    <BaselineSurvey alt="" />
-  </div>
-)
-BaselineSurveyStory.storyName = "Miscellaneous: Baseline Survey"
-
-export const SpreadsheetTemplateStory = () => (
-  <div style={{ width: "156px" }}>
-    <SpreadsheetTemplate alt="" />
-  </div>
-)
-SpreadsheetTemplateStory.storyName = "Miscellaneous: Spreadsheet Template"
-
-export const AddImageStory = () => (
-  <div style={{ width: "156px" }}>
-    <AddImage alt="" />
-  </div>
-)
-AddImageStory.storyName = "Miscellaneous: Add Image"
-
-export const MeetingVoicesStory = () => (
-  <div style={{ width: "156px" }}>
-    <MeetingVoices alt="" />
-  </div>
-)
-MeetingVoicesStory.storyName = "Miscellaneous: Meeting Voices"
-
-export const WorkshopStory = () => (
-  <div style={{ width: "156px" }}>
-    <Workshop alt="" />
-  </div>
-)
-WorkshopStory.storyName = "Miscellaneous: Workshop"
-
-export const VideoStory = () => (
-  <div style={{ width: "156px" }}>
-    <Video alt="" />
-  </div>
-)
-VideoStory.storyName = "Miscellaneous: Video"
-
-export const ReportSharingStory = () => (
-  <div style={{ width: "156px" }}>
-    <ReportSharing alt="" />
-  </div>
-)
-ReportSharingStory.storyName = "Miscellaneous: Report Sharing"
-
-export const BlankSurveyStory = () => (
-  <div style={{ width: "156px" }}>
-    <BlankSurvey alt="" />
-  </div>
-)
-BlankSurveyStory.storyName = "Miscellaneous: Blank Survey"
-
-export const TakeAimStory = () => (
-  <div style={{ width: "156px" }}>
-    <TakeAim alt="" />
-  </div>
-)
-TakeAimStory.storyName = "Miscellaneous: Take Aim"
-
-export const ActionStory = () => (
-  <div style={{ width: "156px" }}>
-    <Action alt="" />
-  </div>
-)
-ActionStory.storyName = "Miscellaneous: Action"
-
-export const Training1Story = () => (
-  <div style={{ width: "156px" }}>
-    <Training1 alt="" />
-  </div>
-)
-Training1Story.storyName = "Miscellaneous: Training 1"
-
-export const Training2Story = () => (
-  <div style={{ width: "156px" }}>
-    <Training2 alt="" />
-  </div>
-)
-Training2Story.storyName = "Miscellaneous: Training 2"
-
-export const Training3Story = () => (
-  <div style={{ width: "156px" }}>
-    <Training3 alt="" />
-  </div>
-)
-Training3Story.storyName = "Miscellaneous: Training 3"
-
-export const ShareReportStory = () => (
-  <div style={{ width: "156px" }}>
-    <ShareReport alt="" />
-  </div>
-)
-ShareReportStory.storyName = "Miscellaneous: Share Report"
-
-export const TeamStory = () => (
-  <div style={{ width: "156px" }}>
-    <Team alt="" />
-  </div>
-)
-TeamStory.storyName = "Miscellaneous: Team"
-
-export const ExecutiveReportSharingStory = () => (
-  <div style={{ width: "156px" }}>
-    <ExecutiveReportSharing alt="" />
-  </div>
-)
-ExecutiveReportSharingStory.storyName =
-  "Miscellaneous: Executive Report Sharing"
-
-export const ManagerReportSharingStory = () => (
-  <div style={{ width: "156px" }}>
-    <ManagerReportSharing alt="" />
-  </div>
-)
-ManagerReportSharingStory.storyName = "Miscellaneous: Manager Report Sharing"
-
-export const LeaderReportSharingStory = () => (
-  <div style={{ width: "156px" }}>
-    <LeaderReportSharing alt="" />
-  </div>
-)
-LeaderReportSharingStory.storyName = "Miscellaneous: Leader Report Sharing"
-
-export const CautionaryStory = () => (
-  <div style={{ width: "156px" }}>
-    <Cautionary alt="" />
-  </div>
-)
-CautionaryStory.storyName = "Moods: Cautionary"
-
-export const InformativeStory = () => (
-  <div style={{ width: "156px" }}>
-    <Informative alt="" />
-  </div>
-)
-InformativeStory.storyName = "Moods: Informative"
-
-export const NegativeStory = () => (
-  <div style={{ width: "156px" }}>
-    <Negative alt="" />
-  </div>
-)
-NegativeStory.storyName = "Moods: Negative"
-
-export const PositiveMaleStory = () => (
-  <div style={{ width: "156px" }}>
-    <PositiveMale alt="" />
-  </div>
-)
-PositiveMaleStory.storyName = "Moods: Positive Male"
-
-export const PositiveFemaleStory = () => (
-  <div style={{ width: "156px" }}>
-    <PositiveFemale alt="" />
-  </div>
-)
-PositiveFemaleStory.storyName = "Moods: Positive Female"
-
-export const OneOnOneStory = () => (
-  <div style={{ width: "156px" }}>
-    <OneOnOne alt="" />
-  </div>
-)
-OneOnOneStory.storyName = "Manager Learning: 1 On 1"
-
-export const ProductivityStory = () => (
-  <div style={{ width: "156px" }}>
-    <Productivity alt="" />
-  </div>
-)
-ProductivityStory.storyName = "Manager Learning: Productivity"
-
-export const StrategyStory = () => (
-  <div style={{ width: "156px" }}>
-    <Strategy alt="" />
-  </div>
-)
-StrategyStory.storyName = "Manager Learning: Strategy"
-
-export const ResilienceStory = () => (
-  <div style={{ width: "156px" }}>
-    <Resilience alt="" />
-  </div>
-)
-ResilienceStory.storyName = "Manager Learning: Resilience"
-
-export const CoachingStory = () => (
-  <div style={{ width: "156px" }}>
-    <Coaching alt="" />
-  </div>
-)
-CoachingStory.storyName = "Manager Learning: Coaching"
-
-export const FeedbackStory = () => (
-  <div style={{ width: "156px" }}>
-    <Feedback alt="" />
-  </div>
-)
-FeedbackStory.storyName = "Manager Learning: Feedback"
-
-export const RemoteManagerStory = () => (
-  <div style={{ width: "156px" }}>
-    <RemoteManager alt="" />
-  </div>
-)
-RemoteManagerStory.storyName = "Manager Learning: Remote Manager"
-
-export const ManagerLearningStory = () => (
-  <div style={{ width: "156px" }}>
-    <ManagerLearning alt="" />
-  </div>
-)
-ManagerLearningStory.storyName = "Manager Learning: Manager Learning"
+const IllustrationExampleTile = ({ Component, name }) => (
+  <div style={{ width: "150px", display: "inline-block", padding: "2rem" }}>
+    <Component alt="" />
+    <Paragraph variant="small">{name}</Paragraph>
+  </div>
+)
+
+export const AllSpotIllustrations = () => {
+  const engagementSpots = [
+    {
+      Component: BenefitsSurvey,
+      name: "Benefits Survey",
+    },
+    {
+      Component: CustomSurvey,
+      name: "Custom Survey",
+    },
+    {
+      Component: CustomUnattributedSurvey,
+      name: "Custom Unattributed Survey",
+    },
+    {
+      Component: EngagementSurvey,
+      name: "Engagement Survey",
+    },
+    {
+      Component: InclusionSurvey,
+      name: "Inclusion Survey",
+    },
+    {
+      Component: QuickEngagementSurvey,
+      name: "Quick Engagement Survey",
+    },
+    {
+      Component: ValuesSurvey1,
+      name: "Values Survey 1",
+    },
+    {
+      Component: ValuesSurvey2,
+      name: "Values Survey 2",
+    },
+    {
+      Component: WellbeingSurvey1,
+      name: "Wellbeing Survey 1",
+    },
+    {
+      Component: WellbeingSurvey2,
+      name: "Wellbeing Survey 2",
+    },
+    {
+      Component: WellbeingSurvey3,
+      name: "Wellbeing Survey 3",
+    },
+    {
+      Component: ChangeReadiness,
+      name: "Change Readiness",
+    },
+    {
+      Component: ChangeSuccess,
+      name: "Change Success",
+    },
+    {
+      Component: PerformanceDiagnostics,
+      name: "Performance Diagnostics",
+    },
+    {
+      Component: LeadingThroughCrisis,
+      name: "Leading Through Crisis",
+    },
+    {
+      Component: EmergencyResponse,
+      name: "Emergency Response",
+    },
+  ]
+
+  const experienceSpots = [
+    {
+      Component: PhasedWeek1OnboardSurvey,
+      name: "Phased Week 1 Onboard Survey",
+    },
+    {
+      Component: PhasedWeek5OnboardSurvey,
+      name: "Phased Week 5 Onboard Survey",
+    },
+    {
+      Component: RemoteOnboardSurvey,
+      name: "Remote Onboard Survey",
+    },
+    {
+      Component: GeneralOnboardSurvey,
+      name: "General Onboard Survey",
+    },
+    {
+      Component: CustomOnboardSurvey,
+      name: "Custom Onboard Survey",
+    },
+    {
+      Component: CandidateSurvey,
+      name: "Candidate Survey",
+    },
+    {
+      Component: ExitSurvey,
+      name: "Exit Survey",
+    },
+    {
+      Component: InternSurvey,
+      name: "Intern Survey",
+    },
+    {
+      Component: SinglePointOnboardSurvey,
+      name: "Single Point Onboard Survey",
+    },
+  ]
+
+  const performanceSpots = [
+    {
+      Component: Individual360,
+      name: "Individual 360",
+    },
+    {
+      Component: Leadership360,
+      name: "Leadership 360",
+    },
+    {
+      Component: Manager360,
+      name: "Manager 360",
+    },
+    {
+      Component: TeamEffectiveness1,
+      name: "Team Effectiveness 1",
+    },
+    {
+      Component: TeamEffectiveness2,
+      name: "Team Effectiveness 2",
+    },
+  ]
+
+  const covidSpots = [
+    {
+      Component: Response,
+      name: "COVID-19 Response",
+    },
+    {
+      Component: WellbeingSurvey,
+      name: "Wellbeing Survey",
+    },
+    {
+      Component: RemoteWorkQSet,
+      name: "Remote Work Q Set",
+    },
+    {
+      Component: ReturnToWorkplace,
+      name: "Return To Workplace",
+    },
+    {
+      Component: PulseSurvey,
+      name: "Pulse Survey",
+    },
+  ]
+
+  const newAccountSpots = [
+    {
+      Component: AccountBasics,
+      name: "Account Basics",
+    },
+    {
+      Component: CompanyDetails,
+      name: "Company Details",
+    },
+    {
+      Component: EmployeeData,
+      name: "Employee Data",
+    },
+    {
+      Component: Gdpr,
+      name: "GDPR",
+    },
+    {
+      Component: Timezone,
+      name: "Timezone",
+    },
+    {
+      Component: AddUser,
+      name: "Add User",
+    },
+  ]
+
+  const moodSpots = [
+    {
+      Component: Cautionary,
+      name: "Cautionary",
+    },
+    {
+      Component: Informative,
+      name: "Informative",
+    },
+    {
+      Component: Negative,
+      name: "Negative",
+    },
+    {
+      Component: Assertive,
+      name: "Assertive"
+    },
+    {
+      Component: Positive,
+      name: "Positive",
+    },
+  ]
+
+  const managerLearningSpots = [
+    {
+      Component: OneOnOne,
+      name: "1 on 1",
+    },
+    {
+      Component: Productivity,
+      name: "Productivity",
+    },
+    {
+      Component: Strategy,
+      name: "Strategy",
+    },
+    {
+      Component: Resilience,
+      name: "Resilience",
+    },
+    {
+      Component: Coaching,
+      name: "Coaching",
+    },
+    {
+      Component: Feedback,
+      name: "Feedback",
+    },
+    {
+      Component: RemoteManager,
+      name: "Remote Manager",
+    },
+    {
+      Component: ManagerLearning,
+      name: "Manager Learning",
+    },
+  ]
+
+  const miscellaneousSpots = [
+    {
+      Component: ViewReports,
+      name: "View Reports",
+    },
+    {
+      Component: ReadArticle,
+      name: "Read Article",
+    },
+    {
+      Component: FastAction,
+      name: "Fast Action",
+    },
+    {
+      Component: BaselineSurvey,
+      name: "Baseline Survey",
+    },
+    {
+      Component: Team,
+      name: "Team",
+    },
+    {
+      Component: Recommendation,
+      name: "Recommendation",
+    },
+    {
+      Component: AddImage,
+      name: "Add Image",
+    },
+    {
+      Component: MeetingVoices,
+      name: "Meeting Voices",
+    },
+    {
+      Component: Workshop,
+      name: "Workshop",
+    },
+    {
+      Component: Video,
+      name: "Video",
+    },
+    {
+      Component: ReportSharing,
+      name: "Report Sharing",
+    },
+    {
+      Component: BlankSurvey,
+      name: "Blank Survey",
+    },
+    {
+      Component: TakeAim,
+      name: "Take Aim",
+    },
+    {
+      Component: Action,
+      name: "Action",
+    },
+    {
+      Component: Training1,
+      name: "Training 1",
+    },
+    {
+      Component: Training2,
+      name: "Training 2",
+    },
+    {
+      Component: Training3,
+      name: "Training 3",
+    },
+    {
+      Component: ShareReport,
+      name: "Share Report",
+    },
+    {
+      Component: ExecutiveReportSharing,
+      name: "ExecutiveReportSharing",
+    },
+    {
+      Component: ManagerReportSharing,
+      name: "Manager Report Sharing",
+    },
+    {
+      Component: LeaderReportSharing,
+      name: "Leader Report Sharing",
+    },
+    {
+      Component: SpreadsheetTemplate,
+      name: "Spreadsheet Template",
+    },
+    {
+      Component: FullImport,
+      name: "Full Import",
+    },
+    {
+      Component: PartialImport,
+      name: "Partial Import",
+    },
+    {
+      Component: HrisImport,
+      name: "Hris Import",
+    },
+    {
+      Component: Alarm,
+      name: "Alarm",
+    },
+    {
+      Component: Fire,
+      name: "Fire",
+    },
+    {
+      Component: UnderConstruction,
+      name: "Under Construction",
+    },
+    {
+      Component: Stop,
+      name: "Stop",
+    },
+    {
+      Component: Trophy,
+      name: "Trophy",
+    },
+    {
+      Component: TrafficCone,
+      name: "Traffic Cone",
+    },
+    {
+      Component: ValueAdd,
+      name: "Value Add",
+    },
+    {
+      Component: Starburst,
+      name: "Starburst",
+    },
+    {
+      Component: Fireworks,
+      name: "Fireworks",
+    },
+  ]
+
+  return (
+    <>
+      <div>
+        <h1>Template Library / Engagement</h1>
+        {engagementSpots.map((props, i) => (
+          <IllustrationExampleTile key={`engagement-${i}`} {...props} />
+        ))}
+      </div>
+      <div>
+        <h1>Template Library / Experience</h1>
+        {experienceSpots.map((props, i) => (
+          <IllustrationExampleTile key={`experience-${i}`} {...props} />
+        ))}
+      </div>
+      <div>
+        <h1>Template Library / Performance</h1>
+        {performanceSpots.map((props, i) => (
+          <IllustrationExampleTile key={`performance-${i}`} {...props} />
+        ))}
+      </div>
+      <div>
+        <h1>Template Library / COVID-19</h1>
+        {covidSpots.map((props, i) => (
+          <IllustrationExampleTile key={`covid-${i}`} {...props} />
+        ))}
+      </div>
+      <div>
+        <h1>New Account</h1>
+        {newAccountSpots.map((props, i) => (
+          <IllustrationExampleTile key={`new-account-${i}`} {...props} />
+        ))}
+      </div>
+      <div>
+        <h1>Moods</h1>
+        {moodSpots.map((props, i) => (
+          <IllustrationExampleTile key={`moods-${i}`} {...props} />
+        ))}
+      </div>
+      <div>
+        <h1>Skills Coach</h1>
+        {managerLearningSpots.map((props, i) => (
+          <IllustrationExampleTile key={`skills-coach-${i}`} {...props} />
+        ))}
+      </div>
+      <div>
+        <h1>Miscellaneous</h1>
+        {miscellaneousSpots.map((props, i) => (
+          <IllustrationExampleTile key={`misc-${i}`} {...props} />
+        ))}
+      </div>
+    </>
+  )
+}

--- a/draft-packages/illustration/docs/IllustrationSpot.stories.tsx
+++ b/draft-packages/illustration/docs/IllustrationSpot.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from "react"
-import { Paragraph } from "@kaizen/component-library"
+import { Heading, Paragraph } from "@kaizen/component-library"
 import {
   AccountBasics,
   Action,
@@ -498,49 +498,49 @@ export const AllSpotIllustrations = () => {
   return (
     <>
       <div>
-        <h1>Template Library / Engagement</h1>
+        <Heading variant="heading-3">Template Library / Engagement</Heading>
         {engagementSpots.map((props, i) => (
           <IllustrationExampleTile key={`engagement-${i}`} {...props} />
         ))}
       </div>
       <div>
-        <h1>Template Library / Experience</h1>
+        <Heading variant="heading-3">Template Library / Experience</Heading>
         {experienceSpots.map((props, i) => (
           <IllustrationExampleTile key={`experience-${i}`} {...props} />
         ))}
       </div>
       <div>
-        <h1>Template Library / Performance</h1>
+        <Heading variant="heading-3">Template Library / Performance</Heading>
         {performanceSpots.map((props, i) => (
           <IllustrationExampleTile key={`performance-${i}`} {...props} />
         ))}
       </div>
       <div>
-        <h1>Template Library / COVID-19</h1>
+        <Heading variant="heading-3">Template Library / COVID-19</Heading>
         {covidSpots.map((props, i) => (
           <IllustrationExampleTile key={`covid-${i}`} {...props} />
         ))}
       </div>
       <div>
-        <h1>New Account</h1>
+        <Heading variant="heading-3">New Account</Heading>
         {newAccountSpots.map((props, i) => (
           <IllustrationExampleTile key={`new-account-${i}`} {...props} />
         ))}
       </div>
       <div>
-        <h1>Moods</h1>
+        <Heading variant="heading-3">Moods</Heading>
         {moodSpots.map((props, i) => (
           <IllustrationExampleTile key={`moods-${i}`} {...props} />
         ))}
       </div>
       <div>
-        <h1>Skills Coach</h1>
+        <Heading variant="heading-3">Skills Coach</Heading>
         {managerLearningSpots.map((props, i) => (
           <IllustrationExampleTile key={`skills-coach-${i}`} {...props} />
         ))}
       </div>
       <div>
-        <h1>Miscellaneous</h1>
+        <Heading variant="heading-3">Miscellaneous</Heading>
         {miscellaneousSpots.map((props, i) => (
           <IllustrationExampleTile key={`misc-${i}`} {...props} />
         ))}

--- a/draft-packages/illustration/package.json
+++ b/draft-packages/illustration/package.json
@@ -32,14 +32,15 @@
   "private": false,
   "license": "MIT",
   "dependencies": {
-    "@kaizen/design-tokens": "^2.8.1",
     "@kaizen/hosted-assets": "^1.1.0"
   },
   "devDependencies": {
     "elm-storybook": "cultureamp/elm-storybook#0.3.0",
-    "rimraf": "^3.0.2"
+    "rimraf": "^3.0.2",
+    "@kaizen/design-tokens": "^2.8.1"
   },
   "peerDependencies": {
+    "@kaizen/design-tokens": "^2.8.1",
     "react": "^16.9.0"
   }
 }


### PR DESCRIPTION
# Objective
Add the Heart spot illustrations, and conditionally render them based on a theme.

# Other notes
Few things to call out: 
* I have used snapshot tests. The removal of any of these illustrations will be a breaking change and we should guard against that in our tests.
* When there is a Heart illustration without a corresponding Zen illustration, a warning will be logged when using these under a Zen theme. I don't feel that we should stop someone from using a Heart illustration in Zen since Zen will eventually be deprecated.
* I've also stopped rendering each of these illustrations as a separate story and have instead made a mega-story that matches the UI kit sticker sheet. I hope that this makes it a little easier to find the illustration needed.
* You're probably best to review this in Chromatic. 

Story is here: https://dev.cultureamp.design/ally/heart-spot-illustrations/storybook/?path=/story/illustration-spot-react--all-spot-illustrations

# Screenshots (if appropriate)
![Screen Shot 2021-04-23 at 11 17 39 am](https://user-images.githubusercontent.com/1621182/115804070-8cecb380-a425-11eb-9cc9-d5e5a486749e.png)



# Checklist
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] If this contains visual changes, has it been reviewed by a designer?
- [ ] If this introduces either a new component or a breaking change to an existing component, has it been reviewed by an advocate? (Ask in #prod_design_systems)
- [ ] I have considered likely risks of these changes and got someone else to QA as appropriate
- [ ] I have or will communicate these changes to the front end practice
