### PR TITLE
Integrate with Backstage (Modify Me!)

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -2,10 +2,30 @@ apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
   name: kaizen-design-system
+  description: Culture Amp's Kaizen Design System :seedling:
+  links:
+    - title: Website
+      url: https://github.com/cultureamp/kaizen-design-system
+    - title: Monitoring Dashboard
+      url: https://app.datadoghq.com/apm/service/kaizen-design-system/http.request?env=production-us # If this link is broken feel free to link to another monitoring view. Alternatively leave as is and create the Datadog dashboard. 
+  #
+  # Tags are required and are based on:
+  # https://cultureamp.atlassian.net/wiki/spaces/CPlatform/pages/1720156463/Authentication+-+One+Platform+Technical+Canvas
+  # Please select values from the options provided
+  tags: 
+    - tier- # tier-1 | tier-2 | tier-3
+    - health- # health-good | health-moderate | health-poor
+    - users- # users-internal | users-account-admins | users-customer-facing | users-na
+    - camp- # e.g camp-platform | camp-perform | camp-example
+    - data- # data-confidential | data-restricted | data-internal-use-only | data-public | data-none
   annotations:
     github.com/project-slug: cultureamp/kaizen-design-system
-  namespace: default
+    github.com/team-slug: cultureamp/foundations 
+    backstage.io/techdocs-ref: url:https://github.com/cultureamp/blob/master/kaizen-design-system
+    buildkite.com/project-slug: culture-amp/kaizen-design-system # Check Me! - this was guessed and may be incorrect
+    # pagerduty.com/integration-key: create an integration key and use its ID here - https://support.pagerduty.com/docs/services-and-integrations
+    # sentry.io/project-slug: kaizen-design-system # Uncomment this line if using Sentry
 spec:
-  type: other
-  lifecycle: unknown
-  owner: foundations
+  type: # openapi | website | service | library
+  owner: foundations # Backstage Teamname should be the same as the Github Team Name (these teams are synced between github and backstage)
+  lifecycle: production # experimental | development | production | deprecated | contained


### PR DESCRIPTION
## Purpose

This PR adds the configuration required for your component to be registered in our service catalogue "Backstage" - [Access Backstage](https://backstage.usw2.dev-us.cultureamp.io) (Dev VPN required)

## Before Merging

All comments in the `catalog-info.yaml` should be deleted before merging as their only purpose is to support this PR.  

It is strongly recommended you review and change this PR to suit the component in this repo with as much detail as possible.

Please consult the [backstage docs](https://backstage.usw2.dev-us.cultureamp.io/catalog/default/component/backstage/docs) and reach out to Mark Walford or the central SRE team #team_sre for help.

## Changes

This PR adds the following:

A `catalog-info.yaml` file. Required by backstage, this file defines this repo in the service catalog.
 The `catalog-info.yaml` is not complete. Please review and makes changes where necessary. Remove all comments.