### PR TITLE
fix: remove hidden overflow on collapsible component

### DIFF
--- a/draft-packages/collapsible/KaizenDraft/Collapsible/CollapsibleGroup.tsx
+++ b/draft-packages/collapsible/KaizenDraft/Collapsible/CollapsibleGroup.tsx
@@ -29,7 +29,6 @@ export const CollapsibleGroup: React.FunctionComponent<Props> = ({
   <div
     className={classnames({
       [styles.container]: !separated,
-      [styles.stickyContainer]: !separated && sticky,
     })}
     data-automation-id={automationId}
   >

--- a/draft-packages/collapsible/KaizenDraft/Collapsible/styles.scss
+++ b/draft-packages/collapsible/KaizenDraft/Collapsible/styles.scss
@@ -9,21 +9,13 @@ $heading-active-color: $kz-var-color-wisteria-100;
 
 .container {
   box-shadow: $kz-var-shadow-small-box-shadow;
-  border-radius: $kz-var-border-borderless-border-radius;
-  overflow: hidden;
-}
 
-// We set overflow: hidden on the container, so that child nodes without border
-// radius do not overlap the container. However, this breaks the sticky headers
-// because it creates a new scroll container. The solution is to use the new
-// overflow: clip setting, but until it has full support across browsers we also
-// need a fallback. When there is full support for overflow:clip, we can use that
-// in .container for everything
-.stickyContainer {
-  overflow: visible;
-  @supports (overflow: clip) {
-    overflow: clip;
-  }
+  // TODO: This has been removed for the meantime as the collapsible component
+  // has an issue of not being able to have border-radius without needing to hide
+  // the overflow - resulting in cropping out modals that overflow the container.
+  // We've removed all radiuses now until we add enough logic to handle all
+  // the edge cases.
+  // border-radius: $kz-var-border-borderless-border-radius;
 }
 
 .separated {


### PR DESCRIPTION
# Objective
- Fix current bug in production in a quick way without disturbing the design too much.
- This is the only way without adding a _lot_ of logic around when the collapsible container is open to dynamically move around where to put the border radius. Annoyingly, we can't have it on the outer container (hence this fix) and having it on the inner container, it would need to move around when opening/closing the component and when it turns sticky. Something too large of a task for a fix that is currently hiding content from customers.

# Motivation and Context
- Fixes this: https://cultureamp.atlassian.net/browse/KR-284

# Screenshots (if appropriate)
### Before
![image](https://user-images.githubusercontent.com/18339250/116349884-58696500-a834-11eb-815a-af1aadd77773.png)

### After
<img width="1200" alt="Screen Shot 2021-04-28 at 3 14 05 pm" src="https://user-images.githubusercontent.com/18339250/116349909-615a3680-a834-11eb-9b73-0b5bc7e114cd.png">


# Checklist
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] If this contains visual changes, has it been reviewed by a designer?
- [ ] If this introduces either a new component or a breaking change to an existing component, has it been reviewed by an advocate? (Ask in #prod_design_systems)
- [ ] I have considered likely risks of these changes and got someone else to QA as appropriate
- [ ] I have or will communicate these changes to the front end practice

# Additional Considerations
- Does there need to be right-to-left (RTL) options for localization and internationalization?
- Has the test suite been updated?
- Have you done cross-browser testing for our [supported browsers](https://academy.cultureamp.com/hc/en-us/articles/204539569-Supported-browsers-for-Participants)?
- Have you updated any relevant documentation or left useful comments in the code?
- Have you reviewed Culture Amp's Web Accessibility guide [Current Compliance, Going Forward, Statement and Answers for Customers](https://cultureamp.atlassian.net/wiki/spaces/Prod/pages/428572998/Web+Accessibility)?
- If this contains substantial visual changes, especially far reaching ones, have you unlocked the Chromatic step in the pipeline?
- Have Storybook stories been updated?

**If you're new to Kaizen, please ask #prod_design_systems to set up an onboarding session to get you up to speed.** If you have an urgent PR to merge before that happens, it is safest to ask in #prod_design_systems to have a design system advocate review the PR to catch any issues.
