### PR TITLE
feat: Improved Heart support for titleblock

### DIFF
--- a/legacy-packages/title-block/ElmStories/TitleBlockStories.elm
+++ b/legacy-packages/title-block/ElmStories/TitleBlockStories.elm
@@ -1,0 +1,47 @@
+module ElmStories.TitleBlockStories exposing (main)
+
+import ElmStorybook exposing (statelessStoryOf, storybook)
+import Heading.Heading as Heading exposing (AllowedColor(..), TypeVariant(..), view)
+import Html exposing (Html, div, text)
+import Html.Attributes exposing (style)
+import KaizenDraft.TitleBlock.TitleBlock as TitleBlock
+import KaizenDraft.Button.Button as Button exposing (..)
+
+navigationButton : List (TitleBlock.NavButton msg)
+navigationButton = [(TitleBlock.NavBtn "Dashboard" Nothing False)
+    , (TitleBlock.NavBtn "Tasks" Nothing False)]
+
+navigationActionsPrimary : List (Html msg)
+navigationActionsPrimary = [ (Button.view Button.primary "Primary action") ]
+
+navigationActionsSecondary : List (Html msg)
+navigationActionsSecondary = [ (Button.view Button.secondary "Action 1")
+    , (Button.view Button.secondary "Action 2") ]
+
+navigationBreadcrumb : TitleBlock.Breadcrumb
+navigationBreadcrumb = {label="Back to reports", link="Home"}
+main =
+    storybook
+        [ statelessStoryOf "Admin, with breadcrumb" <|
+            TitleBlock.view "Home"
+                (TitleBlock.default
+                    |> TitleBlock.actionsList navigationActionsSecondary
+                    |> TitleBlock.reversed False
+                    |> TitleBlock.breadcrumb navigationBreadcrumb
+                )
+        , statelessStoryOf "Admin, with navigation buttons" <|
+            TitleBlock.view "Home"
+                (TitleBlock.default
+                    |> TitleBlock.navigationButtons navigationButton
+                    |> TitleBlock.actionsList navigationActionsSecondary
+                    |> TitleBlock.reversed False
+                )
+        , statelessStoryOf "Reversed" <|
+            TitleBlock.view "Home"
+                (TitleBlock.default
+                    |> TitleBlock.navigationButtons navigationButton
+                    |> TitleBlock.actionsList navigationActionsPrimary
+                    |> TitleBlock.reversed True
+                    |> TitleBlock.breadcrumb navigationBreadcrumb
+                    |> TitleBlock.reverseColor TitleBlock.Wisteria
+                )]

--- a/legacy-packages/title-block/KaizenDraft/TitleBlock/TitleBlock.scss
+++ b/legacy-packages/title-block/KaizenDraft/TitleBlock/TitleBlock.scss
@@ -1,4 +1,5 @@
 @import "~@kaizen/design-tokens/sass/color-vars";
+@import "~@kaizen/design-tokens/sass/variable-identifiers";
 @import "~@kaizen/design-tokens/sass/shadow-vars";
 @import "~@kaizen/design-tokens/sass/layout-vars";
 @import "~@kaizen/design-tokens/sass/layout";
@@ -29,7 +30,7 @@
 
 .titleBlock {
   background-color: $kz-var-color-white;
-  border-bottom: 1px solid $kz-var-color-wisteria-200;
+  border-bottom: 1px solid $kz-var-color-ash;
   width: inherit;
 
   @media print {
@@ -267,7 +268,7 @@
   @include title-block-mobile {
     display: flex;
     margin: 0;
-    border-bottom: 1px solid $ca-border-color;
+    border-bottom: 1px solid $kz-var-color-ash;
     width: 100%;
     background: $kz-var-color-white;
   }
@@ -392,12 +393,18 @@
 .reverseColorWisteria {
   @include title-block-desktop {
     .titleBlock {
-      background-color: $kz-var-color-wisteria-700;
+      background-color: var(
+        $kz-var-id-color-wisteria-600,
+        $kz-var-color-wisteria-700
+      );
     }
   }
   @include title-block-mobile {
     .navContainer {
-      background-color: $kz-var-color-wisteria-500;
+      background-color: var(
+        $kz-var-id-color-wisteria-600,
+        $kz-var-color-wisteria-700
+      );
     }
   }
 }
@@ -518,12 +525,18 @@
 .stickyColorWisteria {
   @include title-block-desktop {
     .titleBlock {
-      background-color: $kz-var-color-wisteria-700;
+      background-color: var(
+        $kz-var-id-color-wisteria-600,
+        $kz-var-color-wisteria-700
+      );
     }
   }
   @include title-block-mobile {
     .navContainer {
-      background-color: $kz-var-color-wisteria-700;
+      background-color: var(
+        $kz-var-id-color-wisteria-600,
+        $kz-var-color-wisteria-700
+      );
     }
   }
 }

--- a/legacy-packages/title-block/docs/ElmTitleBlock.stories.tsx
+++ b/legacy-packages/title-block/docs/ElmTitleBlock.stories.tsx
@@ -1,0 +1,9 @@
+import { loadElmStories } from "elm-storybook"
+const compiledElm = require("../ElmStories/TitleBlockStories.elm").Elm
+  .ElmStories.TitleBlockStories
+
+loadElmStories("Titleblock (Elm) (deprecated)", module, compiledElm, [
+  "Admin, with breadcrumb",
+  "Admin, with navigation buttons",
+  "Reversed",
+])


### PR DESCRIPTION
# Objective
* Added (deprecated) Elm stories for titleblock
* Changed background color to wisteria-600 on heart (maintaining wisteria-700 on Zen) so that it is consistent with Zen navigation bar and other navs in the platform

# Screenshots (if appropriate)
<img width="1429" alt="Screen Shot 2021-04-28 at 7 24 40 pm" src="https://user-images.githubusercontent.com/1621182/116380546-68467080-a857-11eb-84f6-6d2bc6dd3267.png">

# Checklist
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] If this contains visual changes, has it been reviewed by a designer?
- [ ] If this introduces either a new component or a breaking change to an existing component, has it been reviewed by an advocate? (Ask in #prod_design_systems)
- [ ] I have considered likely risks of these changes and got someone else to QA as appropriate
- [ ] I have or will communicate these changes to the front end practice