### PR TITLE
feat: Make tiles flexy when used in TileGrid

### DIFF
--- a/draft-packages/tile/KaizenDraft/Tile/TileGrid.scss
+++ b/draft-packages/tile/KaizenDraft/Tile/TileGrid.scss
@@ -1,17 +1,20 @@
 @import "~@kaizen/design-tokens/sass/spacing-vars";
 @import "~@kaizen/design-tokens/sass/layout-vars";
 @import "~@kaizen/component-library/styles/responsive";
+@import "./dimensions";
 
+// Don't change this classname before checking GenericTile.scss in components/.
+// There is a hack in the Tile which depends on this classname in order to make
+// the Tile work with the TileGrid.
 .grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, 330px);
+  // the more we shave off the width here,
+  // the less the tiles will grow when they lose one from the row
+  grid-template-columns: repeat(auto-fit, minmax($tileWidth - 40px, 1fr));
   grid-gap: $kz-var-spacing-md;
-  justify-content: start;
-  justify-items: start;
-  align-items: center;
 
   @include ca-media-mobile {
-    grid-template-columns: repeat(2, minmax(226px, 370px));
+    grid-template-columns: repeat(2, minmax(226px, $tileHeight));
 
     > * {
       width: 100%;

--- a/draft-packages/tile/KaizenDraft/Tile/components/GenericTile.scss
+++ b/draft-packages/tile/KaizenDraft/Tile/components/GenericTile.scss
@@ -4,9 +4,8 @@
 @import "~@kaizen/deprecated-component-library-helpers/styles/layout";
 @import "~@kaizen/component-library/styles/animation";
 @import "~@kaizen/component-library/styles/responsive";
+@import "../dimensions";
 
-$tileWidth: 330px;
-$tileHeight: 370px;
 $tilePaddingTop: $kz-var-spacing-xl;
 
 .root {
@@ -15,6 +14,11 @@ $tilePaddingTop: $kz-var-spacing-xl;
 
 .tile {
   width: $tileWidth;
+
+  [class*="TileGrid__grid"] & {
+    width: auto;
+  }
+
   height: $tileHeight;
   position: relative;
   box-shadow: $kz-var-shadow-small-box-shadow;

--- a/draft-packages/tile/KaizenDraft/Tile/dimensions.scss
+++ b/draft-packages/tile/KaizenDraft/Tile/dimensions.scss
@@ -1,0 +1,2 @@
+$tileWidth: 330px;
+$tileHeight: 370px;


### PR DESCRIPTION
# ⚠️ Still needs design review.

# Objective

- Stand-alone `Tile`s will retain their fixed width, but now when they're used inside a `TileGrid`, they will become flexy so that the `TileGrid` expands to the width of the container.

# Motivation and Context

The TileGrid underwent a design change but had still not yet been implemented.

# Screenshots (if appropriate)

![2021-04-29 16 44 05](https://user-images.githubusercontent.com/6406263/116511744-41954200-a90a-11eb-995a-d6a0c8921070.gif)

# Checklist
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] If this contains visual changes, has it been reviewed by a designer?
- [ ] If this introduces either a new component or a breaking change to an existing component, has it been reviewed by an advocate? (Ask in #prod_design_systems)
- [ ] I have considered likely risks of these changes and got someone else to QA as appropriate
- [ ] I have or will communicate these changes to the front end practice

# Additional Considerations
- Does there need to be right-to-left (RTL) options for localization and internationalization?
- Has the test suite been updated?
- Have you done cross-browser testing for our [supported browsers](https://academy.cultureamp.com/hc/en-us/articles/204539569-Supported-browsers-for-Participants)?
- Have you updated any relevant documentation or left useful comments in the code?
- Have you reviewed Culture Amp's Web Accessibility guide [Current Compliance, Going Forward, Statement and Answers for Customers](https://cultureamp.atlassian.net/wiki/spaces/Prod/pages/428572998/Web+Accessibility)?
- If this contains substantial visual changes, especially far reaching ones, have you unlocked the Chromatic step in the pipeline?
- Have Storybook stories been updated?

**If you're new to Kaizen, please ask #prod_design_systems to set up an onboarding session to get you up to speed.** If you have an urgent PR to merge before that happens, it is safest to ask in #prod_design_systems to have a design system advocate review the PR to catch any issues.
