### PR TITLE
fix: border radius on collapsible component

### DIFF
--- a/draft-packages/collapsible/KaizenDraft/Collapsible/Collapsible.tsx
+++ b/draft-packages/collapsible/KaizenDraft/Collapsible/Collapsible.tsx
@@ -75,6 +75,7 @@ class Collapsible extends React.Component<Props, State> {
           [styles.groupItem]: group && !separated,
           [styles.separated]: separated,
           [styles.isOpen]: open,
+          [styles.isSingle]: !group,
         })}
         data-automation-id={automationId || `collapsible-container-${id}`}
       >

--- a/draft-packages/collapsible/KaizenDraft/Collapsible/Collapsible.tsx
+++ b/draft-packages/collapsible/KaizenDraft/Collapsible/Collapsible.tsx
@@ -74,8 +74,8 @@ class Collapsible extends React.Component<Props, State> {
           [styles.stickyContainer]: isContainer && sticky,
           [styles.groupItem]: group && !separated,
           [styles.separated]: separated,
-          [styles.isOpen]: open,
-          [styles.isSingle]: !group,
+          [styles.open]: open,
+          [styles.single]: !group,
         })}
         data-automation-id={automationId || `collapsible-container-${id}`}
       >

--- a/draft-packages/collapsible/KaizenDraft/Collapsible/Collapsible.tsx
+++ b/draft-packages/collapsible/KaizenDraft/Collapsible/Collapsible.tsx
@@ -74,6 +74,7 @@ class Collapsible extends React.Component<Props, State> {
           [styles.stickyContainer]: isContainer && sticky,
           [styles.groupItem]: group && !separated,
           [styles.separated]: separated,
+          [styles.isOpen]: open,
         })}
         data-automation-id={automationId || `collapsible-container-${id}`}
       >
@@ -83,6 +84,7 @@ class Collapsible extends React.Component<Props, State> {
             [styles.defaultVariant]: open && variant === "default",
             [styles.clearVariant]: open && variant === "clear",
             [styles.sticky]: sticky,
+            [styles.open]: open,
           })}
           style={sticky && { top: sticky.top }}
           onClick={this.handleClick}

--- a/draft-packages/collapsible/KaizenDraft/Collapsible/CollapsibleGroup.tsx
+++ b/draft-packages/collapsible/KaizenDraft/Collapsible/CollapsibleGroup.tsx
@@ -29,7 +29,6 @@ export const CollapsibleGroup: React.FunctionComponent<Props> = ({
   <div
     className={classnames({
       [styles.container]: !separated,
-      [styles.stickyContainer]: !separated && sticky,
     })}
     data-automation-id={automationId}
   >

--- a/draft-packages/collapsible/KaizenDraft/Collapsible/__snapshots__/Collapsible.spec.tsx.snap
+++ b/draft-packages/collapsible/KaizenDraft/Collapsible/__snapshots__/Collapsible.spec.tsx.snap
@@ -55,13 +55,13 @@ exports[`matches snapshot with everything enabled 1`] = `
       </div>
     </div>
     <div
-      class="container stickyContainer separated"
+      class="container stickyContainer separated open"
       data-automation-id="another-bogus-test-id"
     >
       <button
         aria-controls="2-section"
         aria-expanded="true"
-        class="button defaultVariant sticky"
+        class="button defaultVariant sticky open"
         data-automation-id="collapsible-button-2"
         id="2-button"
         style="top: 20px;"

--- a/draft-packages/collapsible/KaizenDraft/Collapsible/styles.scss
+++ b/draft-packages/collapsible/KaizenDraft/Collapsible/styles.scss
@@ -10,12 +10,12 @@ $heading-active-color: $kz-var-color-wisteria-100;
 .container {
   background-color: white;
   box-shadow: $kz-var-shadow-small-box-shadow;
-  border-radius: 20px;
+  border-radius: $kz-var-border-borderless-border-radius;
 }
 
 .isSingle {
   .button {
-    border-radius: 20px;
+    border-radius: $kz-var-border-borderless-border-radius;
   }
 }
 
@@ -25,7 +25,7 @@ $heading-active-color: $kz-var-color-wisteria-100;
   }
 
   .button {
-    border-radius: 20px;
+    border-radius: $kz-var-border-borderless-border-radius;
   }
 }
 
@@ -35,13 +35,13 @@ $heading-active-color: $kz-var-color-wisteria-100;
   }
 
   &:first-of-type > .button {
-    border-top-left-radius: 20px;
-    border-top-right-radius: 20px;
+    border-top-left-radius: $kz-var-border-borderless-border-radius;
+    border-top-right-radius: $kz-var-border-borderless-border-radius;
   }
 
   &:last-of-type > .button {
-    border-bottom-left-radius: 20px;
-    border-bottom-right-radius: 20px;
+    border-bottom-left-radius: $kz-var-border-borderless-border-radius;
+    border-bottom-right-radius: $kz-var-border-borderless-border-radius;
   }
 }
 

--- a/draft-packages/collapsible/KaizenDraft/Collapsible/styles.scss
+++ b/draft-packages/collapsible/KaizenDraft/Collapsible/styles.scss
@@ -9,21 +9,13 @@ $heading-active-color: $kz-var-color-wisteria-100;
 
 .container {
   box-shadow: $kz-var-shadow-small-box-shadow;
-  border-radius: $kz-var-border-borderless-border-radius;
-  overflow: hidden;
-}
 
-// We set overflow: hidden on the container, so that child nodes without border
-// radius do not overlap the container. However, this breaks the sticky headers
-// because it creates a new scroll container. The solution is to use the new
-// overflow: clip setting, but until it has full support across browsers we also
-// need a fallback. When there is full support for overflow:clip, we can use that
-// in .container for everything
-.stickyContainer {
-  overflow: visible;
-  @supports (overflow: clip) {
-    overflow: clip;
-  }
+  // TODO: This has been removed for the meantime as the collapsible component
+  // has an issue of not being able to have border-radius without needing to hide
+  // the overflow - resulting in cropping out modals that overflow the container.
+  // We've removed all radiuses now until we add enough logic to handle all
+  // the edge cases.
+  // border-radius: $kz-var-border-borderless-border-radius;
 }
 
 .separated {

--- a/draft-packages/collapsible/KaizenDraft/Collapsible/styles.scss
+++ b/draft-packages/collapsible/KaizenDraft/Collapsible/styles.scss
@@ -7,6 +7,8 @@
 
 $heading-active-color: $kz-var-color-wisteria-100;
 
+// We need a full border radius on this container element, then have classes
+// beneath to toggle nested borders off and on for different use cases.
 .container {
   background-color: white;
   box-shadow: $kz-var-shadow-small-box-shadow;
@@ -29,27 +31,30 @@ $heading-active-color: $kz-var-color-wisteria-100;
   }
 }
 
+// When a collapsible group is rendered, we need the first group to have a rounded
+// on top and the last group to have a rounded bottom edge. Then when open, we
+// remove these as the content sits beneath and needs to be straight.
 .groupItem {
   & + .groupItem {
     border-top: 1px solid $ca-border-color;
   }
 
-  &:first-of-type > .button {
+  &:first-of-type > .button:not(.open) {
     border-top-left-radius: $kz-var-border-borderless-border-radius;
     border-top-right-radius: $kz-var-border-borderless-border-radius;
   }
 
-  &:last-of-type > .button {
+  &:last-of-type > .button:not(.open) {
     border-bottom-left-radius: $kz-var-border-borderless-border-radius;
     border-bottom-right-radius: $kz-var-border-borderless-border-radius;
   }
 }
 
-.open {
-  .button {
-    border-bottom-left-radius: 0;
-    border-bottom-right-radius: 0;
-  }
+// Round the bottom corners of the button so when the container is open, the
+// button background is not rounded on the corners and flush with the content beneath.
+.open .button {
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
 }
 
 .button {

--- a/draft-packages/collapsible/KaizenDraft/Collapsible/styles.scss
+++ b/draft-packages/collapsible/KaizenDraft/Collapsible/styles.scss
@@ -89,11 +89,6 @@ $heading-active-color: $kz-var-color-wisteria-100;
   position: -webkit-sticky;
   position: sticky;
   z-index: 10;
-
-  .button {
-    border-top-left-radius: 0;
-    border-top-right-radius: 0;
-  }
 }
 
 .section {

--- a/draft-packages/collapsible/KaizenDraft/Collapsible/styles.scss
+++ b/draft-packages/collapsible/KaizenDraft/Collapsible/styles.scss
@@ -15,9 +15,35 @@ $heading-active-color: $kz-var-color-wisteria-100;
   border-bottom-right-radius: 20px;
 }
 
+.isSingle {
+  .button {
+    border-top-left-radius: 20px;
+    border-top-right-radius: 20px;
+    border-bottom-left-radius: 20px;
+    border-bottom-right-radius: 20px;
+  }
+
+  &.isOpen > div > div > .section {
+    border-bottom-left-radius: 20px;
+    border-bottom-right-radius: 20px;
+  }
+}
+
 .separated {
   & + .separated {
     @include ca-margin($top: $ca-grid * 0.3);
+  }
+
+  .button {
+    border-top-left-radius: 20px;
+    border-top-right-radius: 20px;
+    border-bottom-left-radius: 20px;
+    border-bottom-right-radius: 20px;
+  }
+
+  &.isOpen > div > div > .section {
+    border-bottom-left-radius: 20px;
+    border-bottom-right-radius: 20px;
   }
 }
 

--- a/draft-packages/collapsible/KaizenDraft/Collapsible/styles.scss
+++ b/draft-packages/collapsible/KaizenDraft/Collapsible/styles.scss
@@ -13,7 +13,7 @@ $heading-active-color: $kz-var-color-wisteria-100;
   border-radius: $kz-var-border-borderless-border-radius;
 }
 
-.isSingle {
+.single {
   .button {
     border-radius: $kz-var-border-borderless-border-radius;
   }
@@ -45,7 +45,7 @@ $heading-active-color: $kz-var-color-wisteria-100;
   }
 }
 
-.isOpen {
+.open {
   .button {
     border-bottom-left-radius: 0;
     border-bottom-right-radius: 0;

--- a/draft-packages/collapsible/KaizenDraft/Collapsible/styles.scss
+++ b/draft-packages/collapsible/KaizenDraft/Collapsible/styles.scss
@@ -32,7 +32,8 @@ $heading-active-color: $kz-var-color-wisteria-100;
 }
 
 // When a collapsible group is rendered, we need the first group to have a rounded
-// on top and the last group to have a rounded bottom edge.
+// on top and the last group to have a rounded bottom edge. Then when the last group
+// is open we remove the rounded edge as the content sits beneath and needs to be straight.
 .groupItem {
   & + .groupItem {
     border-top: 1px solid $ca-border-color;

--- a/draft-packages/collapsible/KaizenDraft/Collapsible/styles.scss
+++ b/draft-packages/collapsible/KaizenDraft/Collapsible/styles.scss
@@ -75,8 +75,8 @@ $heading-active-color: $kz-var-color-wisteria-100;
 
 .isOpen {
   .button {
-    border-bottom-left-radius: 0 !important;
-    border-bottom-right-radius: 0 !important;
+    border-bottom-left-radius: 0;
+    border-bottom-right-radius: 0;
   }
 }
 
@@ -117,6 +117,11 @@ $heading-active-color: $kz-var-color-wisteria-100;
   position: -webkit-sticky;
   position: sticky;
   z-index: 10;
+
+  .button {
+    border-top-left-radius: 0;
+    border-top-right-radius: 0;
+  }
 }
 
 .section {

--- a/draft-packages/collapsible/KaizenDraft/Collapsible/styles.scss
+++ b/draft-packages/collapsible/KaizenDraft/Collapsible/styles.scss
@@ -8,24 +8,14 @@
 $heading-active-color: $kz-var-color-wisteria-100;
 
 .container {
+  background-color: white;
   box-shadow: $kz-var-shadow-small-box-shadow;
-  border-top-left-radius: 20px;
-  border-top-right-radius: 20px;
-  border-bottom-left-radius: 20px;
-  border-bottom-right-radius: 20px;
+  border-radius: 20px;
 }
 
 .isSingle {
   .button {
-    border-top-left-radius: 20px;
-    border-top-right-radius: 20px;
-    border-bottom-left-radius: 20px;
-    border-bottom-right-radius: 20px;
-  }
-
-  &.isOpen > div > div > .section {
-    border-bottom-left-radius: 20px;
-    border-bottom-right-radius: 20px;
+    border-radius: 20px;
   }
 }
 
@@ -35,15 +25,7 @@ $heading-active-color: $kz-var-color-wisteria-100;
   }
 
   .button {
-    border-top-left-radius: 20px;
-    border-top-right-radius: 20px;
-    border-bottom-left-radius: 20px;
-    border-bottom-right-radius: 20px;
-  }
-
-  &.isOpen > div > div > .section {
-    border-bottom-left-radius: 20px;
-    border-bottom-right-radius: 20px;
+    border-radius: 20px;
   }
 }
 
@@ -58,16 +40,6 @@ $heading-active-color: $kz-var-color-wisteria-100;
   }
 
   &:last-of-type > .button {
-    border-bottom-left-radius: 20px;
-    border-bottom-right-radius: 20px;
-  }
-
-  &:last-of-type > div > div > .section {
-    border-bottom-left-radius: 20px;
-    border-bottom-right-radius: 20px;
-  }
-
-  &:last-of-type {
     border-bottom-left-radius: 20px;
     border-bottom-right-radius: 20px;
   }
@@ -125,7 +97,6 @@ $heading-active-color: $kz-var-color-wisteria-100;
 }
 
 .section {
-  background-color: white;
   @include ca-padding(
     $top: $ca-grid,
     $end: $ca-grid,

--- a/draft-packages/collapsible/KaizenDraft/Collapsible/styles.scss
+++ b/draft-packages/collapsible/KaizenDraft/Collapsible/styles.scss
@@ -32,14 +32,13 @@ $heading-active-color: $kz-var-color-wisteria-100;
 }
 
 // When a collapsible group is rendered, we need the first group to have a rounded
-// on top and the last group to have a rounded bottom edge. Then when open, we
-// remove these as the content sits beneath and needs to be straight.
+// on top and the last group to have a rounded bottom edge.
 .groupItem {
   & + .groupItem {
     border-top: 1px solid $ca-border-color;
   }
 
-  &:first-of-type > .button:not(.open) {
+  &:first-of-type > .button {
     border-top-left-radius: $kz-var-border-borderless-border-radius;
     border-top-right-radius: $kz-var-border-borderless-border-radius;
   }

--- a/draft-packages/collapsible/KaizenDraft/Collapsible/styles.scss
+++ b/draft-packages/collapsible/KaizenDraft/Collapsible/styles.scss
@@ -9,13 +9,10 @@ $heading-active-color: $kz-var-color-wisteria-100;
 
 .container {
   box-shadow: $kz-var-shadow-small-box-shadow;
-
-  // TODO: This has been removed for the meantime as the collapsible component
-  // has an issue of not being able to have border-radius without needing to hide
-  // the overflow - resulting in cropping out modals that overflow the container.
-  // We've removed all radiuses now until we add enough logic to handle all
-  // the edge cases.
-  // border-radius: $kz-var-border-borderless-border-radius;
+  border-top-left-radius: 20px;
+  border-top-right-radius: 20px;
+  border-bottom-left-radius: 20px;
+  border-bottom-right-radius: 20px;
 }
 
 .separated {
@@ -27,6 +24,33 @@ $heading-active-color: $kz-var-color-wisteria-100;
 .groupItem {
   & + .groupItem {
     border-top: 1px solid $ca-border-color;
+  }
+
+  &:first-of-type > .button {
+    border-top-left-radius: 20px;
+    border-top-right-radius: 20px;
+  }
+
+  &:last-of-type > .button {
+    border-bottom-left-radius: 20px;
+    border-bottom-right-radius: 20px;
+  }
+
+  &:last-of-type > div > div > .section {
+    border-bottom-left-radius: 20px;
+    border-bottom-right-radius: 20px;
+  }
+
+  &:last-of-type {
+    border-bottom-left-radius: 20px;
+    border-bottom-right-radius: 20px;
+  }
+}
+
+.isOpen {
+  .button {
+    border-bottom-left-radius: 0 !important;
+    border-bottom-right-radius: 0 !important;
   }
 }
 


### PR DESCRIPTION
# Objective
- Get the border radius back onto the collapsible component without cropping content

# Motivation and Context
- Without this fix, the corners of the collapsibles aren't rounded
- With this fix, they all are _except_ the sticky component when scrolling - negible and a huge task (e.g. InteractionObserver in a HOC) for something so small.
- Last PR removing the overflow: https://github.com/cultureamp/kaizen-design-system/pull/1509

# Screenshots (if appropriate)
## Looks good across the board
<img width="677" alt="Screen Shot 2021-05-04 at 9 43 47 am" src="https://user-images.githubusercontent.com/18339250/116946349-3b61e580-acbd-11eb-8b6f-7b562fce1e60.png">
<img width="668" alt="Screen Shot 2021-05-04 at 9 44 02 am" src="https://user-images.githubusercontent.com/18339250/116946363-4452b700-acbd-11eb-98f7-13cb373fd2ce.png">
<img width="669" alt="Screen Shot 2021-05-04 at 9 44 13 am" src="https://user-images.githubusercontent.com/18339250/116946371-4ae12e80-acbd-11eb-90a7-ffe408d15500.png">

## Remaining issue (not fixing)
<img width="672" alt="Screen Shot 2021-05-04 at 9 44 29 am" src="https://user-images.githubusercontent.com/18339250/116946447-7b28cd00-acbd-11eb-9839-77de5da87ea4.png">


# Checklist
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] If this contains visual changes, has it been reviewed by a designer?

# Additional Considerations
- Does there need to be right-to-left (RTL) options for localization and internationalization?
- Has the test suite been updated?
- Have you done cross-browser testing for our [supported browsers](https://academy.cultureamp.com/hc/en-us/articles/204539569-Supported-browsers-for-Participants)?
- Have you updated any relevant documentation or left useful comments in the code?
- Have you reviewed Culture Amp's Web Accessibility guide [Current Compliance, Going Forward, Statement and Answers for Customers](https://cultureamp.atlassian.net/wiki/spaces/Prod/pages/428572998/Web+Accessibility)?
- If this contains substantial visual changes, especially far reaching ones, have you unlocked the Chromatic step in the pipeline?
- Have Storybook stories been updated?

**If you're new to Kaizen, please ask #prod_design_systems to set up an onboarding session to get you up to speed.** If you have an urgent PR to merge before that happens, it is safest to ask in #prod_design_systems to have a design system advocate review the PR to catch any issues.
