### PR TITLE
feat: add reversed table header styling

### DIFF
--- a/draft-packages/table/KaizenDraft/Table/Table.tsx
+++ b/draft-packages/table/KaizenDraft/Table/Table.tsx
@@ -84,6 +84,7 @@ type TableHeaderRowCell = React.FunctionComponent<{
   checkable?: boolean
   checkedStatus?: CheckedStatus
   onCheck?: (event: React.ChangeEvent<HTMLInputElement>) => any
+  reversed?: boolean
   /**
    * This boolean would show a "sort by" icon in the table cell header.
    * The problem was that the arrow was pointing in the descending direction only.
@@ -111,6 +112,7 @@ export const TableHeaderRowCell: TableHeaderRowCell = ({
   checkable,
   checkedStatus,
   onCheck,
+  reversed,
   active,
   sorting: sortingRaw,
   // I can't say for certain why "nowrap" was the default value. Normally you wouldn't
@@ -137,6 +139,11 @@ export const TableHeaderRowCell: TableHeaderRowCell = ({
     if (sortingArrowsOnHover && hoverState != isHovered)
       setIsHovered(hoverState)
   }
+
+  const headerColor = !!reversed
+    ? "white-reduced-opacity"
+    : "dark-reduced-opacity"
+  const hoveredHeaderColor = !!reversed ? "white" : "dark"
 
   // For this "cellContents" variable, we start at the inner most child, and
   // wrap it elements, depending on what the props dictate.
@@ -167,7 +174,7 @@ export const TableHeaderRowCell: TableHeaderRowCell = ({
           <Heading
             tag="div"
             variant="heading-6"
-            color={sorting || isHovered ? "dark" : "dark-reduced-opacity"}
+            color={sorting || isHovered ? hoveredHeaderColor : headerColor}
           >
             {labelText}
           </Heading>
@@ -196,7 +203,9 @@ export const TableHeaderRowCell: TableHeaderRowCell = ({
   cellContents = href ? (
     <a
       data-automation-id={automationId}
-      className={styles.headerRowCellButton}
+      className={classNames(styles.headerRowCellButton, {
+        [styles.headerRowCellButtonReversed]: !!reversed,
+      })}
       href={href}
       onClick={
         onClick as (e: React.MouseEvent<HTMLAnchorElement>) => any | undefined
@@ -211,7 +220,9 @@ export const TableHeaderRowCell: TableHeaderRowCell = ({
   ) : onClick ? (
     <button
       data-automation-id={automationId}
-      className={styles.headerRowCellButton}
+      className={classNames(styles.headerRowCellButton, {
+        [styles.headerRowCellButtonReversed]: !!reversed,
+      })}
       onClick={onClick as (e: React.MouseEvent<HTMLButtonElement>) => any}
       onMouseEnter={() => updateHoverState(true)}
       onFocus={() => updateHoverState(true)}

--- a/draft-packages/table/KaizenDraft/Table/styles.scss
+++ b/draft-packages/table/KaizenDraft/Table/styles.scss
@@ -20,6 +20,10 @@ $row-height: 60px;
   &:focus {
     text-decoration: none;
   }
+
+  &.headerRowCellButtonReversed {
+    color: $kz-var-color-white;
+  }
 }
 
 .container {

--- a/draft-packages/table/docs/Table.stories.tsx
+++ b/draft-packages/table/docs/Table.stories.tsx
@@ -28,7 +28,11 @@ const Container: React.FunctionComponent<{
   </div>
 )
 
-const ExampleTableHeaderRow = ({ checkable = false, showHover = false }) => (
+const ExampleTableHeaderRow = ({
+  checkable = false,
+  showHover = false,
+  reversed = false,
+}) => (
   <TableHeaderRow>
     <TableHeaderRowCell
       checkable={checkable}
@@ -42,6 +46,7 @@ const ExampleTableHeaderRow = ({ checkable = false, showHover = false }) => (
       width={4 / 12}
       wrapping="wrap"
       sortingArrowsOnHover={showHover ? "descending" : undefined}
+      reversed={reversed}
     />
     <TableHeaderRowCell
       onClick={() => alert("Sort!")}
@@ -49,6 +54,7 @@ const ExampleTableHeaderRow = ({ checkable = false, showHover = false }) => (
       width={4 / 12}
       wrapping="wrap"
       sortingArrowsOnHover={showHover ? "descending" : undefined}
+      reversed={reversed}
     />
     <TableHeaderRowCell
       labelText="Date"
@@ -56,6 +62,7 @@ const ExampleTableHeaderRow = ({ checkable = false, showHover = false }) => (
       onClick={() => alert("Sort!")}
       wrapping="wrap"
       sortingArrowsOnHover={showHover ? "descending" : undefined}
+      reversed={reversed}
     />
     <TableHeaderRowCell
       labelText="Comments"
@@ -63,6 +70,7 @@ const ExampleTableHeaderRow = ({ checkable = false, showHover = false }) => (
       onClick={() => alert("Sort!")}
       wrapping="wrap"
       sortingArrowsOnHover={showHover ? "descending" : undefined}
+      reversed={reversed}
     />
   </TableHeaderRow>
 )
@@ -167,6 +175,32 @@ export const Multiline = () => (
     </TableContainer>
   </Container>
 )
+
+export const Reversed = () => (
+  <Container>
+    <TableContainer>
+      <TableHeader>
+        <ExampleTableHeaderRow reversed={true} />
+      </TableHeader>
+      <TableCard>
+        <ExampleTableRow expandable={false} />
+      </TableCard>
+      <TableCard>
+        <ExampleTableRow expandable={false} />
+      </TableCard>
+      <TableCard>
+        <ExampleTableRow expandable={false} />
+      </TableCard>
+    </TableContainer>
+  </Container>
+)
+
+Reversed.storyName = "Reversed"
+Reversed.parameters = {
+  backgrounds: {
+    default: "Wisteria 700",
+  },
+}
 
 export const Clickable = () => (
   <Container>


### PR DESCRIPTION
# Objective
Introduce a `reserved` prop for the draft table header text.

Also adding a story to illustrate the reversed style.

# Motivation and Context
For the new performance goals reporting page, a `reversed` prop is needed for header text, so that it is readable on top of the `Skirt` component, styled in Wisteria styling

# Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/20655547/116842627-7d891980-ac20-11eb-902b-cb1922d50694.png)


# Checklist
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] If this contains visual changes, has it been reviewed by a designer?
- [ ] If this introduces either a new component or a breaking change to an existing component, has it been reviewed by an advocate? (Ask in #prod_design_systems)
- [x] I have considered likely risks of these changes and got someone else to QA as appropriate
- [x] I have or will communicate these changes to the front end practice

# Additional Considerations
- Does there need to be right-to-left (RTL) options for localization and internationalization?
- Has the test suite been updated?
- Have you done cross-browser testing for our [supported browsers](https://academy.cultureamp.com/hc/en-us/articles/204539569-Supported-browsers-for-Participants)?
- Have you updated any relevant documentation or left useful comments in the code?
- Have you reviewed Culture Amp's Web Accessibility guide [Current Compliance, Going Forward, Statement and Answers for Customers](https://cultureamp.atlassian.net/wiki/spaces/Prod/pages/428572998/Web+Accessibility)?
- If this contains substantial visual changes, especially far reaching ones, have you unlocked the Chromatic step in the pipeline?
- Have Storybook stories been updated?

**If you're new to Kaizen, please ask #prod_design_systems to set up an onboarding session to get you up to speed.** If you have an urgent PR to merge before that happens, it is safest to ask in #prod_design_systems to have a design system advocate review the PR to catch any issues.
