### PR TITLE
fix: Use 100% height for dismissIcon on Tag to avoid global box-sizing css conflicts

### DIFF
--- a/draft-packages/tag/KaizenDraft/Tag/Tag.scss
+++ b/draft-packages/tag/KaizenDraft/Tag/Tag.scss
@@ -48,14 +48,11 @@ $small: $kz-var-spacing-md;
 .dismissIcon {
   position: relative;
   display: flex;
-  padding: $kz-var-spacing-xs;
-  margin-top: calc(-1 * #{$kz-var-spacing-xs});
+  height: 100%;
+  align-items: center;
+  padding: 0 $kz-var-spacing-xs;
   margin-right: -0.6625rem;
-  margin-bottom: calc(-1 * #{$kz-var-spacing-xs});
   margin-left: -0.225rem;
-
-  // Override Materialize global style for performance-ui
-  box-sizing: content-box;
 
   --dt-dismiss-icon-color-heart: rgba(
     var(#{$kz-var-id-color-wisteria-800-rgb-params}),
@@ -67,7 +64,6 @@ $small: $kz-var-spacing-md;
   );
 
   color: $dt-dismiss-icon-color;
-  height: 16px;
   cursor: pointer;
 
   &:hover {
@@ -95,6 +91,11 @@ $small: $kz-var-spacing-md;
   background-color: white;
   left: 10px;
   top: 10px;
+}
+
+.iconWrapper {
+  height: 16px;
+  width: 16px;
 }
 
 .truncate {

--- a/draft-packages/tag/KaizenDraft/Tag/Tag.scss
+++ b/draft-packages/tag/KaizenDraft/Tag/Tag.scss
@@ -53,6 +53,8 @@ $small: $kz-var-spacing-md;
   margin-right: -0.6625rem;
   margin-bottom: calc(-1 * #{$kz-var-spacing-xs});
   margin-left: -0.225rem;
+
+  // Override Materialize global style for performance-ui
   box-sizing: content-box;
 
   --dt-dismiss-icon-color-heart: rgba(

--- a/draft-packages/tag/KaizenDraft/Tag/Tag.scss
+++ b/draft-packages/tag/KaizenDraft/Tag/Tag.scss
@@ -53,6 +53,7 @@ $small: $kz-var-spacing-md;
   margin-right: -0.6625rem;
   margin-bottom: calc(-1 * #{$kz-var-spacing-xs});
   margin-left: -0.225rem;
+  box-sizing: content-box;
 
   --dt-dismiss-icon-color-heart: rgba(
     var(#{$kz-var-id-color-wisteria-800-rgb-params}),

--- a/draft-packages/tag/KaizenDraft/Tag/Tag.tsx
+++ b/draft-packages/tag/KaizenDraft/Tag/Tag.tsx
@@ -123,7 +123,9 @@ const Tag = (props: TagProps) => {
               onMouseLeave={onMouseLeave}
             >
               <span className={styles.background} />
-              <Icon icon={clearIcon} inheritSize role="img" title="Dismiss" />
+              <div className={styles.iconWrapper}>
+                <Icon icon={clearIcon} inheritSize role="img" title="Dismiss" />
+              </div>
             </span>
           </>
         )}


### PR DESCRIPTION
# Objective
Replaces out top and bottom margins on our Tag dismissIcon with 100% height.

# Motivation and Context
`performance-ui` has the following global css coming from Materialize:
```
*, *:before, *:after {
    box-sizing: inherit;
}
```

This is causing the following issue with our Tag:
![image](https://user-images.githubusercontent.com/1811583/116955554-3d846e00-acd6-11eb-95b3-ae7175050123.png)

# Checklist
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] If this contains visual changes, has it been reviewed by a designer?
- [ ] If this introduces either a new component or a breaking change to an existing component, has it been reviewed by an advocate? (Ask in #prod_design_systems)
- [ ] I have considered likely risks of these changes and got someone else to QA as appropriate
- [ ] I have or will communicate these changes to the front end practice

