### PR TITLE
feat: add badge component to the button

### DIFF
--- a/draft-packages/button/KaizenDraft/Button/components/GenericButton.tsx
+++ b/draft-packages/button/KaizenDraft/Button/components/GenericButton.tsx
@@ -10,6 +10,7 @@ import React, {
   FocusEvent,
   MouseEvent,
 } from "react"
+import { Badge } from "@kaizen/draft-badge"
 
 import styles from "./GenericButton.module.scss"
 
@@ -32,6 +33,7 @@ export type GenericProps = {
   form?: boolean
   reversed?: boolean
   icon?: React.SVGAttributes<SVGSymbolElement>
+  badge?: BadgeProps
   onClick?: (e: MouseEvent) => void
   onMouseDown?: (e: MouseEvent) => void
   href?: string
@@ -74,6 +76,11 @@ export type ButtonProps = GenericProps & LabelProps
 type Props = ButtonProps & {
   iconButton?: boolean
 } & AdditionalContentProps
+
+type BadgeProps = {
+  children: string
+  active?: boolean
+}
 
 export type ButtonRef = { focus: () => void }
 
@@ -293,9 +300,21 @@ const renderDefaultContent = (props: Props) => (
         {props.additionalContent}
       </span>
     )}
+    {renderBadge(props)}
     {props.icon && props.iconPosition === "end" && renderIcon(props.icon)}
   </>
 )
+
+const renderBadge = (props: Props) => {
+  if (props.badge) {
+    const { children } = props.badge
+    return (
+      <Badge variant="active" reversed={props.reversed}>
+        {children}
+      </Badge>
+    )
+  }
+}
 
 const renderContent: React.FunctionComponent<Props> = props => (
   <span className={styles.content}>

--- a/draft-packages/button/KaizenDraft/Button/components/GenericButton.tsx
+++ b/draft-packages/button/KaizenDraft/Button/components/GenericButton.tsx
@@ -78,8 +78,7 @@ type Props = ButtonProps & {
 } & AdditionalContentProps
 
 type BadgeProps = {
-  children: string
-  active?: boolean
+  text: string
 }
 
 export type ButtonRef = { focus: () => void }
@@ -307,10 +306,10 @@ const renderDefaultContent = (props: Props) => (
 
 const renderBadge = (props: Props) => {
   if (props.badge) {
-    const { children } = props.badge
+    const { text } = props.badge
     return (
       <Badge variant="active" reversed={props.reversed}>
-        {children}
+        {text}
       </Badge>
     )
   }

--- a/draft-packages/button/docs/Button.stories.tsx
+++ b/draft-packages/button/docs/Button.stories.tsx
@@ -234,7 +234,7 @@ export const SecondaryWithBadge = args => (
     label="Label"
     icon={filterIcon}
     secondary={true}
-    badge={{ children: "3" }}
+    badge={{ text: "3" }}
     workingLabelHidden
     {...args}
   />
@@ -256,7 +256,7 @@ export const SecondaryWithBadgeDisabled = args => (
     label="Label"
     icon={filterIcon}
     secondary={true}
-    badge={{ children: "3" }}
+    badge={{ text: "3" }}
     workingLabelHidden
     {...args}
   />

--- a/draft-packages/button/docs/Button.stories.tsx
+++ b/draft-packages/button/docs/Button.stories.tsx
@@ -3,6 +3,7 @@ import configureIcon from "@kaizen/component-library/icons/configure.icon.svg"
 import trashIcon from "@kaizen/component-library/icons/trash.icon.svg"
 import React, { useCallback, useRef, useState } from "react"
 import { withDesign } from "storybook-addon-designs"
+import filterIcon from "@kaizen/component-library/icons/filter.icon.svg"
 import { Button, CustomButtonProps, ButtonRef } from ".."
 import { figmaEmbed } from "../../../storybook/helpers"
 
@@ -224,6 +225,49 @@ SecondaryDestructiveWorking.story = {
       type: "figma",
       url:
         "https://www.figma.com/file/GMxm8rvDCbj0Xw3TQWBZ8b/UI-Kit-Zen?node-id=13865%3A1534",
+    },
+  },
+}
+
+export const SecondaryWithBadge = args => (
+  <Button
+    label="Label"
+    icon={filterIcon}
+    secondary={true}
+    badge={{ children: "3" }}
+    workingLabelHidden
+    {...args}
+  />
+)
+SecondaryWithBadge.story = {
+  name: "Secondary, w/ Badge",
+  parameters: {
+    design: {
+      type: "figma",
+      url:
+        "https://www.figma.com/file/eZKEE5kXbEMY3lx84oz8iN/%E2%9D%A4%EF%B8%8F-UI-Kit-Heart?node-id=17582%3A671",
+    },
+  },
+}
+
+export const SecondaryWithBadgeDisabled = args => (
+  <Button
+    disabled
+    label="Label"
+    icon={filterIcon}
+    secondary={true}
+    badge={{ children: "3" }}
+    workingLabelHidden
+    {...args}
+  />
+)
+SecondaryWithBadgeDisabled.story = {
+  name: "Secondary, w/ Badge Disabled",
+  parameters: {
+    design: {
+      type: "figma",
+      url:
+        "https://www.figma.com/file/eZKEE5kXbEMY3lx84oz8iN/%E2%9D%A4%EF%B8%8F-UI-Kit-Heart?node-id=17582%3A678",
     },
   },
 }

--- a/draft-packages/button/package.json
+++ b/draft-packages/button/package.json
@@ -33,6 +33,7 @@
   "license": "MIT",
   "dependencies": {
     "@kaizen/component-library": "^9.6.0",
+    "@kaizen/draft-badge": "^1.3.1",
     "@kaizen/draft-loading-spinner": "^2.1.0",
     "@types/classnames": "^2.2.10",
     "classnames": "^2.2.6"


### PR DESCRIPTION
# Objective
<!-- Describe what this change achieves, and the details of how it works. -->
Add `badge` props to the button to allow for the button to render `Badge` component to the right of the `Button` label

# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
In the new design for [Filtering](https://www.figma.com/file/kz2iLEjs3HIOMfF6k5X4l1/Global-Filter-Menu?node-id=2132%3A3882), there's a need to have a Button that also shows a Badge with a number of selected filter in it. For this particular case, we need to have new props in the Button component to allow the consumer to show badge information in the UI.

# Screenshots (if appropriate)

# Checklist
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] If this contains visual changes, has it been reviewed by a designer?
- [ ] If this introduces either a new component or a breaking change to an existing component, has it been reviewed by an advocate? (Ask in #prod_design_systems)
- [ ] I have considered likely risks of these changes and got someone else to QA as appropriate
- [x] I have or will communicate these changes to the front end practice

# Additional Considerations
- Does there need to be right-to-left (RTL) options for localization and internationalization?
- Has the test suite been updated?
- Have you done cross-browser testing for our [supported browsers](https://academy.cultureamp.com/hc/en-us/articles/204539569-Supported-browsers-for-Participants)?
- Have you updated any relevant documentation or left useful comments in the code?
- Have you reviewed Culture Amp's Web Accessibility guide [Current Compliance, Going Forward, Statement and Answers for Customers](https://cultureamp.atlassian.net/wiki/spaces/Prod/pages/428572998/Web+Accessibility)?
- If this contains substantial visual changes, especially far reaching ones, have you unlocked the Chromatic step in the pipeline?
- Have Storybook stories been updated?

**If you're new to Kaizen, please ask #prod_design_systems to set up an onboarding session to get you up to speed.** If you have an urgent PR to merge before that happens, it is safest to ask in #prod_design_systems to have a design system advocate review the PR to catch any issues.
