### PR TITLE
fix: Prevent default on Menu trigger button

### DIFF
--- a/draft-packages/menu/KaizenDraft/Menu/StatelessMenu.tsx
+++ b/draft-packages/menu/KaizenDraft/Menu/StatelessMenu.tsx
@@ -71,6 +71,7 @@ export const StatelessMenu: React.FunctionComponent<StatelessMenuProps> = ({
 
   const menuButton = renderButton({
     onClick: (e: any) => {
+      e.preventDefault()
       e.stopPropagation()
       toggleMenuDropdown()
     },


### PR DESCRIPTION
# Objective

Adds `e.preventDefault()` to the button that opens the dropdown menu.

# Motivation and Context

Unify found a bug where one of our Menus was behaving as a link when the dropdown button was clicked, without clicking on any of the menu items.

# Checklist
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] If this contains visual changes, has it been reviewed by a designer?
- [ ] If this introduces either a new component or a breaking change to an existing component, has it been reviewed by an advocate? (Ask in #prod_design_systems)
- [ ] I have considered likely risks of these changes and got someone else to QA as appropriate
- [ ] I have or will communicate these changes to the front end practice