### PR TITLE
fix: add default variant for badge in button component when button is in reversed

### DIFF
--- a/draft-packages/button/KaizenDraft/Button/components/GenericButton.tsx
+++ b/draft-packages/button/KaizenDraft/Button/components/GenericButton.tsx
@@ -307,8 +307,9 @@ const renderDefaultContent = (props: Props) => (
 const renderBadge = (props: Props) => {
   if (props.badge) {
     const { text } = props.badge
+    const variant = props.reversed ? "default" : "active"
     return (
-      <Badge variant="active" reversed={props.reversed}>
+      <Badge variant={variant} reversed={props.reversed}>
         {text}
       </Badge>
     )

--- a/draft-packages/button/docs/Button.stories.tsx
+++ b/draft-packages/button/docs/Button.stories.tsx
@@ -262,7 +262,7 @@ export const SecondaryWithBadgeDisabled = args => (
   />
 )
 SecondaryWithBadgeDisabled.story = {
-  name: "Secondary, w/ Badge Disabled",
+  name: "Secondary, w/ Badge, Disabled",
   parameters: {
     design: {
       type: "figma",
@@ -658,6 +658,29 @@ ReversedSecondaryWIconDisabled.story = {
     ...figmaEmbed(
       "https://www.figma.com/file/GMxm8rvDCbj0Xw3TQWBZ8b/UI-Kit-Zen?node-id=13865%3A16975"
     ),
+  },
+}
+
+export const ReversedSecondaryWithBadge = args => (
+  <Button
+    reversed
+    label="Label"
+    icon={filterIcon}
+    secondary={true}
+    badge={{ text: "3" }}
+    workingLabelHidden
+    {...args}
+  />
+)
+ReversedSecondaryWithBadge.story = {
+  name: "Reversed, Secondary w/ Badge",
+  parameters: {
+    ...reversedBg,
+    design: {
+      type: "figma",
+      url:
+        "https://www.figma.com/file/eZKEE5kXbEMY3lx84oz8iN/%E2%9D%A4%EF%B8%8F-UI-Kit-Heart?node-id=17582%3A671",
+    },
   },
 }
 


### PR DESCRIPTION
# Objective
Use `default` variant for the badge component inside the button when the `reversed` props is passed to the button.

# Motivation and Context
Currently the badge component inside the `Button` use `active` variant and it won't render correctly if the button has `reversed` props pass to it. The `Badge` component needs to use `default` variant for the `reverse` state.

# Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/924319/117091183-d03c1000-ad9d-11eb-853c-6c08788be225.png)

# Checklist
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] If this contains visual changes, has it been reviewed by a designer?
- [x] If this introduces either a new component or a breaking change to an existing component, has it been reviewed by an advocate? (Ask in #prod_design_systems)
- [ ] I have considered likely risks of these changes and got someone else to QA as appropriate
- [ ] I have or will communicate these changes to the front end practice