### PR TITLE
fix: use inline-flex for Button to fix edge case

### DIFF
--- a/draft-packages/button/KaizenDraft/Button/components/GenericButton.module.scss
+++ b/draft-packages/button/KaizenDraft/Button/components/GenericButton.module.scss
@@ -68,6 +68,7 @@
   width: 100%;
 
   .button {
+    display: flex;
     width: 100%;
     justify-content: center;
   }

--- a/draft-packages/button/KaizenDraft/Button/styles.scss
+++ b/draft-packages/button/KaizenDraft/Button/styles.scss
@@ -49,7 +49,9 @@ $caButton-verticalPaddingForm: calc(
   font-size: $kz-var-typography-button-primary-font-size;
   line-height: $kz-var-typography-button-primary-line-height;
   letter-spacing: $kz-var-typography-button-primary-letter-spacing;
-  display: flex;
+  display: inline-flex;
+  // ^inline-flex is used over (block) flex here to fix an edge case where the parent element is display:grid
+  //  and this element is an <a>, causing the element to be full width.
   align-items: center;
   box-sizing: border-box;
   min-height: $caButton-height;


### PR DESCRIPTION
# Objective
Replaces `display: flex` with `display: inline-flex` on the `%caButton` button styles by default, then applies `display: flex` when the button is full width.

# Motivation and Context
An edge case has been found where, if the parent of the Button has `display: grid` and the .button element is an `<a>` (an `href` prop has been provided), then the container would be full width like this:
![image](https://user-images.githubusercontent.com/1811583/117108138-1a38ec00-adc6-11eb-9a2e-5ba472e87573.png)

Using `inline-flex` instead fixes this issue.

What's still a mystery to me is why this only happens when the element is an `<a>` and not a `<button>`, given both elements have the same `display` property.

# Checklist
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] If this contains visual changes, has it been reviewed by a designer?
- [ ] If this introduces either a new component or a breaking change to an existing component, has it been reviewed by an advocate? (Ask in #prod_design_systems)
- [ ] I have considered likely risks of these changes and got someone else to QA as appropriate
- [ ] I have or will communicate these changes to the front end practice

# Additional Considerations
- Does there need to be right-to-left (RTL) options for localization and internationalization?
- Has the test suite been updated?
- Have you done cross-browser testing for our [supported browsers](https://academy.cultureamp.com/hc/en-us/articles/204539569-Supported-browsers-for-Participants)?
- Have you updated any relevant documentation or left useful comments in the code?
- Have you reviewed Culture Amp's Web Accessibility guide [Current Compliance, Going Forward, Statement and Answers for Customers](https://cultureamp.atlassian.net/wiki/spaces/Prod/pages/428572998/Web+Accessibility)?
- If this contains substantial visual changes, especially far reaching ones, have you unlocked the Chromatic step in the pipeline?
- Have Storybook stories been updated?

**If you're new to Kaizen, please ask #prod_design_systems to set up an onboarding session to get you up to speed.** If you have an urgent PR to merge before that happens, it is safest to ask in #prod_design_systems to have a design system advocate review the PR to catch any issues.
