### PR TITLE
fix: toast unmounted set state

### DIFF
--- a/packages/component-library/components/Notification/components/GenericNotification.spec.tsx
+++ b/packages/component-library/components/Notification/components/GenericNotification.spec.tsx
@@ -27,7 +27,7 @@ test('Begins "hidden" but transitions out of it immediately', async () => {
 
 test("The cancel button hides the notification and triggers the onHide callback", async () => {
   const onHide = jest.fn()
-  const { container } = render(
+  const { container, getByTitle } = render(
     <GenericNotification
       type="affirmative"
       style="inline"
@@ -42,12 +42,15 @@ test("The cancel button hides the notification and triggers the onHide callback"
   expect(container.querySelector(".hidden")).toBeTruthy()
 
   // After clicking, the element should fade out, but the onHide not trigger yet.
-  const cancelButton = container.querySelector(".cancel")
-  cancelButton && fireEvent.click(cancelButton)
+  const cancelButton = getByTitle("close notification")
+
+  fireEvent.click(cancelButton)
 
   const notification = container.querySelector(".notification")
 
-  await waitFor(() => expect(onHide).toHaveBeenCalledTimes(0))
+  await waitFor(() => {
+    expect(notification).toBeTruthy()
+  })
 
   // Cannot use @testing-library/react `fireEvent` as it relies on jsdom events
   // TransitionEvent has not been implemented yet, using `ReactTestUtils.Simulate` is a workaround
@@ -56,13 +59,14 @@ test("The cancel button hides the notification and triggers the onHide callback"
       propertyName: "margin-top",
     } as any)
 
-  // TODO - This test is really flakey. Needs to be fixed or re-written
-  // After the fade out animation has finished, the onHide handler should trigger.
-  // await waitFor(() => expect(onHide).toHaveBeenCalledTimes(1))
+  await waitFor(() => {
+    expect(container.querySelector(".notification")).toBeFalsy()
+  })
+  await waitFor(() => expect(onHide).toHaveBeenCalledTimes(1))
 })
 
 test("If autohide is specified, we should start hiding after 5s", async () => {
-  const { container, queryByText } = render(
+  const { container } = render(
     <GenericNotification
       type="affirmative"
       style="toast"

--- a/packages/component-library/components/Notification/components/GenericNotification.tsx
+++ b/packages/component-library/components/Notification/components/GenericNotification.tsx
@@ -45,6 +45,9 @@ class GenericNotification extends React.Component<Props, State> {
     hidden: true,
     removed: false,
   }
+
+  autoHideTimeoutId: null | ReturnType<typeof setTimeout> = null
+
   containerRef = React.createRef<HTMLDivElement>()
 
   constructor(props: Props) {
@@ -62,7 +65,14 @@ class GenericNotification extends React.Component<Props, State> {
     })
 
     if (["toast", "inline"].includes(this.props.style) && this.props.autohide) {
-      setTimeout(this.hide, this.autohideDelayMs())
+      this.autoHideTimeoutId = setTimeout(this.hide, this.autohideDelayMs())
+    }
+  }
+
+  componentWillUnmount() {
+    if (this.autoHideTimeoutId) {
+      clearTimeout(this.autoHideTimeoutId)
+      this.autoHideTimeoutId = null
     }
   }
 

--- a/packages/component-library/components/Notification/components/GenericNotification.tsx
+++ b/packages/component-library/components/Notification/components/GenericNotification.tsx
@@ -55,7 +55,11 @@ class GenericNotification extends React.Component<Props, State> {
   }
 
   componentDidMount() {
-    requestAnimationFrame(() => this.setState({ hidden: false }))
+    requestAnimationFrame(() => {
+      if (this.containerRef.current) {
+        this.setState({ hidden: false })
+      }
+    })
 
     if (["toast", "inline"].includes(this.props.style) && this.props.autohide) {
       setTimeout(this.hide, this.autohideDelayMs())


### PR DESCRIPTION
  # Objective
  Toasts were calling setState while unmounted. We don't want this behaviour.
  
  # Motivation and Context
  
  * The set state in requestAnimationFrame needed a mount check
  * When a user hides a notification, we weren't clearing the timeout if it uses autohide
  
  # Screenshots (if appropriate)
  
  # Checklist
  <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
  - [ ] If this contains visual changes, has it been reviewed by a designer?
  - [ ] If this introduces either a new component or a breaking change to an existing component, has it been reviewed by an advocate? (Ask in #prod_design_systems)
  - [ ] I have considered likely risks of these changes and got someone else to QA as appropriate
  - [ ] I have or will communicate these changes to the front end practice
  
  # Additional Considerations
  - Does there need to be right-to-left (RTL) options for localization and internationalization?
  - Has the test suite been updated?
  - Have you done cross-browser testing for our [supported browsers](https://academy.cultureamp.com/hc/en-us/articles/204539569-Supported-browsers-for-Participants)?
  - Have you updated any relevant documentation or left useful comments in the code?
  - Have you reviewed Culture Amp's Web Accessibility guide [Current Compliance, Going Forward, Statement and Answers for Customers](https://cultureamp.atlassian.net/wiki/spaces/Prod/pages/428572998/Web+Accessibility)?
  - If this contains substantial visual changes, especially far reaching ones, have you unlocked the Chromatic step in the pipeline?
  - Have Storybook stories been updated?
  
  **If you're new to Kaizen, please ask #prod_design_systems to set up an onboarding session to get you up to speed.** If you have an urgent PR to merge before that happens, it is safest to ask in #prod_design_systems to have a design system advocate review the PR to catch any issues.
