### PR TITLE
fix: Allow react nodes for heading text

### DIFF
--- a/draft-packages/empty-state/KaizenDraft/EmptyState/EmptyState.tsx
+++ b/draft-packages/empty-state/KaizenDraft/EmptyState/EmptyState.tsx
@@ -30,7 +30,7 @@ type LayoutContextType = "sidebarAndContent" | "contentOnly"
 export type EmptyStateProps = {
   id?: string
   automationId?: string
-  headingText: string
+  headingText: string | React.ReactNode
   bodyText: string | React.ReactNode
   straightCorners?: boolean
   illustrationType?: IllustrationType


### PR DESCRIPTION
# Objective
In order to support translations that happen in some legacy class style components we need to be able to provide a react node to the heading.


# Checklist
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] If this contains visual changes, has it been reviewed by a designer?
- [ ] If this introduces either a new component or a breaking change to an existing component, has it been reviewed by an advocate? (Ask in #prod_design_systems)
- [ ] I have considered likely risks of these changes and got someone else to QA as appropriate
- [ ] I have or will communicate these changes to the front end practice
