### PR TITLE
refactor: modify TitleBlockZen component to render badge from Button instead of additionalContent props

### DIFF
--- a/draft-packages/button/KaizenDraft/Button/components/GenericButton.tsx
+++ b/draft-packages/button/KaizenDraft/Button/components/GenericButton.tsx
@@ -10,7 +10,7 @@ import React, {
   FocusEvent,
   MouseEvent,
 } from "react"
-import { Badge } from "@kaizen/draft-badge"
+import { Badge, BadgeAnimated } from "@kaizen/draft-badge"
 
 import styles from "./GenericButton.module.scss"
 
@@ -79,6 +79,9 @@ type Props = ButtonProps & {
 
 type BadgeProps = {
   text: string
+  animateChange?: boolean
+  variant?: "default" | "dark" | "active"
+  reversed?: boolean
 }
 
 export type ButtonRef = { focus: () => void }
@@ -305,15 +308,22 @@ const renderDefaultContent = (props: Props) => (
 )
 
 const renderBadge = (props: Props) => {
-  if (props.badge) {
-    const { text } = props.badge
-    const variant = props.reversed ? "default" : "active"
+  if (!props.badge) return null
+
+  const { text, animateChange, reversed, variant } = props.badge
+
+  if (animateChange) {
     return (
-      <Badge variant={variant} reversed={props.reversed}>
+      <BadgeAnimated variant={variant} reversed={reversed}>
         {text}
-      </Badge>
+      </BadgeAnimated>
     )
   }
+  return (
+    <Badge variant={variant} reversed={reversed}>
+      {text}
+    </Badge>
+  )
 }
 
 const renderContent: React.FunctionComponent<Props> = props => (

--- a/draft-packages/button/docs/Button.stories.tsx
+++ b/draft-packages/button/docs/Button.stories.tsx
@@ -234,7 +234,7 @@ export const SecondaryWithBadge = args => (
     label="Label"
     icon={filterIcon}
     secondary={true}
-    badge={{ text: "3" }}
+    badge={{ text: "3", variant: "active" }}
     workingLabelHidden
     {...args}
   />
@@ -256,7 +256,7 @@ export const SecondaryWithBadgeDisabled = args => (
     label="Label"
     icon={filterIcon}
     secondary={true}
-    badge={{ text: "3" }}
+    badge={{ text: "3", variant: "active" }}
     workingLabelHidden
     {...args}
   />
@@ -667,7 +667,7 @@ export const ReversedSecondaryWithBadge = args => (
     label="Label"
     icon={filterIcon}
     secondary={true}
-    badge={{ text: "3" }}
+    badge={{ text: "3", reversed: true, variant: "default" }}
     workingLabelHidden
     {...args}
   />

--- a/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/MainActions.tsx
+++ b/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/MainActions.tsx
@@ -1,12 +1,6 @@
 import { Button, IconButton } from "@kaizen/draft-button"
-import GenericButton, {
-  AdditionalContentProps,
-  GenericProps,
-  LabelProps,
-} from "@kaizen/draft-button/KaizenDraft/Button/components/GenericButton"
 import { Menu, MenuContent, MenuItem, MenuItemProps } from "@kaizen/draft-menu"
 import * as React from "react"
-import { Badge, BadgeAnimated } from "@kaizen/draft-badge"
 import chevronDownIcon from "@kaizen/component-library/icons/chevron-down.icon.svg"
 import meatballsIcon from "@kaizen/component-library/icons/meatballs.icon.svg"
 import Toolbar from "./Toolbar"
@@ -14,7 +8,6 @@ import {
   TitleBlockButtonProps,
   isMenuGroupNotButton,
   PrimaryActionProps,
-  BadgeProps,
 } from "./TitleBlockZen"
 
 import styles from "./TitleBlockZen.scss"
@@ -26,19 +19,6 @@ type MainActionsProps = {
   overflowMenuItems?: MenuItemProps[]
   showOverflowMenu?: boolean
 }
-
-const renderBadge = (badge?: BadgeProps) => {
-  if (!badge) return null
-  return badge.animateChange ? (
-    <BadgeAnimated variant="dark">{badge.text}</BadgeAnimated>
-  ) : (
-    <Badge variant="dark">{badge.text}</Badge>
-  )
-}
-
-const ButtonAllowingAdditionalContent = (
-  props: GenericProps & LabelProps & AdditionalContentProps
-) => <GenericButton {...props} />
 
 const MainActions = ({
   primaryAction,
@@ -88,14 +68,21 @@ const MainActions = ({
                 <Menu
                   align="right"
                   button={
-                    <ButtonAllowingAdditionalContent
+                    <Button
                       label={primaryAction.label}
                       primary
                       reversed={reversed}
                       icon={chevronDownIcon}
                       iconPosition="end"
                       data-automation-id="title-block-primary-action-button"
-                      additionalContent={renderBadge(primaryAction.badge)}
+                      badge={
+                        primaryAction.badge
+                          ? {
+                              ...primaryAction.badge,
+                              variant: "dark",
+                            }
+                          : undefined
+                      }
                     />
                   }
                 >
@@ -132,9 +119,7 @@ const MainActions = ({
             {
               key: "primaryAction",
               node: (
-                <ButtonAllowingAdditionalContent
-                  // Temporary grossness before we deprecate a mandatory
-                  // optional field for primary in PrimaryActionProps
+                <Button
                   {...{
                     ...primaryAction,
                     primary:
@@ -147,7 +132,14 @@ const MainActions = ({
                         : reversed,
                   }}
                   data-automation-id="title-block-primary-action-button"
-                  additionalContent={renderBadge(primaryAction.badge)}
+                  badge={
+                    primaryAction.badge
+                      ? {
+                          ...primaryAction.badge,
+                          variant: "dark",
+                        }
+                      : undefined
+                  }
                 />
               ),
             },


### PR DESCRIPTION
# Objective
Refactor the `TitleBlockZen` to use the `badge` props from the `Button` component instead of utilising the `additionalContent` props from the `GenericButton`

# Motivation and Context
With the new `badge` props that's available in the `Button` component, we no longer need to use `additionalContent` props from the `GenericButton` to render a `Badge` component in the `TitleBlockZen`

Fix #1533 

# Screenshots (if appropriate)

# Checklist
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] If this contains visual changes, has it been reviewed by a designer?
- [ ] If this introduces either a new component or a breaking change to an existing component, has it been reviewed by an advocate? (Ask in #prod_design_systems)
- [ ] I have considered likely risks of these changes and got someone else to QA as appropriate
- [ ] I have or will communicate these changes to the front end practice
