### PR TITLE
fix: Ensure tiles don't expand to fill width when they’re short of a row

### DIFF
--- a/draft-packages/tile/KaizenDraft/Tile/TileGrid.scss
+++ b/draft-packages/tile/KaizenDraft/Tile/TileGrid.scss
@@ -7,7 +7,7 @@
   display: grid;
   // the more we shave off the width here,
   // the less the tiles will grow when they lose one from the row
-  grid-template-columns: repeat(auto-fit, minmax($tileWidth - 40px, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax($tileWidth - 40px, 1fr));
   grid-gap: $kz-var-spacing-md;
 
   @include ca-media-mobile {

--- a/draft-packages/tile/docs/Tile.stories.tsx
+++ b/draft-packages/tile/docs/Tile.stories.tsx
@@ -160,3 +160,21 @@ export const TileGridWithTiles = () => (
 )
 
 TileGridWithTiles.storyName = "Tile Grid"
+
+export const TileGridWithFewTiles = () => (
+  <TileGrid>
+    <InformationTile
+      title="Tile heading"
+      metadata="Metadata"
+      footer={<Tag variant="statusLive">Live</Tag>}
+    />
+    <MultiActionTile
+      title="Tile heading"
+      metadata="Metadata"
+      primaryAction={primaryAction}
+      information={information}
+    />
+  </TileGrid>
+)
+
+TileGridWithFewTiles.storyName = "Tile Grid (less than one row)"


### PR DESCRIPTION
# Objective

This is follow-up to https://github.com/cultureamp/kaizen-design-system/pull/1518 which introduced flexible sizing for `Tile` components within the `TileGrid`. That implementation used `auto-fit` to establish the layout, which works fine when we have a full row of items (at least 4), but when the grid contains fewer than 4 items it means the items _streeetch_ to fill the allowable space.

New behaviour is demonstrated here: https://dev.cultureamp.design/max/fix-tile-grid-with-short-rows/storybook/?path=/story/tile-react--tile-grid-with-few-tiles

# Screenshots

With `auto-fit`:

<img width="1538" alt="image" src="https://user-images.githubusercontent.com/4353/118202425-48d95580-b49d-11eb-8120-0bbe30521b95.png">

With `auto-fill`:

<img width="1582" alt="image" src="https://user-images.githubusercontent.com/4353/118202426-4aa31900-b49d-11eb-9c4e-e86c5bd18b15.png">

# Checklist

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] If this contains visual changes, has it been reviewed by a designer?
- [ ] If this introduces either a new component or a breaking change to an existing component, has it been reviewed by an advocate? (Ask in #prod_design_systems)
- [ ] I have considered likely risks of these changes and got someone else to QA as appropriate
- [ ] I have or will communicate these changes to the front end practice

# Additional Considerations
- Does there need to be right-to-left (RTL) options for localization and internationalization?
- Has the test suite been updated?
- Have you done cross-browser testing for our [supported browsers](https://academy.cultureamp.com/hc/en-us/articles/204539569-Supported-browsers-for-Participants)?
- Have you updated any relevant documentation or left useful comments in the code?
- Have you reviewed Culture Amp's Web Accessibility guide [Current Compliance, Going Forward, Statement and Answers for Customers](https://cultureamp.atlassian.net/wiki/spaces/Prod/pages/428572998/Web+Accessibility)?
- If this contains substantial visual changes, especially far reaching ones, have you unlocked the Chromatic step in the pipeline?
- Have Storybook stories been updated?

**If you're new to Kaizen, please ask #prod_design_systems to set up an onboarding session to get you up to speed.** If you have an urgent PR to merge before that happens, it is safest to ask in #prod_design_systems to have a design system advocate review the PR to catch any issues.
