### PR TITLE
feat: Allow actions to open in new tabs

### DIFF
--- a/draft-packages/tile/KaizenDraft/Tile/components/Action.tsx
+++ b/draft-packages/tile/KaizenDraft/Tile/components/Action.tsx
@@ -11,7 +11,14 @@ interface Props {
 type Action = React.FunctionComponent<Props>
 
 const Action: Action = ({ action, secondary = false, disabled = false }) => {
-  const { label, href, onClick, icon, automationId } = action
+  const {
+    label,
+    href,
+    onClick,
+    icon,
+    automationId,
+    newTabAndIUnderstandTheAccessibilityImplications,
+  } = action
 
   return href ? (
     <Button
@@ -21,6 +28,9 @@ const Action: Action = ({ action, secondary = false, disabled = false }) => {
       icon={icon}
       data-automation-id={automationId}
       disabled={disabled}
+      newTabAndIUnderstandTheAccessibilityImplications={
+        newTabAndIUnderstandTheAccessibilityImplications
+      }
     />
   ) : (
     <Button
@@ -30,6 +40,9 @@ const Action: Action = ({ action, secondary = false, disabled = false }) => {
       icon={icon}
       data-automation-id={automationId}
       disabled={disabled}
+      newTabAndIUnderstandTheAccessibilityImplications={
+        newTabAndIUnderstandTheAccessibilityImplications
+      }
     />
   )
 }

--- a/draft-packages/tile/KaizenDraft/Tile/components/GenericTile.tsx
+++ b/draft-packages/tile/KaizenDraft/Tile/components/GenericTile.tsx
@@ -14,6 +14,7 @@ export interface TileAction {
   readonly href?: string
   readonly icon?: React.SVGAttributes<SVGSymbolElement>
   readonly automationId?: string
+  readonly newTabAndIUnderstandTheAccessibilityImplications?: boolean
 }
 
 export interface TileInformation {

--- a/draft-packages/tile/docs/Tile.stories.tsx
+++ b/draft-packages/tile/docs/Tile.stories.tsx
@@ -95,6 +95,26 @@ export const MultiActionWithInformation = () => (
 
 MultiActionWithInformation.storyName = "Multi action tile with information"
 
+export const MultiActionActionInNewTabs = () => (
+  <MultiActionTile
+    title="Tile heading"
+    metadata="Metadata"
+    primaryAction={{
+      ...primaryAction,
+      href: "https://www.cultureamp.com",
+      newTabAndIUnderstandTheAccessibilityImplications: true,
+    }}
+    secondaryAction={{
+      ...secondaryAction,
+      href: "https://www.cultureamp.com",
+      newTabAndIUnderstandTheAccessibilityImplications: true,
+    }}
+  />
+)
+
+MultiActionActionInNewTabs.storyName =
+  "Multi action tile with actions opening in new tabs"
+
 export const Information = () => (
   <InformationTile
     title="Tile heading"


### PR DESCRIPTION
# Objective

Actions in Tile components can be links, but aren’t able to open in new tabs. This adds the `newTabAndIUnderstandTheAccessibilityImplications` prop from the `Button` component (which underpins Tile actions) to enable that behaviour.

# Motivation and Context

I need this specifically for the preview links in the updated Template Library tiles:

<img width="349" alt="image" src="https://user-images.githubusercontent.com/4353/118204840-7b398180-b4a2-11eb-8df5-0a48c30da779.png">

These currently open in a new tab and I’d like to keep that behaviour the same so that users aren’t taken away from the Template Library when they’re exploring how a particular template looks.

# Checklist

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] If this contains visual changes, has it been reviewed by a designer?
- [ ] If this introduces either a new component or a breaking change to an existing component, has it been reviewed by an advocate? (Ask in #prod_design_systems)
- [ ] I have considered likely risks of these changes and got someone else to QA as appropriate
- [ ] I have or will communicate these changes to the front end practice

# Additional Considerations
- Does there need to be right-to-left (RTL) options for localization and internationalization?
- Has the test suite been updated?
- Have you done cross-browser testing for our [supported browsers](https://academy.cultureamp.com/hc/en-us/articles/204539569-Supported-browsers-for-Participants)?
- Have you updated any relevant documentation or left useful comments in the code?
- Have you reviewed Culture Amp's Web Accessibility guide [Current Compliance, Going Forward, Statement and Answers for Customers](https://cultureamp.atlassian.net/wiki/spaces/Prod/pages/428572998/Web+Accessibility)?
- If this contains substantial visual changes, especially far reaching ones, have you unlocked the Chromatic step in the pipeline?
- Have Storybook stories been updated?

**If you're new to Kaizen, please ask #prod_design_systems to set up an onboarding session to get you up to speed.** If you have an urgent PR to merge before that happens, it is safest to ask in #prod_design_systems to have a design system advocate review the PR to catch any issues.
