### PR TITLE
feat: add Heart theme option to Elm Modal and EmptyState (for Heart illustrations)

### DIFF
--- a/draft-packages/empty-state/ElmStories/EmptyStateStories.elm
+++ b/draft-packages/empty-state/ElmStories/EmptyStateStories.elm
@@ -1,11 +1,12 @@
 module ElmStories.EmptyStateStories exposing (main)
 
-import KaizenDraft.Button.Button as Button
 import CssModules exposing (css)
 import ElmStorybook exposing (statelessStoryOf, storybook)
 import Html exposing (Html, div, text)
 import Html.Attributes exposing (dir)
 import Icon.SvgAsset exposing (svgAsset)
+import Kaizen.Theme exposing (Theme(..))
+import KaizenDraft.Button.Button as Button
 import KaizenDraft.EmptyState.EmptyState as EmptyState
 
 
@@ -48,6 +49,7 @@ main =
                         |> EmptyState.illustrationType EmptyState.Informative
                         |> EmptyState.layoutContext EmptyState.SidebarAndContent
                         |> EmptyState.children []
+                        |> EmptyState.theme Heart
                     )
                 ]
         , statelessStoryOf "Default (minimal props)" <|
@@ -56,6 +58,7 @@ main =
                     (EmptyState.default
                         |> EmptyState.headingText "Empty state title"
                         |> EmptyState.bodyText (EmptyState.BodyText "This preset only passes in the headingText and bodyText props, and leaves the rest to fallbacks.")
+                        |> EmptyState.theme Heart
                     )
                 ]
         , statelessStoryOf "Positive" <|
@@ -65,6 +68,7 @@ main =
                         |> EmptyState.headingText "Empty state title"
                         |> EmptyState.bodyText (EmptyState.BodyText "This preset only passes in the headingText and bodyText props, and leaves the rest to fallbacks.")
                         |> EmptyState.illustrationType EmptyState.Positive
+                        |> EmptyState.theme Heart
                     )
                 ]
         , statelessStoryOf "Informative" <|
@@ -74,6 +78,7 @@ main =
                         |> EmptyState.headingText "Empty state title"
                         |> EmptyState.bodyText (EmptyState.BodyText "This preset only passes in the headingText and bodyText props, and leaves the rest to fallbacks.")
                         |> EmptyState.illustrationType EmptyState.Informative
+                        |> EmptyState.theme Heart
                     )
                 ]
         , statelessStoryOf "Action" <|
@@ -83,6 +88,7 @@ main =
                         |> EmptyState.headingText "Empty state title"
                         |> EmptyState.bodyText (EmptyState.BodyText "This preset only passes in the headingText and bodyText props, and leaves the rest to fallbacks.")
                         |> EmptyState.illustrationType EmptyState.Action
+                        |> EmptyState.theme Heart
                     )
                 ]
         , statelessStoryOf "Action, button" <|
@@ -102,6 +108,7 @@ main =
                                     "Label"
                                 ]
                             ]
+                        |> EmptyState.theme Heart
                     )
                 ]
         , statelessStoryOf "Neutral" <|
@@ -111,6 +118,7 @@ main =
                         |> EmptyState.headingText "Empty state title"
                         |> EmptyState.bodyText (EmptyState.BodyText "This preset only passes in the headingText and bodyText props, and leaves the rest to fallbacks.")
                         |> EmptyState.illustrationType EmptyState.Neutral
+                        |> EmptyState.theme Heart
                     )
                 ]
         , statelessStoryOf "Negative" <|
@@ -120,6 +128,7 @@ main =
                         |> EmptyState.headingText "Empty state title"
                         |> EmptyState.bodyText (EmptyState.BodyText "This preset only passes in the headingText and bodyText props, and leaves the rest to fallbacks.")
                         |> EmptyState.illustrationType EmptyState.Negative
+                        |> EmptyState.theme Heart
                     )
                 ]
         , statelessStoryOf "Layout, Content-only" <|
@@ -129,6 +138,7 @@ main =
                         |> EmptyState.headingText "Empty state title"
                         |> EmptyState.bodyText (EmptyState.BodyText "This is an example of the content-only layout (no sidebar).")
                         |> EmptyState.layoutContext EmptyState.ContentOnly
+                        |> EmptyState.theme Heart
                     )
                 ]
         , statelessStoryOf "RTL, Action" <|
@@ -138,6 +148,7 @@ main =
                         |> EmptyState.headingText "Empty state title"
                         |> EmptyState.bodyText (EmptyState.BodyText "This preset only passes in the headingText and bodyText props, and leaves the rest to fallbacks.")
                         |> EmptyState.illustrationType EmptyState.Action
+                        |> EmptyState.theme Heart
                     )
                 ]
         ]

--- a/draft-packages/empty-state/KaizenDraft/EmptyState/EmptyState.elm
+++ b/draft-packages/empty-state/KaizenDraft/EmptyState/EmptyState.elm
@@ -18,7 +18,7 @@ import CssModules exposing (css)
 import Html exposing (Html, div, img, text)
 import Html.Attributes exposing (id, src)
 import Kaizen.HostedAssets.Image as Image exposing (Role(..), image)
-import Kaizen.Theme as Theme exposing (Theme(..))
+import Kaizen.Theme as Theme exposing (Theme(..), defaultTheme)
 
 
 
@@ -68,7 +68,7 @@ defaults =
     , illustrationType = Informative
     , layoutContext = SidebarAndContent
     , children = []
-    , theme = Heart
+    , theme = defaultTheme
     }
 
 

--- a/draft-packages/empty-state/KaizenDraft/EmptyState/EmptyState.elm
+++ b/draft-packages/empty-state/KaizenDraft/EmptyState/EmptyState.elm
@@ -10,13 +10,15 @@ module KaizenDraft.EmptyState.EmptyState exposing
     , id
     , illustrationType
     , layoutContext
+    , theme
     , view
     )
 
 import CssModules exposing (css)
 import Html exposing (Html, div, img, text)
 import Html.Attributes exposing (id, src)
-import WebpackAsset exposing (assetUrl)
+import Kaizen.HostedAssets.Image as Image exposing (Role(..), image)
+import Kaizen.Theme as Theme exposing (Theme(..))
 
 
 
@@ -53,6 +55,7 @@ type alias ConfigValue msg =
     , illustrationType : Illustration
     , layoutContext : LayoutContext
     , children : List (Html msg)
+    , theme : Theme
     }
 
 
@@ -65,32 +68,52 @@ defaults =
     , illustrationType = Informative
     , layoutContext = SidebarAndContent
     , children = []
+    , theme = Heart
     }
 
 
-actionIllustrationUrl : WebpackAsset.AssetUrl
-actionIllustrationUrl =
-    assetUrl "@kaizen/draft-empty-state/KaizenDraft/EmptyState/illustrations/action.png"
+illustrationPath : ConfigValue msg -> String
+illustrationPath config =
+    case config.illustrationType of
+        Action ->
+            case config.theme of
+                Heart ->
+                    "illustrations/heart/scene/empty-states-action.svg"
 
+                Zen ->
+                    "illustrations/scene/empty-states-action.svg"
 
-informativeIllustrationUrl : WebpackAsset.AssetUrl
-informativeIllustrationUrl =
-    assetUrl "@kaizen/draft-empty-state/KaizenDraft/EmptyState/illustrations/informative.png"
+        Neutral ->
+            case config.theme of
+                Heart ->
+                    "illustrations/heart/scene/empty-states-neutral.svg"
 
+                Zen ->
+                    "illustrations/scene/empty-states-neutral.svg"
 
-negativeIllustrationUrl : WebpackAsset.AssetUrl
-negativeIllustrationUrl =
-    assetUrl "@kaizen/draft-empty-state/KaizenDraft/EmptyState/illustrations/negative.png"
+        Positive ->
+            case config.theme of
+                Heart ->
+                    "illustrations/heart/scene/empty-states-positive.svg"
 
+                Zen ->
+                    "illustrations/scene/empty-states-positive.svg"
 
-neutralIllustrationUrl : WebpackAsset.AssetUrl
-neutralIllustrationUrl =
-    assetUrl "@kaizen/draft-empty-state/KaizenDraft/EmptyState/illustrations/neutral.png"
+        Informative ->
+            case config.theme of
+                Heart ->
+                    "illustrations/heart/scene/empty-states-informative.svg"
 
+                Zen ->
+                    "illustrations/scene/empty-states-informative.svg"
 
-positiveIllustrationUrl : WebpackAsset.AssetUrl
-positiveIllustrationUrl =
-    assetUrl "@kaizen/draft-empty-state/KaizenDraft/EmptyState/illustrations/positive.png"
+        Negative ->
+            case config.theme of
+                Heart ->
+                    "illustrations/heart/scene/empty-states-negative.svg"
+
+                Zen ->
+                    "illustrations/scene/empty-states-negative.svg"
 
 
 
@@ -136,28 +159,24 @@ layoutContext value (Config config) =
     Config { config | layoutContext = value }
 
 
+theme : Theme -> Config msg -> Config msg
+theme theme_ (Config config) =
+    Config { config | theme = theme_ }
+
+
 children : List (Html msg) -> Config msg -> Config msg
 children value (Config config) =
     Config { config | children = value }
 
 
-emptyStateIllustration : Illustration -> Html msg
-emptyStateIllustration illustration =
-    case illustration of
-        Positive ->
-            img [ styles.class .illustration, src positiveIllustrationUrl ] []
-
-        Negative ->
-            img [ styles.class .illustration, src negativeIllustrationUrl ] []
-
-        Neutral ->
-            img [ styles.class .illustration, src neutralIllustrationUrl ] []
-
-        Informative ->
-            img [ styles.class .illustration, src informativeIllustrationUrl ] []
-
-        Action ->
-            img [ styles.class .illustration, src actionIllustrationUrl ] []
+emptyStateIllustration : ConfigValue msg -> Html msg
+emptyStateIllustration config =
+    let
+        imageConfig =
+            Image.default
+                |> Image.attributes [ styles.class .illustration ]
+    in
+    image imageConfig (illustrationPath config)
 
 
 illustrationClass :
@@ -233,7 +252,7 @@ view (Config config) =
                ]
         )
         [ div [ styles.class .illustrationSide ]
-            [ emptyStateIllustration config.illustrationType
+            [ emptyStateIllustration config
             ]
         , div [ styles.class .textSide ]
             [ div [ styles.class .textSideInner ]

--- a/draft-packages/modal/ElmStories/ModalStories.elm
+++ b/draft-packages/modal/ElmStories/ModalStories.elm
@@ -5,6 +5,7 @@ import Html exposing (div, text)
 import Html.Attributes exposing (style)
 import Icon.Icon as Icon
 import Icon.SvgAsset exposing (svgAsset)
+import Kaizen.Theme as Theme exposing (Theme(..))
 import KaizenDraft.Button.Button as Button
 import KaizenDraft.Form.TextField.TextField as TextField
 import KaizenDraft.Modal.Modal as Modal
@@ -188,6 +189,7 @@ main =
                                     |> Modal.modalState modalState
                                     -- IMPORTANT: the modal uses this for internal messages
                                     |> Modal.onUpdate ModalUpdate
+                                    |> Modal.theme Heart
                                 )
 
                         _ ->
@@ -216,6 +218,7 @@ main =
                                     |> Modal.modalState modalState
                                     -- IMPORTANT: the modal uses this for internal messages
                                     |> Modal.onUpdate ModalUpdate
+                                    |> Modal.theme Heart
                                 )
 
                         _ ->
@@ -243,6 +246,7 @@ main =
                                     |> Modal.modalState modalState
                                     -- IMPORTANT: the modal uses this for internal messages
                                     |> Modal.onUpdate ModalUpdate
+                                    |> Modal.theme Heart
                                 )
 
                         _ ->
@@ -270,6 +274,7 @@ main =
                                     |> Modal.modalState modalState
                                     -- IMPORTANT: the modal uses this for internal messages
                                     |> Modal.onUpdate ModalUpdate
+                                    |> Modal.theme Heart
                                 )
 
                         _ ->
@@ -297,6 +302,7 @@ main =
                                     |> Modal.modalState modalState
                                     -- IMPORTANT: the modal uses this for internal messages
                                     |> Modal.onUpdate ModalUpdate
+                                    |> Modal.theme Heart
                                 )
 
                         _ ->
@@ -324,6 +330,7 @@ main =
                                     |> Modal.modalState modalState
                                     -- IMPORTANT: the modal uses this for internal messages
                                     |> Modal.onUpdate ModalUpdate
+                                    |> Modal.theme Heart
                                 )
 
                         _ ->
@@ -353,6 +360,7 @@ main =
                                         |> Modal.modalState modalState
                                         -- IMPORTANT: the modal uses this for internal messages
                                         |> Modal.onUpdate ModalUpdate
+                                        |> Modal.theme Heart
                                     )
 
                             _ ->
@@ -402,6 +410,7 @@ main =
                                     |> Modal.modalState modalState
                                     -- IMPORTANT: the modal uses this for internal messages
                                     |> Modal.onUpdate ModalUpdate
+                                    |> Modal.theme Heart
                                 )
 
                         _ ->
@@ -448,6 +457,7 @@ main =
                                     |> Modal.modalState modalState
                                     -- IMPORTANT: the modal uses this for internal messages
                                     |> Modal.onUpdate ModalUpdate
+                                    |> Modal.theme Heart
                                 )
 
                         _ ->

--- a/draft-packages/modal/KaizenDraft/Modal/Modal.elm
+++ b/draft-packages/modal/KaizenDraft/Modal/Modal.elm
@@ -17,6 +17,7 @@ module KaizenDraft.Modal.Modal exposing
     , onUpdate
     , setDefaultFocusableId
     , subscriptions
+    , theme
     , trigger
     , update
     , view
@@ -29,6 +30,7 @@ import Html exposing (Html, div, text)
 import Html.Attributes exposing (style)
 import Html.Events exposing (onClick)
 import Html.Lazy exposing (lazy)
+import Kaizen.Theme exposing (Theme, defaultTheme)
 import KaizenDraft.Events.Events as KaizenEvents
 import KaizenDraft.Modal.Presets.ConfirmationModal as ConfirmationModal
 import KaizenDraft.Modal.Presets.InputEditModal as InputEditModal
@@ -75,6 +77,7 @@ type alias Configuration msg =
     { variant : Variant msg
     , onUpdate : Maybe (ModalMsg -> msg)
     , state : ModalState msg
+    , theme : Theme
     }
 
 
@@ -340,6 +343,7 @@ viewContent (Config modalConfig) =
                             |> ConfirmationModal.confirmLabel contract.confirmLabel
                             |> ConfirmationModal.dismissLabel contract.dismissLabel
                             |> ConfirmationModal.title contract.title
+                            |> ConfirmationModal.theme modalConfig.theme
                 in
                 case confirmationType of
                     Informative ->
@@ -469,6 +473,7 @@ defaults =
     { variant = Generic [ text "" ] ( 600, 456 )
     , onUpdate = Nothing
     , state = initialState
+    , theme = defaultTheme
     }
 
 
@@ -723,6 +728,11 @@ onUpdate msg (Config config) =
 modalState : ModalState msg -> Config msg -> Config msg
 modalState msg (Config config) =
     Config { config | state = msg }
+
+
+theme : Theme -> Config msg -> Config msg
+theme value (Config config) =
+    Config { config | theme = value }
 
 
 

--- a/draft-packages/modal/KaizenDraft/Modal/Presets/ConfirmationModal.elm
+++ b/draft-packages/modal/KaizenDraft/Modal/Presets/ConfirmationModal.elm
@@ -34,7 +34,7 @@ import Html.Attributes.Aria as Aria exposing (ariaHidden, ariaLabelledby)
 import Icon.Icon as Icon
 import Icon.SvgAsset exposing (svgAsset)
 import Json.Decode as Decode
-import Kaizen.HostedAssets exposing (Role(..), assetUrl, image)
+import Kaizen.HostedAssets.Image as Image exposing (Role(..), image)
 import Kaizen.Theme as Theme exposing (Theme(..))
 import KaizenDraft.Button.Button as Button
 import KaizenDraft.Modal.Primitives.Constants as Constants
@@ -259,7 +259,7 @@ header config =
         ]
         [ div [ styles.class .iconContainer ]
             [ div [ styles.class .svgIcon ]
-                [ image (illustrationPath config) Presentation
+                [ image Image.default (illustrationPath config)
                 ]
             ]
         , Text.view (Text.h1 |> Text.style Text.ZenHeading1 |> Text.inline True |> Text.id Constants.ariaLabelledBy) [ text config.title ]

--- a/draft-packages/modal/KaizenDraft/Modal/Presets/ConfirmationModal.elm
+++ b/draft-packages/modal/KaizenDraft/Modal/Presets/ConfirmationModal.elm
@@ -22,6 +22,7 @@ module KaizenDraft.Modal.Presets.ConfirmationModal exposing
     , onHeaderDismissFocus
     , onHeaderDismissPreventKeydown
     , positive
+    , theme
     , title
     , view
     )
@@ -34,6 +35,7 @@ import Icon.Icon as Icon
 import Icon.SvgAsset exposing (svgAsset)
 import Json.Decode as Decode
 import Kaizen.HostedAssets exposing (Role(..), assetUrl, image)
+import Kaizen.Theme as Theme exposing (Theme(..))
 import KaizenDraft.Button.Button as Button
 import KaizenDraft.Modal.Primitives.Constants as Constants
 import KaizenDraft.Modal.Primitives.ModalBody as ModalBody
@@ -73,6 +75,7 @@ type alias Configuration msg =
     , onConfirmBlur : Maybe msg
     , confirmId : Maybe String
     , onConfirmDisabled : Bool
+    , theme : Theme
     }
 
 
@@ -133,6 +136,7 @@ defaults =
     , onConfirmBlur = Nothing
     , confirmId = Just Constants.lastFocusableId
     , onConfirmDisabled = False
+    , theme = Heart
     }
 
 
@@ -209,27 +213,46 @@ view (Config config) =
 header : Configuration msg -> Html msg
 header config =
     let
-        resolveImage =
-            case config.variant of
-                Cautionary ->
-                    image
-                        "illustrations/heart/spot/moods-cautionary.svg"
-                        Presentation
+        resolveIcon =
+            case config.theme of
+                Zen ->
+                    Icon.view Icon.presentation
+                        (case config.variant of
+                            Cautionary ->
+                                svgAsset "@kaizen/draft-modal/KaizenDraft/Modal/illustrations/cautionary.icon.svg"
 
-                Informative ->
-                    image
-                        "illustrations/heart/spot/moods-informative.svg"
-                        Presentation
+                            Informative ->
+                                svgAsset "@kaizen/draft-modal/KaizenDraft/Modal/illustrations/informative.icon.svg"
 
-                Negative ->
-                    image
-                        "illustrations/heart/spot/moods-negative.svg"
-                        Presentation
+                            Negative ->
+                                svgAsset "@kaizen/draft-modal/KaizenDraft/Modal/illustrations/negative.icon.svg"
 
-                Positive ->
-                    image
-                        "illustrations/heart/spot/moods-positive.svg"
-                        Presentation
+                            Positive ->
+                                svgAsset "@kaizen/draft-modal/KaizenDraft/Modal/illustrations/positive.icon.svg"
+                        )
+                        |> Html.map never
+
+                Heart ->
+                    case config.variant of
+                        Cautionary ->
+                            image
+                                "illustrations/heart/spot/moods-cautionary.svg"
+                                Presentation
+
+                        Informative ->
+                            image
+                                "illustrations/heart/spot/moods-informative.svg"
+                                Presentation
+
+                        Negative ->
+                            image
+                                "illustrations/heart/spot/moods-negative.svg"
+                                Presentation
+
+                        Positive ->
+                            image
+                                "illustrations/heart/spot/moods-positive.svg"
+                                Presentation
     in
     div
         [ styles.classList
@@ -242,7 +265,7 @@ header config =
         ]
         [ div [ styles.class .iconContainer ]
             [ div [ styles.class .svgIcon ]
-                [ resolveImage
+                [ resolveIcon
                 ]
             ]
         , Text.view (Text.h1 |> Text.style Text.ZenHeading1 |> Text.inline True |> Text.id Constants.ariaLabelledBy) [ text config.title ]
@@ -436,6 +459,11 @@ onFooterDismissBlur msg (Config config) =
 confirmId : String -> Config msg -> Config msg
 confirmId id_ (Config config) =
     Config { config | confirmId = Just id_ }
+
+
+theme : Theme -> Config msg -> Config msg
+theme theme_ (Config config) =
+    Config { config | theme = theme_ }
 
 
 styles =

--- a/draft-packages/modal/KaizenDraft/Modal/Presets/ConfirmationModal.elm
+++ b/draft-packages/modal/KaizenDraft/Modal/Presets/ConfirmationModal.elm
@@ -27,10 +27,13 @@ module KaizenDraft.Modal.Presets.ConfirmationModal exposing
     )
 
 import CssModules exposing (css)
-import Html exposing (Html, div, text)
+import Html exposing (Html, div, img, text)
+import Html.Attributes exposing (src)
+import Html.Attributes.Aria as Aria exposing (ariaHidden, ariaLabelledby)
 import Icon.Icon as Icon
 import Icon.SvgAsset exposing (svgAsset)
 import Json.Decode as Decode
+import Kaizen.HostedAssets exposing (Role(..), assetUrl, image)
 import KaizenDraft.Button.Button as Button
 import KaizenDraft.Modal.Primitives.Constants as Constants
 import KaizenDraft.Modal.Primitives.ModalBody as ModalBody
@@ -192,7 +195,7 @@ view (Config config) =
                 |> withHeaderDismissId
                 |> withPreventHeaderDismissKeydown
                 |> ModalHeader.dismissReverse False
-            ) 
+            )
         , withBody
         , ModalFooter.view <|
             (ModalFooter.layout (footer config)
@@ -206,19 +209,27 @@ view (Config config) =
 header : Configuration msg -> Html msg
 header config =
     let
-        resolveIcon =
+        resolveImage =
             case config.variant of
                 Cautionary ->
-                    svgAsset "@kaizen/draft-modal/KaizenDraft/Modal/illustrations/cautionary.icon.svg"
+                    image
+                        "illustrations/heart/spot/moods-cautionary.svg"
+                        Presentation
 
                 Informative ->
-                    svgAsset "@kaizen/draft-modal/KaizenDraft/Modal/illustrations/informative.icon.svg"
+                    image
+                        "illustrations/heart/spot/moods-informative.svg"
+                        Presentation
 
                 Negative ->
-                    svgAsset "@kaizen/draft-modal/KaizenDraft/Modal/illustrations/negative.icon.svg"
+                    image
+                        "illustrations/heart/spot/moods-negative.svg"
+                        Presentation
 
                 Positive ->
-                    svgAsset "@kaizen/draft-modal/KaizenDraft/Modal/illustrations/positive.icon.svg"
+                    image
+                        "illustrations/heart/spot/moods-positive.svg"
+                        Presentation
     in
     div
         [ styles.classList
@@ -231,9 +242,7 @@ header config =
         ]
         [ div [ styles.class .iconContainer ]
             [ div [ styles.class .svgIcon ]
-                [ Icon.view Icon.presentation
-                    resolveIcon
-                    |> Html.map never
+                [ resolveImage
                 ]
             ]
         , Text.view (Text.h1 |> Text.style Text.ZenHeading1 |> Text.inline True |> Text.id Constants.ariaLabelledBy) [ text config.title ]

--- a/draft-packages/modal/KaizenDraft/Modal/Presets/ConfirmationModal.elm
+++ b/draft-packages/modal/KaizenDraft/Modal/Presets/ConfirmationModal.elm
@@ -210,50 +210,44 @@ view (Config config) =
         ]
 
 
+illustrationPath : Configuration msg -> String
+illustrationPath config =
+    case config.variant of
+        Cautionary ->
+            case config.theme of
+                Heart ->
+                    "illustrations/heart/spot/moods-cautionary.svg"
+
+                Zen ->
+                    "illustrations/spot/moods-cautionary.svg"
+
+        Informative ->
+            case config.theme of
+                Heart ->
+                    "illustrations/heart/spot/moods-informative.svg"
+
+                Zen ->
+                    "illustrations/spot/moods-informative.svg"
+
+        Negative ->
+            case config.theme of
+                Heart ->
+                    "illustrations/heart/spot/moods-negative.svg"
+
+                Zen ->
+                    "illustrations/spot/moods-negative.svg"
+
+        Positive ->
+            case config.theme of
+                Heart ->
+                    "illustrations/heart/spot/moods-positive.svg"
+
+                Zen ->
+                    "illustrations/spot/moods-positive.svg"
+
+
 header : Configuration msg -> Html msg
 header config =
-    let
-        resolveIcon =
-            case config.theme of
-                Zen ->
-                    Icon.view Icon.presentation
-                        (case config.variant of
-                            Cautionary ->
-                                svgAsset "@kaizen/draft-modal/KaizenDraft/Modal/illustrations/cautionary.icon.svg"
-
-                            Informative ->
-                                svgAsset "@kaizen/draft-modal/KaizenDraft/Modal/illustrations/informative.icon.svg"
-
-                            Negative ->
-                                svgAsset "@kaizen/draft-modal/KaizenDraft/Modal/illustrations/negative.icon.svg"
-
-                            Positive ->
-                                svgAsset "@kaizen/draft-modal/KaizenDraft/Modal/illustrations/positive.icon.svg"
-                        )
-                        |> Html.map never
-
-                Heart ->
-                    case config.variant of
-                        Cautionary ->
-                            image
-                                "illustrations/heart/spot/moods-cautionary.svg"
-                                Presentation
-
-                        Informative ->
-                            image
-                                "illustrations/heart/spot/moods-informative.svg"
-                                Presentation
-
-                        Negative ->
-                            image
-                                "illustrations/heart/spot/moods-negative.svg"
-                                Presentation
-
-                        Positive ->
-                            image
-                                "illustrations/heart/spot/moods-positive.svg"
-                                Presentation
-    in
     div
         [ styles.classList
             [ ( .header, True )
@@ -265,7 +259,7 @@ header config =
         ]
         [ div [ styles.class .iconContainer ]
             [ div [ styles.class .svgIcon ]
-                [ resolveIcon
+                [ image (illustrationPath config) Presentation
                 ]
             ]
         , Text.view (Text.h1 |> Text.style Text.ZenHeading1 |> Text.inline True |> Text.id Constants.ariaLabelledBy) [ text config.title ]

--- a/draft-packages/modal/KaizenDraft/Modal/Presets/ConfirmationModal.elm
+++ b/draft-packages/modal/KaizenDraft/Modal/Presets/ConfirmationModal.elm
@@ -263,7 +263,7 @@ illustrationPath config =
                     "illustrations/heart/spot/moods-positive.svg"
 
                 Zen ->
-                    "illustrations/spot/moods-positive.svg"
+                    "illustrations/spot/moods-positive-female.svg"
 
 
 body : List (Html msg) -> Html msg

--- a/draft-packages/modal/KaizenDraft/Modal/Presets/ConfirmationModal.elm
+++ b/draft-packages/modal/KaizenDraft/Modal/Presets/ConfirmationModal.elm
@@ -35,7 +35,7 @@ import Icon.Icon as Icon
 import Icon.SvgAsset exposing (svgAsset)
 import Json.Decode as Decode
 import Kaizen.HostedAssets.Image as Image exposing (Role(..), image)
-import Kaizen.Theme as Theme exposing (Theme(..))
+import Kaizen.Theme as Theme exposing (Theme(..), defaultTheme)
 import KaizenDraft.Button.Button as Button
 import KaizenDraft.Modal.Primitives.Constants as Constants
 import KaizenDraft.Modal.Primitives.ModalBody as ModalBody
@@ -136,7 +136,7 @@ defaults =
     , onConfirmBlur = Nothing
     , confirmId = Just Constants.lastFocusableId
     , onConfirmDisabled = False
-    , theme = Heart
+    , theme = defaultTheme
     }
 
 

--- a/draft-packages/modal/KaizenDraft/Modal/Presets/ConfirmationModal.elm
+++ b/draft-packages/modal/KaizenDraft/Modal/Presets/ConfirmationModal.elm
@@ -210,6 +210,26 @@ view (Config config) =
         ]
 
 
+header : Configuration msg -> Html msg
+header config =
+    div
+        [ styles.classList
+            [ ( .header, True )
+            , ( .cautionaryHeader, config.variant == Cautionary )
+            , ( .informativeHeader, config.variant == Informative )
+            , ( .negativeHeader, config.variant == Negative )
+            , ( .positiveHeader, config.variant == Positive )
+            ]
+        ]
+        [ div [ styles.class .iconContainer ]
+            [ div [ styles.class .svgIcon ]
+                [ image Image.default (illustrationPath config)
+                ]
+            ]
+        , Text.view (Text.h1 |> Text.style Text.ZenHeading1 |> Text.inline True |> Text.id Constants.ariaLabelledBy) [ text config.title ]
+        ]
+
+
 illustrationPath : Configuration msg -> String
 illustrationPath config =
     case config.variant of
@@ -244,26 +264,6 @@ illustrationPath config =
 
                 Zen ->
                     "illustrations/spot/moods-positive.svg"
-
-
-header : Configuration msg -> Html msg
-header config =
-    div
-        [ styles.classList
-            [ ( .header, True )
-            , ( .cautionaryHeader, config.variant == Cautionary )
-            , ( .informativeHeader, config.variant == Informative )
-            , ( .negativeHeader, config.variant == Negative )
-            , ( .positiveHeader, config.variant == Positive )
-            ]
-        ]
-        [ div [ styles.class .iconContainer ]
-            [ div [ styles.class .svgIcon ]
-                [ image Image.default (illustrationPath config)
-                ]
-            ]
-        , Text.view (Text.h1 |> Text.style Text.ZenHeading1 |> Text.inline True |> Text.id Constants.ariaLabelledBy) [ text config.title ]
-        ]
 
 
 body : List (Html msg) -> Html msg

--- a/elm.json
+++ b/elm.json
@@ -4,6 +4,7 @@
         "./packages/component-library/components",
         "./packages/component-library/stories",
         "./packages/hosted-assets",
+        "./packages/design-tokens/elm",
         "./draft-packages/button",
         "./draft-packages/card",
         "./draft-packages/collapsible",

--- a/elm.json
+++ b/elm.json
@@ -3,6 +3,7 @@
     "source-directories": [
         "./packages/component-library/components",
         "./packages/component-library/stories",
+        "./packages/hosted-assets",
         "./draft-packages/button",
         "./draft-packages/card",
         "./draft-packages/collapsible",

--- a/packages/design-tokens/elm/Kaizen/Theme.elm
+++ b/packages/design-tokens/elm/Kaizen/Theme.elm
@@ -1,6 +1,29 @@
-module Kaizen.Theme exposing (Theme(..))
+module Kaizen.Theme exposing (Theme(..), defaultTheme, themeDecoder)
+
+import Json.Decode as Decode exposing (Decoder)
 
 
 type Theme
     = Heart
     | Zen
+
+
+defaultTheme =
+    Zen
+
+
+themeDecoder : Decoder Theme
+themeDecoder =
+    Decode.string
+        |> Decode.map
+            (\themeString ->
+                case themeString of
+                    "zen" ->
+                        Zen
+
+                    "heart" ->
+                        Heart
+
+                    _ ->
+                        defaultTheme
+            )

--- a/packages/design-tokens/elm/Kaizen/Theme.elm
+++ b/packages/design-tokens/elm/Kaizen/Theme.elm
@@ -1,0 +1,6 @@
+module Kaizen.Theme exposing (Theme(..))
+
+
+type Theme
+    = Heart
+    | Zen

--- a/packages/design-tokens/package.json
+++ b/packages/design-tokens/package.json
@@ -18,7 +18,8 @@
     "index.ts",
     "src",
     "react",
-    "dist"
+    "dist",
+    "elm"
   ],
   "types": "dist/**/*.d.ts",
   "main": "dist/index.js",

--- a/packages/hosted-assets/Kaizen/HostedAssets.elm
+++ b/packages/hosted-assets/Kaizen/HostedAssets.elm
@@ -1,4 +1,8 @@
-module Kaizen.HostedAssets exposing (assetUrl)
+module Kaizen.HostedAssets exposing (Role(..), assetUrl, image)
+
+import Html exposing (Html, img)
+import Html.Attributes exposing (src)
+import Html.Attributes.Aria as Aria exposing (ariaHidden, ariaLabelledby)
 
 
 originBaseUrl =
@@ -17,3 +21,23 @@ assetUrl "some/blob.png" -> "<https://<origin>/some/blob.png">
 assetUrl : String -> String
 assetUrl path =
     [ originBaseUrl, path ] |> String.join "/"
+
+
+type Role
+    = Presentation
+
+
+image : String -> Role -> Html msg
+image assetPath role =
+    img
+        ((src <| assetUrl assetPath) :: a11yAttributes role)
+        []
+
+
+a11yAttributes : Role -> List (Html.Attribute msg)
+a11yAttributes role =
+    case role of
+        Presentation ->
+            [ Aria.role "presentation"
+            , ariaHidden True
+            ]

--- a/packages/hosted-assets/Kaizen/HostedAssets.elm
+++ b/packages/hosted-assets/Kaizen/HostedAssets.elm
@@ -1,8 +1,4 @@
-module Kaizen.HostedAssets exposing (Role(..), assetUrl, image)
-
-import Html exposing (Html, img)
-import Html.Attributes exposing (src)
-import Html.Attributes.Aria as Aria exposing (ariaHidden, ariaLabelledby)
+module Kaizen.HostedAssets exposing (assetUrl)
 
 
 originBaseUrl =
@@ -21,23 +17,3 @@ assetUrl "some/blob.png" -> "<https://<origin>/some/blob.png">
 assetUrl : String -> String
 assetUrl path =
     [ originBaseUrl, path ] |> String.join "/"
-
-
-type Role
-    = Presentation
-
-
-image : String -> Role -> Html msg
-image assetPath role =
-    img
-        ((src <| assetUrl assetPath) :: a11yAttributes role)
-        []
-
-
-a11yAttributes : Role -> List (Html.Attribute msg)
-a11yAttributes role =
-    case role of
-        Presentation ->
-            [ Aria.role "presentation"
-            , ariaHidden True
-            ]

--- a/packages/hosted-assets/Kaizen/HostedAssets/Image.elm
+++ b/packages/hosted-assets/Kaizen/HostedAssets/Image.elm
@@ -1,0 +1,70 @@
+module Kaizen.HostedAssets.Image exposing (Config, Role(..), attributes, default, image)
+
+import Html exposing (Html, img)
+import Html.Attributes exposing (src)
+import Html.Attributes.Aria as Aria exposing (ariaHidden, ariaLabelledby)
+import Kaizen.HostedAssets exposing (assetUrl)
+
+
+type Role
+    = Presentation
+
+
+default : Config msg
+default =
+    Config defaults
+
+
+
+-- CONFIG
+
+
+type Config msg
+    = Config (ConfigValue msg)
+
+
+type alias ConfigValue msg =
+    { role : Role
+    , attributes : List (Html.Attribute msg)
+    }
+
+
+role : Role -> Config msg -> Config msg
+role value (Config config) =
+    Config { config | role = value }
+
+
+defaults : ConfigValue msg
+defaults =
+    { role = Presentation
+    , attributes = []
+    }
+
+
+attributes : List (Html.Attribute msg) -> Config msg -> Config msg
+attributes value (Config config) =
+    Config { config | attributes = value }
+
+
+
+-- VIEW
+
+
+image : Config msg -> String -> Html msg
+image (Config config) assetPath =
+    let
+        attributes_ =
+            [ src (assetUrl assetPath) ]
+                ++ a11yAttributes config
+                ++ config.attributes
+    in
+    img attributes_ []
+
+
+a11yAttributes : ConfigValue msg -> List (Html.Attribute msg)
+a11yAttributes config =
+    case config.role of
+        Presentation ->
+            [ Aria.role "presentation"
+            , ariaHidden True
+            ]


### PR DESCRIPTION
# Summary
- Adds Heart theme option to the Elm Modal and Empty State  illustrations (cautionary, success, informative, negative, action). Defaults to Zen if not hooked up to a "prop drilling" solution of passing the react `themeKey` to the component.
- Adds elm code to @kaizen/design-tokens for themes. Includes `Theme` type (`Zen` or `Heart`) that needs to be passed down to the components. Also a `themeDecoder` for passing the theme to the Elm app via React.
- Exposes an `image` helper function/component in `Kaizen.HostedAssets.Image` to create images that use a path from our hosted assets S3 bucket (we are currently not using hosted assets anywhere in Kaizen for Elm yet, so this was required to use the new illustrations)

#### other things:
- I upgraded the usages of zen illustrations in Elm modal to use the ones in hosted-assets rather than the ones in this repo. I think there is now an opportunity to delete them.
- The stories always show the Heart theme, because the Elm storybook doesn't support theme switching (it's possible, but out of scope for this PR)
- The only other component I could think of with illustrations was Guideance block, but there is no Elm GuideanceBlock component.
- Supporting illustration animation is out of scope.

# Examples:

<img width="677" alt="image" src="https://user-images.githubusercontent.com/702885/121462738-6ba34f00-c9f4-11eb-9a6d-6c2096564fc3.png">

<img width="1085" alt="image" src="https://user-images.githubusercontent.com/702885/121462765-7827a780-c9f4-11eb-9adc-d047dc635f0b.png">





# Story links: 
https://dev.cultureamp.design/elm-modal-with-heart-illustrations/storybook/?path=/story/emptystate-elm--action
https://dev.cultureamp.design/elm-modal-with-heart-illustrations/storybook/?path=/story/modal-elm--confirmation-cautionary-shown-by-default

# Checklist

- [ ] If this contains visual changes, has it been reviewed by a designer?
- [ ] If this introduces either a new component or a breaking change to an existing component, has it been reviewed by an advocate? (Ask in #prod_design_systems)
- [ ] I have considered likely risks of these changes and got someone else to QA as appropriate
- [ ] I have or will communicate these changes to the front end practice

# Additional Considerations
- Does there need to be right-to-left (RTL) options for localization and internationalization?
- Has the test suite been updated?
- Have you done cross-browser testing for our [supported browsers](https://academy.cultureamp.com/hc/en-us/articles/204539569-Supported-browsers-for-Participants)?
- Have you updated any relevant documentation or left useful comments in the code?
- Have you reviewed Culture Amp's Web Accessibility guide [Current Compliance, Going Forward, Statement and Answers for Customers](https://cultureamp.atlassian.net/wiki/spaces/Prod/pages/428572998/Web+Accessibility)?
- If this contains substantial visual changes, especially far reaching ones, have you unlocked the Chromatic step in the pipeline?
- Have Storybook stories been updated?

**If you're new to Kaizen, please ask #prod_design_systems to set up an onboarding session to get you up to speed.** If you have an urgent PR to merge before that happens, it is safest to ask in #prod_design_systems to have a design system advocate review the PR to catch any issues.
