### PR TITLE
test: mock and or fix deprecation warnings in console when running tests

### DIFF
--- a/draft-packages/illustration/KaizenDraft/Illustration/illustration.spec.tsx
+++ b/draft-packages/illustration/KaizenDraft/Illustration/illustration.spec.tsx
@@ -4,7 +4,9 @@ import * as SpotIllustrations from "./Spot"
 import * as SceneIllustrations from "./Scene"
 
 afterEach(cleanup)
-
+beforeEach(() => {
+  jest.spyOn(global.console, "warn").mockImplementation(jest.fn())
+})
 describe("<Illustration />", () => {
   describe("Spot", () => {
     Object.keys(SpotIllustrations).forEach(componentName => {

--- a/draft-packages/illustration/KaizenDraft/Illustration/illustration.spec.tsx
+++ b/draft-packages/illustration/KaizenDraft/Illustration/illustration.spec.tsx
@@ -3,12 +3,17 @@ import * as React from "react"
 import * as SpotIllustrations from "./Spot"
 import * as SceneIllustrations from "./Scene"
 
+let spy = jest.spyOn(global.console, "warn")
+
 afterEach(cleanup)
-beforeEach(() => {
-  jest.spyOn(global.console, "warn").mockImplementation(jest.fn())
-})
 describe("<Illustration />", () => {
   describe("Spot", () => {
+    beforeEach(() => {
+      spy = jest.spyOn(global.console, "warn").mockImplementation(jest.fn())
+    })
+    afterEach(() => {
+      spy.mockRestore()
+    })
     Object.keys(SpotIllustrations).forEach(componentName => {
       const Component: (props: SpotIllustrations.SpotProps) => JSX.Element =
         SpotIllustrations[componentName]
@@ -24,6 +29,12 @@ describe("<Illustration />", () => {
   })
 
   describe("Scene", () => {
+    beforeEach(() => {
+      spy = jest.spyOn(global.console, "warn").mockImplementation(jest.fn())
+    })
+    afterEach(() => {
+      spy.mockRestore()
+    })
     Object.keys(SceneIllustrations).forEach(componentName => {
       const Component: (props: SceneIllustrations.SceneProps) => JSX.Element =
         SceneIllustrations[componentName]

--- a/draft-packages/modal/KaizenDraft/Modal/Primitives/GenericModal.spec.tsx
+++ b/draft-packages/modal/KaizenDraft/Modal/Primitives/GenericModal.spec.tsx
@@ -1,6 +1,7 @@
 import { cleanup, render, fireEvent, configure } from "@testing-library/react"
 import * as React from "react"
 import GenericModal from "./GenericModal"
+import ModalAccessibleLabel from "./ModalAccessibleLabel"
 
 configure({ testIdAttribute: "data-automation-id" })
 
@@ -9,14 +10,18 @@ afterEach(cleanup)
 describe("<GenericModal />", () => {
   it("renders an open modal with the provided content", () => {
     const { getByText } = render(
-      <GenericModal isOpen={true}>Example</GenericModal>
+      <GenericModal isOpen={true}>
+        <ModalAccessibleLabel>Example</ModalAccessibleLabel>
+      </GenericModal>
     )
     expect(getByText("Example")).toBeTruthy()
   })
 
   it("does not render a closed modal with the provided content", () => {
     const { getByText } = render(
-      <GenericModal isOpen={false}>Example</GenericModal>
+      <GenericModal isOpen={false}>
+        <ModalAccessibleLabel>Example</ModalAccessibleLabel>
+      </GenericModal>
     )
     expect(() => getByText("Example")).toThrow()
   })
@@ -25,7 +30,7 @@ describe("<GenericModal />", () => {
     const handleDismiss = jest.fn()
     const document = render(
       <GenericModal isOpen={true} onEscapeKeyup={handleDismiss}>
-        Example
+        <ModalAccessibleLabel>Example</ModalAccessibleLabel>
       </GenericModal>
     )
     fireEvent.keyUp(document.container, { key: "Escape", code: "Escape" })
@@ -40,7 +45,7 @@ describe("<GenericModal />", () => {
         onOutsideModalClick={handleDismiss}
         automationId="GenericModalAutomationId"
       >
-        Example
+        <ModalAccessibleLabel>Example</ModalAccessibleLabel>
       </GenericModal>
     )
     fireEvent.click(getByTestId("GenericModalAutomationId-scrollLayer"))

--- a/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/TitleBlockZen.spec.tsx
+++ b/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/TitleBlockZen.spec.tsx
@@ -473,7 +473,6 @@ describe("<TitleBlockZen />", () => {
   })
 
   describe("when a secondary action is passed with both an href and an onClick", () => {
-    jest.spyOn(global.console, "warn")
     let testOnClickFn
     let secondaryActionWithLinkAndOnClick
     beforeEach(() => {
@@ -485,6 +484,10 @@ describe("<TitleBlockZen />", () => {
       }
     })
     it("renders the secondary action with both the href and onClick", async () => {
+      const mockWarnFn = jest.fn()
+      const spy = jest
+        .spyOn(global.console, "warn")
+        .mockImplementation(mockWarnFn)
       const { getByTestId } = render(
         <TitleBlockZen
           title="Test Title"
@@ -495,8 +498,7 @@ describe("<TitleBlockZen />", () => {
       )
       const btn = getByTestId("title-block-secondary-actions-button")
       expect(btn).toBeTruthy()
-      // eslint-disable-next-line no-console
-      expect(console.warn).toBeCalled()
+      expect(mockWarnFn).toBeCalled()
       expect(btn.textContent).toEqual(secondaryActionWithLinkAndOnClick.label)
       expect(btn.getAttribute("href")).toEqual(
         secondaryActionWithLinkAndOnClick.href
@@ -505,9 +507,14 @@ describe("<TitleBlockZen />", () => {
       await waitFor(() => {
         expect(testOnClickFn).toHaveBeenCalled()
       })
+      spy.mockRestore()
     })
 
     it("renders the action as a single mobile actions drawer item with an onClick", () => {
+      const mockWarnFn = jest.fn()
+      const spy = jest
+        .spyOn(global.console, "warn")
+        .mockImplementation(mockWarnFn)
       const { getAllByTestId } = render(
         <TitleBlockZen
           title="Test Title"
@@ -523,6 +530,7 @@ describe("<TitleBlockZen />", () => {
       )
       fireEvent.click(btn[0])
       expect(testOnClickFn).toHaveBeenCalled()
+      spy.mockRestore()
     })
   })
 

--- a/packages/component-library/components/Notification/ToastNotification.spec.tsx
+++ b/packages/component-library/components/Notification/ToastNotification.spec.tsx
@@ -2,9 +2,14 @@ import { cleanup, render } from "@testing-library/react"
 import * as React from "react"
 import ToastNotification from "./ToastNotification"
 
-afterEach(cleanup)
+let spy = jest.spyOn(global.console, "warn")
+
 beforeEach(() => {
-  jest.spyOn(global.console, "warn").mockImplementation(jest.fn())
+  spy = jest.spyOn(global.console, "warn").mockImplementation(jest.fn())
+})
+afterEach(() => {
+  spy.mockRestore()
+  cleanup()
 })
 test("The basic notification renders correctly", () => {
   const { getByRole } = render(

--- a/packages/component-library/components/Notification/ToastNotification.spec.tsx
+++ b/packages/component-library/components/Notification/ToastNotification.spec.tsx
@@ -3,7 +3,9 @@ import * as React from "react"
 import ToastNotification from "./ToastNotification"
 
 afterEach(cleanup)
-
+beforeEach(() => {
+  jest.spyOn(global.console, "warn").mockImplementation(jest.fn())
+})
 test("The basic notification renders correctly", () => {
   const { getByRole } = render(
     <ToastNotification type="affirmative" title="Success">

--- a/packages/react-deprecate-warning/src/index.spec.tsx
+++ b/packages/react-deprecate-warning/src/index.spec.tsx
@@ -26,35 +26,39 @@ const MockAppClass = class extends React.Component<MockAppProps> {
 describe("Deprecation helpers", () => {
   describe("<withDeprecatedComponent>", () => {
     it("should passthrough a component's props", () => {
+      const spy = jest.spyOn(logger, "warn").mockImplementation(jest.fn())
       const MockWithHOC = withDeprecatedComponent(MockAppFunc, {
         warning: ERROR_MESSAGE,
       })
       render(<MockWithHOC test="hello" />)
 
       expect(screen.getByText(/^Props: /).textContent).toBe("Props: hello")
+      spy.mockRestore()
     })
 
     it("should log a warning to the console", () => {
-      const spy = jest.spyOn(logger, "warn")
+      const warningFunction = jest.fn()
+      const spy = jest.spyOn(logger, "warn").mockImplementation(warningFunction)
       const MockWithHOC = withDeprecatedComponent(MockAppFunc, {
         warning: ERROR_MESSAGE,
       })
       render(<MockWithHOC test="hello" />)
 
-      expect(spy).toHaveBeenCalledTimes(1)
-      expect(spy).toHaveBeenCalledWith(
+      expect(warningFunction).toHaveBeenCalledTimes(1)
+      expect(warningFunction).toHaveBeenCalledWith(
         `DEPRECATED COMPONENT WARNING (MockAppFunc)\n${ERROR_MESSAGE}`
       )
       spy.mockRestore()
     })
 
     it("should accepts class components", () => {
-      const spy = jest.spyOn(logger, "warn")
+      const warningFunction = jest.fn()
+      const spy = jest.spyOn(logger, "warn").mockImplementation(warningFunction)
       const MockWithHOC = withDeprecatedComponent(MockAppClass, {
         warning: ERROR_MESSAGE,
       })
       render(<MockWithHOC test="hello" />)
-      expect(spy).toHaveBeenCalledTimes(1)
+      expect(warningFunction).toHaveBeenCalledTimes(1)
       spy.mockRestore()
     })
   })
@@ -62,7 +66,10 @@ describe("Deprecation helpers", () => {
   describe("<withDeprecatedProp />", () => {
     describe("Deprecated props", () => {
       it("should raise a warning when a deprecated prop is used", () => {
-        const spy = jest.spyOn(logger, "warn")
+        const warningFunction = jest.fn()
+        const spy = jest
+          .spyOn(logger, "warn")
+          .mockImplementation(warningFunction)
         const MockWithHOC = withDeprecatedProp(MockAppClass, {
           warning: {
             test: "test is deprecated, use blah instead",
@@ -81,12 +88,15 @@ describe("Deprecation helpers", () => {
           },
         })
         render(<MockWithHOC test="blah" />)
-        expect(spy).toHaveBeenCalledTimes(1)
+        expect(warningFunction).toHaveBeenCalledTimes(1)
         spy.mockRestore()
       })
 
       it("should not raise multiple warnings when a deprecated prop is used", () => {
-        const spy = jest.spyOn(logger, "warn")
+        const warningFunction = jest.fn()
+        const spy = jest
+          .spyOn(logger, "warn")
+          .mockImplementation(warningFunction)
         const MockWithHOC = withDeprecatedProp(MockAppClass, {
           warning: {
             test: "test is deprecated, use blah instead",
@@ -105,12 +115,15 @@ describe("Deprecation helpers", () => {
           },
         })
         render(<MockWithHOC test="blah" />)
-        expect(spy).toHaveBeenCalledTimes(1)
+        expect(warningFunction).toHaveBeenCalledTimes(1)
         spy.mockRestore()
       })
 
       it("should not raise a warning when using non-deprecated props", () => {
-        const spy = jest.spyOn(logger, "warn")
+        const warningFunction = jest.fn()
+        const spy = jest
+          .spyOn(logger, "warn")
+          .mockImplementation(warningFunction)
         const MockWithHOC = withDeprecatedProp(MockAppClass, {
           warning: {
             variant: [
@@ -128,12 +141,15 @@ describe("Deprecation helpers", () => {
           },
         })
         render(<MockWithHOC variant="default" test="hello" />)
-        expect(spy).toHaveBeenCalledTimes(0)
+        expect(warningFunction).toHaveBeenCalledTimes(0)
         spy.mockRestore()
       })
 
       it("should log separate warnings for each deprecated prop", () => {
-        const spy = jest.spyOn(logger, "warn")
+        const warningFunction = jest.fn()
+        const spy = jest
+          .spyOn(logger, "warn")
+          .mockImplementation(warningFunction)
         const errorMessageOriginal =
           "The variant prop value 'original' is deprecated, use 'default' instead"
         const errorMessageZen =
@@ -154,11 +170,11 @@ describe("Deprecation helpers", () => {
         })
         render(<MockWithHOC variant="original" test="hello" />)
         render(<MockWithHOC variant="zen" test="hello" />)
-        expect(spy).toHaveBeenCalledTimes(2)
-        expect(spy).toHaveBeenCalledWith(
+        expect(warningFunction).toHaveBeenCalledTimes(2)
+        expect(warningFunction).toHaveBeenCalledWith(
           `DEPRECATED PROP WARNING (MockAppFunc)\n${errorMessageOriginal}`
         )
-        expect(spy).toHaveBeenCalledWith(
+        expect(warningFunction).toHaveBeenCalledWith(
           `DEPRECATED PROP WARNING (MockAppFunc)\n${errorMessageZen}`
         )
         spy.mockRestore()
@@ -167,7 +183,10 @@ describe("Deprecation helpers", () => {
 
     describe("Deprecated prop values", () => {
       it("should raise a warning when a deprecated prop _value_ is used", () => {
-        const spy = jest.spyOn(logger, "warn")
+        const warningFunction = jest.fn()
+        const spy = jest
+          .spyOn(logger, "warn")
+          .mockImplementation(warningFunction)
         const MockWithHOC = withDeprecatedProp(MockAppClass, {
           warning: {
             variant: [
@@ -180,12 +199,15 @@ describe("Deprecation helpers", () => {
           },
         })
         render(<MockWithHOC variant="original" test="hello" />)
-        expect(spy).toHaveBeenCalledTimes(1)
+        expect(warningFunction).toHaveBeenCalledTimes(1)
         spy.mockRestore()
       })
 
       it("should _not_ raise a warning when a deprecated prop _value_ is not used", () => {
-        const spy = jest.spyOn(logger, "warn")
+        const warningFunction = jest.fn()
+        const spy = jest
+          .spyOn(logger, "warn")
+          .mockImplementation(warningFunction)
         const MockWithHOC = withDeprecatedProp(MockAppClass, {
           warning: {
             variant: [
@@ -198,7 +220,7 @@ describe("Deprecation helpers", () => {
           },
         })
         render(<MockWithHOC variant="default" test="hello" />)
-        expect(spy).toHaveBeenCalledTimes(0)
+        expect(warningFunction).toHaveBeenCalledTimes(0)
         spy.mockRestore()
       })
     })


### PR DESCRIPTION
# Objective
The console is a little noisy, cleaning it up so we can more easily catch warnings and errors when we (never!) add them.

# Motivation and Context
Theres some 'real' warnings /errors that are harder to see/catch because we have added warnings for consumers. While the warnings are good, we don't want to pollute our console when running tests.

# Changes
* Most of these add a `mockImplementation` to the spy that is being created for console.warn. I've changed any tests that are explicitly looking for this to check the `mockImplementation` call.
* The modals needed a `ModalAccessibleLabel` so I added one instead of mocking the warn function. Modals also have a seperate issue that will be addressed in a follow-up PR.

# Checklist
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] If this contains visual changes, has it been reviewed by a designer?
- [ ] If this introduces either a new component or a breaking change to an existing component, has it been reviewed by an advocate? (Ask in #prod_design_systems)
- [ ] I have considered likely risks of these changes and got someone else to QA as appropriate
- [ ] I have or will communicate these changes to the front end practice

# Additional Considerations
- Does there need to be right-to-left (RTL) options for localization and internationalization?
- Has the test suite been updated?
- Have you done cross-browser testing for our [supported browsers](https://academy.cultureamp.com/hc/en-us/articles/204539569-Supported-browsers-for-Participants)?
- Have you updated any relevant documentation or left useful comments in the code?
- Have you reviewed Culture Amp's Web Accessibility guide [Current Compliance, Going Forward, Statement and Answers for Customers](https://cultureamp.atlassian.net/wiki/spaces/Prod/pages/428572998/Web+Accessibility)?
- If this contains substantial visual changes, especially far reaching ones, have you unlocked the Chromatic step in the pipeline?
- Have Storybook stories been updated?

**If you're new to Kaizen, please ask #prod_design_systems to set up an onboarding session to get you up to speed.** If you have an urgent PR to merge before that happens, it is safest to ask in #prod_design_systems to have a design system advocate review the PR to catch any issues.
