### PR TITLE
feat: guidance block accepts spots version 3

### DIFF
--- a/draft-packages/guidance-block/KaizenDraft/GuidanceBlock/GuidanceBlock.scss
+++ b/draft-packages/guidance-block/KaizenDraft/GuidanceBlock/GuidanceBlock.scss
@@ -50,14 +50,16 @@ $ca-banner-collapse-height-delayed: margin-top $kz-var-animation-duration-fast
 }
 
 .iconWrapper {
+  width: 155px;
+  height: 155px;
   display: flex;
   padding: 0 ($kz-var-spacing-sm);
 
   @include ca-media-tablet {
     text-align: center;
     justify-content: center;
+    align-self: center;
     padding: $kz-var-spacing-sm;
-    width: auto;
   }
 
   @include ca-media-mobile {

--- a/draft-packages/guidance-block/KaizenDraft/GuidanceBlock/GuidanceBlock.spec.tsx
+++ b/draft-packages/guidance-block/KaizenDraft/GuidanceBlock/GuidanceBlock.spec.tsx
@@ -18,7 +18,7 @@ describe("GuidanceBlock", () => {
   test("starts visible", () => {
     const { container } = render(
       <GuidanceBlock
-        img={{ src: "image/path.png", alt: "Call to action banner" }}
+        illustration="Informative"
         text={{
           title: "This is the call to action title",
           description:
@@ -38,7 +38,7 @@ describe("GuidanceBlock", () => {
     const onDismiss = jest.fn()
     const { container } = render(
       <GuidanceBlock
-        img={{ src: "image/path.png", alt: "Call to action banner" }}
+        illustration="Informative"
         text={{
           title: "This is the call to action title",
           description:
@@ -66,7 +66,7 @@ describe("GuidanceBlock", () => {
     const onAction = jest.fn()
     const { container } = render(
       <GuidanceBlock
-        img={{ src: "image/path.png", alt: "Call to action banner" }}
+        illustration="Informative"
         text={{
           title: "This is the call to action title",
           description:
@@ -85,7 +85,7 @@ describe("GuidanceBlock", () => {
   test("when animation ends the element is removed", () => {
     const { container } = render(
       <GuidanceBlock
-        img={{ src: "image/path.png", alt: "Call to action banner" }}
+        illustration="Informative"
         text={{
           title: "This is the call to action title",
           description:
@@ -114,7 +114,7 @@ describe("GuidanceBlock", () => {
   test("when guidance block is persistent", () => {
     const { container } = render(
       <GuidanceBlock
-        img={{ src: "image/path.png", alt: "Call to action banner" }}
+        illustration="Informative"
         text={{
           title: "This is the call to action title",
           description:
@@ -134,7 +134,7 @@ describe("GuidanceBlock", () => {
   test("when secondary action is supplied", () => {
     const { container } = render(
       <GuidanceBlock
-        img={{ src: "image/path.png", alt: "Call to action banner" }}
+        illustration="Informative"
         text={{
           title: "This is the call to action title",
           description:

--- a/draft-packages/guidance-block/KaizenDraft/GuidanceBlock/GuidanceBlock.tsx
+++ b/draft-packages/guidance-block/KaizenDraft/GuidanceBlock/GuidanceBlock.tsx
@@ -8,6 +8,10 @@ import classnames from "classnames"
 import { Tooltip, TooltipProps } from "@kaizen/draft-tooltip"
 import { MOBILE_QUERY } from "@kaizen/component-library/components/NavigationBar/constants"
 import Media from "react-media"
+import {
+  SpotIllustration,
+  SpotIllustrationType,
+} from "@kaizen/draft-illustration"
 
 const styles = require("./GuidanceBlock.scss")
 
@@ -24,10 +28,7 @@ type GuidanceBlockActions = {
 }
 
 export type GuidanceBlockProps = {
-  img: {
-    src: string
-    alt: string
-  }
+  illustration: SpotIllustrationType
   text: {
     title: string
     description: string | React.ReactNode
@@ -140,7 +141,7 @@ class GuidanceBlock extends React.Component<
 
     const {
       actions,
-      img,
+      illustration,
       text,
       persistent,
       withActionButtonArrow,
@@ -157,9 +158,8 @@ class GuidanceBlock extends React.Component<
         onTransitionEnd={this.onTransitionEnd}
       >
         <div className={styles.iconWrapper}>
-          <img src={img.src} alt={img.alt} height="155px" width="155px" />
+          <SpotIllustration illustration={illustration} />
         </div>
-
         <div className={styles.descriptionContainer}>
           <div className={styles.headingWrapper}>
             <Heading tag="h3" variant="heading-3">

--- a/draft-packages/guidance-block/docs/GuidanceBlock.stories.tsx
+++ b/draft-packages/guidance-block/docs/GuidanceBlock.stories.tsx
@@ -1,7 +1,6 @@
 import * as React from "react"
 
 import { GuidanceBlock } from "@kaizen/draft-guidance-block"
-import { assetUrl } from "@kaizen/hosted-assets"
 import { withDesign } from "storybook-addon-designs"
 import { figmaEmbed } from "../../../storybook/helpers"
 
@@ -36,11 +35,9 @@ const guidanceBlockText = {
     "qui tem lupuliz, matis, aguis e fermentis. Mé faiz elementum girarzis, nisi eros vermeio.",
 }
 
-const guidanceBlockImg = assetUrl("illustrations/spot/moods-informative.svg")
-
 const Default = () => (
   <GuidanceBlock
-    img={{ src: guidanceBlockImg, alt: "Guidance block" }}
+    illustration="Informative"
     text={guidanceBlockText}
     actions={{
       primary: {
@@ -58,15 +55,12 @@ const Default = () => (
 )
 
 const DefaultWithoutActions = () => (
-  <GuidanceBlock
-    img={{ src: guidanceBlockImg, alt: "Guidance block" }}
-    text={guidanceBlockText}
-  />
+  <GuidanceBlock illustration="Informative" text={guidanceBlockText} />
 )
 
 const WithoutActionArrowButton = () => (
   <GuidanceBlock
-    img={{ src: guidanceBlockImg, alt: "Guidance block" }}
+    illustration="Informative"
     text={guidanceBlockText}
     actions={{
       primary: {
@@ -85,7 +79,7 @@ const WithoutActionArrowButton = () => (
 
 const WithoutMaxWidth = () => (
   <GuidanceBlock
-    img={{ src: guidanceBlockImg, alt: "" }}
+    illustration="Informative"
     text={guidanceBlockText}
     noMaxWidth
   />
@@ -93,7 +87,7 @@ const WithoutMaxWidth = () => (
 
 const Persistent = () => (
   <GuidanceBlock
-    img={{ src: guidanceBlockImg, alt: "Information illustration" }}
+    illustration="Informative"
     text={guidanceBlockText}
     actions={{
       primary: {
@@ -109,7 +103,7 @@ const Persistent = () => (
 
 const SecondaryAction = () => (
   <GuidanceBlock
-    img={{ src: guidanceBlockImg, alt: "Information illustration" }}
+    illustration="Informative"
     text={guidanceBlockText}
     actions={{
       primary: {
@@ -130,7 +124,7 @@ const SecondaryAction = () => (
 
 const Prominent = () => (
   <GuidanceBlock
-    img={{ src: guidanceBlockImg, alt: "Information illustration" }}
+    illustration="Informative"
     text={guidanceBlockText}
     actions={{
       primary: {
@@ -146,7 +140,7 @@ const Prominent = () => (
 
 const WithCustomDescription = () => (
   <GuidanceBlock
-    img={{ src: guidanceBlockImg, alt: "" }}
+    illustration="Informative"
     text={{
       title: "Informative guidance block title",
       description: (
@@ -175,7 +169,7 @@ const WithCustomDescription = () => (
 
 const WithTooltip = () => (
   <GuidanceBlock
-    img={{ src: guidanceBlockImg, alt: "" }}
+    illustration="Informative"
     text={{
       title: "Informative guidance block title",
       description:

--- a/draft-packages/guidance-block/package.json
+++ b/draft-packages/guidance-block/package.json
@@ -34,6 +34,7 @@
   "dependencies": {
     "@kaizen/component-library": "^9.7.1",
     "@kaizen/draft-button": "^3.3.7",
+    "@kaizen/draft-illustration": "^1.8.2",
     "@kaizen/draft-tooltip": "^2.7.2",
     "@types/classnames": "^2.3.1",
     "classnames": "^2.3.1",

--- a/draft-packages/illustration/KaizenDraft/Illustration/Spot.tsx
+++ b/draft-packages/illustration/KaizenDraft/Illustration/Spot.tsx
@@ -963,3 +963,200 @@ export const Recommendation = (props: SpotProps) => {
     <Base {...props} name="illustrations/heart/spot/miscellaneous-shield.svg" />
   )
 }
+
+export type SpotIllustrationType =
+  | "Cautionary"
+  | "Informative"
+  | "Negative"
+  | "PositiveMale"
+  | "PositiveFemale"
+  | "Positive"
+  | "Assertive"
+  | "BenefitsSurvey"
+  | "CustomSurvey"
+  | "CustomUnattributedSurvey"
+  | "EngagementSurvey"
+  | "InclusionSurvey"
+  | "QuickEngagementSurvey"
+  | "ValuesSurvey1"
+  | "ValuesSurvey2"
+  | "WellbeingSurvey1"
+  | "WellbeingSurvey2"
+  | "WellbeingSurvey3"
+  | "ChangeReadiness"
+  | "ChangeSuccess"
+  | "PerformanceDiagnostics"
+  | "LeadingThroughCrisis"
+  | "EmergencyResponse"
+  | "CandidateSurvey"
+  | "CustomOnboardSurvey"
+  | "ExitSurvey"
+  | "InternSurvey"
+  | "PhasedWeek1OnboardSurvey"
+  | "PhasedWeek5OnboardSurvey"
+  | "SinglePointOnboardSurvey"
+  | "GeneralOnboardSurvey"
+  | "RemoteOnboardSurvey"
+  | "Individual360"
+  | "Leadership360"
+  | "Manager360"
+  | "TeamEffectiveness1"
+  | "TeamEffectiveness2"
+  | "WellbeingSurvey"
+  | "Response"
+  | "RemoteWorkQSet"
+  | "ReturnToWorkplace"
+  | "PulseSurvey"
+  | "AccountBasics"
+  | "CompanyDetails"
+  | "EmployeeData"
+  | "Gdpr"
+  | "Timezone"
+  | "AddUser"
+  | "Strategy"
+  | "Resilience"
+  | "RemoteManager"
+  | "Productivity"
+  | "ManagerLearning"
+  | "Feedback"
+  | "Coaching"
+  | "OneOnOne"
+  | "ViewReports"
+  | "ReadArticle"
+  | "FastAction"
+  | "BaselineSurvey"
+  | "SpreadsheetTemplate"
+  | "AddImage"
+  | "MeetingVoices"
+  | "Workshop"
+  | "Video"
+  | "ReportSharing"
+  | "BlankSurvey"
+  | "TakeAim"
+  | "Action"
+  | "Training1"
+  | "Training2"
+  | "Training3"
+  | "ShareReport"
+  | "Team"
+  | "ExecutiveReportSharing"
+  | "ManagerReportSharing"
+  | "LeaderReportSharing"
+  | "Alarm"
+  | "Fire"
+  | "Fireworks"
+  | "FullImport"
+  | "HrisImport"
+  | "PartialImport"
+  | "Starburst"
+  | "Stop"
+  | "TrafficCone"
+  | "Trophy"
+  | "UnderConstruction"
+  | "ValueAdd"
+  | "Recommendation"
+
+const spotIlustrations = {
+  Cautionary,
+  Informative,
+  Negative,
+  PositiveMale,
+  PositiveFemale,
+  Positive,
+  Assertive,
+  BenefitsSurvey,
+  CustomSurvey,
+  CustomUnattributedSurvey,
+  EngagementSurvey,
+  InclusionSurvey,
+  QuickEngagementSurvey,
+  ValuesSurvey1,
+  ValuesSurvey2,
+  WellbeingSurvey1,
+  WellbeingSurvey2,
+  WellbeingSurvey3,
+  ChangeReadiness,
+  ChangeSuccess,
+  PerformanceDiagnostics,
+  LeadingThroughCrisis,
+  EmergencyResponse,
+  CandidateSurvey,
+  CustomOnboardSurvey,
+  ExitSurvey,
+  InternSurvey,
+  PhasedWeek1OnboardSurvey,
+  PhasedWeek5OnboardSurvey,
+  SinglePointOnboardSurvey,
+  GeneralOnboardSurvey,
+  RemoteOnboardSurvey,
+  Individual360,
+  Leadership360,
+  Manager360,
+  TeamEffectiveness1,
+  TeamEffectiveness2,
+  WellbeingSurvey,
+  Response,
+  RemoteWorkQSet,
+  ReturnToWorkplace,
+  PulseSurvey,
+  AccountBasics,
+  CompanyDetails,
+  EmployeeData,
+  Gdpr,
+  Timezone,
+  AddUser,
+  Strategy,
+  Resilience,
+  RemoteManager,
+  Productivity,
+  ManagerLearning,
+  Feedback,
+  Coaching,
+  OneOnOne,
+  ViewReports,
+  ReadArticle,
+  FastAction,
+  BaselineSurvey,
+  SpreadsheetTemplate,
+  AddImage,
+  MeetingVoices,
+  Workshop,
+  Video,
+  ReportSharing,
+  BlankSurvey,
+  TakeAim,
+  Action,
+  Training1,
+  Training2,
+  Training3,
+  ShareReport,
+  Team,
+  ExecutiveReportSharing,
+  ManagerReportSharing,
+  LeaderReportSharing,
+  Alarm,
+  Fire,
+  Fireworks,
+  FullImport,
+  HrisImport,
+  PartialImport,
+  Starburst,
+  Stop,
+  TrafficCone,
+  Trophy,
+  UnderConstruction,
+  ValueAdd,
+  Recommendation,
+}
+
+export const SpotIllustration = ({
+  illustration,
+  alt = "",
+  ...theRest
+}: Omit<SpotProps, "alt"> & {
+  illustration: SpotIllustrationType
+  alt?: string
+}) => {
+  const Component = spotIlustrations[illustration]
+  return <Component alt={alt} {...theRest} />
+}

--- a/draft-packages/illustration/KaizenDraft/Illustration/illustration.spec.tsx
+++ b/draft-packages/illustration/KaizenDraft/Illustration/illustration.spec.tsx
@@ -8,16 +8,30 @@ afterEach(cleanup)
 describe("<Illustration />", () => {
   describe("Spot", () => {
     Object.keys(SpotIllustrations).forEach(componentName => {
-      const Component: (props: SpotIllustrations.SpotProps) => JSX.Element =
-        SpotIllustrations[componentName]
+      if (componentName === "SpotIllustration") {
+        const Component: (
+          props: Omit<SpotIllustrations.SpotProps, "alt"> & {
+            illustration: SpotIllustrations.SpotIllustrationType
+            alt?: string
+          }
+        ) => JSX.Element = SpotIllustrations[componentName]
+        it("SpotIllustration takes a SpotIllustrationType and renders the corresponding Spot", () => {
+          const { container } = render(<Component illustration="Informative" />)
+          expect(
+            container.querySelector("img[src*='moods-informative.svg']")
+          ).toBeTruthy()
+        })
+      } else {
+        const Component: (props: SpotIllustrations.SpotProps) => JSX.Element =
+          SpotIllustrations[componentName]
+        it(`${componentName} should exist and render an alt tag`, () => {
+          const altTitle = "My accessible title"
+          const wrapper = render(<Component alt={altTitle} />)
 
-      it(`${componentName} should exist and render an alt tag`, () => {
-        const altTitle = "My accessible title"
-        const wrapper = render(<Component alt={altTitle} />)
-
-        expect(wrapper.getByAltText(altTitle)).toBeTruthy()
-        expect(wrapper.container).toMatchSnapshot()
-      })
+          expect(wrapper.getByAltText(altTitle)).toBeTruthy()
+          expect(wrapper.container).toMatchSnapshot()
+        })
+      }
     })
   })
 


### PR DESCRIPTION
# Objective
Here is a third idea for spots. Previous ideas can be found in https://github.com/cultureamp/kaizen-design-system/pull/1571 .
The objective is _still_ to render a Spot within a GuidanceBlock.

# Motivation and Context
Ok so new idea. Take the SpotTypes from idea two, and create a local object within the Spot library so we can pull the correct spot off of it. We then export an... agnostic (?) SpotIllustration component that takes a spot prop and returns the correct one by plucking it off the object.

This probably needs to be 2 PRs again.

Also this one contains a breaking change of **Removing the img prop** (dun dun DUN)

# Screenshots (if appropriate)

# Checklist
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] If this contains visual changes, has it been reviewed by a designer?
- [ ] If this introduces either a new component or a breaking change to an existing component, has it been reviewed by an advocate? (Ask in #prod_design_systems)
- [ ] I have considered likely risks of these changes and got someone else to QA as appropriate
- [ ] I have or will communicate these changes to the front end practice

# Additional Considerations
- Does there need to be right-to-left (RTL) options for localization and internationalization?
- Has the test suite been updated?
- Have you done cross-browser testing for our [supported browsers](https://academy.cultureamp.com/hc/en-us/articles/204539569-Supported-browsers-for-Participants)?
- Have you updated any relevant documentation or left useful comments in the code?
- Have you reviewed Culture Amp's Web Accessibility guide [Current Compliance, Going Forward, Statement and Answers for Customers](https://cultureamp.atlassian.net/wiki/spaces/Prod/pages/428572998/Web+Accessibility)?
- If this contains substantial visual changes, especially far reaching ones, have you unlocked the Chromatic step in the pipeline?
- Have Storybook stories been updated?

**If you're new to Kaizen, please ask #prod_design_systems to set up an onboarding session to get you up to speed.** If you have an urgent PR to merge before that happens, it is safest to ask in #prod_design_systems to have a design system advocate review the PR to catch any issues.
