### PR TITLE
feat: Add Spot to GuidanceBlock v1

### DIFF
--- a/draft-packages/guidance-block/KaizenDraft/GuidanceBlock/GuidanceBlock.scss
+++ b/draft-packages/guidance-block/KaizenDraft/GuidanceBlock/GuidanceBlock.scss
@@ -50,12 +50,15 @@ $ca-banner-collapse-height-delayed: margin-top $kz-var-animation-duration-fast
 }
 
 .iconWrapper {
+  width: 155px;
+  height: 155px;
   display: flex;
   padding: 0 ($kz-var-spacing-sm);
 
   @include ca-media-tablet {
     text-align: center;
     justify-content: center;
+    align-self: center;
     padding: $kz-var-spacing-sm;
     width: auto;
   }

--- a/draft-packages/guidance-block/KaizenDraft/GuidanceBlock/GuidanceBlock.scss
+++ b/draft-packages/guidance-block/KaizenDraft/GuidanceBlock/GuidanceBlock.scss
@@ -11,6 +11,7 @@ $bannerPadding: $kz-var-spacing-sm;
 $ca-banner-fade-out: opacity $kz-var-animation-duration-slow ease;
 $ca-banner-collapse-height-delayed: margin-top $kz-var-animation-duration-fast
   $kz-var-animation-duration-slow ease;
+$illustration-size: 155px;
 
 .banner.noMaxWidth {
   max-width: inherit;
@@ -49,9 +50,9 @@ $ca-banner-collapse-height-delayed: margin-top $kz-var-animation-duration-fast
   }
 }
 
-.iconWrapper {
-  width: 155px;
-  height: 155px;
+.illustration {
+  width: $illustration-size;
+  height: $illustration-size;
   display: flex;
   padding: 0 ($kz-var-spacing-sm);
 

--- a/draft-packages/guidance-block/KaizenDraft/GuidanceBlock/GuidanceBlock.spec.tsx
+++ b/draft-packages/guidance-block/KaizenDraft/GuidanceBlock/GuidanceBlock.spec.tsx
@@ -2,6 +2,7 @@ import { cleanup, render } from "@testing-library/react"
 import { fireEvent } from "@testing-library/dom"
 import * as React from "react"
 import * as ReactTestUtils from "react-dom/test-utils"
+import { Informative } from "@kaizen/draft-illustration"
 import GuidanceBlock from "./GuidanceBlock"
 
 window.matchMedia = jest.fn().mockImplementation(() => ({
@@ -18,7 +19,7 @@ describe("GuidanceBlock", () => {
   test("starts visible", () => {
     const { container } = render(
       <GuidanceBlock
-        img={{ src: "image/path.png", alt: "Call to action banner" }}
+        illustration={<Informative alt="" />}
         text={{
           title: "This is the call to action title",
           description:
@@ -38,7 +39,7 @@ describe("GuidanceBlock", () => {
     const onDismiss = jest.fn()
     const { container } = render(
       <GuidanceBlock
-        img={{ src: "image/path.png", alt: "Call to action banner" }}
+        illustration={<Informative alt="" />}
         text={{
           title: "This is the call to action title",
           description:
@@ -66,7 +67,7 @@ describe("GuidanceBlock", () => {
     const onAction = jest.fn()
     const { container } = render(
       <GuidanceBlock
-        img={{ src: "image/path.png", alt: "Call to action banner" }}
+        illustration={<Informative alt="" />}
         text={{
           title: "This is the call to action title",
           description:
@@ -85,7 +86,7 @@ describe("GuidanceBlock", () => {
   test("when animation ends the element is removed", () => {
     const { container } = render(
       <GuidanceBlock
-        img={{ src: "image/path.png", alt: "Call to action banner" }}
+        illustration={<Informative alt="" />}
         text={{
           title: "This is the call to action title",
           description:
@@ -114,7 +115,7 @@ describe("GuidanceBlock", () => {
   test("when guidance block is persistent", () => {
     const { container } = render(
       <GuidanceBlock
-        img={{ src: "image/path.png", alt: "Call to action banner" }}
+        illustration={<Informative alt="" />}
         text={{
           title: "This is the call to action title",
           description:
@@ -134,7 +135,7 @@ describe("GuidanceBlock", () => {
   test("when secondary action is supplied", () => {
     const { container } = render(
       <GuidanceBlock
-        img={{ src: "image/path.png", alt: "Call to action banner" }}
+        illustration={<Informative alt="" />}
         text={{
           title: "This is the call to action title",
           description:

--- a/draft-packages/guidance-block/KaizenDraft/GuidanceBlock/GuidanceBlock.tsx
+++ b/draft-packages/guidance-block/KaizenDraft/GuidanceBlock/GuidanceBlock.tsx
@@ -154,7 +154,7 @@ class GuidanceBlock extends React.Component<
         ref={this.containerRef}
         onTransitionEnd={this.onTransitionEnd}
       >
-        <div className={styles.iconWrapper}>{illustration}</div>
+        <div className={styles.illustration}>{illustration}</div>
 
         <div className={styles.descriptionContainer}>
           <div className={styles.headingWrapper}>

--- a/draft-packages/guidance-block/KaizenDraft/GuidanceBlock/GuidanceBlock.tsx
+++ b/draft-packages/guidance-block/KaizenDraft/GuidanceBlock/GuidanceBlock.tsx
@@ -8,6 +8,7 @@ import classnames from "classnames"
 import { Tooltip, TooltipProps } from "@kaizen/draft-tooltip"
 import { MOBILE_QUERY } from "@kaizen/component-library/components/NavigationBar/constants"
 import Media from "react-media"
+import { SpotProps } from "@kaizen/draft-illustration"
 
 const styles = require("./GuidanceBlock.scss")
 
@@ -24,10 +25,7 @@ type GuidanceBlockActions = {
 }
 
 export type GuidanceBlockProps = {
-  img: {
-    src: string
-    alt: string
-  }
+  illustration: React.ReactElement<SpotProps>
   text: {
     title: string
     description: string | React.ReactNode
@@ -140,7 +138,7 @@ class GuidanceBlock extends React.Component<
 
     const {
       actions,
-      img,
+      illustration,
       text,
       persistent,
       withActionButtonArrow,
@@ -156,9 +154,7 @@ class GuidanceBlock extends React.Component<
         ref={this.containerRef}
         onTransitionEnd={this.onTransitionEnd}
       >
-        <div className={styles.iconWrapper}>
-          <img src={img.src} alt={img.alt} height="155px" width="155px" />
-        </div>
+        <div className={styles.iconWrapper}>{illustration}</div>
 
         <div className={styles.descriptionContainer}>
           <div className={styles.headingWrapper}>

--- a/draft-packages/guidance-block/docs/GuidanceBlock.stories.tsx
+++ b/draft-packages/guidance-block/docs/GuidanceBlock.stories.tsx
@@ -1,10 +1,9 @@
 import * as React from "react"
 
 import { GuidanceBlock } from "@kaizen/draft-guidance-block"
-import { assetUrl } from "@kaizen/hosted-assets"
+import { Informative } from "@kaizen/draft-illustration"
 import { withDesign } from "storybook-addon-designs"
 import { figmaEmbed } from "../../../storybook/helpers"
-
 const externalLinkIcon = require("@kaizen/component-library/icons/external-link.icon.svg")
   .default
 
@@ -36,11 +35,9 @@ const guidanceBlockText = {
     "qui tem lupuliz, matis, aguis e fermentis. Mé faiz elementum girarzis, nisi eros vermeio.",
 }
 
-const guidanceBlockImg = assetUrl("illustrations/spot/moods-informative.svg")
-
 const Default = () => (
   <GuidanceBlock
-    img={{ src: guidanceBlockImg, alt: "Guidance block" }}
+    illustration={<Informative alt="" />}
     text={guidanceBlockText}
     actions={{
       primary: {
@@ -59,14 +56,14 @@ const Default = () => (
 
 const DefaultWithoutActions = () => (
   <GuidanceBlock
-    img={{ src: guidanceBlockImg, alt: "Guidance block" }}
+    illustration={<Informative alt="" />}
     text={guidanceBlockText}
   />
 )
 
 const WithoutActionArrowButton = () => (
   <GuidanceBlock
-    img={{ src: guidanceBlockImg, alt: "Guidance block" }}
+    illustration={<Informative alt="" />}
     text={guidanceBlockText}
     actions={{
       primary: {
@@ -85,7 +82,7 @@ const WithoutActionArrowButton = () => (
 
 const WithoutMaxWidth = () => (
   <GuidanceBlock
-    img={{ src: guidanceBlockImg, alt: "" }}
+    illustration={<Informative alt="" />}
     text={guidanceBlockText}
     noMaxWidth
   />
@@ -93,7 +90,7 @@ const WithoutMaxWidth = () => (
 
 const Persistent = () => (
   <GuidanceBlock
-    img={{ src: guidanceBlockImg, alt: "Information illustration" }}
+    illustration={<Informative alt="" />}
     text={guidanceBlockText}
     actions={{
       primary: {
@@ -109,7 +106,7 @@ const Persistent = () => (
 
 const SecondaryAction = () => (
   <GuidanceBlock
-    img={{ src: guidanceBlockImg, alt: "Information illustration" }}
+    illustration={<Informative alt="" />}
     text={guidanceBlockText}
     actions={{
       primary: {
@@ -130,7 +127,7 @@ const SecondaryAction = () => (
 
 const Prominent = () => (
   <GuidanceBlock
-    img={{ src: guidanceBlockImg, alt: "Information illustration" }}
+    illustration={<Informative alt="" />}
     text={guidanceBlockText}
     actions={{
       primary: {
@@ -146,7 +143,7 @@ const Prominent = () => (
 
 const WithCustomDescription = () => (
   <GuidanceBlock
-    img={{ src: guidanceBlockImg, alt: "" }}
+    illustration={<Informative alt="" />}
     text={{
       title: "Informative guidance block title",
       description: (
@@ -175,7 +172,7 @@ const WithCustomDescription = () => (
 
 const WithTooltip = () => (
   <GuidanceBlock
-    img={{ src: guidanceBlockImg, alt: "" }}
+    illustration={<Informative alt="" />}
     text={{
       title: "Informative guidance block title",
       description:

--- a/draft-packages/guidance-block/package.json
+++ b/draft-packages/guidance-block/package.json
@@ -34,6 +34,7 @@
   "dependencies": {
     "@kaizen/component-library": "^9.7.4",
     "@kaizen/draft-button": "^3.3.10",
+    "@kaizen/draft-illustration": "^1.8.3",
     "@kaizen/draft-tooltip": "^2.7.5",
     "@types/classnames": "^2.3.1",
     "classnames": "^2.3.1",


### PR DESCRIPTION
# Objective
We want to render a Spot inside a GuidanceBlock

# Motivation and Context
This is v1, v3 can be found here: https://github.com/cultureamp/kaizen-design-system/pull/1594

Change GuidanceBlock to accept an `illustration` prop of `React.ReactElement<SpotProps>`. Render that where we used to render the `img`.

# Screenshots (if appropriate)

# Checklist
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] If this contains visual changes, has it been reviewed by a designer?
- [x] If this introduces either a new component or a breaking change to an existing component, has it been reviewed by an advocate? (Ask in #prod_design_systems)
- [x] I have considered likely risks of these changes and got someone else to QA as appropriate
- [x] I have or will communicate these changes to the front end practice

# Additional Considerations
- Does there need to be right-to-left (RTL) options for localization and internationalization?
- Has the test suite been updated?
- Have you done cross-browser testing for our [supported browsers](https://academy.cultureamp.com/hc/en-us/articles/204539569-Supported-browsers-for-Participants)?
- Have you updated any relevant documentation or left useful comments in the code?
- Have you reviewed Culture Amp's Web Accessibility guide [Current Compliance, Going Forward, Statement and Answers for Customers](https://cultureamp.atlassian.net/wiki/spaces/Prod/pages/428572998/Web+Accessibility)?
- If this contains substantial visual changes, especially far reaching ones, have you unlocked the Chromatic step in the pipeline?
- Have Storybook stories been updated?

**If you're new to Kaizen, please ask #prod_design_systems to set up an onboarding session to get you up to speed.** If you have an urgent PR to merge before that happens, it is safest to ask in #prod_design_systems to have a design system advocate review the PR to catch any issues.
