### PR TITLE
fix: Fallback to blank survey for Heart template illustrations without Zen equivalents

### DIFF
--- a/draft-packages/illustration/KaizenDraft/Illustration/Spot.tsx
+++ b/draft-packages/illustration/KaizenDraft/Illustration/Spot.tsx
@@ -233,30 +233,22 @@ export const PerformanceDiagnostics = (props: SpotProps) => {
 
 export const LeadingThroughCrisis = (props: SpotProps) => {
   const theme = useTheme()
-  if (theme.themeKey === "zen") {
-    noZenIllustrationWarning("LeadingThroughCrisis")
-  }
+  const illustrationPath =
+    theme.themeKey === "zen"
+      ? "illustrations/spot/miscellaneous-blank-survey.svg"
+      : "illustrations/heart/spot/template-library-leading-through-crisis.svg"
 
-  return (
-    <Base
-      {...props}
-      name="illustrations/heart/spot/template-library-leading-through-crisis.svg"
-    />
-  )
+  return <Base {...props} name={illustrationPath} />
 }
 
 export const EmergencyResponse = (props: SpotProps) => {
   const theme = useTheme()
-  if (theme.themeKey === "zen") {
-    noZenIllustrationWarning("EmergencyResponse")
-  }
+  const illustrationPath =
+    theme.themeKey === "zen"
+      ? "illustrations/spot/miscellaneous-blank-survey.svg"
+      : "illustrations/heart/spot/template-library-emergency-response.svg"
 
-  return (
-    <Base
-      {...props}
-      name="illustrations/heart/spot/template-library-emergency-response.svg"
-    />
-  )
+  return <Base {...props} name={illustrationPath} />
 }
 
 /**
@@ -334,30 +326,22 @@ export const SinglePointOnboardSurvey = (props: SpotProps) => {
 
 export const GeneralOnboardSurvey = (props: SpotProps) => {
   const theme = useTheme()
-  if (theme.themeKey === "zen") {
-    noZenIllustrationWarning("GeneralOnboardSurvey")
-  }
+  const illustrationPath =
+    theme.themeKey === "zen"
+      ? "illustrations/spot/miscellaneous-blank-survey.svg"
+      : "illustrations/heart/spot/template-library-general-onboard-survey.svg"
 
-  return (
-    <Base
-      {...props}
-      name="illustrations/heart/spot/template-library-general-onboard-survey.svg"
-    />
-  )
+  return <Base {...props} name={illustrationPath} />
 }
 
 export const RemoteOnboardSurvey = (props: SpotProps) => {
   const theme = useTheme()
-  if (theme.themeKey === "zen") {
-    noZenIllustrationWarning("GeneralOnboardSurvey")
-  }
+  const illustrationPath =
+    theme.themeKey === "zen"
+      ? "illustrations/spot/miscellaneous-blank-survey.svg"
+      : "illustrations/heart/spot/template-library-remote-onboard-survey.svg"
 
-  return (
-    <Base
-      {...props}
-      name="illustrations/heart/spot/template-library-remote-onboard-survey.svg"
-    />
-  )
+  return <Base {...props} name={illustrationPath} />
 }
 
 /**
@@ -419,72 +403,52 @@ export const TeamEffectiveness2 = (props: SpotProps) => {
 
 export const WellbeingSurvey = (props: SpotProps) => {
   const theme = useTheme()
-  if (theme.themeKey === "zen") {
-    noZenIllustrationWarning("WellbeingSurvey")
-  }
+  const illustrationPath =
+    theme.themeKey === "zen"
+      ? "illustrations/spot/miscellaneous-blank-survey.svg"
+      : "illustrations/heart/spot/template-library-wellbeing-survey.svg"
 
-  return (
-    <Base
-      {...props}
-      name="illustrations/heart/spot/template-library-wellbeing-survey.svg"
-    />
-  )
+  return <Base {...props} name={illustrationPath} />
 }
 
 export const Response = (props: SpotProps) => {
   const theme = useTheme()
-  if (theme.themeKey === "zen") {
-    noZenIllustrationWarning("Response")
-  }
+  const illustrationPath =
+    theme.themeKey === "zen"
+      ? "illustrations/spot/miscellaneous-blank-survey.svg"
+      : "illustrations/heart/spot/template-library-response.svg"
 
-  return (
-    <Base
-      {...props}
-      name="illustrations/heart/spot/template-library-response.svg"
-    />
-  )
+  return <Base {...props} name={illustrationPath} />
 }
 
 export const RemoteWorkQSet = (props: SpotProps) => {
   const theme = useTheme()
-  if (theme.themeKey === "zen") {
-    noZenIllustrationWarning("RemoteWorkQSet")
-  }
+  const illustrationPath =
+    theme.themeKey === "zen"
+      ? "illustrations/spot/miscellaneous-blank-survey.svg"
+      : "illustrations/heart/spot/template-library-remote-work-q-set.svg"
 
-  return (
-    <Base
-      {...props}
-      name="illustrations/heart/spot/template-library-remote-work-q-set.svg"
-    />
-  )
+  return <Base {...props} name={illustrationPath} />
 }
 
 export const ReturnToWorkplace = (props: SpotProps) => {
   const theme = useTheme()
-  if (theme.themeKey === "zen") {
-    noZenIllustrationWarning("ReturnToWorkplace")
-  }
+  const illustrationPath =
+    theme.themeKey === "zen"
+      ? "illustrations/spot/miscellaneous-blank-survey.svg"
+      : "illustrations/heart/spot/template-library-return-to-workplace.svg"
 
-  return (
-    <Base
-      {...props}
-      name="illustrations/heart/spot/template-library-return-to-workplace.svg"
-    />
-  )
+  return <Base {...props} name={illustrationPath} />
 }
 
 export const PulseSurvey = (props: SpotProps) => {
   const theme = useTheme()
-  if (theme.themeKey === "zen") {
-    noZenIllustrationWarning("PulseSurvey")
-  }
+  const illustrationPath =
+    theme.themeKey === "zen"
+      ? "illustrations/spot/miscellaneous-blank-survey.svg"
+      : "illustrations/heart/spot/template-library-pulse-survey.svg"
 
-  return (
-    <Base
-      {...props}
-      name="illustrations/heart/spot/template-library-pulse-survey.svg"
-    />
-  )
+  return <Base {...props} name={illustrationPath} />
 }
 
 /**

--- a/draft-packages/illustration/KaizenDraft/Illustration/__snapshots__/illustration.spec.tsx.snap
+++ b/draft-packages/illustration/KaizenDraft/Illustration/__snapshots__/illustration.spec.tsx.snap
@@ -695,7 +695,7 @@ exports[`<Illustration /> Spot EmergencyResponse should exist and render an alt 
   <img
     alt="My accessible title"
     class=" wrapper"
-    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/heart/spot/template-library-emergency-response.svg"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/spot/miscellaneous-blank-survey.svg"
   />
 </div>
 `;
@@ -805,7 +805,7 @@ exports[`<Illustration /> Spot GeneralOnboardSurvey should exist and render an a
   <img
     alt="My accessible title"
     class=" wrapper"
-    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/heart/spot/template-library-general-onboard-survey.svg"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/spot/miscellaneous-blank-survey.svg"
   />
 </div>
 `;
@@ -885,7 +885,7 @@ exports[`<Illustration /> Spot LeadingThroughCrisis should exist and render an a
   <img
     alt="My accessible title"
     class=" wrapper"
-    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/heart/spot/template-library-leading-through-crisis.svg"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/spot/miscellaneous-blank-survey.svg"
   />
 </div>
 `;
@@ -1035,7 +1035,7 @@ exports[`<Illustration /> Spot PulseSurvey should exist and render an alt tag 1`
   <img
     alt="My accessible title"
     class=" wrapper"
-    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/heart/spot/template-library-pulse-survey.svg"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/spot/miscellaneous-blank-survey.svg"
   />
 </div>
 `;
@@ -1085,7 +1085,7 @@ exports[`<Illustration /> Spot RemoteOnboardSurvey should exist and render an al
   <img
     alt="My accessible title"
     class=" wrapper"
-    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/heart/spot/template-library-remote-onboard-survey.svg"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/spot/miscellaneous-blank-survey.svg"
   />
 </div>
 `;
@@ -1095,7 +1095,7 @@ exports[`<Illustration /> Spot RemoteWorkQSet should exist and render an alt tag
   <img
     alt="My accessible title"
     class=" wrapper"
-    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/heart/spot/template-library-remote-work-q-set.svg"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/spot/miscellaneous-blank-survey.svg"
   />
 </div>
 `;
@@ -1125,7 +1125,7 @@ exports[`<Illustration /> Spot Response should exist and render an alt tag 1`] =
   <img
     alt="My accessible title"
     class=" wrapper"
-    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/heart/spot/template-library-response.svg"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/spot/miscellaneous-blank-survey.svg"
   />
 </div>
 `;
@@ -1135,7 +1135,7 @@ exports[`<Illustration /> Spot ReturnToWorkplace should exist and render an alt 
   <img
     alt="My accessible title"
     class=" wrapper"
-    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/heart/spot/template-library-return-to-workplace.svg"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/spot/miscellaneous-blank-survey.svg"
   />
 </div>
 `;
@@ -1365,7 +1365,7 @@ exports[`<Illustration /> Spot WellbeingSurvey should exist and render an alt ta
   <img
     alt="My accessible title"
     class=" wrapper"
-    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/heart/spot/template-library-wellbeing-survey.svg"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/spot/miscellaneous-blank-survey.svg"
   />
 </div>
 `;


### PR DESCRIPTION
# Objective

There are a few spot illustrations for templates that are missing Zen equivalents. This PR add automatic fallbacks for these to the Zen “Blank Survey” illustration so that consumers don’t have to think about mapping them.

# Motivation and Context

These illustrations are all "template" illustrations and would need to be mapped manually to the same result within consuming code to avoid having Heart illustrations accidentally bleed into Zen-themed interfaces. Doing the mapping here means that we won’t get accidental mix-ups, and that consumers can still override with more specific fallbacks if they’d like to.

# Screenshots (if appropriate)

<details>
<summary>Zen</summary>

![localhost_6006_iframe html_id=illustration-spot-react--all-spot-illustrations viewMode=story (1)](https://user-images.githubusercontent.com/4353/118422580-d7044480-b706-11eb-97e7-6d576849d92c.png)

</details>

<details>
<summary>Heart</summary>

![localhost_6006_iframe html_id=illustration-spot-react--all-spot-illustrations viewMode=story](https://user-images.githubusercontent.com/4353/118422586-da97cb80-b706-11eb-8c67-fc1048139570.png)

</details>

# Checklist
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] If this contains visual changes, has it been reviewed by a designer?
- [ ] If this introduces either a new component or a breaking change to an existing component, has it been reviewed by an advocate? (Ask in #prod_design_systems)
- [ ] I have considered likely risks of these changes and got someone else to QA as appropriate
- [ ] I have or will communicate these changes to the front end practice

# Additional Considerations
- Does there need to be right-to-left (RTL) options for localization and internationalization?
- Has the test suite been updated?
- Have you done cross-browser testing for our [supported browsers](https://academy.cultureamp.com/hc/en-us/articles/204539569-Supported-browsers-for-Participants)?
- Have you updated any relevant documentation or left useful comments in the code?
- Have you reviewed Culture Amp's Web Accessibility guide [Current Compliance, Going Forward, Statement and Answers for Customers](https://cultureamp.atlassian.net/wiki/spaces/Prod/pages/428572998/Web+Accessibility)?
- If this contains substantial visual changes, especially far reaching ones, have you unlocked the Chromatic step in the pipeline?
- Have Storybook stories been updated?

**If you're new to Kaizen, please ask #prod_design_systems to set up an onboarding session to get you up to speed.** If you have an urgent PR to merge before that happens, it is safest to ask in #prod_design_systems to have a design system advocate review the PR to catch any issues.
