### PR TITLE
fix: Make box-sizing explicit

### DIFF
--- a/packages/component-library/components/Notification/_styles.scss
+++ b/packages/component-library/components/Notification/_styles.scss
@@ -161,6 +161,7 @@ $ca-notification-slide-right: transform $ca-duration-fast ease-out;
 
 %ca-notification__icon {
   align-items: flex-start;
+  box-sizing: content-box;
 
   %ca-notification---affirmative & {
     color: $kz-var-color-seedling-500;
@@ -213,6 +214,7 @@ $ca-notification-slide-right: transform $ca-duration-fast ease-out;
 }
 
 %ca-notification__text-container {
+  box-sizing: content-box;
   display: flex;
   flex-direction: row;
   flex-wrap: wrap;


### PR DESCRIPTION
# Objective

The GlobalNotification shows this bug when used in consumers, but it doesn't show up in Storybook:

![image](https://user-images.githubusercontent.com/6406263/118427027-a83e9c00-b70f-11eb-9ba0-de8c720d8c8d.png)

The bug appears to show because the component sets `box-sizing: border-box` at the top level, and does not reset this to `content-box` for the icon, despite the icon depending on it to show correctly.

# Checklist
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] If this contains visual changes, has it been reviewed by a designer?
- [ ] If this introduces either a new component or a breaking change to an existing component, has it been reviewed by an advocate? (Ask in #prod_design_systems)
- [ ] I have considered likely risks of these changes and got someone else to QA as appropriate
- [ ] I have or will communicate these changes to the front end practice