### PR TITLE
feat: quickfix option for Elm Tooltip to not take up space

### DIFF
--- a/draft-packages/tooltip/ElmStories/TooltipStories.elm
+++ b/draft-packages/tooltip/ElmStories/TooltipStories.elm
@@ -23,4 +23,13 @@ main =
                     )
                     (div [] [ Tag.view (Tag.default |> Tag.inline True) "Above" ])
                 ]
+        , statelessStoryOf "Default - dontTakeUpSpaceWhenHiddenQuickFix" <|
+            div [ style "margin-top" "200px", style "position" "relative" ]
+                [ Tooltip.view
+                    (Tooltip.default "This tooltip does not take up space or cause unwanted scrollbars when not visible. However, there is no animation."
+                        |> Tooltip.position Tooltip.Above
+                        |> Tooltip.dontTakeUpSpaceWhenHiddenQuickFix True
+                    )
+                    (div [] [ Tag.view (Tag.default |> Tag.inline True) "Above" ])
+                ]
         ]

--- a/draft-packages/tooltip/KaizenDraft/Tooltip/Tooltip.elm
+++ b/draft-packages/tooltip/KaizenDraft/Tooltip/Tooltip.elm
@@ -4,6 +4,7 @@ module KaizenDraft.Tooltip.Tooltip exposing
     , Position(..)
     , Variant(..)
     , default
+    , dontTakeUpSpaceWhenHiddenQuickFix
     , position
     , styles
     , toolTip
@@ -21,6 +22,7 @@ type Config
 type alias Configuration =
     { variant : Variant
     , positionAt : Position
+    , dontTakeUpSpaceWhenHiddenQuickFix : Bool
     }
 
 
@@ -51,16 +53,32 @@ position p (Config config) =
     Config { config | positionAt = p }
 
 
+{-| this fixes an issue where the tooltip takes up space even when it is hidden. This can cause ugly & annoying horizontal scrollbars to appear when they shouldn't. Ideally the the tooltip would reposition itself to make use of available space, which would also solve this problem, but that would require a major rewrite.
+
+IMPORTANT NOTE: there is a major caviat with this option: the animation becomes disabled! This is because the div goes from `display: none` to `display: block` at the same time as the animation starts, so it doesn't kick in. So, this should only be used in scenarios where having unwanted scrollbars is worse than not having aniation.
+
+-}
+dontTakeUpSpaceWhenHiddenQuickFix : Bool -> Config -> Config
+dontTakeUpSpaceWhenHiddenQuickFix value (Config config) =
+    Config { config | dontTakeUpSpaceWhenHiddenQuickFix = value }
+
+
 defaults : Configuration
 defaults =
     { variant = Default ""
     , positionAt = Above
+    , dontTakeUpSpaceWhenHiddenQuickFix = False
     }
 
 
 view : Config -> Html msg -> Html msg
 view (Config config) content =
-    div [ styles.class .tooltipWrap ]
+    div
+        [ styles.classList
+            [ ( .tooltipWrap, True )
+            , ( .dontTakeUpSpaceWhenHiddenQuickFix, config.dontTakeUpSpaceWhenHiddenQuickFix )
+            ]
+        ]
         [ content
         , div
             [ styles.classList [ ( .contentWrap, True ), ( .above, config.positionAt == Above ) ] ]
@@ -108,4 +126,5 @@ styles =
         , above = "above"
         , below = "below"
         , shadow = "shadow"
+        , dontTakeUpSpaceWhenHiddenQuickFix = "dontTakeUpSpaceWhenHiddenQuickFix"
         }

--- a/draft-packages/tooltip/KaizenDraft/Tooltip/TooltipElm.scss
+++ b/draft-packages/tooltip/KaizenDraft/Tooltip/TooltipElm.scss
@@ -25,23 +25,6 @@
   text-align: center;
 }
 
-.contentWrap {
-  display: block;
-  width: 400px;
-  position: absolute;
-  transform: translateX(-50%);
-  left: 50%;
-  z-index: 2;
-}
-
-.contentWrap.above {
-  top: 0;
-}
-
-.contentWrap.below {
-  bottom: 0;
-}
-
 .tooltipContent {
   @include kz-typography-paragraph-body($size: 14);
   color: $kz-var-color-wisteria-800;
@@ -72,7 +55,32 @@
 .tooltipWrap {
   position: initial;
   display: inline-block;
+
+  .contentWrap {
+    display: block;
+    width: 400px;
+    position: absolute;
+    transform: translateX(-50%);
+    left: 50%;
+    z-index: 2;
+
+    &.above {
+      top: 0;
+    }
+
+    &.below {
+      bottom: 0;
+    }
+  }
+
+  &.dontTakeUpSpaceWhenHiddenQuickFix .contentWrap {
+    display: none; //hide unless hovering the tooltipWrap. NOTE: this disables the animation as a compromise
+  }
+
   &:hover {
+    .contentWrap {
+      display: block;
+    }
     .above {
       opacity: 1;
       transform: translateX(-50%) translateY(calc(-100% + -6px));

--- a/draft-packages/tooltip/docs/ElmTooltip.stories.tsx
+++ b/draft-packages/tooltip/docs/ElmTooltip.stories.tsx
@@ -6,4 +6,5 @@ const compiledElm = require("../ElmStories/TooltipStories.elm").Elm.ElmStories
 loadElmStories("Tooltip (Elm)", module, compiledElm, [
   "Default - Below",
   "Default - Above",
+  "Default - dontTakeUpSpaceWhenHiddenQuickFix",
 ])


### PR DESCRIPTION
# Objective
There is an issue with the existing tooltip implementation with Elm in that it takes up space when it is hidden. This causes ugly and annoying horizontal scrollbars too appear in confined spaces.

A quick fix is achieved by making `.contentWrap` have `display: none` when the tooltip is not hovered. The downside is that there is no animation.

This adds an optional (not on by default) parameter `dontTakeUpSpaceWhenHiddenQuickFix` that makes the tooltip not take up space, but also disables the animation.

There isn't a simple way to acheive this without completely rewriting the component to use something like popper.js, like has been done for the React version.


# Checklist
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] If this contains visual changes, has it been reviewed by a designer?
- [ ] If this introduces either a new component or a breaking change to an existing component, has it been reviewed by an advocate? (Ask in #prod_design_systems)
- [ ] I have considered likely risks of these changes and got someone else to QA as appropriate
- [ ] I have or will communicate these changes to the front end practice

# Additional Considerations
- Does there need to be right-to-left (RTL) options for localization and internationalization?
- Has the test suite been updated?
- Have you done cross-browser testing for our [supported browsers](https://academy.cultureamp.com/hc/en-us/articles/204539569-Supported-browsers-for-Participants)?
- Have you updated any relevant documentation or left useful comments in the code?
- Have you reviewed Culture Amp's Web Accessibility guide [Current Compliance, Going Forward, Statement and Answers for Customers](https://cultureamp.atlassian.net/wiki/spaces/Prod/pages/428572998/Web+Accessibility)?
- If this contains substantial visual changes, especially far reaching ones, have you unlocked the Chromatic step in the pipeline?
- Have Storybook stories been updated?

**If you're new to Kaizen, please ask #prod_design_systems to set up an onboarding session to get you up to speed.** If you have an urgent PR to merge before that happens, it is safest to ask in #prod_design_systems to have a design system advocate review the PR to catch any issues.
