### PR TITLE
feat: Add 180 versions for performance template library spots

### DIFF
--- a/draft-packages/illustration/KaizenDraft/Illustration/Spot.tsx
+++ b/draft-packages/illustration/KaizenDraft/Illustration/Spot.tsx
@@ -377,6 +377,36 @@ export const Manager360 = (props: SpotProps) => {
   return <Base {...props} name={illustrationPath} />
 }
 
+export const Individual180 = (props: SpotProps) => {
+  const theme = useTheme()
+  const illustrationPath =
+    theme.themeKey === "zen"
+      ? "illustrations/spot/miscellaneous-blank-survey.svg"
+      : "illustrations/heart/spot/template-library-individual-180.svg"
+
+  return <Base {...props} name={illustrationPath} />
+}
+
+export const Leadership180 = (props: SpotProps) => {
+  const theme = useTheme()
+  const illustrationPath =
+    theme.themeKey === "zen"
+      ? "illustrations/spot/miscellaneous-blank-survey.svg"
+      : "illustrations/heart/spot/template-library-leadership-180.svg"
+
+  return <Base {...props} name={illustrationPath} />
+}
+
+export const Manager180 = (props: SpotProps) => {
+  const theme = useTheme()
+  const illustrationPath =
+    theme.themeKey === "zen"
+      ? "illustrations/spot/miscellaneous-blank-survey.svg"
+      : "illustrations/heart/spot/template-library-manager-180.svg"
+
+  return <Base {...props} name={illustrationPath} />
+}
+
 export const TeamEffectiveness1 = (props: SpotProps) => {
   const theme = useTheme()
   const illustrationPath =

--- a/draft-packages/illustration/KaizenDraft/Illustration/__snapshots__/illustration.spec.tsx.snap
+++ b/draft-packages/illustration/KaizenDraft/Illustration/__snapshots__/illustration.spec.tsx.snap
@@ -830,6 +830,16 @@ exports[`<Illustration /> Spot InclusionSurvey should exist and render an alt ta
 </div>
 `;
 
+exports[`<Illustration /> Spot Individual180 should exist and render an alt tag 1`] = `
+<div>
+  <img
+    alt="My accessible title"
+    class=" wrapper"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/spot/miscellaneous-blank-survey.svg"
+  />
+</div>
+`;
+
 exports[`<Illustration /> Spot Individual360 should exist and render an alt tag 1`] = `
 <div>
   <img
@@ -870,6 +880,16 @@ exports[`<Illustration /> Spot LeaderReportSharing should exist and render an al
 </div>
 `;
 
+exports[`<Illustration /> Spot Leadership180 should exist and render an alt tag 1`] = `
+<div>
+  <img
+    alt="My accessible title"
+    class=" wrapper"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/spot/miscellaneous-blank-survey.svg"
+  />
+</div>
+`;
+
 exports[`<Illustration /> Spot Leadership360 should exist and render an alt tag 1`] = `
 <div>
   <img
@@ -881,6 +901,16 @@ exports[`<Illustration /> Spot Leadership360 should exist and render an alt tag 
 `;
 
 exports[`<Illustration /> Spot LeadingThroughCrisis should exist and render an alt tag 1`] = `
+<div>
+  <img
+    alt="My accessible title"
+    class=" wrapper"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/spot/miscellaneous-blank-survey.svg"
+  />
+</div>
+`;
+
+exports[`<Illustration /> Spot Manager180 should exist and render an alt tag 1`] = `
 <div>
   <img
     alt="My accessible title"

--- a/draft-packages/illustration/docs/IllustrationSpot.stories.tsx
+++ b/draft-packages/illustration/docs/IllustrationSpot.stories.tsx
@@ -28,12 +28,15 @@ import {
   Gdpr,
   GeneralOnboardSurvey,
   InclusionSurvey,
+  Individual180,
   Individual360,
   Informative,
   InternSurvey,
   LeaderReportSharing,
+  Leadership180,
   Leadership360,
   LeadingThroughCrisis,
+  Manager180,
   Manager360,
   ManagerLearning,
   ManagerReportSharing,
@@ -237,6 +240,18 @@ export const AllSpotIllustrations = () => {
     {
       Component: Manager360,
       name: "Manager 360",
+    },
+    {
+      Component: Individual180,
+      name: "Individual 180",
+    },
+    {
+      Component: Leadership180,
+      name: "Leadership 180",
+    },
+    {
+      Component: Manager180,
+      name: "Manager 180",
     },
     {
       Component: TeamEffectiveness1,


### PR DESCRIPTION
# Objective

Add 180 versions for template library illustrations: Individual, Manager, and Leadership. We currently only have 360 versions for these.

The illustrations won’t appear in Storybook until https://github.com/cultureamp/kaizen-design-system-assets/pull/34 is merged. Note that because we don’t have Zen versions of these illustrations that we’re falling back to the "Blank Survey" spot like all other Template Library spots.

# Motivation and Context

We have templates that reference 180s but no illustration to match them.

# Screenshots (if appropriate)

<img width="171" alt="image" src="https://user-images.githubusercontent.com/4353/118641429-7a477d80-b81d-11eb-9148-4957559a22b6.png">
<img width="161" alt="image" src="https://user-images.githubusercontent.com/4353/118641446-7ddb0480-b81d-11eb-8bec-f585fc8c0dff.png">
<img width="156" alt="image" src="https://user-images.githubusercontent.com/4353/118641462-82072200-b81d-11eb-87c2-acc00d64d20b.png">

# Checklist
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] If this contains visual changes, has it been reviewed by a designer?
- [ ] If this introduces either a new component or a breaking change to an existing component, has it been reviewed by an advocate? (Ask in #prod_design_systems)
- [ ] I have considered likely risks of these changes and got someone else to QA as appropriate
- [ ] I have or will communicate these changes to the front end practice

# Additional Considerations
- Does there need to be right-to-left (RTL) options for localization and internationalization?
- Has the test suite been updated?
- Have you done cross-browser testing for our [supported browsers](https://academy.cultureamp.com/hc/en-us/articles/204539569-Supported-browsers-for-Participants)?
- Have you updated any relevant documentation or left useful comments in the code?
- Have you reviewed Culture Amp's Web Accessibility guide [Current Compliance, Going Forward, Statement and Answers for Customers](https://cultureamp.atlassian.net/wiki/spaces/Prod/pages/428572998/Web+Accessibility)?
- If this contains substantial visual changes, especially far reaching ones, have you unlocked the Chromatic step in the pipeline?
- Have Storybook stories been updated?

**If you're new to Kaizen, please ask #prod_design_systems to set up an onboarding session to get you up to speed.** If you have an urgent PR to merge before that happens, it is safest to ask in #prod_design_systems to have a design system advocate review the PR to catch any issues.
