### PR TITLE
feat: add wrapping element to illustration

### DIFF
--- a/draft-packages/guidance-block/KaizenDraft/GuidanceBlock/GuidanceBlock.scss
+++ b/draft-packages/guidance-block/KaizenDraft/GuidanceBlock/GuidanceBlock.scss
@@ -50,9 +50,7 @@ $illustration-size: 155px;
   }
 }
 
-.illustration {
-  width: $illustration-size;
-  height: $illustration-size;
+.illustrationWrapper {
   display: flex;
   padding: 0 ($kz-var-spacing-sm);
 
@@ -66,6 +64,11 @@ $illustration-size: 155px;
   @include ca-media-mobile {
     display: none;
   }
+}
+
+.illustration {
+  width: $illustration-size;
+  height: $illustration-size;
 }
 
 .descriptionContainer {

--- a/draft-packages/guidance-block/KaizenDraft/GuidanceBlock/GuidanceBlock.tsx
+++ b/draft-packages/guidance-block/KaizenDraft/GuidanceBlock/GuidanceBlock.tsx
@@ -154,7 +154,9 @@ class GuidanceBlock extends React.Component<
         ref={this.containerRef}
         onTransitionEnd={this.onTransitionEnd}
       >
-        <div className={styles.illustration}>{illustration}</div>
+        <div className={styles.illustrationWrapper}>
+          <div className={styles.illustration}>{illustration}</div>
+        </div>
 
         <div className={styles.descriptionContainer}>
           <div className={styles.headingWrapper}>


### PR DESCRIPTION
Ok... The width and height of the illustration element must be seperate from the element that has padding for the guidance block style. This is because consumers are likely to implement `box-sizing: border-box` which will destroy the dimensions of the image.

Alternatively, the guidance block should _use_ `box-sizing: border-box` but I don't know anymore, I'm losing my
mind. Or it should specify `box-sizing: content-box` to at least combat top level resets?

# Objective
Ah... Originally I wanted to render an image but now I just want out.

# Motivation and Context
Previous PRs can be found here:
https://github.com/cultureamp/kaizen-design-system/pull/1595
https://github.com/cultureamp/kaizen-design-system/pull/1606
https://github.com/cultureamp/kaizen-design-system/pull/1610

# Screenshots (if appropriate)
<img width="1083" alt="1" src="https://user-images.githubusercontent.com/1510005/118654464-b6d6a180-b83c-11eb-8028-9cfe0be35d7b.png">
<img width="1062" alt="2" src="https://user-images.githubusercontent.com/1510005/118654477-ba6a2880-b83c-11eb-8e5e-452a391b4d63.png">

# Checklist
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] If this contains visual changes, has it been reviewed by a designer?
- [ ] If this introduces either a new component or a breaking change to an existing component, has it been reviewed by an advocate? (Ask in #prod_design_systems)
- [ ] I have considered likely risks of these changes and got someone else to QA as appropriate
- [ ] I have or will communicate these changes to the front end practice

# Additional Considerations
- Does there need to be right-to-left (RTL) options for localization and internationalization?
- Has the test suite been updated?
- Have you done cross-browser testing for our [supported browsers](https://academy.cultureamp.com/hc/en-us/articles/204539569-Supported-browsers-for-Participants)?
- Have you updated any relevant documentation or left useful comments in the code?
- Have you reviewed Culture Amp's Web Accessibility guide [Current Compliance, Going Forward, Statement and Answers for Customers](https://cultureamp.atlassian.net/wiki/spaces/Prod/pages/428572998/Web+Accessibility)?
- If this contains substantial visual changes, especially far reaching ones, have you unlocked the Chromatic step in the pipeline?
- Have Storybook stories been updated?

**If you're new to Kaizen, please ask #prod_design_systems to set up an onboarding session to get you up to speed.** If you have an urgent PR to merge before that happens, it is safest to ask in #prod_design_systems to have a design system advocate review the PR to catch any issues.
