### PR TITLE
feat: allow the scale labels to show if the disabledlabel is not provided

### DIFF
--- a/draft-packages/slider/KaizenDraft/Slider/Slider.spec.tsx
+++ b/draft-packages/slider/KaizenDraft/Slider/Slider.spec.tsx
@@ -1,0 +1,73 @@
+import React from "react"
+import { cleanup, render } from "@testing-library/react"
+import "@testing-library/jest-dom"
+
+import { Slider, SliderProps } from "./Slider"
+
+afterEach(cleanup)
+
+const defaultProps: SliderProps = {
+  labelLow: "Low",
+  labelHigh: "High",
+  initialValue: 5,
+}
+
+const renderSlider = (props?: SliderProps) => {
+  const merged = { ...defaultProps, ...props }
+  return render(<Slider {...merged} />)
+}
+
+describe("<Slider />", () => {
+  describe("when disabled not provided", () => {
+    it("the range input is enabled", async () => {
+      const { findByRole } = renderSlider()
+      expect(await findByRole("slider")).not.toBeDisabled()
+    })
+    it("the scale labels are show if the disabledLabel is provided", () => {
+      const { queryByText } = renderSlider({
+        disabledLabel: "Slider Disabled",
+      })
+      expect(queryByText("Low")).not.toBeNull()
+      expect(queryByText("High")).not.toBeNull()
+      expect(queryByText("Slider Disabled")).toBeNull()
+    })
+  })
+  describe("when disabled set to false", () => {
+    it("the range input is enabled", async () => {
+      const { findByRole } = renderSlider({ disabled: false })
+      expect(await findByRole("slider")).not.toBeDisabled()
+    })
+    it("the scale labels are show if the disabledLabel is provided", () => {
+      const { queryByText } = renderSlider({
+        disabled: false,
+        disabledLabel: "Slider Disabled",
+      })
+      expect(queryByText("Low")).not.toBeNull()
+      expect(queryByText("High")).not.toBeNull()
+      expect(queryByText("Slider Disabled")).toBeNull()
+    })
+  })
+  describe("when disabled set to true", () => {
+    it("the range input is disabled", async () => {
+      const { findByRole } = renderSlider({ disabled: true })
+      expect(await findByRole("slider")).toBeDisabled()
+    })
+    it("the scale labels are hidden if the disabledLabel is provided", () => {
+      const { queryByText } = renderSlider({
+        disabled: true,
+        disabledLabel: "Slider Disabled",
+      })
+      expect(queryByText("Low")).toBeNull()
+      expect(queryByText("High")).toBeNull()
+      expect(queryByText("Slider Disabled")).not.toBeNull()
+    })
+    it("the scale labels are shown when no disabledLabel is provided", () => {
+      const { queryByText } = renderSlider({
+        disabled: true,
+      })
+      expect(queryByText("Low")).not.toBeNull()
+      expect(queryByText("High")).not.toBeNull()
+      expect(queryByText("Slider Disabled")).toBeNull()
+    })
+  })
+})

--- a/draft-packages/slider/KaizenDraft/Slider/Slider.tsx
+++ b/draft-packages/slider/KaizenDraft/Slider/Slider.tsx
@@ -31,6 +31,8 @@ export const Slider = ({
   }, [initialValue])
 
   const throttledOnChange = useCallback(throttle(onChange, 200), [onChange])
+  const showDisabledLabel =
+    disabled === true && disabledLabel !== undefined && disabledLabel !== ""
 
   return (
     <div
@@ -60,7 +62,7 @@ export const Slider = ({
         disabled={disabled}
       />
       <div className={styles.labelsContainer}>
-        {!disabled && (
+        {!showDisabledLabel && (
           <div className={styles.sliderLabels}>
             <Paragraph
               variant="extra-small"
@@ -78,7 +80,7 @@ export const Slider = ({
             </Paragraph>
           </div>
         )}
-        {disabled && disabledLabel && (
+        {showDisabledLabel && (
           <Paragraph
             variant="extra-small"
             color="dark-reduced-opacity"


### PR DESCRIPTION
# Objective
When the disabledLabel is not provided the slider will continue to show the low and high labels for the scale.

# Motivation and Context
When using the slider with 1-1s we need to show the scale to the manger who is viewing the slider, but cannot edit the slider.

# Checklist
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] If this contains visual changes, has it been reviewed by a designer?
- [ ] If this introduces either a new component or a breaking change to an existing component, has it been reviewed by an advocate? (Ask in #prod_design_systems)
- [ ] I have considered likely risks of these changes and got someone else to QA as appropriate
- [ ] I have or will communicate these changes to the front end practice

# Additional Considerations
- Does there need to be right-to-left (RTL) options for localization and internationalization?
- Has the test suite been updated?
- Have you done cross-browser testing for our [supported browsers](https://academy.cultureamp.com/hc/en-us/articles/204539569-Supported-browsers-for-Participants)?
- Have you updated any relevant documentation or left useful comments in the code?
- Have you reviewed Culture Amp's Web Accessibility guide [Current Compliance, Going Forward, Statement and Answers for Customers](https://cultureamp.atlassian.net/wiki/spaces/Prod/pages/428572998/Web+Accessibility)?
- If this contains substantial visual changes, especially far reaching ones, have you unlocked the Chromatic step in the pipeline?
- Have Storybook stories been updated?

**If you're new to Kaizen, please ask #prod_design_systems to set up an onboarding session to get you up to speed.** If you have an urgent PR to merge before that happens, it is safest to ask in #prod_design_systems to have a design system advocate review the PR to catch any issues.
