### PR TITLE
chore: Remove (Zen) from Button stories

### DIFF
--- a/draft-packages/button/docs/Button.stories.tsx
+++ b/draft-packages/button/docs/Button.stories.tsx
@@ -8,7 +8,7 @@ import { Button, CustomButtonProps, ButtonRef } from ".."
 import { figmaEmbed } from "../../../storybook/helpers"
 
 export default {
-  title: "Button (Zen) (React)",
+  title: "Button (React)",
   component: Button,
   args: {
     label: "Label",

--- a/draft-packages/button/docs/ElmButton.stories.tsx
+++ b/draft-packages/button/docs/ElmButton.stories.tsx
@@ -3,7 +3,7 @@ import { loadElmStories } from "elm-storybook"
 const compiledElm = require("../ElmStories/ButtonStories.elm").Elm.ElmStories
   .ButtonStories
 
-loadElmStories("Button (Zen) (Elm)", module, compiledElm, [
+loadElmStories("Button (Elm)", module, compiledElm, [
   "Default",
   "Primary",
   "Secondary",


### PR DESCRIPTION
Quick follow up to https://github.com/cultureamp/kaizen-design-system/pull/1632 - remove `(Zen)` from the Button stories because it no longer makes sense.