### PR TITLE
fix: Fix issue with autohide for draft-menu

### DIFF
--- a/draft-packages/menu/KaizenDraft/Menu/MenuDropdown.tsx
+++ b/draft-packages/menu/KaizenDraft/Menu/MenuDropdown.tsx
@@ -60,12 +60,14 @@ const MenuDropdown = ({
       if (
         popperElement &&
         e.target instanceof Node &&
-        !popperElement.contains(e.target)
+        !popperElement.contains(e.target) &&
+        referenceElement !== e.target &&
+        !referenceElement?.contains(e.target)
       ) {
         hideMenuDropdown()
       }
     },
-    [popperElement, hideMenuDropdown]
+    [popperElement, referenceElement, hideMenuDropdown]
   )
 
   const handleDocumentResize = useCallback(() => {
@@ -81,7 +83,7 @@ const MenuDropdown = ({
 
   useEffect(() => {
     if (autoHide !== "off") {
-      document.addEventListener("click", handleDocumentClickForAutoHide, false)
+      document.addEventListener("click", handleDocumentClickForAutoHide, true)
     }
     window.addEventListener("resize", handleDocumentResize, false)
 
@@ -90,7 +92,7 @@ const MenuDropdown = ({
         document.removeEventListener(
           "click",
           handleDocumentClickForAutoHide,
-          false
+          true
         )
       }
       window.removeEventListener("resize", handleDocumentResize, false)

--- a/draft-packages/menu/KaizenDraft/Menu/MenuDropdown.tsx
+++ b/draft-packages/menu/KaizenDraft/Menu/MenuDropdown.tsx
@@ -82,10 +82,17 @@ const MenuDropdown = ({
   }
 
   useEffect(() => {
+    window.addEventListener("resize", handleDocumentResize, false)
+
+    return () => {
+      window.removeEventListener("resize", handleDocumentResize, false)
+    }
+  }, [handleDocumentResize])
+
+  useEffect(() => {
     if (autoHide !== "off") {
       document.addEventListener("click", handleDocumentClickForAutoHide, true)
     }
-    window.addEventListener("resize", handleDocumentResize, false)
 
     return () => {
       if (autoHide !== "off") {
@@ -95,9 +102,8 @@ const MenuDropdown = ({
           true
         )
       }
-      window.removeEventListener("resize", handleDocumentResize, false)
     }
-  }, [autoHide, handleDocumentClickForAutoHide, handleDocumentResize])
+  }, [autoHide, handleDocumentClickForAutoHide])
 
   return (
     <div


### PR DESCRIPTION
# Objective

This moves the event listener that checks for document-level clicks (and decides whether or not to hide the dropdown menu) into the capturing phase rather than the bubbling phase. In doing so we also need to check that the `referenceElement` isn’t the targeted event (or one of its children).

# Motivation and Context

We’re seeing issues in multiple places where multiple `<Menu>` instances are open as users move between menus. I.e., if a user:

1. Opens a menu by clicking on its button
2. Attempts to open a different menu by clicking on its button
3. Both menus would be open

This strangely doesn’t manifest within the Kaizen Storybook (even though it should), but we’ve seen it occur in multiple different consuming applications (comparisons-service, unified-home). The issue occurs because of the `e.stopPropagation()` call within `renderButton` which, like it says on the box, stops the propagation through the bubbling phase of events.

# Checklist
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] If this contains visual changes, has it been reviewed by a designer?
- [ ] If this introduces either a new component or a breaking change to an existing component, has it been reviewed by an advocate? (Ask in #prod_design_systems)
- [ ] I have considered likely risks of these changes and got someone else to QA as appropriate
- [ ] I have or will communicate these changes to the front end practice

# Additional Considerations
- Does there need to be right-to-left (RTL) options for localization and internationalization?
- Has the test suite been updated?
- Have you done cross-browser testing for our [supported browsers](https://academy.cultureamp.com/hc/en-us/articles/204539569-Supported-browsers-for-Participants)?
- Have you updated any relevant documentation or left useful comments in the code?
- Have you reviewed Culture Amp's Web Accessibility guide [Current Compliance, Going Forward, Statement and Answers for Customers](https://cultureamp.atlassian.net/wiki/spaces/Prod/pages/428572998/Web+Accessibility)?
- If this contains substantial visual changes, especially far reaching ones, have you unlocked the Chromatic step in the pipeline?
- Have Storybook stories been updated?

**If you're new to Kaizen, please ask #prod_design_systems to set up an onboarding session to get you up to speed.** If you have an urgent PR to merge before that happens, it is safest to ask in #prod_design_systems to have a design system advocate review the PR to catch any issues.
