### PR TITLE
feat: visually centre rating slider dot on default

### DIFF
--- a/draft-packages/slider/KaizenDraft/Slider/Slider.spec.tsx
+++ b/draft-packages/slider/KaizenDraft/Slider/Slider.spec.tsx
@@ -89,5 +89,11 @@ describe("<Slider />", () => {
       fireEvent.change(slider, { target: { value: 4.5 } })
       expect(slider).not.toHaveValue("4.5")
     })
+    it("a fractional number should round correctly", async () => {
+      const { findByRole } = renderSlider()
+      const slider = await findByRole("slider")
+      fireEvent.change(slider, { target: { value: 6.5 } })
+      expect(slider).toHaveValue("7")
+    })
   })
 })

--- a/draft-packages/slider/KaizenDraft/Slider/Slider.spec.tsx
+++ b/draft-packages/slider/KaizenDraft/Slider/Slider.spec.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { cleanup, render } from "@testing-library/react"
+import { cleanup, fireEvent, render } from "@testing-library/react"
 import "@testing-library/jest-dom"
 
 import { Slider, SliderProps } from "./Slider"
@@ -9,7 +9,7 @@ afterEach(cleanup)
 const defaultProps: SliderProps = {
   labelLow: "Low",
   labelHigh: "High",
-  initialValue: 5,
+  initialValue: 5.5,
 }
 
 const renderSlider = (props?: SliderProps) => {
@@ -68,6 +68,26 @@ describe("<Slider />", () => {
       expect(queryByText("Low")).not.toBeNull()
       expect(queryByText("High")).not.toBeNull()
       expect(queryByText("Slider Disabled")).toBeNull()
+    })
+  })
+  describe("when no initial value is provided", () => {
+    it("the value should default", async () => {
+      const { findByRole } = renderSlider()
+      expect(await findByRole("slider")).toHaveValue("5.5")
+    })
+  })
+  describe("when the value is changed", () => {
+    it("a whole number should work", async () => {
+      const { findByRole } = renderSlider()
+      const slider = await findByRole("slider")
+      fireEvent.change(slider, { target: { value: 6 } })
+      expect(slider).toHaveValue("6")
+    })
+    it("a fractional number should fail", async () => {
+      const { findByRole } = renderSlider()
+      const slider = await findByRole("slider")
+      fireEvent.change(slider, { target: { value: 4.5 } })
+      expect(slider).not.toHaveValue("4.5")
     })
   })
 })

--- a/draft-packages/slider/KaizenDraft/Slider/Slider.tsx
+++ b/draft-packages/slider/KaizenDraft/Slider/Slider.tsx
@@ -16,7 +16,7 @@ export interface SliderProps {
 
 export const Slider = ({
   automationId,
-  initialValue,
+  initialValue = 5.5, // Set default dot to visually center
   disabled = false,
   onChange = () => undefined,
   labelLow = "Not at all",
@@ -24,6 +24,7 @@ export const Slider = ({
   disabledLabel,
 }: SliderProps) => {
   const [value, setValue] = useState(initialValue)
+  const [step, setStep] = useState(0.5) // Let the dot center between the notch initially
 
   // Update local value if a new initialValue is received from the server
   useEffect(() => {
@@ -49,14 +50,15 @@ export const Slider = ({
         role="slider"
         min="1"
         max="10"
-        step="1"
-        value={value || 5}
-        aria-valuenow={value || 5}
+        step={step}
+        value={value}
+        aria-valuenow={value}
         aria-valuemin={1}
         aria-valuemax={10}
         onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+          setStep(1) // Put the stepper to 1 to avoid floating value
           const v = Number.parseFloat(e.target.value)
-          setValue(v)
+          setValue(Math.round(v))
           throttledOnChange(Math.round(v)) // Save final rounded value
         }}
         disabled={disabled}


### PR DESCRIPTION
# Objective
Currently, the default Slider component has the dot slightly off-center. To give a symmetrical view in the ui, design agrees to make this change across our products - to show it at the center initially.

# Motivation and Context
When user lands in a page with default Sliders, the ui looks a bit unpolished/unfinished. The rating in our system is saved as a whole number (DB). For the slider to be at the center (UI), it had to accept a floating number. Hence, on the first load - the step is set to accept a floating number, in the event the user changes the position of slider, it goes back to whole number stepping and stays as our existing implementation + behaviour.

# Screenshots

https://user-images.githubusercontent.com/26585669/119603689-01ee4700-be31-11eb-8fa7-9deffa8c4fe0.mov

# Checklist
- [x] If this contains visual changes, has it been reviewed by a designer?
- [ ] If this introduces either a new component or a breaking change to an existing component, has it been reviewed by an advocate? (Ask in #prod_design_systems)
- [ ] I have considered likely risks of these changes and got someone else to QA as appropriate
- [x] I have or will communicate these changes to the front end practice

# Additional Considerations
Yes - Has the test suite been updated?
Yes - Have you done cross-browser testing for our [supported browsers](https://academy.cultureamp.com/hc/en-us/articles/204539569-Supported-browsers-for-Participants)?
Yes - Have you updated any relevant documentation or left useful comments in the code?
