### PR TITLE
fix: Only add aria-labelledby when Icon is meaningful img

### DIFF
--- a/draft-packages/collapsible/KaizenDraft/Collapsible/__snapshots__/Collapsible.spec.tsx.snap
+++ b/draft-packages/collapsible/KaizenDraft/Collapsible/__snapshots__/Collapsible.spec.tsx.snap
@@ -24,7 +24,6 @@ exports[`matches snapshot with everything enabled 1`] = `
         <div>
           <svg
             aria-hidden="true"
-            aria-labelledby="80284680-3304-5869-9788-7428e6c6ee86"
             class="icon"
             focusable="false"
             role="presentation"
@@ -79,7 +78,6 @@ exports[`matches snapshot with everything enabled 1`] = `
         <div>
           <svg
             aria-hidden="true"
-            aria-labelledby="80284680-3304-5869-9788-7428e6c6ee86"
             class="icon"
             focusable="false"
             role="presentation"

--- a/draft-packages/tile/KaizenDraft/Tile/__snapshots__/Tile.spec.tsx.snap
+++ b/draft-packages/tile/KaizenDraft/Tile/__snapshots__/Tile.spec.tsx.snap
@@ -120,7 +120,6 @@ exports[`<InformationTile /> snapshots renders InformationTile with information 
               >
                 <svg
                   aria-hidden="true"
-                  aria-labelledby="80284680-3304-5869-9788-7428e6c6ee86"
                   class="icon"
                   focusable="false"
                   role="presentation"
@@ -192,7 +191,6 @@ exports[`<InformationTile /> snapshots renders InformationTile with information 
               >
                 <svg
                   aria-hidden="true"
-                  aria-labelledby="80284680-3304-5869-9788-7428e6c6ee86"
                   class="icon"
                   focusable="false"
                   role="presentation"

--- a/packages/component-library/components/Icon/Icon.tsx
+++ b/packages/component-library/components/Icon/Icon.tsx
@@ -56,12 +56,12 @@ const Icon: Icon = ({
 
   const labelledBy =
     // read out title and description together if both are present
-    isMeaningfulImg && desc ? `${titleId} ${descId}` : `${titleId}`
+    desc ? `${titleId} ${descId}` : `${titleId}`
 
   const accessibilityProps = {
     role,
     ["aria-hidden"]: !isMeaningfulImg,
-    ["aria-labelledby"]: labelledBy,
+    ["aria-labelledby"]: isMeaningfulImg && labelledBy ? labelledBy : undefined,
   }
 
   return (

--- a/packages/component-library/components/Notification/__snapshots__/GlobalNotification.spec.tsx.snap
+++ b/packages/component-library/components/Notification/__snapshots__/GlobalNotification.spec.tsx.snap
@@ -11,7 +11,6 @@ exports[`The basic notification renders correctly 1`] = `
   >
     <svg
       aria-hidden="true"
-      aria-labelledby="80284680-3304-5869-9788-7428e6c6ee86"
       class="icon inheritSize"
       focusable="false"
       role="presentation"
@@ -69,7 +68,6 @@ exports[`You can change the type 1`] = `
   >
     <svg
       aria-hidden="true"
-      aria-labelledby="80284680-3304-5869-9788-7428e6c6ee86"
       class="icon inheritSize"
       focusable="false"
       role="presentation"

--- a/packages/component-library/components/Notification/__snapshots__/InlineNotification.spec.tsx.snap
+++ b/packages/component-library/components/Notification/__snapshots__/InlineNotification.spec.tsx.snap
@@ -11,7 +11,6 @@ exports[`Persistent versions of the notifications work 1`] = `
   >
     <svg
       aria-hidden="true"
-      aria-labelledby="80284680-3304-5869-9788-7428e6c6ee86"
       class="icon inheritSize"
       focusable="false"
       role="presentation"
@@ -49,7 +48,6 @@ exports[`The basic notification renders correctly 1`] = `
   >
     <svg
       aria-hidden="true"
-      aria-labelledby="80284680-3304-5869-9788-7428e6c6ee86"
       class="icon inheritSize"
       focusable="false"
       role="presentation"


### PR DESCRIPTION
Closes https://github.com/cultureamp/kaizen-design-system/issues/1289

I'd imagine this is what the original author was trying to do here. At the moment `aria-labelledby` is always added to the Icon svg, but it links to nothing if the Icon isn't a meaningful image and the `<title>` part hasn't been added.