### PR TITLE
feat: elm tag allow text wrapping option + dismiss button size fix

### DIFF
--- a/draft-packages/form/ElmStories/SelectFieldStories.elm
+++ b/draft-packages/form/ElmStories/SelectFieldStories.elm
@@ -141,6 +141,7 @@ main =
                     [ SelectField.view
                         (SelectField.multi
                             { truncationWidth = Just 300
+                            , allowTextWrapping = False
                             , selectedItems = List.map buildMenuItem state.selectedItems
                             , toMsg = SelectMsg
                             , id = "multi-select-searchable-demo"

--- a/draft-packages/form/KaizenDraft/Form/SelectField/SelectField.elm
+++ b/draft-packages/form/KaizenDraft/Form/SelectField/SelectField.elm
@@ -104,6 +104,7 @@ single required =
 
 multi :
     { truncationWidth : Maybe Float
+    , allowTextWrapping : Bool
     , selectedItems : List (Select.MenuItem item)
     , toMsg : ToMsg msg item
     , id : String
@@ -118,7 +119,9 @@ multi required =
         { config
             | variant =
                 Select.Multi
-                    { truncationWidth = required.truncationWidth }
+                    { truncationWidth = required.truncationWidth
+                    , allowTextWrapping = required.allowTextWrapping
+                    }
                     required.selectedItems
             , id = required.id
         }

--- a/draft-packages/select/ElmStories/SelectStories.elm
+++ b/draft-packages/select/ElmStories/SelectStories.elm
@@ -107,7 +107,7 @@ main =
                 Html.map SelectMsg <|
                     div [ style "width" "500px", style "margin-top" "12px" ]
                         [ Select.view
-                            (Select.multi { truncationWidth = Just 300 } (List.map buildMenuItem m.selectedMembers)
+                            (Select.multi { truncationWidth = Just 300, allowTextWrapping = False } (List.map buildMenuItem m.selectedMembers)
                                 |> Select.state m.selectState
                                 |> Select.menuItems (List.map buildMenuItem m.members)
                                 |> Select.searchable True

--- a/draft-packages/select/KaizenDraft/Select/Select.elm
+++ b/draft-packages/select/KaizenDraft/Select/Select.elm
@@ -192,7 +192,9 @@ type alias Configuration item =
 
 
 type alias MultiSelectTagConfig =
-    { truncationWidth : Maybe Float }
+    { truncationWidth : Maybe Float
+    , allowTextWrapping : Bool
+    }
 
 
 type SelectType
@@ -1077,7 +1079,7 @@ viewDummyInput viewDummyInputData =
 
 
 viewMultiValue : MultiSelectTagConfig -> InitialMousedown -> Int -> MenuItem item -> Html (Msg item)
-viewMultiValue { truncationWidth } mousedownedItem index menuItem =
+viewMultiValue { truncationWidth, allowTextWrapping } mousedownedItem index menuItem =
     let
         isMousedowned =
             case mousedownedItem of
@@ -1102,6 +1104,13 @@ viewMultiValue { truncationWidth } mousedownedItem index menuItem =
                 Nothing ->
                     tagConfig
 
+        resolveAllowTextWrapping tagConfig =
+            if allowTextWrapping then
+                Tag.allowTextWrapping True tagConfig
+
+            else
+                tagConfig
+
         resolveVariant =
             case menuItem.menuItemType of
                 Default ->
@@ -1125,6 +1134,7 @@ viewMultiValue { truncationWidth } mousedownedItem index menuItem =
                             |> Tag.onMousedown (MultiItemFocus index)
                             |> Tag.inline True
                             |> resolveTruncationWidth
+                            |> resolveAllowTextWrapping
                             |> resolveMouseleave
                         )
                         mi.label

--- a/draft-packages/tag/ElmStories/TagStories.elm
+++ b/draft-packages/tag/ElmStories/TagStories.elm
@@ -108,4 +108,22 @@ main =
                 , Tag.view (Tag.sentiment Tag.SentimentPositive |> Tag.inline True |> Tag.dismissible True) "Inline"
                 , Tag.view (Tag.validation Tag.ValidationPositive |> Tag.inline True |> Tag.dismissible True) "Inline"
                 ]
+        , statelessStoryOf "Medium - Allow Text Wrapping" <|
+            storyContainer
+                [ div
+                    [ style "width" "200px" ]
+                    [ Tag.view (Tag.default |> Tag.dismissible True |> Tag.allowTextWrapping True) "Normal 1"
+                    , Tag.view (Tag.default |> Tag.dismissible True |> Tag.allowTextWrapping True) "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras semper erat eget nisl porta congue. Vivamus in ipsum ut nisi cursus interdum eget eget felis. Mauris maximus cursus mauris."
+                    , Tag.view (Tag.default |> Tag.dismissible True |> Tag.allowTextWrapping True) "Normal 2"
+                    ]
+                ]
+        , statelessStoryOf "Small - Allow Text Wrapping" <|
+            storyContainer
+                [ div
+                    [ style "width" "200px" ]
+                    [ Tag.view (Tag.default |> Tag.size Tag.Small |> Tag.dismissible True |> Tag.allowTextWrapping True) "Normal 1"
+                    , Tag.view (Tag.default |> Tag.size Tag.Small |> Tag.dismissible True |> Tag.allowTextWrapping True) "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras semper erat eget nisl porta congue. Vivamus in ipsum ut nisi cursus interdum eget eget felis. Mauris maximus cursus mauris."
+                    , Tag.view (Tag.default |> Tag.size Tag.Small |> Tag.dismissible True |> Tag.allowTextWrapping True) "Normal 2"
+                    ]
+                ]
         ]

--- a/draft-packages/tag/KaizenDraft/Tag/Tag.elm
+++ b/draft-packages/tag/KaizenDraft/Tag/Tag.elm
@@ -334,9 +334,11 @@ viewClear config =
                 ]
     in
     span ([ styles.class .dismissIcon ] ++ events)
-        [ Icon.view (Icon.presentation |> Icon.inheritSize True)
-            (svgAsset "@kaizen/component-library/icons/clear.icon.svg")
-            |> Html.map never
+        [ div [ styles.class .iconWrapper ]
+            [ Icon.view (Icon.presentation |> Icon.inheritSize True)
+                (svgAsset "@kaizen/component-library/icons/clear.icon.svg")
+                |> Html.map never
+            ]
         ]
 
 
@@ -367,4 +369,5 @@ styles =
         , textContent = "textContent"
         , pulse = "pulse"
         , pulseRing = "pulseRing"
+        , iconWrapper = "iconWrapper"
         }

--- a/draft-packages/tag/KaizenDraft/Tag/Tag.elm
+++ b/draft-packages/tag/KaizenDraft/Tag/Tag.elm
@@ -3,6 +3,7 @@ module KaizenDraft.Tag.Tag exposing
     , Size(..)
     , Status(..)
     , Validation(..)
+    , allowTextWrapping
     , default
     , dismissible
     , inline
@@ -39,6 +40,7 @@ type alias Configuration msg =
     , onMousedown : Maybe msg
     , onMouseleave : Maybe msg
     , truncationWidth : Maybe Float
+    , allowTextWrapping : Bool
     }
 
 
@@ -133,6 +135,11 @@ truncateWidth width (Config config) =
     Config { config | truncationWidth = Just width }
 
 
+allowTextWrapping : Bool -> Config msg -> Config msg
+allowTextWrapping value (Config config) =
+    Config { config | allowTextWrapping = value }
+
+
 
 -- root class adds margin right, inline removes all margins.
 
@@ -152,6 +159,7 @@ defaults =
     , onMousedown = Nothing
     , onMouseleave = Nothing
     , truncationWidth = Nothing
+    , allowTextWrapping = False
     }
 
 
@@ -250,13 +258,21 @@ view (Config config) value =
     div
         [ styles.classList
             ([ ( .root, True )
-             , ( .medium, config.size == Medium )
-             , ( .small, config.size == Small )
+             , ( .medium, config.size == Medium && not config.allowTextWrapping )
+             , ( .small, config.size == Small && not config.allowTextWrapping )
              , ( .inline, config.inline )
              , ( .dismissible, config.dismissible )
              ]
                 ++ resolveVariantStyle
             )
+        , stylesElmExtra.classList
+            [ ( .mediumAllowingTextWrapping
+              , config.size == Medium && config.allowTextWrapping
+              )
+            , ( .smallAllowingTextWrapping
+              , config.size == Small && config.allowTextWrapping
+              )
+            ]
         ]
         [ div [ styles.class .layoutContainer ]
             [ resolveValidationIcon
@@ -370,4 +386,11 @@ styles =
         , pulse = "pulse"
         , pulseRing = "pulseRing"
         , iconWrapper = "iconWrapper"
+        }
+
+
+stylesElmExtra =
+    css "@kaizen/draft-tag/KaizenDraft/Tag/TagElmExtra.scss"
+        { mediumAllowingTextWrapping = "mediumAllowingTextWrapping"
+        , smallAllowingTextWrapping = "smallAllowingTextWrapping"
         }

--- a/draft-packages/tag/KaizenDraft/Tag/TagElmExtra.scss
+++ b/draft-packages/tag/KaizenDraft/Tag/TagElmExtra.scss
@@ -1,0 +1,13 @@
+@import "./Tag.scss";
+
+.mediumAllowingTextWrapping {
+  min-height: $medium;
+  padding-top: 4px; // padding required because vertical centering doesn't work with min-height
+  padding-bottom: 4px;
+}
+
+.smallAllowingTextWrapping {
+  min-height: $small;
+  padding-top: 1px; // padding required because vertical centering doesn't work with min-height
+  padding-bottom: 1px;
+}

--- a/draft-packages/tag/docs/ElmTag.stories.tsx
+++ b/draft-packages/tag/docs/ElmTag.stories.tsx
@@ -22,4 +22,6 @@ loadElmStories("Tag (Elm)", module, compiledElm, [
   "Status - Draft",
   "Status - Closed",
   "Status - Action",
+  "Medium - Allow Text Wrapping",
+  "Small - Allow Text Wrapping",
 ])


### PR DESCRIPTION
**NOTE: Elm only, no code that is consumed by React has been touched**

### allow text wrapping option
This is a option to deal with tags with user generated content
that is so large that the text escapes the available horizontal
space (such as in a multi-select field). Currently the tag
completely breaks if this happens. There's an existing option
to add truncation (ellipsis) with a fixed max width, but the problem
with that is there is no tooltip, there is no way to distinguish
tags that start with the same text (this is a real problem in production)

Ideally, we'd implement the tooltip when the tag truncates (as is specified in the docs for Tag), but this
is unfortunately in the way too hard basket for Elm. You need to measure
the width of the text with an effect, and then the component requires state
to keep track of it - it would be a major change to the component. Not only
would it be difficult to implement but it would be a major headache for consumers. Is it worth it for a technology we have contained?

So, as a quick fix, this option allows the tag's content to grow vertically so
that it can be read, and is in response to an urgent required fix in production.

Before

<img width="234" alt="image" src="https://user-images.githubusercontent.com/702885/120573699-5e6cea00-c461-11eb-9265-65869572b14c.png">

after

<img width="238" alt="image" src="https://user-images.githubusercontent.com/702885/120573761-780e3180-c461-11eb-82b3-c5c9ced2ec97.png">

(the lack of vertical margin is expected - you have to add it yourself, that's just how the component already was - this isn't a problem in multi-select widget which adds it, this is just to demonstrate the wrapping. Also it's Zen theme because I forgot to switch themes when getting the screenshots)


### fix the dismiss button size
In doing this PR, I discovered that the Elm dismiss button became way too large recently. This has been fixed (it must have been introduced when the React Tag was changed without the Elm tag being tested)

before

<img width="221" alt="image" src="https://user-images.githubusercontent.com/702885/120573930-b99edc80-c461-11eb-8f0f-b9fb11604af2.png">

after

<img width="198" alt="image" src="https://user-images.githubusercontent.com/702885/120573964-c7546200-c461-11eb-91ab-5c6fd5c5cc7d.png">


