### PR TITLE
fix: add new survey statuses to title block zen component

### DIFF
--- a/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/TitleBlockZen.spec.tsx
+++ b/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/TitleBlockZen.spec.tsx
@@ -1,9 +1,10 @@
 import "./matchMedia.mock"
 
 import { configure, fireEvent } from "@testing-library/dom"
-import { cleanup, render, waitFor } from "@testing-library/react"
+import { cleanup, render, waitFor, screen } from "@testing-library/react"
 import * as React from "react"
-import { NavigationTab, TitleBlockZen } from "./index"
+import { TitleBlockZen } from "./index"
+import "@testing-library/jest-dom"
 
 configure({
   testIdAttribute: "data-automation-id",
@@ -642,6 +643,32 @@ describe("<TitleBlockZen />", () => {
     })
   })
 
+  describe("survey status", () => {
+    it("it doesn't render tag when field is omitted", async () => {
+      render(<TitleBlockZen title="Test Title">Example</TitleBlockZen>)
+
+      await waitFor(() => {
+        expect(
+          screen.queryByTestId("survey-status-tag")
+        ).not.toBeInTheDocument()
+      })
+    })
+    it("it renders tag with correct text and variant when draft status", async () => {
+      render(
+        <TitleBlockZen
+          title="Test Title"
+          surveyStatus={{ text: "draft text", status: "draft" }}
+        >
+          Example
+        </TitleBlockZen>
+      )
+
+      const tagElement = await (await screen.findByTestId("survey-status-tag"))
+        .firstChild
+      expect(tagElement).toHaveTextContent("draft text")
+      expect(tagElement).toHaveClass("statusDraft")
+    })
+  })
   describe("automation ID behaviour", () => {
     describe("when default automation IDs are not provided alongside required conditional renders", () => {
       it("renders the default automation IDs", () => {

--- a/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/TitleBlockZen.spec.tsx
+++ b/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/TitleBlockZen.spec.tsx
@@ -653,20 +653,40 @@ describe("<TitleBlockZen />", () => {
         ).not.toBeInTheDocument()
       })
     })
-    it("it renders tag with correct text and variant when draft status", async () => {
-      render(
-        <TitleBlockZen
-          title="Test Title"
-          surveyStatus={{ text: "draft text", status: "draft" }}
-        >
-          Example
-        </TitleBlockZen>
-      )
 
-      const tagElement = await (await screen.findByTestId("survey-status-tag"))
-        .firstChild
-      expect(tagElement).toHaveTextContent("draft text")
-      expect(tagElement).toHaveClass("statusDraft")
+    const surveyStatuses = ["draft", "live", "closed", "scheduled"]
+    const statusClassNameMap = {
+      draft: "statusDraft",
+      live: "statusLive",
+      closed: "statusClosed",
+      scheduled: "statusClosed",
+    }
+    surveyStatuses.forEach(status => {
+      it(`it renders tag with correct text and variant when ${status} status`, async () => {
+        render(
+          <TitleBlockZen
+            title="Test Title"
+            surveyStatus={{
+              text: `${status} text`,
+              status: `${status}` as
+                | "draft"
+                | "live"
+                | "scheduled"
+                | "closed"
+                | "default",
+            }}
+          >
+            Example
+          </TitleBlockZen>
+        )
+
+        const tagElement = await (
+          await screen.findByTestId("survey-status-tag")
+        ).firstChild
+
+        expect(tagElement).toHaveTextContent(`${status} text`)
+        expect(tagElement).toHaveClass(statusClassNameMap[status])
+      })
     })
   })
   describe("automation ID behaviour", () => {

--- a/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/TitleBlockZen.spec.tsx
+++ b/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/TitleBlockZen.spec.tsx
@@ -654,15 +654,14 @@ describe("<TitleBlockZen />", () => {
       })
     })
 
-    const surveyStatuses = ["draft", "live", "closed", "scheduled"]
-    const statusClassNameMap = {
-      draft: "statusDraft",
-      live: "statusLive",
-      closed: "statusClosed",
-      scheduled: "statusClosed",
-    }
-    surveyStatuses.forEach(status => {
-      it(`it renders tag with correct text and variant when ${status} status`, async () => {
+    it.each([
+      ["draft", "statusDraft"],
+      ["live", "statusLive"],
+      ["closed", "statusClosed"],
+      ["scheduled", "statusClosed"],
+    ])(
+      "it renders tag with correct text and variant when %s status",
+      async (status, expectedClassName) => {
         render(
           <TitleBlockZen
             title="Test Title"
@@ -680,14 +679,13 @@ describe("<TitleBlockZen />", () => {
           </TitleBlockZen>
         )
 
-        const tagElement = await (
-          await screen.findByTestId("survey-status-tag")
-        ).firstChild
+        const tagElement = (await screen.findByTestId("survey-status-tag"))
+          .firstChild
 
         expect(tagElement).toHaveTextContent(`${status} text`)
-        expect(tagElement).toHaveClass(statusClassNameMap[status])
-      })
-    })
+        expect(tagElement).toHaveClass(expectedClassName)
+      }
+    )
   })
   describe("automation ID behaviour", () => {
     describe("when default automation IDs are not provided alongside required conditional renders", () => {

--- a/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/TitleBlockZen.tsx
+++ b/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/TitleBlockZen.tsx
@@ -164,7 +164,7 @@ type TextDirection = "ltr" | "rtl"
 
 type SurveyStatus = {
   text: string
-  status: "draft" | "live" | "default"
+  status: "draft" | "live" | "scheduled" | "closed" | "default"
 }
 
 type Breadcrumb = {
@@ -178,8 +178,24 @@ const renderTag = (surveyStatus: SurveyStatus) => {
   if (surveyStatus.status === "draft") {
     tagVariant = "statusDraft"
   }
+
+  /*
+    scheduled is actually a draft survey status that has a launch job scheduled
+    still, we want to differentiate on the UI and render a specific tag
+    the styles must be identical to the draft style
+
+    we have similar behaviour on programs index page's table
+  */
+  if (surveyStatus.status === "scheduled") {
+    tagVariant = "statusDraft"
+  }
+
   if (surveyStatus.status === "live") {
     tagVariant = "statusLive"
+  }
+
+  if (surveyStatus.status === "closed") {
+    tagVariant = "statusClosed"
   }
 
   if (surveyStatus.status === "default") {
@@ -187,7 +203,7 @@ const renderTag = (surveyStatus: SurveyStatus) => {
   }
 
   return (
-    <div className={styles.tag}>
+    <div data-automation-id="survey-status-tag" className={styles.tag}>
       <Tag variant={tagVariant} size="small">
         {surveyStatus.text}
       </Tag>

--- a/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/TitleBlockZen.tsx
+++ b/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/TitleBlockZen.tsx
@@ -187,7 +187,7 @@ const renderTag = (surveyStatus: SurveyStatus) => {
     we have similar behaviour on programs index page's table
   */
   if (surveyStatus.status === "scheduled") {
-    tagVariant = "statusDraft"
+    tagVariant = "statusClosed"
   }
 
   if (surveyStatus.status === "live") {

--- a/draft-packages/title-block-zen/docs/TitleBlockZen.stories.tsx
+++ b/draft-packages/title-block-zen/docs/TitleBlockZen.stories.tsx
@@ -8,7 +8,7 @@ import arrowForwardIcon from "@kaizen/component-library/icons/arrow-forward.icon
 import { assetUrl } from "@kaizen/hosted-assets"
 import { Container, Content, Skirt, SkirtCard } from "@kaizen/draft-page-layout"
 import { withDesign } from "storybook-addon-designs"
-import { Story } from "@storybook/react"
+import { Args, Story } from "@storybook/react"
 import { NavigationTab, TitleBlockZen } from ".."
 import { figmaEmbed } from "../../../storybook/helpers"
 
@@ -62,7 +62,7 @@ const DefaultTemplate = args => (
   </OffsetPadding>
 )
 
-export const Default: Story<React.ReactNode> = DefaultTemplate.bind({})
+export const Default: Story<Args> = DefaultTemplate.bind({})
 Default.args = {
   title: "Page title",
   surveyStatus: { text: "Live", status: "live" },

--- a/draft-packages/title-block-zen/docs/TitleBlockZen.stories.tsx
+++ b/draft-packages/title-block-zen/docs/TitleBlockZen.stories.tsx
@@ -8,6 +8,7 @@ import arrowForwardIcon from "@kaizen/component-library/icons/arrow-forward.icon
 import { assetUrl } from "@kaizen/hosted-assets"
 import { Container, Content, Skirt, SkirtCard } from "@kaizen/draft-page-layout"
 import { withDesign } from "storybook-addon-designs"
+import { Story } from "@storybook/react"
 import { NavigationTab, TitleBlockZen } from ".."
 import { figmaEmbed } from "../../../storybook/helpers"
 
@@ -55,57 +56,60 @@ const SECONDARY_ACTIONS = [
   },
 ]
 
-export const Default = () => (
+const DefaultTemplate = args => (
   <OffsetPadding>
-    <TitleBlockZen
-      title="Page title"
-      surveyStatus={{ text: "Live", status: "live" }}
-      primaryAction={{
-        label: "Primary link",
-        icon: addIcon,
-        disabled: true,
-        href: "#",
-      }}
-      defaultAction={{
-        label: "Default link",
-        href: "#",
-      }}
-      secondaryActions={SECONDARY_ACTIONS}
-      secondaryOverflowMenuItems={[
-        {
-          action: () => {
-            alert("test")
-          },
-          label: "Overflow action 1",
-          icon: starIcon,
-        },
-        {
-          action: "#",
-          label: "Overflow link 1",
-          icon: starIcon,
-        },
-      ]}
-      handleHamburgerClick={() => {
-        alert("Hamburger clicked")
-      }}
-      breadcrumb={{
-        path: "#",
-        text: "Back to home",
-        handleClick: event => {
-          alert("breadcrumb clicked!")
-        },
-      }}
-      navigationTabs={[
-        <NavigationTab text="Label" href="#" active />,
-        <NavigationTab text="Label" href="#" />,
-        <NavigationTab text="Label" href="#" />,
-        <NavigationTab text="Label" href="#" />,
-        <NavigationTab text="Label" href="#" />,
-        <NavigationTab text="Label" href="#" />,
-      ]}
-    />
+    <TitleBlockZen {...args} />
   </OffsetPadding>
 )
+
+export const Default: Story<React.ReactNode> = DefaultTemplate.bind({})
+Default.args = {
+  title: "Page title",
+  surveyStatus: { text: "Live", status: "live" },
+  primaryAction: {
+    label: "Primary link",
+    icon: addIcon,
+    disabled: true,
+    href: "#",
+  },
+  defaultAction: {
+    label: "Default link",
+    href: "#",
+  },
+  secondaryActions: SECONDARY_ACTIONS,
+  secondaryOverflowMenuItems: [
+    {
+      action: () => {
+        alert("test")
+      },
+      label: "Overflow action 1",
+      icon: starIcon,
+    },
+    {
+      action: "#",
+      label: "Overflow link 1",
+      icon: starIcon,
+    },
+  ],
+  handleHamburgerClick: () => {
+    alert("Hamburger clicked")
+  },
+  breadcrumb: {
+    path: "#",
+    text: "Back to home",
+    handleClick: event => {
+      alert("breadcrumb clicked!")
+    },
+  },
+  navigationTabs: () => [
+    <NavigationTab text="Label" href="#" active />,
+    <NavigationTab text="Label" href="#" />,
+    <NavigationTab text="Label" href="#" />,
+    <NavigationTab text="Label" href="#" />,
+    <NavigationTab text="Label" href="#" />,
+    <NavigationTab text="Label" href="#" />,
+  ],
+}
 
 Default.storyName = "Default"
 


### PR DESCRIPTION
# Objective
make the title block zen component support the scheduled and closed statuses

# Motivation and Context
When the title block is showing a survey config or report page we show a tag next to the survey title with the status of the survey. When we released title block in Jun 2020, the title block zen had only "draft", "live" and "default" states. The reality is that a survey can have more than that. This changes silently broke a feature released in Oct 2019 by engagement camp where it showed the scheduled status on the title block.
More context in the github issue description: https://github.com/cultureamp/kaizen-design-system/issues/1669

# Screenshots (if appropriate)

![Screen Shot 2021-06-04 at 3 52 03 pm](https://user-images.githubusercontent.com/995875/120752324-d8c66880-c54c-11eb-8768-fe7925ffe462.png)


# Checklist
- [x] If this contains visual changes, has it been reviewed by a designer?
- [x] If this introduces either a new component or a breaking change to an existing component, has it been reviewed by an advocate? (Ask in #prod_design_systems)
- [x] I have considered likely risks of these changes and got someone else to QA as appropriate
- [x] I have or will communicate these changes to the front end practice

# Additional Considerations
- Does there need to be right-to-left (RTL) options for localization and internationalization?
- Has the test suite been updated?
- Have you done cross-browser testing for our [supported browsers](https://academy.cultureamp.com/hc/en-us/articles/204539569-Supported-browsers-for-Participants)?
- Have you updated any relevant documentation or left useful comments in the code?
- Have you reviewed Culture Amp's Web Accessibility guide [Current Compliance, Going Forward, Statement and Answers for Customers](https://cultureamp.atlassian.net/wiki/spaces/Prod/pages/428572998/Web+Accessibility)?
- If this contains substantial visual changes, especially far reaching ones, have you unlocked the Chromatic step in the pipeline?
- Have Storybook stories been updated?
