### PR TITLE
chore: Default Storybook to Heart

### DIFF
--- a/storybook/theme-switcher-addon/themeManager.ts
+++ b/storybook/theme-switcher-addon/themeManager.ts
@@ -1,17 +1,12 @@
 /* eslint-disable import/no-extraneous-dependencies */
-import {
-  defaultTheme,
-  heartTheme,
-  ThemeManager,
-  zenTheme,
-} from "@kaizen/design-tokens"
+import { heartTheme, ThemeManager, zenTheme } from "@kaizen/design-tokens"
 import { THEME_KEY_STORE_KEY } from "./constants"
 export const themeOfKey = (themeKey: string) => {
   switch (themeKey) {
-    case "heart":
-      return heartTheme
-    default:
+    case "zen":
       return zenTheme
+    default:
+      return heartTheme
   }
 }
 
@@ -19,7 +14,9 @@ export const getInitialTheme = () =>
   themeOfKey(
     window.location.search.match(/(\?|\&)theme=(zen|heart)/)?.[2] ||
       localStorage.getItem(THEME_KEY_STORE_KEY) ||
-      defaultTheme.themeKey
+      "heart"
+    // ^This should ideally be `defaultTheme.themeKey` (defaultTheme imported from kaizen/design-tokens)
+    // but this has been manually overridden to "heart" to avoid having to wait for that change (which has other factors blocking it)
   )
 
 export const themeManager = new ThemeManager(getInitialTheme())


### PR DESCRIPTION
The Storybook theme switcher add on is defaulting to Zen. Now that we've GA'ed Heart, let's switch this to default to Heart instead.
