### PR TITLE
chore: Add dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,4 @@
-version: 1
+version: 2
 updates:
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 5
+    ignore:
+      - depedency-name: "*"
+        update-types: ["version-update:semver-patch"]

--- a/storybook/theme-switcher-addon/themeManager.ts
+++ b/storybook/theme-switcher-addon/themeManager.ts
@@ -1,17 +1,12 @@
 /* eslint-disable import/no-extraneous-dependencies */
-import {
-  defaultTheme,
-  heartTheme,
-  ThemeManager,
-  zenTheme,
-} from "@kaizen/design-tokens"
+import { heartTheme, ThemeManager, zenTheme } from "@kaizen/design-tokens"
 import { THEME_KEY_STORE_KEY } from "./constants"
 export const themeOfKey = (themeKey: string) => {
   switch (themeKey) {
-    case "heart":
-      return heartTheme
-    default:
+    case "zen":
       return zenTheme
+    default:
+      return heartTheme
   }
 }
 
@@ -19,7 +14,9 @@ export const getInitialTheme = () =>
   themeOfKey(
     window.location.search.match(/(\?|\&)theme=(zen|heart)/)?.[2] ||
       localStorage.getItem(THEME_KEY_STORE_KEY) ||
-      defaultTheme.themeKey
+      "heart"
+    // ^This should ideally be `defaultTheme.themeKey` (defaultTheme imported from kaizen/design-tokens)
+    // but this has been manually overridden to "heart" to avoid having to wait for that change (which has other factors blocking it)
   )
 
 export const themeManager = new ThemeManager(getInitialTheme())


### PR DESCRIPTION
# Objective
This config will supercede the org-level defaults for Dependabot. 

**If you're new to Kaizen, please ask #prod_design_systems to set up an onboarding session to get you up to speed.** If you have an urgent PR to merge before that happens, it is safest to ask in #prod_design_systems to have a design system advocate review the PR to catch any issues.
