### PR TITLE
fix: remove stylelint color-named rule

### DIFF
--- a/stylelint.config.js
+++ b/stylelint.config.js
@@ -4,12 +4,6 @@ module.exports = {
     "no-duplicate-at-import-rules": true,
     "block-no-empty": true,
     "block-opening-brace-space-before": "always",
-    "color-named": [
-      "always-where-possible",
-      {
-        severity: "warning",
-      },
-    ],
     "declaration-bang-space-after": "never",
     "comment-no-empty": true,
     "no-duplicate-selectors": true,


### PR DESCRIPTION
https://github.com/cultureamp/kaizen-design-system/issues/1049

we don't use color names like "white" in Kaizen, so we shouldn't warn when not using them. (https://stylelint.io/user-guide/rules/list/color-named/)

### before
(noisy warnings)
```
packages/design-tokens/sass/color-vars.scss
 313:48  ⚠  Expected "#ffffff" to be "white"   color-named

packages/design-tokens/sass/color.scss
 48:18  ⚠  Expected "#ffffff" to be "white"   color-named

✨  Done in 1.43s.
```

### after
(no noise)
```
✨  Done in 1.65s.
```
