### PR TITLE
ci: Allow consumption of private @cultureamp packages

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -2,6 +2,7 @@ env:
   KAIZEN_ROLE_ARN: ${BRANCH_ROLE_ARN}
   KAIZEN_DOMAIN_NAME: ${BRANCH_DOMAIN_NAME}
   KAIZEN_DISTRIBUTION_ID: ${BRANCH_DISTRIBUTION_ID}
+  GITHUB_REGISTRY_TOKEN: ${GITHUB_REGISTRY_TOKEN}
 
 x-defaults: &defaults
   agent_query_rules: ["queue=build-unrestricted"]

--- a/.buildkite/scripts/build-site.sh
+++ b/.buildkite/scripts/build-site.sh
@@ -1,5 +1,8 @@
 #!/bin/sh
 set -e
+ 
+# shellcheck source=setup-registry.sh
+. ".buildkite/scripts/helpers/setup-registry.sh"
 
 export GATSBY_TELEMETRY_DISABLED=true
 

--- a/.buildkite/scripts/build-storybook.sh
+++ b/.buildkite/scripts/build-storybook.sh
@@ -1,6 +1,9 @@
 #!/bin/sh
 set -e
 
+# shellcheck source=setup-registry.sh
+. ".buildkite/scripts/helpers/setup-registry.sh"
+
 yarn install --frozen-lockfile
 yarn storybook:build
 tar -czf ./storybook.tar.gz ./storybook/public

--- a/.buildkite/scripts/compile.sh
+++ b/.buildkite/scripts/compile.sh
@@ -1,5 +1,8 @@
 #!/bin/sh
 set -e
 
+# shellcheck source=setup-registry.sh
+. ".buildkite/scripts/helpers/setup-registry.sh"
+
 yarn install --frozen-lockfile
 yarn tsc

--- a/.buildkite/scripts/helpers/setup-registry.sh
+++ b/.buildkite/scripts/helpers/setup-registry.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -e
+
+echo "Authenticating against the GitHub package registry"
+npm config set "//npm.pkg.github.com/:_authToken" "${GITHUB_REGISTRY_TOKEN}"
+
+printf "Logged in as: "
+npm whoami --registry=https://npm.pkg.github.com

--- a/.buildkite/scripts/helpers/setup-registry.sh
+++ b/.buildkite/scripts/helpers/setup-registry.sh
@@ -2,7 +2,10 @@
 set -e
 
 echo "Authenticating against the GitHub package registry"
-npm config set "//npm.pkg.github.com/:_authToken" "${GITHUB_REGISTRY_TOKEN}"
+# NOTE: we are adding a literal ${GITHUB_REGISTRY_TOKEN} to the npm config here;
+#       npm/yarn will interpret it and sub in the environment variable for us,
+#       meaning we don't have to store the secret on disk.
+npm config set "//npm.pkg.github.com/:_authToken" '${GITHUB_REGISTRY_TOKEN}'
 
 printf "Logged in as: "
 npm whoami --registry=https://npm.pkg.github.com

--- a/.buildkite/scripts/lint.sh
+++ b/.buildkite/scripts/lint.sh
@@ -1,5 +1,8 @@
 #!/bin/sh
 set -e
 
+# shellcheck source=setup-registry.sh
+. ".buildkite/scripts/helpers/setup-registry.sh"
+
 yarn install --frozen-lockfile
 yarn lint

--- a/.buildkite/scripts/release.sh
+++ b/.buildkite/scripts/release.sh
@@ -4,6 +4,9 @@ set -e
 # shellcheck source=helpers/get-secret.sh
 . ".buildkite/scripts/helpers/get-secret.sh"
 
+# shellcheck source=setup-registry.sh
+. ".buildkite/scripts/helpers/setup-registry.sh"
+
 GITHUB_SSH_HOST_KEY="
 github.com ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXY
 PCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mU

--- a/.buildkite/scripts/run-chromatic-build.sh
+++ b/.buildkite/scripts/run-chromatic-build.sh
@@ -4,6 +4,9 @@ set -e
 # shellcheck source=helpers/get-secret.sh
 . ".buildkite/scripts/helpers/get-secret.sh"
 
+# shellcheck source=setup-registry.sh
+. ".buildkite/scripts/helpers/setup-registry.sh"
+
 export CHROMATIC_APP_CODE
 CHROMATIC_APP_CODE=$(get_secret "chromatic-app-code") || exit $?
 

--- a/.buildkite/scripts/test-react-16.sh
+++ b/.buildkite/scripts/test-react-16.sh
@@ -1,5 +1,8 @@
 #!/bin/sh
 set -e
 
+# shellcheck source=setup-registry.sh
+. ".buildkite/scripts/helpers/setup-registry.sh"
+
 yarn install --frozen-lockfile
 yarn test --ci

--- a/.buildkite/scripts/test-react-17.sh
+++ b/.buildkite/scripts/test-react-17.sh
@@ -1,6 +1,9 @@
 #!/bin/sh
 set -e
 
+# shellcheck source=setup-registry.sh
+. ".buildkite/scripts/helpers/setup-registry.sh"
+
 yarn install --frozen-lockfile
 
 USE_REACT_17=true yarn test --ci

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+@cultureamp:registry=https://npm.pkg.github.com/

--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ To learn more, see the designer section of the [Contributing guidelines](./CONTR
 
 ## Getting started
 
+### Setup
+Set up access to private Culture Amp packages on your laptop. You will need to update `~.npmrc` with a Github token linked to your account. Refer to the [instructions here](https://github.com/cultureamp/node-packages/blob/master/how-to-setup-a-project-to-use-private-cultureamp-packages.md). 
+
+### Installation
 To begin developing the design system locally, run the following from the repository root:
 
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,7 @@ x-defaults: &defaults
     - KAIZEN_BASE_PATH
     - GITHUB_STATUS_TOKEN
     - BUILDKITE_BRANCH
+    - GITHUB_REGISTRY_TOKEN
 
 services:
   build:

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "clean:storybook": "rimraf 'storybook/public'",
     "clean": "lerna run clean && yarn gatsby clean && yarn clean:storybook && rimraf 'elm-stuff'",
     "reset": "yarn clean && yarn install --force",
-    "chromatic": "chromatic"
+    "chromatic": "chromatic",
+    "preinstall": "scripts/check-if-authenticated-to-github-registry.bash"
   },
   "babel": {
     "presets": [

--- a/scripts/check-if-authenticated-to-github-registry.bash
+++ b/scripts/check-if-authenticated-to-github-registry.bash
@@ -9,7 +9,8 @@ else
   echo
   echo "You need to log into the GitHub package registry to install private @cultureamp packages."
   echo
-  echo "Follow: https://github.com/cultureamp/node-packages/blob/master/README.md"
+  echo "Read this to find out how:"
+  echo "  https://github.com/cultureamp/node-packages/blob/master/how-to-use-private-cultureamp-packages-on-your-laptop.md"
   echo
   exit 1
 fi

--- a/scripts/check-if-authenticated-to-github-registry.bash
+++ b/scripts/check-if-authenticated-to-github-registry.bash
@@ -1,0 +1,15 @@
+#!/usr/bin/env sh
+set -u
+
+registry_user=$(npm whoami --registry "https://npm.pkg.github.com/")
+
+if [ $? -eq 0 ] || [ ! -z "$registry_user" ]; then
+  echo "Logged in to GitHub package registry as: ${registry_user}"
+else
+  echo
+  echo "You need to log into the GitHub package registry to install private @cultureamp packages."
+  echo
+  echo "Follow: https://github.com/cultureamp/node-packages/blob/master/README.md"
+  echo
+  exit 1
+fi


### PR DESCRIPTION
# Objective
Setup build so that we have the _option_ of consuming private packages in this repo in the future. 

This will allow us to share webpack config so that Kaizen configs do not need to be maintained separately. 