### PR TITLE
fix: Update Collapsible colours to be more Heart compatible

### DIFF
--- a/draft-packages/collapsible/KaizenDraft/Collapsible/styles.scss
+++ b/draft-packages/collapsible/KaizenDraft/Collapsible/styles.scss
@@ -5,7 +5,8 @@
 @import "~@kaizen/component-library/styles/border";
 @import "~@kaizen/component-library/styles/animation";
 
-$heading-active-color: $kz-var-color-wisteria-100;
+$heading-active-color: rgba($kz-var-color-slate-rgb-params, 0.05);
+$border-color: rgba($kz-var-color-slate-rgb-params, 0.2);
 
 // We need a full border radius on this container element, then have classes
 // beneath to toggle nested borders off and on for different use cases.
@@ -36,7 +37,7 @@ $heading-active-color: $kz-var-color-wisteria-100;
 // is open we remove the rounded edge as the content sits beneath and needs to be straight.
 .groupItem {
   & + .groupItem {
-    border-top: 1px solid $ca-border-color;
+    border-top: 1px solid $border-color;
   }
 
   &:first-of-type > .button {
@@ -87,7 +88,7 @@ $heading-active-color: $kz-var-color-wisteria-100;
 }
 
 .clearVariant {
-  border-bottom: 1px solid $kz-var-color-wisteria-200;
+  border-bottom: 1px solid $border-color;
 }
 
 .sticky {


### PR DESCRIPTION
# Objective
Getting rid of purple background and borders on the Collapsible component.

This component hasn't been added to the UI Kit yet so it hasn't had a proper Heart uplift on the design or code side, this will tide us over until then.

# Screenshots (if appropriate)

Before (Zen):
![image](https://user-images.githubusercontent.com/1811583/121270467-2522f700-c905-11eb-91e6-0660268c0393.png)

Before (Heart):
![image](https://user-images.githubusercontent.com/1811583/121270640-6f0bdd00-c905-11eb-9df3-54020a10ac14.png)

After (Zen):
![image](https://user-images.githubusercontent.com/1811583/121270556-4b489700-c905-11eb-9981-e29c2c099e0c.png)

After (Heart):
![image](https://user-images.githubusercontent.com/1811583/121270598-5ef3fd80-c905-11eb-8825-73af4122115d.png)


# Checklist
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] If this contains visual changes, has it been reviewed by a designer?
- [ ] If this introduces either a new component or a breaking change to an existing component, has it been reviewed by an advocate? (Ask in #prod_design_systems)
- [ ] I have considered likely risks of these changes and got someone else to QA as appropriate
- [ ] I have or will communicate these changes to the front end practice

# Additional Considerations
- Does there need to be right-to-left (RTL) options for localization and internationalization?
- Has the test suite been updated?
- Have you done cross-browser testing for our [supported browsers](https://academy.cultureamp.com/hc/en-us/articles/204539569-Supported-browsers-for-Participants)?
- Have you updated any relevant documentation or left useful comments in the code?
- Have you reviewed Culture Amp's Web Accessibility guide [Current Compliance, Going Forward, Statement and Answers for Customers](https://cultureamp.atlassian.net/wiki/spaces/Prod/pages/428572998/Web+Accessibility)?
- If this contains substantial visual changes, especially far reaching ones, have you unlocked the Chromatic step in the pipeline?
- Have Storybook stories been updated?

**If you're new to Kaizen, please ask #prod_design_systems to set up an onboarding session to get you up to speed.** If you have an urgent PR to merge before that happens, it is safest to ask in #prod_design_systems to have a design system advocate review the PR to catch any issues.
