### PR TITLE
fix: change elm select "faded" placeholder from wisteria-300 to 800

### DIFF
--- a/draft-packages/select/ElmStories/SelectStories.elm
+++ b/draft-packages/select/ElmStories/SelectStories.elm
@@ -144,4 +144,15 @@ main =
                             )
                             (Select.selectIdentifier "Single Clearable Select")
                         ]
+        , storyOf "Single, no placeholder (test case)" config <|
+            \m ->
+                Html.map SelectMsg <|
+                    div [ style "width" "300px", style "margin-top" "12px" ]
+                        [ Select.view
+                            (Select.single (buildSelected m)
+                                |> Select.state m.selectState
+                                |> Select.menuItems (List.map buildMenuItem m.members)
+                            )
+                            (Select.selectIdentifier "single-no-placeholder")
+                        ]
         ]

--- a/draft-packages/select/KaizenDraft/Select/styles.elm.scss
+++ b/draft-packages/select/KaizenDraft/Select/styles.elm.scss
@@ -88,7 +88,7 @@
 }
 
 .faded {
-  color: $kz-var-color-wisteria-300;
+  color: $kz-var-color-wisteria-800;
 }
 
 .bold {
@@ -97,7 +97,7 @@
 }
 
 .fadedBold {
-  color: $kz-var-color-wisteria-300;
+  color: $kz-var-color-wisteria-800;
   font-weight: $ca-weight-book;
 }
 

--- a/draft-packages/select/docs/ElmSelect.stories.tsx
+++ b/draft-packages/select/docs/ElmSelect.stories.tsx
@@ -14,6 +14,7 @@ loadElmStories(
     "Multi-Select Searchable",
     "Single Clearable",
     "Single Disabled",
+    "Single, no placeholder (test case)",
   ],
   Ports
 )


### PR DESCRIPTION
wisteria-300 is that ugly pink colour. This now matches the
React component for the default styling of a placeholder for
a select component.

before

<img width="370" alt="image" src="https://user-images.githubusercontent.com/702885/121316114-52df5e80-c94c-11eb-8ee2-8f96c37d94de.png">

after

<img width="355" alt="image" src="https://user-images.githubusercontent.com/702885/121316165-638fd480-c94c-11eb-8bcc-082e54a892db.png">

the React version (for reference)

<img width="348" alt="image" src="https://user-images.githubusercontent.com/702885/121316341-94700980-c94c-11eb-8428-d32574e24dbb.png">

