### PR TITLE
fix: Remove hasRendered state from ModalHeader

### DIFF
--- a/draft-packages/modal/KaizenDraft/Modal/Primitives/ModalHeader.tsx
+++ b/draft-packages/modal/KaizenDraft/Modal/Primitives/ModalHeader.tsx
@@ -13,32 +13,9 @@ export interface ModalHeaderProps {
   readonly children: React.ReactNode
 }
 
-export interface ModalHeaderState {
-  hasRendered: boolean
-}
-
-class ModalHeader extends React.Component<ModalHeaderProps, ModalHeaderState> {
-  state = { hasRendered: false }
-
-  componentDidMount() {
-    requestAnimationFrame(() => this.setState({ hasRendered: true }))
-  }
-
+class ModalHeader extends React.Component<ModalHeaderProps> {
   render() {
     const { unpadded, reversed, onDismiss, children } = this.props
-    const { hasRendered } = this.state
-
-    // The dismiss button in the header is the first focusable element in
-    // the modal DOM so it would typically receive keyboard focus automatically
-    // when the modal opens
-
-    // For more natural behaviour, the keyboard focus shouldn't be moved
-    // immediately to the dismiss button over other focusable elements in the
-    // modal like the primary and secondary actions
-
-    // So, remove the dismiss button from the tab ordering when the modal first
-    // opens then restore it to the native tab ordering after rendering
-    const disableDismissButtonFocus = !hasRendered
 
     return (
       <GenericModalSection unpadded={unpadded}>
@@ -49,9 +26,6 @@ class ModalHeader extends React.Component<ModalHeaderProps, ModalHeaderState> {
             reversed={reversed}
             onClick={onDismiss}
             disabled={onDismiss == undefined}
-            disableTabFocusAndIUnderstandTheAccessibilityImplications={
-              disableDismissButtonFocus
-            }
           />
         </div>
         {children}


### PR DESCRIPTION
# Objective
In `performance-ui`, when I'm writing tests that render modals, in the happy, multiple-`it`s-passing case, I end up polluting the console with:

```
    Warning: Can't perform a React state update on an unmounted component. This is a no-op, but it indicates a memory leak in your application. To fix, cancel all subscriptions and asynchronous tasks in the componentWillUnmount method.
        in ModalHeader (created by InformationModal)
```

I think this is because the ModalHeader has a setState in a requestAnimationFrame and I guess our tests are so damn good that we're unmounting too quickly?

To add a mount check, I needed to make `GenericModalSection` accept a forwardRef. So I made this a feat?

# Motivation and Context
I tried avoiding this in user-land but it's not possible to mock internal references that these components have to themselves so e.g

```
jest.mock("@kaizen/draft-modal", () => ({ ...requireActual('@kaizen/draft-modal'), ModalHeader: 'div' }))
```
Doesn't fly.

# Screenshots (if appropriate)

# Checklist
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] If this contains visual changes, has it been reviewed by a designer?
- [ ] If this introduces either a new component or a breaking change to an existing component, has it been reviewed by an advocate? (Ask in #prod_design_systems)
- [ ] I have considered likely risks of these changes and got someone else to QA as appropriate
- [ ] I have or will communicate these changes to the front end practice

# Additional Considerations
- Does there need to be right-to-left (RTL) options for localization and internationalization?
- Has the test suite been updated?
- Have you done cross-browser testing for our [supported browsers](https://academy.cultureamp.com/hc/en-us/articles/204539569-Supported-browsers-for-Participants)?
- Have you updated any relevant documentation or left useful comments in the code?
- Have you reviewed Culture Amp's Web Accessibility guide [Current Compliance, Going Forward, Statement and Answers for Customers](https://cultureamp.atlassian.net/wiki/spaces/Prod/pages/428572998/Web+Accessibility)?
- If this contains substantial visual changes, especially far reaching ones, have you unlocked the Chromatic step in the pipeline?
- Have Storybook stories been updated?

**If you're new to Kaizen, please ask #prod_design_systems to set up an onboarding session to get you up to speed.** If you have an urgent PR to merge before that happens, it is safest to ask in #prod_design_systems to have a design system advocate review the PR to catch any issues.
