### PR TITLE
fix: Stop propagation at top of modal

### DIFF
--- a/draft-packages/modal/KaizenDraft/Modal/Primitives/GenericModal.tsx
+++ b/draft-packages/modal/KaizenDraft/Modal/Primitives/GenericModal.tsx
@@ -180,6 +180,7 @@ class GenericModal extends React.Component<GenericModalProps> {
         enter={styles.animatingEnter}
         leave={styles.animatingLeave}
         data-generic-modal-transition-wrapper
+        onClick={(e: React.MouseEvent) => e.stopPropagation()}
       >
         <FocusLock
           disabled={focusLockDisabled}


### PR DESCRIPTION
# Objective

The modal was causing issues on the Unified Home task list, where if you open it via the overflow menu on a task, its click events bubble up and trigger the click event on the task row, which opens the list of subtasks.

I confirmed that this was happening by logging the value of `e.target` and `e.currentTarget` on the task list row's click handler, and sure enough `e.target` showed whichever node of the modal that I clicked on, including just clicking anywhere on the div (not a button).

This PR stops event propagation at the top level of the modal to fix this issue in any future cases as well. I have called `stopPropagation` on the `Transition` component because it is the highest node in the DOM – if I called it any further down the tree, it would break functionality around dismissing the modal by clicking outside it.

Example of the bug:

![2021-06-10 13 26 52](https://user-images.githubusercontent.com/6406263/121460130-c5ede100-c9ef-11eb-9eb8-6a70a9ae2148.gif)

# Checklist
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] If this contains visual changes, has it been reviewed by a designer?
- [x] If this introduces either a new component or a breaking change to an existing component, has it been reviewed by an advocate? (Ask in #prod_design_systems)
- [ ] I have considered likely risks of these changes and got someone else to QA as appropriate
- [ ] I have or will communicate these changes to the front end practice
