### PR TITLE
feat: Add responsiveness to BrandMoment

### DIFF
--- a/packages/brand-moment/package.json
+++ b/packages/brand-moment/package.json
@@ -41,11 +41,11 @@
   },
   "devDependencies": {
     "@kaizen/design-tokens": "^2.9.0",
+    "@kaizen/draft-select": "^1.16.2",
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
     "@kaizen/design-tokens": "^2.8.2",
-    "@kaizen/draft-select": "^1.16.2",
     "react": "^16.9.0"
   }
 }

--- a/packages/brand-moment/package.json
+++ b/packages/brand-moment/package.json
@@ -45,6 +45,7 @@
   },
   "peerDependencies": {
     "@kaizen/design-tokens": "^2.8.2",
+    "@kaizen/draft-select": "^1.16.2",
     "react": "^16.9.0"
   }
 }

--- a/packages/brand-moment/src/BrandMoment.scss
+++ b/packages/brand-moment/src/BrandMoment.scss
@@ -73,6 +73,7 @@ $breakpoint-xl: 1366px; // TODO: create an xl breakpoint in design-tokens and re
   flex: 1 0 auto;
   display: flex;
   align-items: center;
+  margin-bottom: $kz-var-spacing-xxl;
 }
 
 .mainInner {
@@ -149,7 +150,7 @@ $breakpoint-xl: 1366px; // TODO: create an xl breakpoint in design-tokens and re
   border-top: 1px solid $kz-var-color-wisteria-800;
   border-left: 1px solid $kz-var-color-wisteria-800;
   padding: $kz-var-spacing-sm $kz-var-spacing-md;
-  margin: $kz-var-spacing-xxl 0 $kz-var-spacing-lg;
+  margin: 0 0 $kz-var-spacing-lg;
 }
 
 .poweredByContainer {

--- a/packages/brand-moment/src/BrandMoment.scss
+++ b/packages/brand-moment/src/BrandMoment.scss
@@ -144,6 +144,8 @@ $breakpoint-xl: 1366px; // TODO: create an xl breakpoint in design-tokens and re
 }
 
 .footerInner {
+  display: flex;
+  flex-direction: column;
   border-top: 1px solid $kz-var-color-wisteria-800;
   border-left: 1px solid $kz-var-color-wisteria-800;
   padding: $kz-var-spacing-sm $kz-var-spacing-md;
@@ -151,22 +153,38 @@ $breakpoint-xl: 1366px; // TODO: create an xl breakpoint in design-tokens and re
 }
 
 .poweredByContainer {
-  display: flex;
-  margin: $kz-var-spacing-sm 0;
-}
-
-.poweredByText {
   flex: 0 0 auto;
-  margin-right: $kz-var-spacing-xs;
+  order: 2;
+  display: flex;
 }
 
-@media (min-width: $kz-layout-breakpoints-medium) {
+.footerTextContainer {
+  flex: 1 1 auto;
+  order: 1;
+  margin-bottom: $kz-var-spacing-md;
+}
+
+.poweredByLogo {
+  margin-left: $kz-var-spacing-xs;
+
+  > img {
+    max-width: 133px;
+  }
+}
+
+@media (min-width: $kz-layout-breakpoints-large) {
   .footerInner {
-    display: flex;
+    flex-direction: row;
     align-items: center;
   }
 
-  .poweredByContainer {
+  .footerTextContainer {
+    order: initial;
     margin-bottom: 0;
+    margin-left: $kz-var-spacing-md;
+  }
+
+  .poweredByContainer {
+    order: initial;
   }
 }

--- a/packages/brand-moment/src/BrandMoment.scss
+++ b/packages/brand-moment/src/BrandMoment.scss
@@ -1,9 +1,16 @@
 @import "~@kaizen/design-tokens/sass/color-vars";
 @import "~@kaizen/design-tokens/sass/spacing-vars";
+@import "~@kaizen/design-tokens/sass/layout";
+@import "~@kaizen/design-tokens/sass/layout-vars";
+
+$breakpoint-xl: 1366px; // TODO: create an xl breakpoint in design-tokens and replace this out
+
+// --------------------------------
+// Body
+// --------------------------------
 
 .body {
   width: 100%;
-  height: 100vh;
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -21,23 +28,81 @@
   }
 }
 
+@media (min-width: $kz-layout-breakpoints-large) {
+  .body {
+    min-height: 100vh;
+  }
+}
+
+// --------------------------------
+// Reusable container
+// --------------------------------
+
+.container {
+  max-width: $kz-var-layout-content-max-width;
+  margin: 0 auto;
+  padding: 0 $kz-var-spacing-md;
+}
+
+@media (min-width: $kz-layout-breakpoints-large) {
+  .container {
+    padding: 0 $kz-var-spacing-xxl;
+  }
+}
+
+@media (min-width: $breakpoint-xl) {
+  .container {
+    padding: 0 $kz-var-spacing-xxxxl;
+  }
+}
+
+// --------------------------------
+// Header
+// --------------------------------
+
 .header {
   width: 100%;
   margin-bottom: $kz-var-spacing-md;
 }
 
+// --------------------------------
+// Main
+// --------------------------------
+
 .main {
-  width: 100%;
   flex: 1 0 auto;
   display: flex;
+  align-items: center;
+}
+
+.mainInner {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: $kz-var-spacing-xl $kz-var-spacing-lg;
+  align-items: center;
+}
+
+@media (min-width: $kz-layout-breakpoints-medium) {
+  .mainInner {
+    row-gap: $kz-var-spacing-xxl;
+  }
+}
+
+@media (min-width: $kz-layout-breakpoints-large) {
+  .mainInner {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+
+@media (min-width: $breakpoint-xl) {
+  .mainInner {
+    column-gap: $kz-var-spacing-xxxxl;
+  }
 }
 
 .left {
-  flex: 1 1 50%;
   display: flex;
-  justify-content: flex-end;
-  align-items: center;
-  padding: 0 $kz-var-spacing-xl;
+  justify-content: center;
 }
 
 .leftInner {
@@ -46,11 +111,10 @@
 }
 
 .right {
-  flex: 1 1 50%;
   flex-direction: column;
   display: flex;
   justify-content: center;
-  padding: 0 $kz-var-spacing-xl;
+  align-items: center;
 }
 
 .rightInner {
@@ -61,22 +125,48 @@
   display: flex;
 }
 
+@media (min-width: $kz-layout-breakpoints-large) {
+  .left {
+    justify-content: flex-end;
+  }
+
+  .right {
+    align-items: flex-start;
+  }
+}
+
+// --------------------------------
+// Footer
+// --------------------------------
+
 .footer {
-  display: flex;
-  align-items: center;
   flex: 0 0 auto;
+}
+
+.footerInner {
   border-top: 1px solid $kz-var-color-wisteria-800;
   border-left: 1px solid $kz-var-color-wisteria-800;
-  padding: $kz-var-spacing-sm;
-  margin: $kz-var-spacing-lg;
-  max-width: 1392px;
+  padding: $kz-var-spacing-sm $kz-var-spacing-md;
+  margin: $kz-var-spacing-xxl 0 $kz-var-spacing-lg;
 }
 
 .poweredByContainer {
   display: flex;
+  margin: $kz-var-spacing-sm 0;
 }
 
 .poweredByText {
-  flex: 1 0 auto;
+  flex: 0 0 auto;
   margin-right: $kz-var-spacing-xs;
+}
+
+@media (min-width: $kz-layout-breakpoints-medium) {
+  .footerInner {
+    display: flex;
+    align-items: center;
+  }
+
+  .poweredByContainer {
+    margin-bottom: 0;
+  }
 }

--- a/packages/brand-moment/src/BrandMoment.tsx
+++ b/packages/brand-moment/src/BrandMoment.tsx
@@ -31,64 +31,72 @@ export const BrandMoment = (props: Props) => (
   >
     <header className={styles.header}>{props.header}</header>
     <main className={styles.main}>
-      <div className={styles.left}>
-        <div className={styles.leftInner}>{props.illustration}</div>
-      </div>
-      <div className={styles.right}>
-        <div className={styles.rightInner}>
-          {props.text.subtitle && (
-            <Box mb={0.5}>
-              <Heading variant="heading-3" tag="h1">
-                {props.text.subtitle}
-              </Heading>
-            </Box>
-          )}
-          <Box mb={1.5}>
-            <Heading
-              variant="display-0"
-              tag={props.text.subtitle ? "h2" : "h1"}
-            >
-              {props.text.title}
-            </Heading>
-          </Box>
-          {props.text.body && (
-            <Box mb={1.5}>
-              <Paragraph variant="intro-lede">{props.text.body}</Paragraph>
-            </Box>
-          )}
-          {props.body && <Box mb={1.5}>{props.body}</Box>}
-          <div className={styles.actions}>
-            <Button primary {...props.primaryAction} />
-            {props.secondaryAction && (
-              <Box ml={0.5}>
-                <Button secondary {...props.secondaryAction} />
+      <div className={styles.container}>
+        <div className={styles.mainInner}>
+          <div className={styles.left}>
+            <div className={styles.leftInner}>{props.illustration}</div>
+          </div>
+          <div className={styles.right}>
+            <div className={styles.rightInner}>
+              {props.text.subtitle && (
+                <Box mb={0.5}>
+                  <Heading variant="heading-3" tag="h1">
+                    {props.text.subtitle}
+                  </Heading>
+                </Box>
+              )}
+              <Box mb={1.5}>
+                <Heading
+                  variant="display-0"
+                  tag={props.text.subtitle ? "h2" : "h1"}
+                >
+                  {props.text.title}
+                </Heading>
               </Box>
-            )}
+              {props.text.body && (
+                <Box mb={1.5}>
+                  <Paragraph variant="intro-lede">{props.text.body}</Paragraph>
+                </Box>
+              )}
+              {props.body && <Box mb={1.5}>{props.body}</Box>}
+              <div className={styles.actions}>
+                <Button primary {...props.primaryAction} />
+                {props.secondaryAction && (
+                  <Box ml={0.5}>
+                    <Button secondary {...props.secondaryAction} />
+                  </Box>
+                )}
+              </div>
+            </div>
           </div>
         </div>
       </div>
     </main>
     {props.text.footer && (
       <footer className={styles.footer}>
-        <Box mr={2}>
-          <div className={styles.poweredByContainer}>
-            <div className={styles.poweredByText}>
-              <Paragraph variant="extra-small" color="dark-reduced-opacity">
-                Powered by
-              </Paragraph>
-            </div>
-            <div>
-              <img
-                src={assetUrl("brand/logo-horizontal-default.svg")}
-                alt="Culture Amp"
-                width={133}
-              />
-            </div>
+        <div className={styles.container}>
+          <div className={styles.footerInner}>
+            <Box mr={2}>
+              <div className={styles.poweredByContainer}>
+                <div className={styles.poweredByText}>
+                  <Paragraph variant="extra-small" color="dark-reduced-opacity">
+                    Powered by
+                  </Paragraph>
+                </div>
+                <div>
+                  <img
+                    src={assetUrl("brand/logo-horizontal-default.svg")}
+                    alt="Culture Amp"
+                    width={133}
+                  />
+                </div>
+              </div>
+            </Box>
+            <Paragraph variant="extra-small" color="dark-reduced-opacity">
+              {props.text.footer}
+            </Paragraph>
           </div>
-        </Box>
-        <Paragraph variant="extra-small" color="dark-reduced-opacity">
-          {props.text.footer}
-        </Paragraph>
+        </div>
       </footer>
     )}
   </div>

--- a/packages/brand-moment/src/BrandMoment.tsx
+++ b/packages/brand-moment/src/BrandMoment.tsx
@@ -84,11 +84,13 @@ export const BrandMoment = (props: Props) => (
                   </Paragraph>
                 </div>
                 <div>
-                  <img
-                    src={assetUrl("brand/logo-horizontal-default.svg")}
-                    alt="Culture Amp"
-                    width={133}
-                  />
+                  <a href="https://www.cultureamp.com">
+                    <img
+                      src={assetUrl("brand/logo-horizontal-default.svg")}
+                      alt="Culture Amp"
+                      width={133}
+                    />
+                  </a>
                 </div>
               </div>
             </Box>

--- a/packages/brand-moment/src/BrandMoment.tsx
+++ b/packages/brand-moment/src/BrandMoment.tsx
@@ -91,9 +91,7 @@ export const BrandMoment = (props: Props) => (
               </a>
             </div>
             <div className={styles.footerTextContainer}>
-              <Paragraph variant="extra-small" color="dark-reduced-opacity">
-                {props.text.footer}
-              </Paragraph>
+              <Paragraph variant="extra-small">{props.text.footer}</Paragraph>
             </div>
           </div>
         </div>

--- a/packages/brand-moment/src/BrandMoment.tsx
+++ b/packages/brand-moment/src/BrandMoment.tsx
@@ -76,27 +76,25 @@ export const BrandMoment = (props: Props) => (
       <footer className={styles.footer}>
         <div className={styles.container}>
           <div className={styles.footerInner}>
-            <Box mr={2}>
-              <div className={styles.poweredByContainer}>
-                <div className={styles.poweredByText}>
-                  <Paragraph variant="extra-small" color="dark-reduced-opacity">
-                    Powered by
-                  </Paragraph>
-                </div>
-                <div>
-                  <a href="https://www.cultureamp.com">
-                    <img
-                      src={assetUrl("brand/logo-horizontal-default.svg")}
-                      alt="Culture Amp"
-                      width={133}
-                    />
-                  </a>
-                </div>
-              </div>
-            </Box>
-            <Paragraph variant="extra-small" color="dark-reduced-opacity">
-              {props.text.footer}
-            </Paragraph>
+            <div className={styles.poweredByContainer}>
+              <Paragraph variant="extra-small" color="dark-reduced-opacity">
+                Powered by
+              </Paragraph>
+              <a
+                href="https://www.cultureamp.com"
+                className={styles.poweredByLogo}
+              >
+                <img
+                  src={assetUrl("brand/logo-horizontal-default.svg")}
+                  alt="Culture Amp"
+                />
+              </a>
+            </div>
+            <div className={styles.footerTextContainer}>
+              <Paragraph variant="extra-small" color="dark-reduced-opacity">
+                {props.text.footer}
+              </Paragraph>
+            </div>
           </div>
         </div>
       </footer>

--- a/packages/brand-moment/src/stories/BrandMoment.stories.tsx
+++ b/packages/brand-moment/src/stories/BrandMoment.stories.tsx
@@ -47,7 +47,7 @@ export const DemoIntro = () => (
     }}
   />
 )
-DemoIntro.storyName = "Informative Intro"
+DemoIntro.storyName = "Informative intro"
 
 export const CaptureIntro = () => (
   <BrandMoment
@@ -59,8 +59,15 @@ export const CaptureIntro = () => (
       title: "Manager Effectiveness Survey",
       body:
         "Thank you for taking the time to respond to this survey. It’ll help us better understand your experience and perspective.",
-      footer:
-        "Your responses and information are securely collected and kept by Culture Amp in accordance with our Privacy Policy. Your responses will be reported to Hooli based on the specific rules for this survey. If you have any additional questions, please contact us at support@cultureamp.com.",
+      footer: (
+        <>
+          Your responses and information are securely collected and kept by
+          Culture Amp in accordance with our <a href="#">Privacy Policy</a>.
+          Your responses will be reported to Hooli based on the specific rules
+          for this survey. If you have any additional questions, please contact
+          us at <a href="#">support@cultureamp.com</a>.
+        </>
+      ),
     }}
     primaryAction={{
       label: "Take survey",
@@ -90,8 +97,15 @@ export const CaptureOutro = () => (
           <a href="#">retake the survey</a>.
         </>
       ),
-      footer:
-        "Your responses and information are securely collected and kept by Culture Amp in accordance with our Privacy Policy. Your responses will be reported to Hooli based on the specific rules for this survey. If you have any additional questions, please contact us at support@cultureamp.com.",
+      footer: (
+        <>
+          Your responses and information are securely collected and kept by
+          Culture Amp in accordance with our <a href="#">Privacy Policy</a>.
+          Your responses will be reported to Hooli based on the specific rules
+          for this survey. If you have any additional questions, please contact
+          us at <a href="#">support@cultureamp.com</a>.
+        </>
+      ),
     }}
     primaryAction={{
       label: "Go to Home",

--- a/packages/brand-moment/src/stories/BrandMoment.stories.tsx
+++ b/packages/brand-moment/src/stories/BrandMoment.stories.tsx
@@ -47,7 +47,7 @@ export const DemoIntro = () => (
     }}
   />
 )
-DemoIntro.storyName = "Demo Intro"
+DemoIntro.storyName = "Informative Intro"
 
 export const CaptureIntro = () => (
   <BrandMoment
@@ -74,7 +74,7 @@ export const CaptureIntro = () => (
     }}
   />
 )
-CaptureIntro.storyName = "Capture Intro"
+CaptureIntro.storyName = "Informative intro (customer focused)"
 
 export const CaptureOutro = () => (
   <BrandMoment
@@ -105,7 +105,7 @@ export const CaptureOutro = () => (
     }}
   />
 )
-CaptureOutro.storyName = "Capture Outro"
+CaptureOutro.storyName = "Positive outro (customer focused)"
 
 export const Error = () => (
   <BrandMoment

--- a/packages/brand-moment/src/stories/BrandMoment.stories.tsx
+++ b/packages/brand-moment/src/stories/BrandMoment.stories.tsx
@@ -30,7 +30,7 @@ export default {
   decorators: [story => <div style={{ margin: "-1rem" }}>{story()}</div>],
 }
 
-export const DemoIntro = () => (
+export const InformativeIntro = () => (
   <BrandMoment
     mood="informative"
     illustration={<EmptyStatesAction alt="" />}
@@ -47,9 +47,34 @@ export const DemoIntro = () => (
     }}
   />
 )
-DemoIntro.storyName = "Informative intro"
+InformativeIntro.storyName = "Informative intro"
 
-export const CaptureIntro = () => (
+export const PositiveOutro = () => (
+  <BrandMoment
+    mood="positive"
+    illustration={<EmptyStatesNeutral alt="" />}
+    header={<MinimalBasic />}
+    text={{
+      title: "Import in progress",
+      body: (
+        <>
+          That’s it for now. Your data is importing but you don’t need to hang
+          out here while it happens. Get on with your day and we’ll let you know
+          on the <a href="#">Users page</a> when it’s complete.
+        </>
+      ),
+    }}
+    primaryAction={{
+      label: "Go to Users",
+      href: "#",
+      icon: arrowRightIcon,
+      iconPosition: "end",
+    }}
+  />
+)
+PositiveOutro.storyName = "Positive outro"
+
+export const InformativeIntroCustomerFocused = () => (
   <BrandMoment
     mood="informative"
     illustration={<EmptyStatesPositive alt="" />}
@@ -81,9 +106,10 @@ export const CaptureIntro = () => (
     }}
   />
 )
-CaptureIntro.storyName = "Informative intro (customer focused)"
+InformativeIntroCustomerFocused.storyName =
+  "Informative intro (customer focused)"
 
-export const CaptureOutro = () => (
+export const PositiveOutroCustomerFocused = () => (
   <BrandMoment
     mood="positive"
     illustration={<EmptyStatesNeutral alt="" />}
@@ -119,7 +145,7 @@ export const CaptureOutro = () => (
     }}
   />
 )
-CaptureOutro.storyName = "Positive outro (customer focused)"
+PositiveOutroCustomerFocused.storyName = "Positive outro (customer focused)"
 
 export const Error = () => (
   <BrandMoment

--- a/packages/brand-moment/src/stories/BrandMoment.stories.tsx
+++ b/packages/brand-moment/src/stories/BrandMoment.stories.tsx
@@ -1,8 +1,7 @@
 import React from "react"
 import {
-  EmptyStatesAction,
   EmptyStatesNegative,
-  EmptyStatesNeutral,
+  EmptyStatesInformative,
   EmptyStatesPositive,
 } from "@kaizen/draft-illustration"
 import arrowRightIcon from "@kaizen/component-library/icons/arrow-right.icon.svg"
@@ -33,7 +32,7 @@ export default {
 export const InformativeIntro = () => (
   <BrandMoment
     mood="informative"
-    illustration={<EmptyStatesAction alt="" />}
+    illustration={<EmptyStatesInformative alt="" />}
     header={<MinimalBasic />}
     text={{
       subtitle: "Welcome to Culture Amp",
@@ -52,7 +51,7 @@ InformativeIntro.storyName = "Informative intro"
 export const PositiveOutro = () => (
   <BrandMoment
     mood="positive"
-    illustration={<EmptyStatesNeutral alt="" />}
+    illustration={<EmptyStatesPositive alt="" />}
     header={<MinimalBasic />}
     text={{
       title: "Import in progress",
@@ -77,7 +76,7 @@ PositiveOutro.storyName = "Positive outro"
 export const InformativeIntroCustomerFocused = () => (
   <BrandMoment
     mood="informative"
-    illustration={<EmptyStatesPositive alt="" />}
+    illustration={<EmptyStatesInformative alt="" />}
     header={<MinimalCustomerFocused />}
     text={{
       subtitle: "A survey for Hooli",
@@ -112,7 +111,7 @@ InformativeIntroCustomerFocused.storyName =
 export const PositiveOutroCustomerFocused = () => (
   <BrandMoment
     mood="positive"
-    illustration={<EmptyStatesNeutral alt="" />}
+    illustration={<EmptyStatesPositive alt="" />}
     header={<MinimalCustomerFocused />}
     text={{
       subtitle: "Manager Effectiveness Survey",

--- a/packages/brand-moment/src/stories/ExampleHeaders.scss
+++ b/packages/brand-moment/src/stories/ExampleHeaders.scss
@@ -36,6 +36,12 @@
   }
 }
 
+.customerFocused .logoContainer {
+  width: 84px;
+  height: 84px;
+  padding: $kz-var-spacing-sm;
+}
+
 .fakeNav {
   background: $kz-var-color-wisteria-600;
   padding: $kz-var-spacing-md;

--- a/packages/brand-moment/src/stories/ExampleHeaders.scss
+++ b/packages/brand-moment/src/stories/ExampleHeaders.scss
@@ -32,6 +32,7 @@
 
   > img {
     width: 100%;
+    border-radius: 4px;
   }
 }
 

--- a/packages/brand-moment/src/stories/ExampleHeaders.scss
+++ b/packages/brand-moment/src/stories/ExampleHeaders.scss
@@ -1,6 +1,7 @@
 @import "~@kaizen/design-tokens/sass/border-vars";
 @import "~@kaizen/design-tokens/sass/color-vars";
 @import "~@kaizen/design-tokens/sass/spacing-vars";
+@import "~@kaizen/design-tokens/sass/shadow-vars";
 
 .header {
   display: flex;
@@ -30,6 +31,7 @@
   height: 48px;
   padding: $kz-var-spacing-xs;
   border-radius: $kz-var-border-solid-border-radius;
+  box-shadow: $kz-var-shadow-small-box-shadow;
 
   > img {
     width: 100%;

--- a/packages/brand-moment/src/stories/ExampleHeaders.scss
+++ b/packages/brand-moment/src/stories/ExampleHeaders.scss
@@ -21,6 +21,17 @@
   justify-content: flex-end;
 }
 
+.logoLink {
+  display: flex;
+  align-items: center;
+  padding: calc(#{$kz-var-spacing-sm} - #{$kz-var-border-solid-border-width}) 0;
+  max-width: 133px;
+
+  > img {
+    width: 100%;
+  }
+}
+
 .logoContainer {
   background: $kz-var-color-white;
   box-sizing: border-box;

--- a/packages/brand-moment/src/stories/ExampleHeaders.scss
+++ b/packages/brand-moment/src/stories/ExampleHeaders.scss
@@ -1,5 +1,6 @@
 @import "~@kaizen/design-tokens/sass/border-vars";
 @import "~@kaizen/design-tokens/sass/color-vars";
+@import "~@kaizen/design-tokens/sass/layout";
 @import "~@kaizen/design-tokens/sass/spacing-vars";
 @import "~@kaizen/design-tokens/sass/shadow-vars";
 
@@ -8,10 +9,6 @@
   align-items: center;
   justify-content: center;
   padding: $kz-var-spacing-sm $kz-var-spacing-md;
-}
-
-.header.customerFocused {
-  padding: $kz-var-spacing-lg $kz-var-spacing-md;
 }
 
 .headerLeft {
@@ -38,7 +35,30 @@
   }
 }
 
-.customerFocused .logoContainer {
+.headerCustomerFocused {
+  display: grid;
+  justify-items: center;
+  grid-template-rows: auto auto;
+  gap: $kz-var-spacing-md;
+  padding: $kz-var-spacing-lg $kz-var-spacing-md;
+}
+
+@media (min-width: $kz-layout-breakpoints-medium) {
+  .headerCustomerFocused {
+    align-items: flex-start;
+    grid-template-columns: 1fr auto 1fr;
+  }
+
+  .headerCustomerFocused .logoContainer {
+    grid-column-start: 2;
+  }
+
+  .headerCustomerFocused .rightAlign {
+    margin-left: auto;
+  }
+}
+
+.headerCustomerFocused .logoContainer {
   width: 84px;
   height: 84px;
   padding: $kz-var-spacing-sm;

--- a/packages/brand-moment/src/stories/ExampleHeaders.scss
+++ b/packages/brand-moment/src/stories/ExampleHeaders.scss
@@ -9,6 +9,10 @@
   padding: $kz-var-spacing-sm $kz-var-spacing-md;
 }
 
+.header.customerFocused {
+  padding: $kz-var-spacing-lg $kz-var-spacing-md;
+}
+
 .headerLeft {
   flex: 0 0 50%;
 }

--- a/packages/brand-moment/src/stories/ExampleHeaders.scss
+++ b/packages/brand-moment/src/stories/ExampleHeaders.scss
@@ -38,12 +38,22 @@
 .headerCustomerFocused {
   display: grid;
   justify-items: center;
-  grid-template-rows: auto auto;
-  gap: $kz-var-spacing-md;
+  grid-template-columns: auto auto;
   padding: $kz-var-spacing-lg $kz-var-spacing-md;
 }
 
-@media (min-width: $kz-layout-breakpoints-medium) {
+.headerCustomerFocused .logoContainer {
+  width: 48px;
+  height: 48px;
+  padding: $kz-var-spacing-xs;
+  margin-right: auto;
+}
+
+.headerCustomerFocused .rightAlign {
+  margin-left: auto;
+}
+
+@media (min-width: $kz-layout-breakpoints-large) {
   .headerCustomerFocused {
     align-items: flex-start;
     grid-template-columns: 1fr auto 1fr;
@@ -51,17 +61,10 @@
 
   .headerCustomerFocused .logoContainer {
     grid-column-start: 2;
+    width: 84px;
+    height: 84px;
+    padding: $kz-var-spacing-sm;
   }
-
-  .headerCustomerFocused .rightAlign {
-    margin-left: auto;
-  }
-}
-
-.headerCustomerFocused .logoContainer {
-  width: 84px;
-  height: 84px;
-  padding: $kz-var-spacing-sm;
 }
 
 .fakeNav {

--- a/packages/brand-moment/src/stories/ExampleHeaders.tsx
+++ b/packages/brand-moment/src/stories/ExampleHeaders.tsx
@@ -1,5 +1,6 @@
 import React from "react"
 import { assetUrl } from "@kaizen/hosted-assets"
+import { Select } from "@kaizen/draft-select"
 import styles from "./ExampleHeaders.scss"
 
 export const MinimalBasic = () => (
@@ -21,10 +22,26 @@ export const MinimalBasic = () => (
   </div>
 )
 
+const exampleLocales = [
+  { value: "a", label: "English (US English)" },
+  { value: "b", label: "العربية (Arabic)" },
+  { value: "c", label: "беларускі (Belarusian)" },
+  { value: "d", label: "български (Bulgarian)" },
+  { value: "e", label: "čeština (Czech)" },
+]
+
 export const MinimalCustomerFocused = () => (
-  <div className={`${styles.header} ${styles.customerFocused}`}>
+  <div className={styles.headerCustomerFocused}>
     <div className={styles.logoContainer}>
       <img src={assetUrl("brand/enso-default.svg")} alt="Culture Amp" />
+    </div>
+    <div className={styles.rightAlign}>
+      <Select
+        options={exampleLocales}
+        isSearchable={false}
+        defaultValue={exampleLocales[0]}
+        variant="secondary"
+      />
     </div>
   </div>
 )

--- a/packages/brand-moment/src/stories/ExampleHeaders.tsx
+++ b/packages/brand-moment/src/stories/ExampleHeaders.tsx
@@ -22,7 +22,7 @@ export const MinimalBasic = () => (
 )
 
 export const MinimalCustomerFocused = () => (
-  <div className={styles.header}>
+  <div className={`${styles.header} ${styles.customerFocused}`}>
     <div className={styles.logoContainer}>
       <img src={assetUrl("brand/enso-default.svg")} alt="Culture Amp" />
     </div>

--- a/packages/brand-moment/src/stories/ExampleHeaders.tsx
+++ b/packages/brand-moment/src/stories/ExampleHeaders.tsx
@@ -1,6 +1,9 @@
 import React from "react"
 import { assetUrl } from "@kaizen/hosted-assets"
+import { Box } from "@kaizen/component-library"
 import { Select } from "@kaizen/draft-select"
+import { Button } from "@kaizen/draft-button"
+import closeIcon from "@kaizen/component-library/icons/close.icon.svg"
 import styles from "./ExampleHeaders.scss"
 
 export const MinimalBasic = () => (
@@ -15,6 +18,9 @@ export const MinimalBasic = () => (
       </a>
     </div>
     <div className={styles.headerRight}>
+      <Box mr={0.5}>
+        <Button href="#" label="Exit" icon={closeIcon} secondary />
+      </Box>
       <div className={styles.logoContainer}>
         <img src={assetUrl("brand/enso-default.svg")} alt="Culture Amp" />
       </div>

--- a/packages/brand-moment/src/stories/ExampleHeaders.tsx
+++ b/packages/brand-moment/src/stories/ExampleHeaders.tsx
@@ -9,11 +9,10 @@ import styles from "./ExampleHeaders.scss"
 export const MinimalBasic = () => (
   <div className={styles.header}>
     <div className={styles.headerLeft}>
-      <a href="/" aria-label="Home">
+      <a href="/" aria-label="Home" className={styles.logoLink}>
         <img
           src={assetUrl("brand/logo-horizontal-default.svg")}
           alt="Culture Amp"
-          width={126}
         />
       </a>
     </div>


### PR DESCRIPTION
# Objective
Main objective here was to add responsiveness to the `BrandMoment` component, which was previously mainly built around larger viewports and didn't scale down well.

Before:
https://user-images.githubusercontent.com/1811583/122691403-d1080300-d272-11eb-8412-6afc9cb6cb24.mov

After:
https://user-images.githubusercontent.com/1811583/122691472-365bf400-d273-11eb-9d18-8ac44371b140.mov

Notes:
* I've switched from flex to grid for the main container so that I could utilise `gap`.
* I've used a mobile first approach to media query styling. Small viewport styles are applied by default, then larger viewport styles are added under `min-width` media queries.


----

I've also bundled in a bunch of small tweaks that came out of a review with @katsambarcus 

### Small component adjustments:
- [x] Footer logo should link to cultureamp.com
- [x] ‘Powered by CA’ can go below text on small viewport
- [x] Remove reduced opacity from footer text

### Story adjustments:
- [x] Rename stories to reflect types of brand moments
- [x] Add <a> tags to example footer links
- [x] Make customer focused logo larger
- [x] Add box shadow to logo container
- [x] Add a non customer focused outro example
- [x] Put locale selector into capture examples
- [x] Add exit button to a story as an example
- [x] Add a 4px border radius to the logo inside of the container for logos that aren't transparent or white

**Note:** this doesn't yet changing the typography or CTA button width based on viewport as the designs suggest. There is work happening at the moment to make this easy to do, so we can come through once that's done and add that here.


