### PR TITLE
fix: elm tooltip heart uplift quick fix

### DIFF
--- a/draft-packages/tooltip/KaizenDraft/Tooltip/TooltipElm.scss
+++ b/draft-packages/tooltip/KaizenDraft/Tooltip/TooltipElm.scss
@@ -20,7 +20,7 @@
   padding: $ca-grid / 2 $ca-grid / 2;
   z-index: 2;
   border: $kz-var-border-solid-border-width $kz-var-border-solid-border-style
-    $kz-var-color-wisteria-200;
+    $kz-var-color-ash;
   box-shadow: $kz-var-shadow-small-box-shadow;
   text-align: center;
 }
@@ -121,7 +121,7 @@
 }
 
 .root::before {
-  border-top: 10px solid $kz-var-color-wisteria-200;
+  border-top: 10px solid $kz-var-color-ash;
 }
 
 .root::after {
@@ -131,7 +131,7 @@
 }
 
 .shadow::before {
-  border-top: 0px solid $kz-var-color-wisteria-200;
+  border-top: 0px solid $kz-var-color-ash;
 }
 
 // Triangle portion is a little darker to bring out shadow


### PR DESCRIPTION
The Elm tooltip still has a `wisteria-200` border (now lilac). This is a quick fix to replace them with `ash`. The Heart tooltips are not meant to have borders at all - this is just a quick fix, not a full upgrade.

Before:
<img width="284" alt="image" src="https://user-images.githubusercontent.com/702885/122007099-f4f2c100-cdfa-11eb-8701-02a48202ff51.png">

After:
<img width="257" alt="image" src="https://user-images.githubusercontent.com/702885/122007524-59ae1b80-cdfb-11eb-8159-a8c4dd7f7036.png">


