### PR TITLE
feat: controlHasUnconstrainedHeight option for Elm Select

### DIFF
--- a/draft-packages/form/KaizenDraft/Form/SelectField/SelectField.elm
+++ b/draft-packages/form/KaizenDraft/Form/SelectField/SelectField.elm
@@ -2,6 +2,7 @@ module KaizenDraft.Form.SelectField.SelectField exposing
     ( Config
     , Status(..)
     , clearable
+    , controlHasUnconstrainedHeight
     , description
     , disabled
     , id
@@ -57,6 +58,7 @@ type alias ConfigValue msg item =
     , disabled : Bool
     , reversed : Bool
     , validationMessage : Maybe String
+    , controlHasUnconstrainedHeight : Bool
     }
 
 
@@ -81,6 +83,7 @@ defaults toMsg =
     , disabled = False
     , reversed = False
     , validationMessage = Nothing
+    , controlHasUnconstrainedHeight = False
     }
 
 
@@ -201,6 +204,11 @@ status value (Config config) =
     Config { config | status = value }
 
 
+controlHasUnconstrainedHeight : Bool -> Config msg item -> Config msg item
+controlHasUnconstrainedHeight predicate (Config config) =
+    Config { config | controlHasUnconstrainedHeight = predicate }
+
+
 view : Config msg item -> Html msg
 view (Config config) =
     let
@@ -283,6 +291,7 @@ view (Config config) =
                 |> Select.searchable config.searchable
                 |> Select.clearable config.clearable
                 |> Select.disabled config.disabled
+                |> Select.controlHasUnconstrainedHeight config.controlHasUnconstrainedHeight
 
         selectInputId =
             config.id ++ "-field-input"

--- a/draft-packages/select/ElmStories/SelectStories.elm
+++ b/draft-packages/select/ElmStories/SelectStories.elm
@@ -27,7 +27,7 @@ model =
     { selectState = Select.initState |> Select.usePorts True
     , selectedMembers = []
     , selectedMember = Nothing
-    , members = [ "Mindy", "Jaime", "Rafa", "Elaine", "Julio", "Priyanka", "Prince", "Charith", "Nick" ]
+    , members = [ "Mindy", "Jaime", "Rafa", "Elaine", "Julio", "Priyanka", "Prince", "Charith", "Nick", "AVeryLongNameWithoutAnySpacesAtall", "A very long long name with spaces inside it" ]
     }
 
 

--- a/draft-packages/select/ElmStories/SelectStories.elm
+++ b/draft-packages/select/ElmStories/SelectStories.elm
@@ -27,7 +27,7 @@ model =
     { selectState = Select.initState |> Select.usePorts True
     , selectedMembers = []
     , selectedMember = Nothing
-    , members = [ "Mindy", "Jaime", "Rafa", "Elaine", "Julio", "Priyanka", "Prince", "Charith", "Nick", "AVeryLongNameWithoutAnySpacesAtall", "A very long long name with spaces inside it" ]
+    , members = [ "Mindy", "Jaime", "Rafa", "Elaine", "Julio", "Priyanka", "Prince", "Charith", "Nick", "AVeryLongNameWithoutAnySpacesAtall", "A very very very very very very very very very very long name with spaces inside it" ]
     }
 
 
@@ -154,5 +154,29 @@ main =
                                 |> Select.menuItems (List.map buildMenuItem m.members)
                             )
                             (Select.selectIdentifier "single-no-placeholder")
+                        ]
+        , storyOf
+            "Single Clearable, controlHasUnconstrainedHeight"
+            (let
+                thisInitialModel =
+                    { model | selectedMember = Just "A very very very very very very very very very very long name with spaces inside it" }
+             in
+             { update = update
+             , init = ( thisInitialModel, Cmd.none )
+             , subscriptions = \_ -> Sub.none
+             }
+            )
+          <|
+            \m ->
+                Html.map SelectMsg <|
+                    div [ style "width" "300px", style "margin-top" "12px" ]
+                        [ Select.view
+                            (Select.single (buildSelected m)
+                                |> Select.state m.selectState
+                                |> Select.menuItems (List.map buildMenuItem m.members)
+                                |> Select.clearable True
+                                |> Select.controlHasUnconstrainedHeight True
+                            )
+                            (Select.selectIdentifier "single-control-has-unconstrained-height")
                         ]
         ]

--- a/draft-packages/select/KaizenDraft/Select/Select.elm
+++ b/draft-packages/select/KaizenDraft/Select/Select.elm
@@ -8,6 +8,7 @@ module KaizenDraft.Select.Select exposing
     , Style(..)
     , Variant(..)
     , clearable
+    , controlHasUnconstrainedHeight
     , defaults
     , disabled
     , dummyInputIdPrefix
@@ -188,6 +189,7 @@ type alias Configuration item =
     , searchable : Bool
     , clearable : Bool
     , disabled : Bool
+    , controlHasUnconstrainedHeight : Bool
     }
 
 
@@ -275,6 +277,7 @@ defaults =
     , searchable = True
     , clearable = False
     , disabled = False
+    , controlHasUnconstrainedHeight = False
     }
 
 
@@ -329,6 +332,11 @@ clearable predicate (Config config) =
 disabled : Bool -> Config item -> Config item
 disabled predicate (Config config) =
     Config { config | disabled = predicate }
+
+
+controlHasUnconstrainedHeight : Bool -> Config item -> Config item
+controlHasUnconstrainedHeight predicate (Config config) =
+    Config { config | controlHasUnconstrainedHeight = predicate }
 
 
 
@@ -786,6 +794,7 @@ view (Config config) selectId =
                 , ( .isFocused, state_.controlFocused )
                 , ( .cautionary, config.selectType == Cautionary && state_.controlFocused == False )
                 , ( .error, config.selectType == Error && state_.controlFocused == False )
+                , ( .controlHasUnconstrainedHeight, config.controlHasUnconstrainedHeight )
                 ]
              , attribute "data-automation-id" "Select__Control"
              ]
@@ -1462,4 +1471,5 @@ styles =
         , preventPointer = "preventPointer"
         , clearButtonWrapper = "clearButtonWrapper"
         , disabled = "disabled"
+        , controlHasUnconstrainedHeight = "controlHasUnconstrainedHeight"
         }

--- a/draft-packages/select/KaizenDraft/Select/SelectInput.elm
+++ b/draft-packages/select/KaizenDraft/Select/SelectInput.elm
@@ -15,6 +15,7 @@ module KaizenDraft.Select.SelectInput exposing
     , view
     )
 
+import CssModules exposing (css)
 import Html exposing (Html, div, input, text)
 import Html.Attributes exposing (attribute, id, size, style, type_, value)
 import Html.Events exposing (on, onBlur, onFocus, preventDefaultOn)
@@ -206,15 +207,8 @@ view (Config config) id_ =
             , style "letter-spacing" "normal"
             , style "text-transform" "none"
             ]
-
-        autoSizeInputContainerStyles =
-            [ style "padding-bottom" "2px"
-            , style "padding-top" "2px"
-            , style "box-sizing" "border-box"
-            , style "margin" "2px"
-            ]
     in
-    div autoSizeInputContainerStyles
+    div [ styles.class .autosizeInputContainer ]
         [ input
             ([ id (inputId id_), value inputValue, type_ "text", attribute "autocomplete" "new-password" ] ++ events ++ inputStyles)
             []
@@ -222,3 +216,9 @@ view (Config config) id_ =
         -- query the div width to set the input width
         , div ([ id (sizerId id_) ] ++ sizerStyles) [ text inputValue ]
         ]
+
+
+styles =
+    css "@kaizen/draft-select/KaizenDraft/Select/styles.elm.scss"
+        { autosizeInputContainer = "autosizeInputContainer"
+        }

--- a/draft-packages/select/KaizenDraft/Select/styles.elm.scss
+++ b/draft-packages/select/KaizenDraft/Select/styles.elm.scss
@@ -12,6 +12,8 @@
   // box-shadow: 0 0 0 1px $color;
 }
 
+$control-height: $ca-grid * 2;
+
 .basePlaceholder {
   @include kz-typography-paragraph-body;
   margin-left: 2px;
@@ -20,6 +22,12 @@
   position: absolute;
   transform: translateY(-50%);
   box-sizing: border-box;
+
+  .controlHasUnconstrainedHeight & {
+    position: relative;
+    top: 0;
+    transform: none;
+  }
 }
 .container {
   position: relative;
@@ -37,7 +45,7 @@
   display: flex;
   flex-wrap: wrap;
   justify-content: space-between;
-  min-height: 48px;
+  min-height: $control-height;
   position: relative;
   box-sizing: border-box;
   border: $kz-var-border-solid-border-width $kz-var-border-solid-border-style
@@ -70,7 +78,13 @@
   overflow: hidden;
 
   .disabled & {
-    position: static;
+    position: static; // TODO calc based on border width
+  }
+
+  .controlHasUnconstrainedHeight & {
+    min-height: calc(
+      #{$control-height} - (#{$kz-var-border-solid-border-width} * 2)
+    );
   }
 }
 
@@ -80,6 +94,12 @@
   text-overflow: ellipsis;
   white-space: nowrap;
   overflow: hidden;
+
+  .controlHasUnconstrainedHeight & {
+    white-space: normal;
+    overflow: visible;
+    word-break: break-word;
+  }
 }
 
 .placeholder {
@@ -217,5 +237,19 @@
   button:not(:disabled):hover {
     // not(:disabled) is required for extra specificity to override the default button background
     background-color: transparent;
+  }
+}
+
+.autosizeInputContainer {
+  @include kz-typography-paragraph-body;
+  @include ca-inherit-baseline;
+  padding-bottom: 2px;
+  padding-top: 2px;
+  box-sizing: border-box;
+  margin: 2px;
+
+  .controlHasUnconstrainedHeight & {
+    position: absolute;
+    top: 6px;
   }
 }

--- a/draft-packages/select/docs/ElmSelect.stories.tsx
+++ b/draft-packages/select/docs/ElmSelect.stories.tsx
@@ -15,6 +15,7 @@ loadElmStories(
     "Single Clearable",
     "Single Disabled",
     "Single, no placeholder (test case)",
+    "Single Clearable, controlHasUnconstrainedHeight",
   ],
   Ports
 )


### PR DESCRIPTION
# Objective
This adds an optional `controlHasUnconstrainedHeight` option that defaults to false. The default behaviour (as is current) is that the control* is always only takes up one line, and that if the select item is longer than the available spac,e it gets truncated with an ellipsis. That is problematic if being able to read the full text of the selected item is very important for the use case. This gives an option to view the the full option, with text wrapping instead of truncation (with unconstrained height). 




*WTF is "a control", as in the noun, not the verb? You know, that thing you click on that's not the dropdown that opens up. It's just what it's called, don't blame me! ... also, WTF is "a select" - "select" is a verb, not a noun! There is no noun form of "select" in the dictionary. Yeah, I know... don't get me started, it's just what it's called 😞 




# Motivation and Context
https://trello.com/c/QigAAifj/978-should-have-need-a-way-to-check-long-values-on-user-modal

# Story

https://dev.cultureamp.design/ted/elm-select-grow-vertically-option/storybook/?path=/story/select-elm--single-clearable-controlhasunconstrainedheight

# Screenshots
long sentence with spaces

<img width="345" alt="image" src="https://user-images.githubusercontent.com/702885/122876575-039c2380-d379-11eb-86f7-85de2a05dc17.png">

long word with no spaces (uses `word-break: break-word;`)

<img width="335" alt="image" src="https://user-images.githubusercontent.com/702885/122876782-40681a80-d379-11eb-9af9-a75578e767e5.png">

A usual short word

<img width="339" alt="image" src="https://user-images.githubusercontent.com/702885/122876909-61c90680-d379-11eb-9c39-5df9ea2973b0.png">

A short word, after clicking the control, when the `searchable` option is enabled and the cursor is showing:

<img width="379" alt="image" src="https://user-images.githubusercontent.com/702885/122877165-a5237500-d379-11eb-8b64-2c1840b7e135.png">

A short word, after clicking the control, when the `searchable` option is enabled and the cursor is showing:

<img width="384" alt="image" src="https://user-images.githubusercontent.com/702885/122877792-562a0f80-d37a-11eb-8b10-1e19fc7b089f.png">
Why is the cursor in a weird spot? See Caviats.

#### Caviats

- The cursor is in a misaligned spot when you pick a long word, and then you search. Unfortunately I don't think there's a way to solve this without significantly rewriting the existing css (and risk breaking edge cases that are widely used in the product). I tried to implement this in a way that there would be no changes to the implementation of the existing CSS. Because this component has been implemented on the assumption that there would be only one line, everything is vertically centered. It would be extremely fiddly, messy  and risky to undo that assumption (either updating the existing implementation, or having a massive amount of overrides for the `controlHasUnconstrainedHeight`). Also, seeing as have contained Elm, it doesn't seem worth the risk or effort.
- I would have liked to have put more padding at the top and the bottom when there is a long word, but again, this is tricky because everything is vertically centered and doesn't have much padding.
- The is a bigger gap between the long text and the "clear" button that is necessary. This is really tricky to fix without also breaking the existing implementation (it's a really complex component!)

I'm hoping we can accept these compromises as the end result of being able to read the full text of long words is a huge UX improvement.


# Checklist
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] If this contains visual changes, has it been reviewed by a designer?
- [ ] I have considered likely risks of these changes and got someone else to QA as appropriate

# Additional Considerations
- Does there need to be right-to-left (RTL) options for localization and internationalization?
- Has the test suite been updated?
- Have you done cross-browser testing for our [supported browsers](https://academy.cultureamp.com/hc/en-us/articles/204539569-Supported-browsers-for-Participants)?
- Have you updated any relevant documentation or left useful comments in the code?
- Have you reviewed Culture Amp's Web Accessibility guide [Current Compliance, Going Forward, Statement and Answers for Customers](https://cultureamp.atlassian.net/wiki/spaces/Prod/pages/428572998/Web+Accessibility)?
- If this contains substantial visual changes, especially far reaching ones, have you unlocked the Chromatic step in the pipeline?
- Have Storybook stories been updated?

**If you're new to Kaizen, please ask #prod_design_systems to set up an onboarding session to get you up to speed.** If you have an urgent PR to merge before that happens, it is safest to ask in #prod_design_systems to have a design system advocate review the PR to catch any issues.
