### PR TITLE
fix: Add better RTL support to BrandMoment

### DIFF
--- a/packages/brand-moment/src/BrandMoment.scss
+++ b/packages/brand-moment/src/BrandMoment.scss
@@ -10,7 +10,7 @@ $breakpoint-xl: 1366px; // TODO: create an xl breakpoint in design-tokens and re
 // --------------------------------
 
 .body {
-  width: 100%;
+  inline-size: 100%;
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -30,7 +30,7 @@ $breakpoint-xl: 1366px; // TODO: create an xl breakpoint in design-tokens and re
 
 @media (min-width: $kz-layout-breakpoints-large) {
   .body {
-    min-height: 100vh;
+    min-block-size: 100vh;
   }
 }
 
@@ -39,7 +39,7 @@ $breakpoint-xl: 1366px; // TODO: create an xl breakpoint in design-tokens and re
 // --------------------------------
 
 .container {
-  max-width: $kz-var-layout-content-max-width;
+  max-inline-size: $kz-var-layout-content-max-width;
   margin: 0 auto;
   padding: 0 $kz-var-spacing-md;
 }
@@ -61,8 +61,8 @@ $breakpoint-xl: 1366px; // TODO: create an xl breakpoint in design-tokens and re
 // --------------------------------
 
 .header {
-  width: 100%;
-  margin-bottom: $kz-var-spacing-md;
+  inline-size: 100%;
+  margin-block-end: $kz-var-spacing-md;
 }
 
 // --------------------------------
@@ -73,7 +73,7 @@ $breakpoint-xl: 1366px; // TODO: create an xl breakpoint in design-tokens and re
   flex: 1 0 auto;
   display: flex;
   align-items: center;
-  margin-bottom: $kz-var-spacing-xxl;
+  margin-block-end: $kz-var-spacing-xxl;
 }
 
 .mainInner {
@@ -107,8 +107,8 @@ $breakpoint-xl: 1366px; // TODO: create an xl breakpoint in design-tokens and re
 }
 
 .leftInner {
-  width: 100%;
-  max-width: 525px;
+  inline-size: 100%;
+  max-inline-size: 525px;
 }
 
 .right {
@@ -119,7 +119,7 @@ $breakpoint-xl: 1366px; // TODO: create an xl breakpoint in design-tokens and re
 }
 
 .rightInner {
-  max-width: 543px;
+  max-inline-size: 543px;
 }
 
 .actions {
@@ -147,10 +147,10 @@ $breakpoint-xl: 1366px; // TODO: create an xl breakpoint in design-tokens and re
 .footerInner {
   display: flex;
   flex-direction: column;
-  border-top: 1px solid $kz-var-color-wisteria-800;
-  border-left: 1px solid $kz-var-color-wisteria-800;
+  border-block-start: 1px solid $kz-var-color-wisteria-800;
+  border-inline-start: 1px solid $kz-var-color-wisteria-800;
   padding: $kz-var-spacing-sm $kz-var-spacing-md;
-  margin: 0 0 $kz-var-spacing-lg;
+  margin-block-end: $kz-var-spacing-lg;
 }
 
 .poweredByContainer {
@@ -162,14 +162,14 @@ $breakpoint-xl: 1366px; // TODO: create an xl breakpoint in design-tokens and re
 .footerTextContainer {
   flex: 1 1 auto;
   order: 1;
-  margin-bottom: $kz-var-spacing-md;
+  margin-block-end: $kz-var-spacing-md;
 }
 
 .poweredByLogo {
-  margin-left: $kz-var-spacing-xs;
+  margin-inline-start: $kz-var-spacing-xs;
 
   > img {
-    max-width: 133px;
+    max-inline-size: 133px;
   }
 }
 
@@ -181,8 +181,8 @@ $breakpoint-xl: 1366px; // TODO: create an xl breakpoint in design-tokens and re
 
   .footerTextContainer {
     order: initial;
-    margin-bottom: 0;
-    margin-left: $kz-var-spacing-md;
+    margin-block-end: 0;
+    margin-inline-start: $kz-var-spacing-md;
   }
 
   .poweredByContainer {

--- a/packages/brand-moment/src/stories/BrandMoment.stories.tsx
+++ b/packages/brand-moment/src/stories/BrandMoment.stories.tsx
@@ -4,6 +4,7 @@ import {
   EmptyStatesInformative,
   EmptyStatesPositive,
 } from "@kaizen/draft-illustration"
+import arrowLeftIcon from "@kaizen/component-library/icons/arrow-left.icon.svg"
 import arrowRightIcon from "@kaizen/component-library/icons/arrow-right.icon.svg"
 import securityTipIcon from "@kaizen/component-library/icons/security-tip.icon.svg"
 import mailIcon from "@kaizen/component-library/icons/email.icon.svg"
@@ -26,10 +27,16 @@ export default {
       `,
     },
   },
-  decorators: [story => <div style={{ margin: "-1rem" }}>{story()}</div>],
+  decorators: [
+    (story, { globals: { textDirection } }) => (
+      <div id="brand-moment-container" style={{ margin: "-1rem" }}>
+        {story({ isRTL: textDirection === "rtl" })}
+      </div>
+    ),
+  ],
 }
 
-export const InformativeIntro = () => (
+export const InformativeIntro = (_, { isRTL }) => (
   <BrandMoment
     mood="informative"
     illustration={<EmptyStatesInformative alt="" />}
@@ -41,14 +48,14 @@ export const InformativeIntro = () => (
     primaryAction={{
       label: "Get started",
       href: "#",
-      icon: arrowRightIcon,
+      icon: isRTL ? arrowLeftIcon : arrowRightIcon,
       iconPosition: "end",
     }}
   />
 )
 InformativeIntro.storyName = "Informative intro"
 
-export const PositiveOutro = () => (
+export const PositiveOutro = (_, { isRTL }) => (
   <BrandMoment
     mood="positive"
     illustration={<EmptyStatesPositive alt="" />}
@@ -66,14 +73,14 @@ export const PositiveOutro = () => (
     primaryAction={{
       label: "Go to Users",
       href: "#",
-      icon: arrowRightIcon,
+      icon: isRTL ? arrowLeftIcon : arrowRightIcon,
       iconPosition: "end",
     }}
   />
 )
 PositiveOutro.storyName = "Positive outro"
 
-export const InformativeIntroCustomerFocused = () => (
+export const InformativeIntroCustomerFocused = (_, { isRTL }) => (
   <BrandMoment
     mood="informative"
     illustration={<EmptyStatesInformative alt="" />}
@@ -96,7 +103,7 @@ export const InformativeIntroCustomerFocused = () => (
     primaryAction={{
       label: "Take survey",
       href: "#",
-      icon: arrowRightIcon,
+      icon: isRTL ? arrowLeftIcon : arrowRightIcon,
       iconPosition: "end",
     }}
     secondaryAction={{
@@ -108,7 +115,7 @@ export const InformativeIntroCustomerFocused = () => (
 InformativeIntroCustomerFocused.storyName =
   "Informative intro (customer focused)"
 
-export const PositiveOutroCustomerFocused = () => (
+export const PositiveOutroCustomerFocused = (_, { isRTL }) => (
   <BrandMoment
     mood="positive"
     illustration={<EmptyStatesPositive alt="" />}
@@ -135,7 +142,7 @@ export const PositiveOutroCustomerFocused = () => (
     primaryAction={{
       label: "Go to Home",
       href: "#",
-      icon: arrowRightIcon,
+      icon: isRTL ? arrowLeftIcon : arrowRightIcon,
       iconPosition: "end",
     }}
     secondaryAction={{
@@ -146,7 +153,7 @@ export const PositiveOutroCustomerFocused = () => (
 )
 PositiveOutroCustomerFocused.storyName = "Positive outro (customer focused)"
 
-export const Error = () => (
+export const Error = (_, { isRTL }) => (
   <BrandMoment
     mood="negative"
     illustration={<EmptyStatesNegative alt="" />}
@@ -170,7 +177,7 @@ export const Error = () => (
     primaryAction={{
       label: "Go to Home",
       href: "#",
-      icon: arrowRightIcon,
+      icon: isRTL ? arrowLeftIcon : arrowRightIcon,
       iconPosition: "end",
     }}
     secondaryAction={{

--- a/packages/brand-moment/src/stories/ExampleHeaders.scss
+++ b/packages/brand-moment/src/stories/ExampleHeaders.scss
@@ -25,24 +25,24 @@
   display: flex;
   align-items: center;
   padding: calc(#{$kz-var-spacing-sm} - #{$kz-var-border-solid-border-width}) 0;
-  max-width: 133px;
+  max-inline-size: 133px;
 
   > img {
-    width: 100%;
+    inline-size: 100%;
   }
 }
 
 .logoContainer {
   background: $kz-var-color-white;
   box-sizing: border-box;
-  width: 48px;
-  height: 48px;
+  inline-size: 48px;
+  block-size: 48px;
   padding: $kz-var-spacing-xs;
   border-radius: $kz-var-border-solid-border-radius;
   box-shadow: $kz-var-shadow-small-box-shadow;
 
   > img {
-    width: 100%;
+    inline-size: 100%;
     border-radius: 4px;
   }
 }
@@ -55,14 +55,14 @@
 }
 
 .headerCustomerFocused .logoContainer {
-  width: 48px;
-  height: 48px;
+  inline-size: 48px;
+  block-size: 48px;
   padding: $kz-var-spacing-xs;
-  margin-right: auto;
+  margin-inline-end: auto;
 }
 
 .headerCustomerFocused .rightAlign {
-  margin-left: auto;
+  margin-inline-start: auto;
 }
 
 @media (min-width: $kz-layout-breakpoints-large) {
@@ -73,8 +73,8 @@
 
   .headerCustomerFocused .logoContainer {
     grid-column-start: 2;
-    width: 84px;
-    height: 84px;
+    inline-size: 84px;
+    block-size: 84px;
     padding: $kz-var-spacing-sm;
   }
 }

--- a/storybook/preview.tsx
+++ b/storybook/preview.tsx
@@ -59,10 +59,30 @@ window.addEventListener("storage", () => {
     .emit(THEME_CHANGE_EVENT_TYPE, localStorage.getItem(THEME_KEY_STORE_KEY))
 })
 
+export const globalTypes = {
+  textDirection: {
+    name: "Text direction",
+    description: "",
+    defaultValue: "ltr",
+    toolbar: {
+      icon: "globe",
+      items: ["ltr", "rtl"],
+    },
+  },
+}
+
 export const decorators = [
   (Story: React.ComponentType) => (
     <ThemeProvider themeManager={themeManager}>
       <Story />
     </ThemeProvider>
   ),
+  (Story, props) => {
+    const dir = props.args.textDirection ?? props.globals.textDirection
+    return (
+      <div dir={dir}>
+        <Story {...props} />
+      </div>
+    )
+  },
 ]


### PR DESCRIPTION
# Objective
Adds better RTL support to the `BrandMoment` component, mainly by swapping out directional properties with the awesome new [logical properties](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Logical_Properties). Browser support: https://caniuse.com/css-logical-props

Also adds an ltr/rtl switcher to the Kaizen storybook for easy RTL support checking on any component.

# Motivation and Context
I had descoped this from the first pass with the intention of coming back and tidying this up. It wasn't too bad because I used a lot of grid and flex, but there were still a few things to fix up.

# Notes
* Our `Box` component's RTL support isn't so great - it requires you to send in an `rtl` prop which I would like to deprecate in favour of just using logical properties as I have done here. As a result - the spacing between two action buttons isn't there on RTL, until we make that update. Not a blocker IMO.

# Screenshots

Before:
![image](https://user-images.githubusercontent.com/1811583/123051419-1f6cfb80-d445-11eb-8614-89b4576cc02e.png)

After:
![image](https://user-images.githubusercontent.com/1811583/123051039-ae2d4880-d444-11eb-966b-5d7acae28520.png)

ltr/rtl Storybook switcher:
![rtl-storybook](https://user-images.githubusercontent.com/1811583/123052233-f5680900-d445-11eb-8f7d-c6449773ab85.gif)