### PR TITLE
feat: Allow the Avatar to handle the case where the fullname cannot be provided

### DIFF
--- a/draft-packages/avatar/KaizenDraft/Avatar/Avatar.tsx
+++ b/draft-packages/avatar/KaizenDraft/Avatar/Avatar.tsx
@@ -7,15 +7,17 @@ import styles from "./styles.module.scss"
 
 type AvatarSizes = "small" | "medium" | "large" | "xlarge"
 
-const getInitials: (fullName: string, max2Characters?: boolean) => string = (
+const getInitials: (fullName?: string, max2Characters?: boolean) => string = (
   fullName,
   max2Characters = false
 ) =>
-  fullName
-    .split(/\s/)
-    .reduce((acc, name) => `${acc}${name.slice(0, 1)}`, "")
-    .toUpperCase()
-    .substring(0, max2Characters ? 2 : 8)
+  fullName == null
+    ? ""
+    : fullName
+        .split(/\s/)
+        .reduce((acc, name) => `${acc}${name.slice(0, 1)}`, "")
+        .toUpperCase()
+        .substring(0, max2Characters ? 2 : 8)
 
 const getMaxFontSizePixels: (size: AvatarSizes) => number = size => {
   if (size === "small") return 8
@@ -28,7 +30,7 @@ export interface AvatarProps {
   /**
    * We use this for the alt text of the avatar, and to derive intials when user has no avatar image.
    */
-  fullName: string
+  fullName?: string
   /**
    * Default behaviour when an avatarSrc is not provided is to generate initials from the username.
    * This disables this feature and shows the generic avatar.
@@ -66,7 +68,8 @@ export const Avatar = ({
     setAvatarState(avatarSrc ? "loading" : "none")
   }, [avatarSrc])
 
-  const isLongName = getInitials(fullName).length > 2 && size !== "small"
+  const initials = getInitials(fullName)
+  const isLongName = initials.length > 2 && size !== "small"
 
   const onImageFailure = () => setAvatarState("error")
   const onImageSuccess = () => setAvatarState("success")
@@ -96,7 +99,7 @@ export const Avatar = ({
         />
       )}
       {(avatarState === "none" || avatarState === "error") &&
-        (disableInitials ? (
+        (disableInitials || initials === "" ? (
           fallbackIcon
         ) : (
           <div
@@ -107,7 +110,7 @@ export const Avatar = ({
             {isLongName ? (
               // Only called if 3 or more initials, fits text width for long names
               <Textfit mode="single" max={getMaxFontSizePixels(size)}>
-                {getInitials(fullName)}
+                {initials}
               </Textfit>
             ) : (
               getInitials(fullName, size === "small")

--- a/draft-packages/avatar/docs/Avatar.stories.tsx
+++ b/draft-packages/avatar/docs/Avatar.stories.tsx
@@ -121,4 +121,16 @@ export const WithLongInitials = () => (
   </>
 )
 
+export const WithoutNameOrAvatar = () => (
+  <>
+    <Avatar size="xlarge" />
+    <br />
+    <Avatar size="large" />
+    <br />
+    <Avatar size="medium" />
+    <br />
+    <Avatar size="small" />
+  </>
+)
+
 DefaultUser.storyName = "Default User (Shows when image fails to load)"


### PR DESCRIPTION
# Objective
Handle fallback case where the the fullname cannot be provided and the default icon should get shown.

# Motivation and Context
During an update of performance-ui it was found that there are a few places where the value may not exist.

# Checklist
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] If this contains visual changes, has it been reviewed by a designer?
- [ ] If this introduces either a new component or a breaking change to an existing component, has it been reviewed by an advocate? (Ask in #prod_design_systems)
- [ ] I have considered likely risks of these changes and got someone else to QA as appropriate
- [ ] I have or will communicate these changes to the front end practice

# Additional Considerations
- Does there need to be right-to-left (RTL) options for localization and internationalization?
- Has the test suite been updated?
- Have you done cross-browser testing for our [supported browsers](https://academy.cultureamp.com/hc/en-us/articles/204539569-Supported-browsers-for-Participants)?
- Have you updated any relevant documentation or left useful comments in the code?
- Have you reviewed Culture Amp's Web Accessibility guide [Current Compliance, Going Forward, Statement and Answers for Customers](https://cultureamp.atlassian.net/wiki/spaces/Prod/pages/428572998/Web+Accessibility)?
- If this contains substantial visual changes, especially far reaching ones, have you unlocked the Chromatic step in the pipeline?
- Have Storybook stories been updated?

**If you're new to Kaizen, please ask #prod_design_systems to set up an onboarding session to get you up to speed.** If you have an urgent PR to merge before that happens, it is safest to ask in #prod_design_systems to have a design system advocate review the PR to catch any issues.
