### PR TITLE
feat: Remove title from back of Tile component

### DIFF
--- a/draft-packages/tile/KaizenDraft/Tile/__snapshots__/Tile.spec.tsx.snap
+++ b/draft-packages/tile/KaizenDraft/Tile/__snapshots__/Tile.spec.tsx.snap
@@ -205,24 +205,6 @@ exports[`<InformationTile /> snapshots renders InformationTile with information 
         </span>
       </div>
       <div
-        class="title"
-      >
-        <h3
-          class="heading heading-3 dark small"
-        >
-          Title
-        </h3>
-        <div
-          class="pt-0-point-25 m-0"
-        >
-          <p
-            class="paragraph small dark-reduced-opacity"
-          >
-            Metadata
-          </p>
-        </div>
-      </div>
-      <div
         class="information"
       >
         <p

--- a/draft-packages/tile/KaizenDraft/Tile/components/GenericTile.scss
+++ b/draft-packages/tile/KaizenDraft/Tile/components/GenericTile.scss
@@ -63,6 +63,7 @@ $tilePaddingTop: $kz-var-spacing-xl;
 .faceBack {
   padding-top: $tilePaddingTop;
   transform: rotateY(180deg);
+  background-color: $kz-var-color-cluny-100;
 }
 
 .isFlipped {
@@ -88,21 +89,18 @@ $tilePaddingTop: $kz-var-spacing-xl;
 
 .information {
   @include ca-padding(
-    $top: 18px,
     $bottom: $kz-var-spacing-md,
     $start: $kz-var-spacing-md,
     $end: $kz-var-spacing-md
   );
-  margin-top: $kz-var-spacing-sm;
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: space-between;
   box-sizing: border-box;
-  background-color: $kz-var-color-cluny-100;
   width: 100%;
   height: 100%;
-  text-align: center;
+  text-align: left;
   border-radius: 0 0 7px 7px;
 }
 

--- a/draft-packages/tile/KaizenDraft/Tile/components/GenericTile.tsx
+++ b/draft-packages/tile/KaizenDraft/Tile/components/GenericTile.tsx
@@ -124,7 +124,6 @@ const GenericTile: GenericTile = ({
             disabled={!isFlipped}
           />
         </div>
-        {renderTitle()}
         <div className={styles.information}>
           {renderInformation(information)}
         </div>


### PR DESCRIPTION
https://cultureamp.slack.com/archives/C0189KBPM4Y/p1623800537096700

# Objective

Remove the title from the back of the Title component.

# Motivation and Context

Removing the title from the back increases the available space for content. This was prompted by a desire to show a "View available languages" button for survey template tiles, but we're likely to run into space issues pretty regularly.

I've also left-aligned the text, at Marc's direction.

Context: https://cultureamp.slack.com/archives/C0189KBPM4Y/p1623800537096700

# Screenshots (if appropriate)

Before:
![image](https://user-images.githubusercontent.com/11305534/125387200-de7f5b80-e3e0-11eb-80bb-7d239f3cbcde.png)

After:
![image](https://user-images.githubusercontent.com/11305534/125387221-e50dd300-e3e0-11eb-816d-1ec23c077c73.png)

UI Kit:
![image](https://user-images.githubusercontent.com/11305534/125387255-efc86800-e3e0-11eb-95b3-3930ebfdc7bf.png)


# Checklist
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] If this contains visual changes, has it been reviewed by a designer?
- [x] If this introduces either a new component or a breaking change to an existing component, has it been reviewed by an advocate? (Ask in #prod_design_systems)
- [x] I have considered likely risks of these changes and got someone else to QA as appropriate
- [x] I have or will communicate these changes to the front end practice

# Additional Considerations
- Does there need to be right-to-left (RTL) options for localization and internationalization?
- Has the test suite been updated?
- Have you done cross-browser testing for our [supported browsers](https://academy.cultureamp.com/hc/en-us/articles/204539569-Supported-browsers-for-Participants)?
- Have you updated any relevant documentation or left useful comments in the code?
- Have you reviewed Culture Amp's Web Accessibility guide [Current Compliance, Going Forward, Statement and Answers for Customers](https://cultureamp.atlassian.net/wiki/spaces/Prod/pages/428572998/Web+Accessibility)?
- If this contains substantial visual changes, especially far reaching ones, have you unlocked the Chromatic step in the pipeline?
- Have Storybook stories been updated?

**If you're new to Kaizen, please ask #prod_design_systems to set up an onboarding session to get you up to speed.** If you have an urgent PR to merge before that happens, it is safest to ask in #prod_design_systems to have a design system advocate review the PR to catch any issues.
