### PR TITLE
fix: Constrain brand width to 100% of container

### DIFF
--- a/packages/brand/src/Brand/Brand.scss
+++ b/packages/brand/src/Brand/Brand.scss
@@ -1,0 +1,3 @@
+.img {
+  max-inline-size: 100%;
+}

--- a/packages/brand/src/Brand/Brand.tsx
+++ b/packages/brand/src/Brand/Brand.tsx
@@ -1,5 +1,6 @@
 import React from "react"
 import { assetUrl } from "@kaizen/hosted-assets"
+import styles from "./Brand.scss"
 
 export interface BrandProps {
   variant:
@@ -18,6 +19,7 @@ export const Brand = (props: BrandProps) => {
     <img
       src={assetUrl(`brand/${props.variant}${brandTheme}.svg`)}
       alt={props.alt}
+      className={styles.img}
     />
   )
 }


### PR DESCRIPTION
# Objective
Constrains the size of the image on the Brand component to 100% of the container width.

# Motivation and Context
When implementing the Brand component into the new minimal nav, I found that the logo was going over the container width. This fixes that.
