### PR TITLE
feat: Add mp4 fallbacks to animated illustrations

### DIFF
--- a/draft-packages/illustration/KaizenDraft/Illustration/Players/VideoPlayer.spec.tsx
+++ b/draft-packages/illustration/KaizenDraft/Illustration/Players/VideoPlayer.spec.tsx
@@ -67,13 +67,17 @@ describe("<VideoPlayer />", () => {
           data-testid="kz-video-player"
           muted=""
           playsinline=""
-          poster="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/heart/spot/moods-cautionary.svg"
+          poster="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/heart/spot/moods-cautionary.svg.png"
           preload="metadata"
           width="100%"
         >
           <source
-            src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/heart/spot/moods-cautionary.webm"
+            src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/heart/spot/moods-cautionary.webm.webm"
             type="video/webm"
+          />
+          <source
+            src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/heart/spot/moods-cautionary.webm.mp4"
+            type="video/mp4"
           />
         </video>
       `)
@@ -100,13 +104,17 @@ describe("<VideoPlayer />", () => {
           data-testid="kz-video-player"
           muted=""
           playsinline=""
-          poster="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/heart/spot/moods-cautionary.svg"
+          poster="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/heart/spot/moods-cautionary.svg.png"
           preload="metadata"
           width="100%"
         >
           <source
-            src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/heart/spot/moods-cautionary.webm"
+            src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/heart/spot/moods-cautionary.webm.webm"
             type="video/webm"
+          />
+          <source
+            src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/heart/spot/moods-cautionary.webm.mp4"
+            type="video/mp4"
           />
         </video>
       `)

--- a/draft-packages/illustration/KaizenDraft/Illustration/Players/VideoPlayer.tsx
+++ b/draft-packages/illustration/KaizenDraft/Illustration/Players/VideoPlayer.tsx
@@ -115,7 +115,8 @@ export const VideoPlayer = ({
       autoPlay={prefersReducedMotion ? false : autoplay}
       playsInline={true}
     >
-      <source src={assetUrl(ambientAnimation)} type="video/webm" />
+      <source src={assetUrl(`${ambientAnimation}.webm`)} type="video/webm" />
+      <source src={assetUrl(`${ambientAnimation}.mp4`)} type="video/mp4" />
     </video>
   )
 }

--- a/draft-packages/illustration/KaizenDraft/Illustration/Players/VideoPlayer.tsx
+++ b/draft-packages/illustration/KaizenDraft/Illustration/Players/VideoPlayer.tsx
@@ -111,7 +111,7 @@ export const VideoPlayer = ({
       data-testid="kz-video-player"
       className={styles.wrapper}
       loop={loop}
-      poster={assetUrl(fallback)}
+      poster={assetUrl(`${fallback}.png`)}
       autoPlay={prefersReducedMotion ? false : autoplay}
       playsInline={true}
     >

--- a/draft-packages/illustration/KaizenDraft/Illustration/Scene.tsx
+++ b/draft-packages/illustration/KaizenDraft/Illustration/Scene.tsx
@@ -33,8 +33,8 @@ export const BrandMomentCaptureIntro = ({
       <VideoPlayer
         {...otherProps}
         fallback="illustrations/heart/scene/brand-moments-capture-intro-loop.png"
-        ambientAnimation="illustrations/heart/scene/brand-moments-capture-intro-loop.webm"
-        initialAnimation="illustrations/heart/scene/brand-moments-capture-intro.webm"
+        ambientAnimation="illustrations/heart/scene/brand-moments-capture-intro-loop"
+        initialAnimation="illustrations/heart/scene/brand-moments-capture-intro"
       />
     )
   }
@@ -57,7 +57,7 @@ export const BrandMomentPositiveOutro = ({
       <VideoPlayer
         {...otherProps}
         fallback="illustrations/heart/scene/brand-moments-positive-outro.png"
-        ambientAnimation="illustrations/heart/scene/brand-moments-positive-outro.webm"
+        ambientAnimation="illustrations/heart/scene/brand-moments-positive-outro"
       />
     )
   }
@@ -80,7 +80,7 @@ export const BrandMomentLogin = ({
       <VideoPlayer
         {...otherProps}
         fallback="illustrations/heart/scene/brand-moments-login.png"
-        ambientAnimation="illustrations/heart/scene/brand-moments-login.webm"
+        ambientAnimation="illustrations/heart/scene/brand-moments-login"
       />
     )
   }
@@ -104,7 +104,7 @@ export const BrandMomentError = ({
       <VideoPlayer
         {...otherProps}
         fallback="illustrations/heart/scene/brand-moments-error.png"
-        ambientAnimation="illustrations/heart/scene/brand-moments-error.webm"
+        ambientAnimation="illustrations/heart/scene/brand-moments-error"
       />
     )
   }
@@ -128,7 +128,7 @@ export const EmptyStatesAction = ({
       <VideoPlayer
         {...otherProps}
         fallback="illustrations/heart/scene/empty-states-action.svg"
-        ambientAnimation="illustrations/heart/scene/empty-states-action.webm"
+        ambientAnimation="illustrations/heart/scene/empty-states-action"
       />
     )
   }
@@ -156,7 +156,7 @@ export const EmptyStatesInformative = ({
       <VideoPlayer
         {...otherProps}
         fallback="illustrations/heart/scene/empty-states-informative.svg"
-        ambientAnimation="illustrations/heart/scene/empty-states-informative.webm"
+        ambientAnimation="illustrations/heart/scene/empty-states-informative"
       />
     )
   }
@@ -184,7 +184,7 @@ export const EmptyStatesNegative = ({
       <VideoPlayer
         {...otherProps}
         fallback="illustrations/heart/scene/empty-states-negative.svg"
-        ambientAnimation="illustrations/heart/scene/empty-states-negative.webm"
+        ambientAnimation="illustrations/heart/scene/empty-states-negative"
       />
     )
   }
@@ -212,7 +212,7 @@ export const EmptyStatesPositive = ({
       <VideoPlayer
         {...otherProps}
         fallback="illustrations/heart/scene/empty-states-positive.svg"
-        ambientAnimation="illustrations/heart/scene/empty-states-positive.webm"
+        ambientAnimation="illustrations/heart/scene/empty-states-positive"
       />
     )
   }
@@ -240,7 +240,7 @@ export const EmptyStatesNeutral = ({
       <VideoPlayer
         {...otherProps}
         fallback="illustrations/heart/scene/empty-states-neutral.svg"
-        ambientAnimation="illustrations/heart/scene/empty-states-neutral.webm"
+        ambientAnimation="illustrations/heart/scene/empty-states-neutral"
       />
     )
   }

--- a/draft-packages/illustration/KaizenDraft/Illustration/Scene.tsx
+++ b/draft-packages/illustration/KaizenDraft/Illustration/Scene.tsx
@@ -32,7 +32,7 @@ export const BrandMomentCaptureIntro = ({
     return (
       <VideoPlayer
         {...otherProps}
-        fallback="illustrations/heart/scene/brand-moments-capture-intro-loop.png"
+        fallback="illustrations/heart/scene/brand-moments-capture-intro-loop"
         ambientAnimation="illustrations/heart/scene/brand-moments-capture-intro-loop"
         initialAnimation="illustrations/heart/scene/brand-moments-capture-intro"
       />
@@ -56,7 +56,7 @@ export const BrandMomentPositiveOutro = ({
     return (
       <VideoPlayer
         {...otherProps}
-        fallback="illustrations/heart/scene/brand-moments-positive-outro.png"
+        fallback="illustrations/heart/scene/brand-moments-positive-outro"
         ambientAnimation="illustrations/heart/scene/brand-moments-positive-outro"
       />
     )
@@ -79,7 +79,7 @@ export const BrandMomentLogin = ({
     return (
       <VideoPlayer
         {...otherProps}
-        fallback="illustrations/heart/scene/brand-moments-login.png"
+        fallback="illustrations/heart/scene/brand-moments-login"
         ambientAnimation="illustrations/heart/scene/brand-moments-login"
       />
     )
@@ -103,7 +103,7 @@ export const BrandMomentError = ({
     return (
       <VideoPlayer
         {...otherProps}
-        fallback="illustrations/heart/scene/brand-moments-error.png"
+        fallback="illustrations/heart/scene/brand-moments-error"
         ambientAnimation="illustrations/heart/scene/brand-moments-error"
       />
     )
@@ -127,7 +127,7 @@ export const EmptyStatesAction = ({
     return (
       <VideoPlayer
         {...otherProps}
-        fallback="illustrations/heart/scene/empty-states-action.svg"
+        fallback="illustrations/heart/scene/empty-states-action"
         ambientAnimation="illustrations/heart/scene/empty-states-action"
       />
     )
@@ -155,7 +155,7 @@ export const EmptyStatesInformative = ({
     return (
       <VideoPlayer
         {...otherProps}
-        fallback="illustrations/heart/scene/empty-states-informative.svg"
+        fallback="illustrations/heart/scene/empty-states-informative"
         ambientAnimation="illustrations/heart/scene/empty-states-informative"
       />
     )
@@ -183,7 +183,7 @@ export const EmptyStatesNegative = ({
     return (
       <VideoPlayer
         {...otherProps}
-        fallback="illustrations/heart/scene/empty-states-negative.svg"
+        fallback="illustrations/heart/scene/empty-states-negative"
         ambientAnimation="illustrations/heart/scene/empty-states-negative"
       />
     )
@@ -211,7 +211,7 @@ export const EmptyStatesPositive = ({
     return (
       <VideoPlayer
         {...otherProps}
-        fallback="illustrations/heart/scene/empty-states-positive.svg"
+        fallback="illustrations/heart/scene/empty-states-positive"
         ambientAnimation="illustrations/heart/scene/empty-states-positive"
       />
     )
@@ -239,7 +239,7 @@ export const EmptyStatesNeutral = ({
     return (
       <VideoPlayer
         {...otherProps}
-        fallback="illustrations/heart/scene/empty-states-neutral.svg"
+        fallback="illustrations/heart/scene/empty-states-neutral"
         ambientAnimation="illustrations/heart/scene/empty-states-neutral"
       />
     )


### PR DESCRIPTION
NOTE: mp4 formats do not support transparency. For this reason, whenever the mp4 fallback is active (<IE11, some versions of Safari) a background colour has been encoded into the video. Ensure the background colour always matches your intended usage.

# Checklist
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] If this contains visual changes, has it been reviewed by a designer?
- [ ] If this introduces either a new component or a breaking change to an existing component, has it been reviewed by an advocate? (Ask in #prod_design_systems)
- [ ] I have considered likely risks of these changes and got someone else to QA as appropriate
- [ ] I have or will communicate these changes to the front end practice

**If you're new to Kaizen, please ask #prod_design_systems to set up an onboarding session to get you up to speed.** If you have an urgent PR to merge before that happens, it is safest to ask in #prod_design_systems to have a design system advocate review the PR to catch any issues.
