### PR TITLE
fix: Select types passing through to consumer

### DIFF
--- a/draft-packages/select/KaizenDraft/Select/Select.tsx
+++ b/draft-packages/select/KaizenDraft/Select/Select.tsx
@@ -3,7 +3,7 @@ import * as React from "react"
 import ReactSelect, { components } from "react-select"
 import Async from "react-select/async"
 import { AsyncProps as ReactAsyncSelectProps } from "react-select/src/Async"
-import { Props as ReactSelectProps } from "react-select/src/Select"
+import { NamedProps as ReactSelectProps } from "react-select/src/Select"
 
 import { Icon } from "@kaizen/component-library"
 import chevronDownIcon from "@kaizen/component-library/icons/chevron-down.icon.svg"
@@ -13,7 +13,7 @@ import styles from "./styles.react.scss"
 
 export type { ValueType } from "react-select"
 
-export type SelectProps = {
+export interface SelectProps extends ReactSelectProps<any, boolean> {
   /**
    * The secondary variant is a more subdued variant that takes up as little space as possible
    * `variant="secondary" reversed="false" is not implemented and will throw a "not implemented" error
@@ -41,62 +41,57 @@ export type SelectProps = {
 
 export type VariantType = "default" | "secondary" | "secondary-small"
 
-export const Select = React.forwardRef(
-  (
-    props: SelectProps & ReactSelectProps<any, boolean>,
-    ref: React.Ref<any>
-  ) => {
-    if (props.fullWidth === false && props.variant !== "secondary") {
-      throw new Error(
-        'the prop fullWidth=false is not yet implemented when variant="default"'
-      )
-    }
-    const { variant = "default", reversed = false } = props
-
-    // the default for fullWidth depends on the variant
-    const fullWidth =
-      props.fullWidth != null
-        ? props.fullWidth
-        : variant === "secondary" || variant === "secondary-small"
-        ? false
-        : true
-
-    if (reversed === true && variant === "default") {
-      throw new Error(
-        'the combo variant="default" and reversed=true is not yet implemented for the Select component'
-      )
-    }
-
-    const classes = classNames(props.className, styles.specificityIncreaser, {
-      [styles.default]: !reversed,
-      [styles.reversed]: reversed,
-      [styles.secondary]: variant === "secondary",
-      [styles.secondarySmall]: variant === "secondary-small",
-      [styles.notFullWidth]: !fullWidth,
-      [styles.disabled]: props.isDisabled,
-    })
-    return (
-      <ReactSelect
-        {...props}
-        ref={ref}
-        components={{
-          Control,
-          Placeholder,
-          DropdownIndicator,
-          Menu,
-          Option,
-          NoOptionsMessage,
-          SingleValue,
-          MultiValue,
-          IndicatorsContainer,
-          ClearIndicator,
-          IndicatorSeparator: null,
-        }}
-        className={classes}
-      />
+export const Select = React.forwardRef<any, SelectProps>((props, ref) => {
+  if (props.fullWidth === false && props.variant !== "secondary") {
+    throw new Error(
+      'the prop fullWidth=false is not yet implemented when variant="default"'
     )
   }
-)
+  const { variant = "default", reversed = false } = props
+
+  // the default for fullWidth depends on the variant
+  const fullWidth =
+    props.fullWidth != null
+      ? props.fullWidth
+      : variant === "secondary" || variant === "secondary-small"
+      ? false
+      : true
+
+  if (reversed === true && variant === "default") {
+    throw new Error(
+      'the combo variant="default" and reversed=true is not yet implemented for the Select component'
+    )
+  }
+
+  const classes = classNames(props.className, styles.specificityIncreaser, {
+    [styles.default]: !reversed,
+    [styles.reversed]: reversed,
+    [styles.secondary]: variant === "secondary",
+    [styles.secondarySmall]: variant === "secondary-small",
+    [styles.notFullWidth]: !fullWidth,
+    [styles.disabled]: props.isDisabled,
+  })
+  return (
+    <ReactSelect
+      {...props}
+      ref={ref}
+      components={{
+        Control,
+        Placeholder,
+        DropdownIndicator,
+        Menu,
+        Option,
+        NoOptionsMessage,
+        SingleValue,
+        MultiValue,
+        IndicatorsContainer,
+        ClearIndicator,
+        IndicatorSeparator: null,
+      }}
+      className={classes}
+    />
+  )
+})
 Select.displayName = "Select"
 
 interface AsyncProps


### PR DESCRIPTION
When updating the Select draft package in performance-ui, type errors were discovered. It seems no types were being 'passed through' to the Select component so we were getting errors around function types accepting `any`.

On master
![Kapture 2021-07-21 at 13 57 11](https://user-images.githubusercontent.com/4666090/126429137-c02ebd59-3732-4b37-b8fd-60b3e082f27f.gif)

This change:
![Kapture 2021-07-21 at 13 56 07](https://user-images.githubusercontent.com/4666090/126429119-8742c226-8a9e-4c23-aef1-b18389836eab.gif)



Looks like a recent change converting the component to a forwarded ref component caused the issue even though normally it wouldn't have been a problem. I think the complexity of some of `react-select`'s types caused them to become lost. However switching to the `NamedProps` interface worked as this is the type that is used under `Props` which we were originally using and is probably the one we should have been using.


# Checklist
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] If this contains visual changes, has it been reviewed by a designer?
- [ ] If this introduces either a new component or a breaking change to an existing component, has it been reviewed by an advocate? (Ask in #prod_design_systems)
- [ ] I have considered likely risks of these changes and got someone else to QA as appropriate
- [x] I have or will communicate these changes to the front end practice

# Additional Considerations
- Does there need to be right-to-left (RTL) options for localization and internationalization?
- Has the test suite been updated?
- Have you done cross-browser testing for our [supported browsers](https://academy.cultureamp.com/hc/en-us/articles/204539569-Supported-browsers-for-Participants)?
- Have you updated any relevant documentation or left useful comments in the code?
- Have you reviewed Culture Amp's Web Accessibility guide [Current Compliance, Going Forward, Statement and Answers for Customers](https://cultureamp.atlassian.net/wiki/spaces/Prod/pages/428572998/Web+Accessibility)?
- If this contains substantial visual changes, especially far reaching ones, have you unlocked the Chromatic step in the pipeline?
- Have Storybook stories been updated?

**If you're new to Kaizen, please ask #prod_design_systems to set up an onboarding session to get you up to speed.** If you have an urgent PR to merge before that happens, it is safest to ask in #prod_design_systems to have a design system advocate review the PR to catch any issues.
