### PR TITLE
feat: Add starter kit brand moment illustration

### DIFF
--- a/draft-packages/illustration/KaizenDraft/Illustration/Scene.tsx
+++ b/draft-packages/illustration/KaizenDraft/Illustration/Scene.tsx
@@ -117,6 +117,13 @@ export const BrandMomentError = ({
   )
 }
 
+export const BrandMomentStarterKit = (props: SceneProps) => (
+  <Base
+    {...props}
+    name="illustrations/heart/scene/brand-moments-starter-kit.svg"
+  />
+)
+
 export const EmptyStatesAction = ({
   isAnimated,
   alt,

--- a/draft-packages/illustration/KaizenDraft/Illustration/__snapshots__/illustration.spec.tsx.snap
+++ b/draft-packages/illustration/KaizenDraft/Illustration/__snapshots__/illustration.spec.tsx.snap
@@ -40,6 +40,16 @@ exports[`<Illustration /> Scene BrandMomentPositiveOutro should exist and render
 </div>
 `;
 
+exports[`<Illustration /> Scene BrandMomentStarterKit should exist and render an alt tag 1`] = `
+<div>
+  <img
+    alt="My accessible title"
+    class=" wrapper"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/heart/scene/brand-moments-starter-kit.svg"
+  />
+</div>
+`;
+
 exports[`<Illustration /> Scene EmptyStatesAction should exist and render an alt tag 1`] = `
 <div>
   <img

--- a/draft-packages/illustration/docs/IllustrationScene.stories.tsx
+++ b/draft-packages/illustration/docs/IllustrationScene.stories.tsx
@@ -55,6 +55,7 @@ import {
   BrandMomentPositiveOutro,
   BrandMomentLogin,
   BrandMomentError,
+  BrandMomentStarterKit,
 } from ".."
 
 const withFixedWidth = Story => (
@@ -90,6 +91,9 @@ export const BrandMoments = args => (
     </div>
     <div style={{ width: "450px" }}>
       <BrandMomentError {...args} />
+    </div>
+    <div style={{ width: "450px" }}>
+      <BrandMomentStarterKit alt="" />
     </div>
   </>
 )


### PR DESCRIPTION
# Objective
<!-- Describe what this change achieves, and the details of how it works. -->
Makes this available to be used as an illustration https://github.com/cultureamp/kaizen-design-system-assets/pull/42

# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
For use in a new brand moment in Skills Coach
https://www.figma.com/file/RsaX0uZxUWZKwpCRdnvTwj/%F0%9F%9A%A7-Skills-Coach-2021-Q3?node-id=7926%3A48341

# Screenshots (if appropriate)

# Checklist
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] If this contains visual changes, has it been reviewed by a designer?
- [ ] If this introduces either a new component or a breaking change to an existing component, has it been reviewed by an advocate? (Ask in #prod_design_systems)
- [ ] I have considered likely risks of these changes and got someone else to QA as appropriate
- [ ] I have or will communicate these changes to the front end practice

# Additional Considerations
- Does there need to be right-to-left (RTL) options for localization and internationalization?
- Has the test suite been updated?
- Have you done cross-browser testing for our [supported browsers](https://academy.cultureamp.com/hc/en-us/articles/204539569-Supported-browsers-for-Participants)?
- Have you updated any relevant documentation or left useful comments in the code?
- Have you reviewed Culture Amp's Web Accessibility guide [Current Compliance, Going Forward, Statement and Answers for Customers](https://cultureamp.atlassian.net/wiki/spaces/Prod/pages/428572998/Web+Accessibility)?
- If this contains substantial visual changes, especially far reaching ones, have you unlocked the Chromatic step in the pipeline?
- Have Storybook stories been updated?

**If you're new to Kaizen, please ask #prod_design_systems to set up an onboarding session to get you up to speed.** If you have an urgent PR to merge before that happens, it is safest to ask in #prod_design_systems to have a design system advocate review the PR to catch any issues.
