### PR TITLE
fix: Add deprecated jsdocs and wrap with withDeprecatedComponent

### DIFF
--- a/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/NavigationBar.tsx
+++ b/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/NavigationBar.tsx
@@ -43,7 +43,7 @@ class NavigationBar extends React.Component<Props, State> {
   static displayName = "NavigationBar"
   static Link = Link
   static Menu = Menu
-  static defaultProps = {
+  static defaultProps: Props = {
     environment: "production",
     loading: false,
     colorScheme: "cultureamp",

--- a/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/NavigationBar.tsx
+++ b/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/NavigationBar.tsx
@@ -23,7 +23,7 @@ type Props = {
   loading?: boolean
   colorScheme?: ColorScheme
   badgeHref?: string
-  onNavigationChange: NavigationChange
+  onNavigationChange?: NavigationChange
   headerComponent?: {
     desktop: React.ReactElement
     mobile: React.ReactElement
@@ -73,7 +73,7 @@ class NavigationBar extends React.Component<Props, State> {
               this.setState({
                 mobileKey: this.state.mobileKey + 1,
               })
-              onNavigationChange(event)
+              onNavigationChange && onNavigationChange(event)
             }
           },
           hasExtendedNavigation: !!children?.secondary?.length,

--- a/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/NavigationBar.tsx
+++ b/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/NavigationBar.tsx
@@ -3,6 +3,7 @@ import * as React from "react"
 import classNames from "classnames"
 import Media from "react-media"
 import uuid from "uuid/v4"
+import { withDeprecatedComponent } from "@kaizen/react-deprecate-warning"
 import { ZenControlledOffCanvas } from "./helpers"
 import Badge from "./components/Badge"
 import Link from "./components/Link"
@@ -35,6 +36,9 @@ type State = {
   mobileKey: number
 }
 
+/**
+ * @deprecated ZenNavigationBar is deprecated. See https://github.com/cultureamp/unified-navigation instead
+ */
 class NavigationBar extends React.Component<Props, State> {
   static displayName = "NavigationBar"
   static Link = Link
@@ -179,4 +183,7 @@ class NavigationBar extends React.Component<Props, State> {
     )
   }
 }
-export default NavigationBar
+export default withDeprecatedComponent(NavigationBar, {
+  warning:
+    "ZenNavigationBar is deprecated. See https://github.com/cultureamp/unified-navigation instead",
+})

--- a/draft-packages/zen-navigation-bar/docs/ZenNavigationBar.stories.tsx
+++ b/draft-packages/zen-navigation-bar/docs/ZenNavigationBar.stories.tsx
@@ -13,7 +13,7 @@ import academyIcon from "@kaizen/component-library/icons/academy.icon.svg"
 import supportIcon from "@kaizen/component-library/icons/support.icon.svg"
 
 export default {
-  title: "ZenNavigationBar (React)",
+  title: "ZenNavigationBar (React) (deprecated)",
 }
 
 const handleNavigationChange = (event: { preventDefault: () => void }) => {

--- a/draft-packages/zen-navigation-bar/package.json
+++ b/draft-packages/zen-navigation-bar/package.json
@@ -34,6 +34,7 @@
   "dependencies": {
     "@kaizen/component-library": "^10.0.10",
     "@kaizen/draft-button": "^3.3.22",
+    "@kaizen/react-deprecate-warning": "^1.1.5",
     "@types/classnames": "^2.2.10",
     "classnames": "^2.2.6",
     "react-media": "^1.9.2",

--- a/legacy-packages/title-block/KaizenDraft/TitleBlock/TitleBlock.tsx
+++ b/legacy-packages/title-block/KaizenDraft/TitleBlock/TitleBlock.tsx
@@ -56,6 +56,9 @@ const COMPACT_NAVIGATION_SCROLL_THRESHOLD = 5
 const meetsCompactThreshold = () =>
   (window.scrollY || window.pageYOffset) >= COMPACT_NAVIGATION_SCROLL_THRESHOLD
 
+/**
+ * @deprecated TitleBlock is deprecated. Please use draft-title-block-zen instead.
+ */
 class TitleBlock extends React.Component<Props, State> {
   static defaultProps: Pick<Props, "textDirection"> = {
     textDirection: "ltr",

--- a/packages/component-library/components/Dropdown/Dropdown.tsx
+++ b/packages/component-library/components/Dropdown/Dropdown.tsx
@@ -1,5 +1,6 @@
 import classNames from "classnames"
 import * as React from "react"
+import { withDeprecatedComponent } from "@kaizen/react-deprecate-warning"
 import { Icon } from "../Icon"
 import chevronDownIcon from "../../icons/chevron-down.icon.svg"
 import ellipsisIcon from "../../icons/ellipsis.icon.svg"
@@ -154,4 +155,6 @@ class Dropdown extends React.Component<DropdownProps, DropdownState> {
   }
 }
 
-export default Dropdown
+export default withDeprecatedComponent(Dropdown, {
+  warning: "Dropdown is deprecated. Use @kaizen/draft-menu instead.",
+})

--- a/packages/component-library/components/Dropdown/Dropdown.tsx
+++ b/packages/component-library/components/Dropdown/Dropdown.tsx
@@ -27,7 +27,7 @@ export type DropdownProps = {
  */
 class Dropdown extends React.Component<DropdownProps, DropdownState> {
   static displayName = "Dropdown"
-  static defaultProps = {
+  static defaultProps: DropdownProps = {
     iconPosition: "start",
   }
 

--- a/packages/component-library/components/Layout/Layout.tsx
+++ b/packages/component-library/components/Layout/Layout.tsx
@@ -1,5 +1,6 @@
 import * as React from "react"
 
+import { withDeprecatedComponent } from "@kaizen/react-deprecate-warning"
 import styles from "./Layout.module.scss"
 
 const NavigationBar: React.FunctionComponent = ({ children }) => (
@@ -57,6 +58,9 @@ const Announcers: React.FunctionComponent = ({ children }) => (
 
 Announcers.displayName = "Announcers"
 
+/**
+ * @deprecated Layout is deprecated. Please use draft-page-layout instead.
+ */
 class Layout extends React.Component {
   static displayName = "Layout"
   static NavigationBar = NavigationBar
@@ -114,4 +118,6 @@ const extractChildOfType = (
   return match
 }
 
-export default Layout
+export default withDeprecatedComponent(Layout, {
+  warning: "Layout is deprecated. Use @kaizen/draft-page-layout instead.",
+})

--- a/packages/component-library/components/Layout/Layout.tsx
+++ b/packages/component-library/components/Layout/Layout.tsx
@@ -1,6 +1,4 @@
 import * as React from "react"
-
-import { withDeprecatedComponent } from "@kaizen/react-deprecate-warning"
 import styles from "./Layout.module.scss"
 
 const NavigationBar: React.FunctionComponent = ({ children }) => (
@@ -118,6 +116,4 @@ const extractChildOfType = (
   return match
 }
 
-export default withDeprecatedComponent(Layout, {
-  warning: "Layout is deprecated. Use @kaizen/draft-page-layout instead.",
-})
+export default Layout

--- a/packages/component-library/components/MenuList/MenuList.tsx
+++ b/packages/component-library/components/MenuList/MenuList.tsx
@@ -1,6 +1,7 @@
 /* !!! This component is deprecated. Please do not use for new code  !!! */
 
 import * as React from "react"
+import { withDeprecatedComponent } from "@kaizen/react-deprecate-warning"
 import styles from "./Menu.module.scss"
 
 /**
@@ -12,4 +13,6 @@ const MenuList = (props: { children: React.ReactNode }) => (
 
 MenuList.displayName = "MenuList"
 
-export default MenuList
+export default withDeprecatedComponent(MenuList, {
+  warning: "MenuList is deprecated. Use @kaizen/draft-menu.",
+})

--- a/packages/component-library/components/NavigationBar/NavigationBar.tsx
+++ b/packages/component-library/components/NavigationBar/NavigationBar.tsx
@@ -2,6 +2,7 @@ import classNames from "classnames"
 import * as React from "react"
 import Media from "react-media"
 import uuidv4 from "uuid/v4"
+import { withDeprecatedComponent } from "@kaizen/react-deprecate-warning"
 import { ControlledOffCanvas } from "../OffCanvas"
 import {
   LocalBadge,
@@ -26,6 +27,9 @@ type Props = {
   children?: Navigation
 }
 
+/**
+ * @deprecated NavigationBar is deprecated. See https://github.com/cultureamp/unified-navigation instead
+ */
 class NavigationBar extends React.Component<Props, unknown> {
   static displayName = "NavigationBar"
   static Link = Link
@@ -134,4 +138,7 @@ class NavigationBar extends React.Component<Props, unknown> {
   }
 }
 
-export default NavigationBar
+export default withDeprecatedComponent(NavigationBar, {
+  warning:
+    "NavigationBar is deprecated. See https://github.com/cultureamp/unified-navigation instead",
+})

--- a/packages/component-library/components/NavigationBar/NavigationBar.tsx
+++ b/packages/component-library/components/NavigationBar/NavigationBar.tsx
@@ -34,7 +34,7 @@ class NavigationBar extends React.Component<Props, unknown> {
   static displayName = "NavigationBar"
   static Link = Link
   static Menu = Menu
-  static defaultProps = {
+  static defaultProps: Props = {
     environment: "production",
     loading: false,
     colorScheme: "cultureamp",

--- a/packages/component-library/components/OffCanvas/OffCanvas.tsx
+++ b/packages/component-library/components/OffCanvas/OffCanvas.tsx
@@ -35,10 +35,6 @@ export const OffCanvasContext = React.createContext<OffCanvasContextProps>({
  * @deprecated OffCanvas is deprecated.
  */
 export class OffCanvas extends React.Component<Props> {
-  static defaultProps = {
-    withTrigger: false,
-  }
-
   render() {
     const {
       menuId,

--- a/packages/component-library/components/OffCanvas/OffCanvas.tsx
+++ b/packages/component-library/components/OffCanvas/OffCanvas.tsx
@@ -128,6 +128,6 @@ const withTrigger = (Component: React.ComponentType<any>) =>
     }
   }
 
-export default withDeprecatedComponent(OffCanvas, {
+export default withDeprecatedComponent(withTrigger(OffCanvas), {
   warning: "OffCanvas is deprecated.",
 })

--- a/packages/component-library/components/OffCanvas/OffCanvas.tsx
+++ b/packages/component-library/components/OffCanvas/OffCanvas.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable max-classes-per-file */
 import classNames from "classnames"
 import * as React from "react"
+import { withDeprecatedComponent } from "@kaizen/react-deprecate-warning"
 import Header from "./components/Header"
 import Menu from "./components/Menu"
 
@@ -30,6 +31,9 @@ export const OffCanvasContext = React.createContext<OffCanvasContextProps>({
   resetVisibleMenus: () => undefined,
 })
 
+/**
+ * @deprecated OffCanvas is deprecated.
+ */
 export class OffCanvas extends React.Component<Props> {
   static defaultProps = {
     withTrigger: false,
@@ -128,4 +132,6 @@ const withTrigger = (Component: React.ComponentType<any>) =>
     }
   }
 
-export default withContextProvider(withTrigger(OffCanvas))
+export default withDeprecatedComponent(OffCanvas, {
+  warning: "OffCanvas is deprecated.",
+})

--- a/packages/component-library/components/Text/Text.tsx
+++ b/packages/component-library/components/Text/Text.tsx
@@ -3,6 +3,7 @@
 import classNames from "classnames"
 import * as React from "react"
 
+import { withDeprecatedComponent } from "@kaizen/react-deprecate-warning"
 import styles from "./Text.module.scss"
 
 type TextProps = {
@@ -60,4 +61,6 @@ const Text: React.FunctionComponent<TextProps> = ({
 
 Text.displayName = "Text"
 
-export default Text
+export default withDeprecatedComponent(Text, {
+  warning: "Text is deprecated. Use Paragraph or Heading instead.",
+})


### PR DESCRIPTION
Closes https://github.com/cultureamp/kaizen-design-system/issues/1101

# Objective
Adds any missing `@deprecated` doc blocks to our deprecated components + wraps them in the `withDeprecatedComponent` HOC where that was missing as well.

# Motivation and Context
This helps to make it clear when engineers are using something that is deprecated.