### PR TITLE
chore: Enable Chromatic TurboSnap

### DIFF
--- a/.buildkite/scripts/run-chromatic-build.sh
+++ b/.buildkite/scripts/run-chromatic-build.sh
@@ -11,5 +11,5 @@ export CHROMATIC_APP_CODE
 CHROMATIC_APP_CODE=$(get_secret "chromatic-app-code") || exit $?
 
 yarn install --frozen-lockfile
-yarn storybook:build
-yarn chromatic --exit-zero-on-changes --storybook-build-dir storybook/public
+yarn storybook:build --webpack-stats-json
+yarn chromatic --only-changed --exit-zero-on-changes --storybook-build-dir storybook/public


### PR DESCRIPTION
# Objective
Enables [Chromatic TurboSnap](https://www.chromatic.com/docs/turbosnap) by adding the two required parameters to our storybook build and chromatic cli script.

# Motivation and Context
This will make Chromatic only create snapshots when there are changes, which will save us a ton of credits and allow us to disable the current functionality of only running it if you comment on the PR with "Run Chromatic"