### PR TITLE
refactor: Remove prefer-arrow-function eslint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -22,12 +22,7 @@ module.exports = {
   parserOptions: {
     sourceType: "module",
   },
-  plugins: [
-    "@typescript-eslint",
-    "import",
-    "sort-imports-es6-autofix",
-    "prefer-arrow",
-  ],
+  plugins: ["@typescript-eslint", "import", "sort-imports-es6-autofix"],
   rules: {
     "@typescript-eslint/adjacent-overload-signatures": "error",
     "@typescript-eslint/array-type": [
@@ -189,7 +184,6 @@ module.exports = {
     "no-var": "error",
     "object-shorthand": "error",
     "one-var": ["error", "never"],
-    "prefer-arrow/prefer-arrow-functions": "error",
     "prefer-const": "error",
     "prefer-object-spread": "error",
     "quote-props": ["error", "as-needed"],

--- a/draft-packages/illustration/KaizenDraft/Illustration/Players/VideoPlayer.tsx
+++ b/draft-packages/illustration/KaizenDraft/Illustration/Players/VideoPlayer.tsx
@@ -76,7 +76,6 @@ export const VideoPlayer = ({
     }
     reducedMotionQuery.addEventListener("change", updateMotionPreferences, true)
 
-    // eslint-disable-next-line prefer-arrow/prefer-arrow-functions
     return function cleanup() {
       reducedMotionQuery.removeEventListener("change", updateMotionPreferences)
     }

--- a/package.json
+++ b/package.json
@@ -86,7 +86,6 @@
     "eslint": "^7.21.0",
     "eslint-config-prettier": "^8.1.0",
     "eslint-plugin-import": "^2.22.1",
-    "eslint-plugin-prefer-arrow": "^1.2.3",
     "eslint-plugin-sort-imports-es6-autofix": "^0.5.0",
     "focus-visible": "^5.2.0",
     "identity-obj-proxy": "^3.0.0",

--- a/storybook/theme-switcher-addon/preset.ts
+++ b/storybook/theme-switcher-addon/preset.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line prefer-arrow/prefer-arrow-functions
 export function managerEntries(entry = []) {
   return [...entry, require.resolve("./register")]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -9754,11 +9754,6 @@ eslint-plugin-jsx-a11y@^6.3.1:
     jsx-ast-utils "^2.4.1"
     language-tags "^1.0.5"
 
-eslint-plugin-prefer-arrow@^1.2.3:
-  version "1.2.3"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-prefer-arrow/-/eslint-plugin-prefer-arrow-1.2.3.tgz#e7fbb3fa4cd84ff1015b9c51ad86550e55041041"
-  integrity sha512-J9I5PKCOJretVuiZRGvPQxCbllxGAV/viI20JO3LYblAodofBxyMnZAJ+WGeClHgANnSJberTNoFWWjrWKBuXQ==
-
 eslint-plugin-react-hooks@^1.7.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-1.7.0.tgz#6210b6d5a37205f0b92858f895a4e827020a7d04"


### PR DESCRIPTION
As discussed on Slack: https://cultureamp.slack.com/archives/C016N8Y1E10/p1627023487120400

The rule that prevents us from defining functions using the `function Name()` syntax is not desired by a few of us in the team (but opening this up to any arguments against the chanage).


# Checklist
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] If this contains visual changes, has it been reviewed by a designer?
- [ ] If this introduces either a new component or a breaking change to an existing component, has it been reviewed by an advocate? (Ask in #prod_design_systems)
- [ ] I have considered likely risks of these changes and got someone else to QA as appropriate
- [ ] I have or will communicate these changes to the front end practice

# Additional Considerations
- Does there need to be right-to-left (RTL) options for localization and internationalization?
- Has the test suite been updated?
- Have you done cross-browser testing for our [supported browsers](https://academy.cultureamp.com/hc/en-us/articles/204539569-Supported-browsers-for-Participants)?
- Have you updated any relevant documentation or left useful comments in the code?
- Have you reviewed Culture Amp's Web Accessibility guide [Current Compliance, Going Forward, Statement and Answers for Customers](https://cultureamp.atlassian.net/wiki/spaces/Prod/pages/428572998/Web+Accessibility)?
- If this contains substantial visual changes, especially far reaching ones, have you unlocked the Chromatic step in the pipeline?
- Have Storybook stories been updated?

**If you're new to Kaizen, please ask #prod_design_systems to set up an onboarding session to get you up to speed.** If you have an urgent PR to merge before that happens, it is safest to ask in #prod_design_systems to have a design system advocate review the PR to catch any issues.
