### PR TITLE
docs: Group components in Storybook

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,7 @@ You can edit Kaizen Site documentation using GitHub's interface.
 2. **Edit**: Click the pencil icon to "Edit this file".
 3. **Preview**: Makes your changes to the content and click "Preview changes" to see how they look.
 4. **Commit**:
-    - Under "Commit changes", write a commit message starting with `docs: `, such as `docs: update typography documentation`.
+    - Under "Commit changes", write a commit message starting with `docs:`, such as `docs: update typography documentation`.
     - Create a new branch for this commit and start a pull request, e.g. `di/update-typography-guidelines`.
     - Click the "Commit changes" button. This will start a pull request.
 5. **Create PR**: Click the "Create pull request" button. Add someone as a reviewer or let #prod_design_systems know.
@@ -37,18 +37,16 @@ You can edit Kaizen Site documentation using GitHub's interface.
 
 Once it's approved, click "Squash and merge" to publish your changes. Share the link to the updated documentation on #updates_design_systems for awareness.
 
-
-
 ## Contributing code
 
 ### Need to know
 
 Every contribution must be **design reviewed** and **communicated**.
 
-- **Kaizen Site** changes use `docs: ` at the start of the first commit message and PR title.
-- **New features** in components use `feat: ` at the start of PR titles. For 1 commit, use `feat: ` in the commit message too.
-- **Fixes** in components use `fix: ` at the start of PR titles. For 1 commit, use `fix: ` in the commit message too.
-- **Breaking changes** that are not backwards compatible use feat or fix as above and include `BREAKING CHANGE: ` in the body of a commit message.
+- **Kaizen Site** changes use `docs:` at the start of the first commit message and PR title.
+- **New features** in components use `feat:` at the start of PR titles. For 1 commit, use `feat:` in the commit message too.
+- **Fixes** in components use `fix:` at the start of PR titles. For 1 commit, use `fix:` in the commit message too.
+- **Breaking changes** that are not backwards compatible use feat or fix as above and include `BREAKING CHANGE:` in the body of a commit message.
 - **Design token** changes… let's talk about that.
 
 ### Quality and reviews
@@ -174,7 +172,7 @@ import { loadElmStories } from "elm-storybook"
 
 // JS stories
 
-loadElmStories("MyComponent (Elm)", module, require("./MyComponent.elm"), [
+loadElmStories("Elm/MyComponent", module, require("./MyComponent.elm"), [
   "Your new story #1",
   "Your new story #2",
 ])

--- a/draft-packages/avatar/docs/Avatar.stories.tsx
+++ b/draft-packages/avatar/docs/Avatar.stories.tsx
@@ -3,9 +3,10 @@ import * as React from "react"
 import { withDesign } from "storybook-addon-designs"
 import { Avatar } from "@kaizen/draft-avatar"
 import { figmaEmbed } from "../../../storybook/helpers"
+import { CATEGORIES } from "../../../storybook/constants"
 
 export default {
-  title: "Components/Avatar",
+  title: `${CATEGORIES.components}/Avatar`,
   component: Avatar,
   parameters: {
     docs: {

--- a/draft-packages/avatar/docs/Avatar.stories.tsx
+++ b/draft-packages/avatar/docs/Avatar.stories.tsx
@@ -5,7 +5,7 @@ import { Avatar } from "@kaizen/draft-avatar"
 import { figmaEmbed } from "../../../storybook/helpers"
 
 export default {
-  title: "Avatar (React)",
+  title: "Components/Avatar",
   component: Avatar,
   parameters: {
     docs: {

--- a/draft-packages/badge/docs/Badge.stories.tsx
+++ b/draft-packages/badge/docs/Badge.stories.tsx
@@ -7,7 +7,7 @@ import { withDesign } from "storybook-addon-designs"
 import { figmaEmbed } from "../../../storybook/helpers"
 
 export default {
-  title: "Badge (React)",
+  title: "Components/Badge",
   component: Badge,
   parameters: {
     docs: {

--- a/draft-packages/badge/docs/Badge.stories.tsx
+++ b/draft-packages/badge/docs/Badge.stories.tsx
@@ -5,9 +5,10 @@ import { ToggleSwitchField, ToggledStatus } from "@kaizen/draft-form"
 import { Badge, BadgeAnimated } from "@kaizen/draft-badge"
 import { withDesign } from "storybook-addon-designs"
 import { figmaEmbed } from "../../../storybook/helpers"
+import { CATEGORIES } from "../../../storybook/constants"
 
 export default {
-  title: "Components/Badge",
+  title: `${CATEGORIES.components}/Badge`,
   component: Badge,
   parameters: {
     docs: {

--- a/draft-packages/button/docs/Button.stories.tsx
+++ b/draft-packages/button/docs/Button.stories.tsx
@@ -6,9 +6,10 @@ import { withDesign } from "storybook-addon-designs"
 import filterIcon from "@kaizen/component-library/icons/filter.icon.svg"
 import { Button, CustomButtonProps, ButtonRef } from ".."
 import { figmaEmbed } from "../../../storybook/helpers"
+import { CATEGORIES, SUB_CATEGORIES } from "../../../storybook/constants"
 
 export default {
-  title: "Components/Button/Button",
+  title: `${CATEGORIES.components}/${SUB_CATEGORIES.button}/Button`,
   component: Button,
   args: {
     label: "Label",

--- a/draft-packages/button/docs/Button.stories.tsx
+++ b/draft-packages/button/docs/Button.stories.tsx
@@ -8,7 +8,7 @@ import { Button, CustomButtonProps, ButtonRef } from ".."
 import { figmaEmbed } from "../../../storybook/helpers"
 
 export default {
-  title: "Button (React)",
+  title: "Components/Button/Button",
   component: Button,
   args: {
     label: "Label",

--- a/draft-packages/button/docs/ElmButton.stories.tsx
+++ b/draft-packages/button/docs/ElmButton.stories.tsx
@@ -1,9 +1,10 @@
 import { loadElmStories } from "elm-storybook"
+import { CATEGORIES } from "../../../storybook/constants"
 
 const compiledElm = require("../ElmStories/ButtonStories.elm").Elm.ElmStories
   .ButtonStories
 
-loadElmStories("Elm/Button", module, compiledElm, [
+loadElmStories(`${CATEGORIES.elm}/Button`, module, compiledElm, [
   "Default",
   "Primary",
   "Secondary",

--- a/draft-packages/button/docs/ElmButton.stories.tsx
+++ b/draft-packages/button/docs/ElmButton.stories.tsx
@@ -3,7 +3,7 @@ import { loadElmStories } from "elm-storybook"
 const compiledElm = require("../ElmStories/ButtonStories.elm").Elm.ElmStories
   .ButtonStories
 
-loadElmStories("Button (Elm)", module, compiledElm, [
+loadElmStories("Elm/Button", module, compiledElm, [
   "Default",
   "Primary",
   "Secondary",

--- a/draft-packages/button/docs/IconButton.stories.tsx
+++ b/draft-packages/button/docs/IconButton.stories.tsx
@@ -1,9 +1,10 @@
 import configureIcon from "@kaizen/component-library/icons/configure.icon.svg"
 import * as React from "react"
 import { IconButton } from ".."
+import { CATEGORIES, SUB_CATEGORIES } from "../../../storybook/constants"
 
 export default {
-  title: "Components/Button/Icon Button",
+  title: `${CATEGORIES.components}/${SUB_CATEGORIES.button}/Icon Button`,
   component: IconButton,
   parameters: {
     docs: {

--- a/draft-packages/button/docs/IconButton.stories.tsx
+++ b/draft-packages/button/docs/IconButton.stories.tsx
@@ -3,7 +3,7 @@ import * as React from "react"
 import { IconButton } from ".."
 
 export default {
-  title: "IconButton (React)",
+  title: "Components/Button/Icon Button",
   component: IconButton,
   parameters: {
     docs: {

--- a/draft-packages/card/docs/Card.stories.tsx
+++ b/draft-packages/card/docs/Card.stories.tsx
@@ -3,9 +3,10 @@ import * as React from "react"
 import { withDesign } from "storybook-addon-designs"
 import { Card } from ".."
 import { figmaEmbed } from "../../../storybook/helpers"
+import { CATEGORIES } from "../../../storybook/constants"
 
 export default {
-  title: "Components/Card",
+  title: `${CATEGORIES.components}/Card`,
   component: Card,
   parameters: {
     docs: {

--- a/draft-packages/card/docs/Card.stories.tsx
+++ b/draft-packages/card/docs/Card.stories.tsx
@@ -5,7 +5,7 @@ import { Card } from ".."
 import { figmaEmbed } from "../../../storybook/helpers"
 
 export default {
-  title: "Card (React)",
+  title: "Components/Card",
   component: Card,
   parameters: {
     docs: {

--- a/draft-packages/card/docs/ElmCard.stories.tsx
+++ b/draft-packages/card/docs/ElmCard.stories.tsx
@@ -3,4 +3,4 @@ import { loadElmStories } from "elm-storybook"
 const compiledElm = require("../ElmStories/CardStories.elm").Elm.ElmStories
   .CardStories
 
-loadElmStories("Card (Elm)", module, compiledElm, ["Default"])
+loadElmStories("Elm/Card", module, compiledElm, ["Default"])

--- a/draft-packages/card/docs/ElmCard.stories.tsx
+++ b/draft-packages/card/docs/ElmCard.stories.tsx
@@ -1,6 +1,7 @@
 import { loadElmStories } from "elm-storybook"
+import { CATEGORIES } from "../../../storybook/constants"
 
 const compiledElm = require("../ElmStories/CardStories.elm").Elm.ElmStories
   .CardStories
 
-loadElmStories("Elm/Card", module, compiledElm, ["Default"])
+loadElmStories(`${CATEGORIES.elm}/Card`, module, compiledElm, ["Default"])

--- a/draft-packages/collapsible/docs/Collapsible.stories.tsx
+++ b/draft-packages/collapsible/docs/Collapsible.stories.tsx
@@ -19,7 +19,7 @@ feugiat sodales, nisl ligula aliquet lorem, sit amet scelerisque
 arcu quam a sapien. Donec in viverra urna.`
 
 export default {
-  title: "Collapsible (React)",
+  title: "Components/Collapsible",
   component: Collapsible,
   parameters: {
     backgrounds: { default: "Gray 100" },

--- a/draft-packages/collapsible/docs/Collapsible.stories.tsx
+++ b/draft-packages/collapsible/docs/Collapsible.stories.tsx
@@ -3,6 +3,7 @@ import { Collapsible, CollapsibleGroup } from "@kaizen/draft-collapsible"
 
 import * as React from "react"
 import translationIcon from "@kaizen/component-library/icons/translation.icon.svg"
+import { CATEGORIES } from "../../../storybook/constants"
 import styles from "./Collapsible.stories.scss"
 
 const ListItem = ({ children }: { children: JSX.Element }) => (
@@ -19,7 +20,7 @@ feugiat sodales, nisl ligula aliquet lorem, sit amet scelerisque
 arcu quam a sapien. Donec in viverra urna.`
 
 export default {
-  title: "Components/Collapsible",
+  title: `${CATEGORIES.components}/Collapsible`,
   component: Collapsible,
   parameters: {
     backgrounds: { default: "Gray 100" },

--- a/draft-packages/divider/docs/Divider.stories.tsx
+++ b/draft-packages/divider/docs/Divider.stories.tsx
@@ -12,7 +12,7 @@ const reversedBg = {
 }
 
 export default {
-  title: "Divider (React)",
+  title: "Components/Divider",
   component: Divider,
   parameters: {
     docs: {

--- a/draft-packages/divider/docs/Divider.stories.tsx
+++ b/draft-packages/divider/docs/Divider.stories.tsx
@@ -4,6 +4,7 @@ import { Box, Heading, Paragraph } from "@kaizen/component-library"
 import * as React from "react"
 import { withDesign } from "storybook-addon-designs"
 import { figmaEmbed } from "../../../storybook/helpers"
+import { CATEGORIES } from "../../../storybook/constants"
 
 const reversedBg = {
   backgrounds: {
@@ -12,7 +13,7 @@ const reversedBg = {
 }
 
 export default {
-  title: "Components/Divider",
+  title: `${CATEGORIES.components}/Divider`,
   component: Divider,
   parameters: {
     docs: {

--- a/draft-packages/divider/docs/ElmDivider.stories.tsx
+++ b/draft-packages/divider/docs/ElmDivider.stories.tsx
@@ -3,7 +3,7 @@ import { loadElmStories } from "elm-storybook"
 const compiledElm = require("../ElmStories/DividerStories.elm").Elm.ElmStories
   .DividerStories
 
-loadElmStories("Divider (Elm)", module, compiledElm, [
+loadElmStories("Elm/Divider", module, compiledElm, [
   "Default",
   "Canvas",
   "Canvas (Reversed)",

--- a/draft-packages/divider/docs/ElmDivider.stories.tsx
+++ b/draft-packages/divider/docs/ElmDivider.stories.tsx
@@ -1,9 +1,10 @@
 import { loadElmStories } from "elm-storybook"
+import { CATEGORIES } from "../../../storybook/constants"
 
 const compiledElm = require("../ElmStories/DividerStories.elm").Elm.ElmStories
   .DividerStories
 
-loadElmStories("Elm/Divider", module, compiledElm, [
+loadElmStories(`${CATEGORIES.elm}/Divider`, module, compiledElm, [
   "Default",
   "Canvas",
   "Canvas (Reversed)",

--- a/draft-packages/empty-state/docs/ElmEmptyState.stories.tsx
+++ b/draft-packages/empty-state/docs/ElmEmptyState.stories.tsx
@@ -1,9 +1,10 @@
 import { loadElmStories } from "elm-storybook"
+import { CATEGORIES } from "../../../storybook/constants"
 
 const compiledElm = require("../ElmStories/EmptyStateStories.elm").Elm
   .ElmStories.EmptyStateStories
 
-loadElmStories("Elm/Empty State", module, compiledElm, [
+loadElmStories(`${CATEGORIES.elm}/Empty State`, module, compiledElm, [
   "Default",
   "Default (minimal props)",
   "Layout, Content-only",

--- a/draft-packages/empty-state/docs/ElmEmptyState.stories.tsx
+++ b/draft-packages/empty-state/docs/ElmEmptyState.stories.tsx
@@ -3,7 +3,7 @@ import { loadElmStories } from "elm-storybook"
 const compiledElm = require("../ElmStories/EmptyStateStories.elm").Elm
   .ElmStories.EmptyStateStories
 
-loadElmStories("EmptyState (Elm)", module, compiledElm, [
+loadElmStories("Elm/Empty State", module, compiledElm, [
   "Default",
   "Default (minimal props)",
   "Layout, Content-only",

--- a/draft-packages/empty-state/docs/EmptyState.stories.tsx
+++ b/draft-packages/empty-state/docs/EmptyState.stories.tsx
@@ -29,7 +29,7 @@ const ContentOnlyLayout = ({ children }: { children: React.ReactNode }) => (
 )
 
 export default {
-  title: "EmptyState (React)",
+  title: "Components/Empty State",
   component: EmptyState,
   parameters: {
     docs: {

--- a/draft-packages/empty-state/docs/EmptyState.stories.tsx
+++ b/draft-packages/empty-state/docs/EmptyState.stories.tsx
@@ -8,6 +8,7 @@ import { Button } from "@kaizen/draft-button"
 import { withDesign } from "storybook-addon-designs"
 import { EmptyState } from ".."
 import { figmaEmbed } from "../../../storybook/helpers"
+import { CATEGORIES } from "../../../storybook/constants"
 
 import styles from "./EmptyState.stories.scss"
 
@@ -29,7 +30,7 @@ const ContentOnlyLayout = ({ children }: { children: React.ReactNode }) => (
 )
 
 export default {
-  title: "Components/Empty State",
+  title: `${CATEGORIES.components}/Empty State`,
   component: EmptyState,
   parameters: {
     docs: {

--- a/draft-packages/filter-menu-button/docs/FilterMenuButton.stories.tsx
+++ b/draft-packages/filter-menu-button/docs/FilterMenuButton.stories.tsx
@@ -18,7 +18,7 @@ const withMinHeight = Story => {
 }
 
 export default {
-  title: "FilterMenuButton (React)",
+  title: "Components/Filter Menu",
   component: FilterMenuButton,
   parameters: {
     docs: {

--- a/draft-packages/filter-menu-button/docs/FilterMenuButton.stories.tsx
+++ b/draft-packages/filter-menu-button/docs/FilterMenuButton.stories.tsx
@@ -4,6 +4,7 @@ import { FilterMenuButton } from "@kaizen/draft-filter-menu-button"
 import { CheckboxField, CheckboxGroup } from "@kaizen/draft-form"
 import isChromatic from "chromatic/isChromatic"
 import React, { useState } from "react"
+import { CATEGORIES } from "../../../storybook/constants"
 import styles from "./FilterMenuButton.stories.scss"
 
 /**
@@ -18,7 +19,7 @@ const withMinHeight = Story => {
 }
 
 export default {
-  title: "Components/Filter Menu",
+  title: `${CATEGORIES.components}/Filter Menu`,
   component: FilterMenuButton,
   parameters: {
     docs: {

--- a/draft-packages/form/docs/CheckboxField.stories.tsx
+++ b/draft-packages/form/docs/CheckboxField.stories.tsx
@@ -48,7 +48,7 @@ class CheckboxFieldExample extends React.Component<Props> {
 }
 
 export default {
-  title: "CheckboxField (React)",
+  title: "Components/Form/Checkbox Field",
   component: CheckboxField,
   parameters: {
     docs: {

--- a/draft-packages/form/docs/CheckboxField.stories.tsx
+++ b/draft-packages/form/docs/CheckboxField.stories.tsx
@@ -2,6 +2,7 @@ import { CheckboxField } from "@kaizen/draft-form"
 import * as React from "react"
 import { withDesign } from "storybook-addon-designs"
 import { figmaEmbed } from "../../../storybook/helpers"
+import { CATEGORIES, SUB_CATEGORIES } from "../../../storybook/constants"
 
 type RenderProps = {
   checkedStatus: string
@@ -48,7 +49,7 @@ class CheckboxFieldExample extends React.Component<Props> {
 }
 
 export default {
-  title: "Components/Form/Checkbox Field",
+  title: `${CATEGORIES.components}/${SUB_CATEGORIES.form}/Checkbox Field`,
   component: CheckboxField,
   parameters: {
     docs: {

--- a/draft-packages/form/docs/CheckboxGroup.stories.tsx
+++ b/draft-packages/form/docs/CheckboxGroup.stories.tsx
@@ -2,6 +2,7 @@ import { CheckboxGroup, CheckboxField, Label } from "@kaizen/draft-form"
 import * as React from "react"
 import { withDesign } from "storybook-addon-designs"
 import { figmaEmbed } from "../../../storybook/helpers"
+import { CATEGORIES, SUB_CATEGORIES } from "../../../storybook/constants"
 
 interface RenderProps {
   checkedStatus: string
@@ -42,7 +43,7 @@ class CheckboxGroupExample extends React.Component<Props> {
 }
 
 export default {
-  title: "Components/Form/Checkbox Group",
+  title: `${CATEGORIES.components}/${SUB_CATEGORIES.form}/Checkbox Group`,
   component: CheckboxGroup,
   parameters: {
     docs: {

--- a/draft-packages/form/docs/CheckboxGroup.stories.tsx
+++ b/draft-packages/form/docs/CheckboxGroup.stories.tsx
@@ -42,7 +42,7 @@ class CheckboxGroupExample extends React.Component<Props> {
 }
 
 export default {
-  title: "CheckboxGroup (React)",
+  title: "Components/Form/Checkbox Group",
   component: CheckboxGroup,
   parameters: {
     docs: {

--- a/draft-packages/form/docs/ElmCheckboxField.stories.tsx
+++ b/draft-packages/form/docs/ElmCheckboxField.stories.tsx
@@ -3,7 +3,7 @@ import { loadElmStories } from "elm-storybook"
 const compiledElm = require("../ElmStories/CheckboxFieldStories.elm").Elm
   .ElmStories.CheckboxFieldStories
 
-loadElmStories("CheckboxField (Elm)", module, compiledElm, [
+loadElmStories("Elm/Checkbox Field", module, compiledElm, [
   "On",
   "Mixed",
   "Off",

--- a/draft-packages/form/docs/ElmCheckboxField.stories.tsx
+++ b/draft-packages/form/docs/ElmCheckboxField.stories.tsx
@@ -1,9 +1,10 @@
 import { loadElmStories } from "elm-storybook"
+import { CATEGORIES } from "../../../storybook/constants"
 
 const compiledElm = require("../ElmStories/CheckboxFieldStories.elm").Elm
   .ElmStories.CheckboxFieldStories
 
-loadElmStories("Elm/Checkbox Field", module, compiledElm, [
+loadElmStories(`${CATEGORIES.elm}/Checkbox Field`, module, compiledElm, [
   "On",
   "Mixed",
   "Off",

--- a/draft-packages/form/docs/ElmRadioField.stories.tsx
+++ b/draft-packages/form/docs/ElmRadioField.stories.tsx
@@ -3,7 +3,7 @@ import { loadElmStories } from "elm-storybook"
 const compiledElm = require("../ElmStories/RadioFieldStories.elm").Elm
   .ElmStories.RadioFieldStories
 
-loadElmStories("RadioField (Elm)", module, compiledElm, [
+loadElmStories("Elm/Radio Field", module, compiledElm, [
   "Interactive",
   "Unselected disabled",
   "Unselected default",

--- a/draft-packages/form/docs/ElmRadioField.stories.tsx
+++ b/draft-packages/form/docs/ElmRadioField.stories.tsx
@@ -1,9 +1,10 @@
 import { loadElmStories } from "elm-storybook"
+import { CATEGORIES } from "../../../storybook/constants"
 
 const compiledElm = require("../ElmStories/RadioFieldStories.elm").Elm
   .ElmStories.RadioFieldStories
 
-loadElmStories("Elm/Radio Field", module, compiledElm, [
+loadElmStories(`${CATEGORIES.elm}/Radio Field`, module, compiledElm, [
   "Interactive",
   "Unselected disabled",
   "Unselected default",

--- a/draft-packages/form/docs/ElmSelectField.stories.tsx
+++ b/draft-packages/form/docs/ElmSelectField.stories.tsx
@@ -1,11 +1,12 @@
 import { loadElmStories } from "elm-storybook"
 import Ports from "@kaizen/draft-select/KaizenDraft/Select/ports"
+import { CATEGORIES } from "../../../storybook/constants"
 
 const compiledElm = require("../ElmStories/SelectFieldStories.elm").Elm
   .ElmStories.SelectFieldStories
 
 loadElmStories(
-  "Elm/Select Field",
+  `${CATEGORIES.elm}/Select Field`,
   module,
   compiledElm,
   ["Single", "Single Disabled", "Multi-Select"],

--- a/draft-packages/form/docs/ElmSelectField.stories.tsx
+++ b/draft-packages/form/docs/ElmSelectField.stories.tsx
@@ -5,7 +5,7 @@ const compiledElm = require("../ElmStories/SelectFieldStories.elm").Elm
   .ElmStories.SelectFieldStories
 
 loadElmStories(
-  "SelectField (Elm)",
+  "Elm/Select Field",
   module,
   compiledElm,
   ["Single", "Single Disabled", "Multi-Select"],

--- a/draft-packages/form/docs/ElmTextAreaField.stories.tsx
+++ b/draft-packages/form/docs/ElmTextAreaField.stories.tsx
@@ -3,7 +3,7 @@ import { loadElmStories } from "elm-storybook"
 const compiledElm = require("../ElmStories/TextAreaFieldStories.elm").Elm
   .ElmStories.TextAreaFieldStories
 
-loadElmStories("TextAreaField (Elm)", module, compiledElm, [
+loadElmStories("Elm/Text Area Field", module, compiledElm, [
   "Default",
   "Default, Controlled, Prefilled Value",
   "Default, Uncontrolled, Prefilled Value",

--- a/draft-packages/form/docs/ElmTextAreaField.stories.tsx
+++ b/draft-packages/form/docs/ElmTextAreaField.stories.tsx
@@ -1,9 +1,10 @@
 import { loadElmStories } from "elm-storybook"
+import { CATEGORIES } from "../../../storybook/constants"
 
 const compiledElm = require("../ElmStories/TextAreaFieldStories.elm").Elm
   .ElmStories.TextAreaFieldStories
 
-loadElmStories("Elm/Text Area Field", module, compiledElm, [
+loadElmStories(`${CATEGORIES.elm}/Text Area Field`, module, compiledElm, [
   "Default",
   "Default, Controlled, Prefilled Value",
   "Default, Uncontrolled, Prefilled Value",

--- a/draft-packages/form/docs/ElmTextField.stories.tsx
+++ b/draft-packages/form/docs/ElmTextField.stories.tsx
@@ -1,9 +1,10 @@
 import { loadElmStories } from "elm-storybook"
+import { CATEGORIES } from "../../../storybook/constants"
 
 const compiledElm = require("../ElmStories/TextFieldStories.elm").Elm.ElmStories
   .TextFieldStories
 
-loadElmStories("Elm/Text Field", module, compiledElm, [
+loadElmStories(`${CATEGORIES.elm}/Text Field`, module, compiledElm, [
   "Default",
   "Default, Controlled, Prefilled Value",
   "Default, Uncontrolled, Prefilled Value",

--- a/draft-packages/form/docs/ElmTextField.stories.tsx
+++ b/draft-packages/form/docs/ElmTextField.stories.tsx
@@ -3,7 +3,7 @@ import { loadElmStories } from "elm-storybook"
 const compiledElm = require("../ElmStories/TextFieldStories.elm").Elm.ElmStories
   .TextFieldStories
 
-loadElmStories("TextField (Elm)", module, compiledElm, [
+loadElmStories("Elm/Text Field", module, compiledElm, [
   "Default",
   "Default, Controlled, Prefilled Value",
   "Default, Uncontrolled, Prefilled Value",

--- a/draft-packages/form/docs/ElmToggleSwitchField.stories.tsx
+++ b/draft-packages/form/docs/ElmToggleSwitchField.stories.tsx
@@ -1,9 +1,10 @@
 import { loadElmStories } from "elm-storybook"
+import { CATEGORIES } from "../../../storybook/constants"
 
 const compiledElm = require("../ElmStories/ToggleSwitchFieldStories.elm").Elm
   .ElmStories.ToggleSwitchFieldStories
 
-loadElmStories("Elm/Toggle Switch Field", module, compiledElm, [
+loadElmStories(`${CATEGORIES.elm}/Toggle Switch Field`, module, compiledElm, [
   "Default theme",
   "Freemium theme",
   "Disabled Off",

--- a/draft-packages/form/docs/ElmToggleSwitchField.stories.tsx
+++ b/draft-packages/form/docs/ElmToggleSwitchField.stories.tsx
@@ -3,7 +3,7 @@ import { loadElmStories } from "elm-storybook"
 const compiledElm = require("../ElmStories/ToggleSwitchFieldStories.elm").Elm
   .ElmStories.ToggleSwitchFieldStories
 
-loadElmStories("ToggleSwitchField (Elm)", module, compiledElm, [
+loadElmStories("Elm/Toggle Switch Field", module, compiledElm, [
   "Default theme",
   "Freemium theme",
   "Disabled Off",

--- a/draft-packages/form/docs/RadioField.stories.tsx
+++ b/draft-packages/form/docs/RadioField.stories.tsx
@@ -51,7 +51,7 @@ class RadioFieldExample extends React.Component<Props> {
 }
 
 export default {
-  title: "RadioField (React)",
+  title: "Components/Form/Radio Field",
   component: RadioField,
   parameters: {
     docs: {

--- a/draft-packages/form/docs/RadioField.stories.tsx
+++ b/draft-packages/form/docs/RadioField.stories.tsx
@@ -2,6 +2,7 @@ import { RadioField } from "@kaizen/draft-form"
 import * as React from "react"
 import { withDesign } from "storybook-addon-designs"
 import { figmaEmbed } from "../../../storybook/helpers"
+import { CATEGORIES, SUB_CATEGORIES } from "../../../storybook/constants"
 
 const ExampleContent = () => (
   <div style={{ padding: "1em 2em", maxWidth: "400px" }} />
@@ -51,7 +52,7 @@ class RadioFieldExample extends React.Component<Props> {
 }
 
 export default {
-  title: "Components/Form/Radio Field",
+  title: `${CATEGORIES.components}/${SUB_CATEGORIES.form}/Radio Field`,
   component: RadioField,
   parameters: {
     docs: {

--- a/draft-packages/form/docs/RadioGroup.stories.tsx
+++ b/draft-packages/form/docs/RadioGroup.stories.tsx
@@ -37,7 +37,7 @@ class RadioGroupExample extends React.Component<Props> {
 }
 
 export default {
-  title: "RadioGroup (React)",
+  title: "Components/Form/Radio Group",
   component: RadioGroup,
   parameters: {
     docs: {

--- a/draft-packages/form/docs/RadioGroup.stories.tsx
+++ b/draft-packages/form/docs/RadioGroup.stories.tsx
@@ -2,6 +2,7 @@ import { Label, RadioField, RadioGroup } from "@kaizen/draft-form"
 import * as React from "react"
 import { withDesign } from "storybook-addon-designs"
 import { figmaEmbed } from "../../../storybook/helpers"
+import { CATEGORIES, SUB_CATEGORIES } from "../../../storybook/constants"
 
 type RenderProps = {
   selectedOption: string
@@ -37,7 +38,7 @@ class RadioGroupExample extends React.Component<Props> {
 }
 
 export default {
-  title: "Components/Form/Radio Group",
+  title: `${CATEGORIES.components}/${SUB_CATEGORIES.form}/Radio Group`,
   component: RadioGroup,
   parameters: {
     docs: {

--- a/draft-packages/form/docs/TextAreaField.stories.tsx
+++ b/draft-packages/form/docs/TextAreaField.stories.tsx
@@ -53,7 +53,7 @@ const reversedBg = {
 }
 
 export default {
-  title: "TextAreaField (React)",
+  title: "Components/Form/Text Area Field",
   component: TextAreaField,
   parameters: {
     docs: {

--- a/draft-packages/form/docs/TextAreaField.stories.tsx
+++ b/draft-packages/form/docs/TextAreaField.stories.tsx
@@ -2,6 +2,7 @@ import { TextAreaField } from "@kaizen/draft-form"
 import { withDesign } from "storybook-addon-designs"
 import React from "react"
 import { figmaEmbed } from "../../../storybook/helpers"
+import { CATEGORIES, SUB_CATEGORIES } from "../../../storybook/constants"
 
 interface RenderProps {
   controlledValue: string
@@ -53,7 +54,7 @@ const reversedBg = {
 }
 
 export default {
-  title: "Components/Form/Text Area Field",
+  title: `${CATEGORIES.components}/${SUB_CATEGORIES.form}/Text Area Field`,
   component: TextAreaField,
   parameters: {
     docs: {

--- a/draft-packages/form/docs/TextField.stories.tsx
+++ b/draft-packages/form/docs/TextField.stories.tsx
@@ -8,6 +8,7 @@ import { TextField } from "@kaizen/draft-form"
 import lockIcon from "@kaizen/component-library/icons/lock.icon.svg"
 import userIcon from "@kaizen/component-library/icons/user.icon.svg"
 import { figmaEmbed } from "../../../storybook/helpers"
+import { CATEGORIES, SUB_CATEGORIES } from "../../../storybook/constants"
 
 const ExampleContainer: React.FunctionComponent = ({ children }) => (
   <div style={{ width: "98%", margin: "1%" }}>{children}</div>
@@ -20,7 +21,7 @@ const ReversedBg = {
 }
 
 export default {
-  title: "Components/Form/Text Field",
+  title: `${CATEGORIES.components}/${SUB_CATEGORIES.form}/Text Field`,
   component: TextField,
   parameters: {
     docs: {

--- a/draft-packages/form/docs/TextField.stories.tsx
+++ b/draft-packages/form/docs/TextField.stories.tsx
@@ -20,7 +20,7 @@ const ReversedBg = {
 }
 
 export default {
-  title: "TextField (React)",
+  title: "Components/Form/Text Field",
   component: TextField,
   parameters: {
     docs: {

--- a/draft-packages/form/docs/ToggleSwitchField.stories.tsx
+++ b/draft-packages/form/docs/ToggleSwitchField.stories.tsx
@@ -43,7 +43,7 @@ const RtlContainer = ({ children }: { children: React.ReactNode }) => (
 )
 
 export default {
-  title: "ToggleSwitchField (React)",
+  title: "Components/Form/Toggle Switch Field",
   component: ToggleSwitchField,
   parameters: {
     docs: {

--- a/draft-packages/form/docs/ToggleSwitchField.stories.tsx
+++ b/draft-packages/form/docs/ToggleSwitchField.stories.tsx
@@ -5,6 +5,7 @@ import {
 } from "@kaizen/draft-form"
 import * as React from "react"
 import { withDesign } from "storybook-addon-designs"
+import { CATEGORIES, SUB_CATEGORIES } from "../../../storybook/constants"
 import { figmaEmbed } from "../../../storybook/helpers"
 
 class ToggleStateContainer extends React.Component<
@@ -43,7 +44,7 @@ const RtlContainer = ({ children }: { children: React.ReactNode }) => (
 )
 
 export default {
-  title: "Components/Form/Toggle Switch Field",
+  title: `${CATEGORIES.components}/${SUB_CATEGORIES.form}/Toggle Switch Field`,
   component: ToggleSwitchField,
   parameters: {
     docs: {

--- a/draft-packages/guidance-block/docs/GuidanceBlock.stories.tsx
+++ b/draft-packages/guidance-block/docs/GuidanceBlock.stories.tsx
@@ -4,11 +4,12 @@ import { GuidanceBlock } from "@kaizen/draft-guidance-block"
 import { Informative } from "@kaizen/draft-illustration"
 import { withDesign } from "storybook-addon-designs"
 import { figmaEmbed } from "../../../storybook/helpers"
+import { CATEGORIES } from "../../../storybook/constants"
 const externalLinkIcon = require("@kaizen/component-library/icons/external-link.icon.svg")
   .default
 
 export default {
-  title: "Components/Guidance Block",
+  title: `${CATEGORIES.components}/Guidance Block`,
   component: GuidanceBlock,
   parameters: {
     docs: {

--- a/draft-packages/guidance-block/docs/GuidanceBlock.stories.tsx
+++ b/draft-packages/guidance-block/docs/GuidanceBlock.stories.tsx
@@ -8,7 +8,7 @@ const externalLinkIcon = require("@kaizen/component-library/icons/external-link.
   .default
 
 export default {
-  title: "GuidanceBlock (React)",
+  title: "Components/Guidance Block",
   component: GuidanceBlock,
   parameters: {
     docs: {

--- a/draft-packages/hero-card/docs/HeroCard.stories.tsx
+++ b/draft-packages/hero-card/docs/HeroCard.stories.tsx
@@ -23,7 +23,7 @@ const renderContent = () => (
 )
 
 export default {
-  title: "HeroCard (React)",
+  title: "Components/Hero Card",
   component: HeroCard,
   parameters: {
     docs: {

--- a/draft-packages/hero-card/docs/HeroCard.stories.tsx
+++ b/draft-packages/hero-card/docs/HeroCard.stories.tsx
@@ -2,6 +2,7 @@ import { Button } from "@kaizen/draft-button"
 import { HeroCard } from "@kaizen/draft-hero-card"
 import * as React from "react"
 import { withDesign } from "storybook-addon-designs"
+import { CATEGORIES } from "../../../storybook/constants"
 import { figmaEmbed } from "../../../storybook/helpers"
 
 const surveyIllustration = require("./survey.png")
@@ -23,7 +24,7 @@ const renderContent = () => (
 )
 
 export default {
-  title: "Components/Hero Card",
+  title: `${CATEGORIES.components}/Hero Card`,
   component: HeroCard,
   parameters: {
     docs: {

--- a/draft-packages/hierarchical-menu/docs/HierarchicalMenu.stories.tsx
+++ b/draft-packages/hierarchical-menu/docs/HierarchicalMenu.stories.tsx
@@ -41,7 +41,7 @@ const StoryContainer = ({ children }: StoryContainerProps) => {
 }
 
 export default {
-  title: "HierarchicalMenu (React)",
+  title: "Components/Hierarchical Menu",
   component: HierarchicalMenu,
   parameters: {
     docs: {

--- a/draft-packages/hierarchical-menu/docs/HierarchicalMenu.stories.tsx
+++ b/draft-packages/hierarchical-menu/docs/HierarchicalMenu.stories.tsx
@@ -5,6 +5,7 @@ import {
   Hierarchy,
   HierarchyNode,
 } from "@kaizen/draft-hierarchical-menu"
+import { CATEGORIES } from "../../../storybook/constants"
 import {
   ResponseTime,
   levelZero,
@@ -41,7 +42,7 @@ const StoryContainer = ({ children }: StoryContainerProps) => {
 }
 
 export default {
-  title: "Components/Hierarchical Menu",
+  title: `${CATEGORIES.components}/Hierarchical Menu`,
   component: HierarchicalMenu,
   parameters: {
     docs: {

--- a/draft-packages/hierarchical-select/docs/HierarchicalSelect.stories.tsx
+++ b/draft-packages/hierarchical-select/docs/HierarchicalSelect.stories.tsx
@@ -64,7 +64,7 @@ const SelectionSummary = (props: {
 )
 
 export default {
-  title: "HierarchicalSelect (React)",
+  title: "Components/Hierarchical Select",
   component: HierarchicalSelect,
   docs: {
     description: {

--- a/draft-packages/hierarchical-select/docs/HierarchicalSelect.stories.tsx
+++ b/draft-packages/hierarchical-select/docs/HierarchicalSelect.stories.tsx
@@ -4,6 +4,7 @@ import { Paragraph } from "@kaizen/component-library"
 import { Button } from "@kaizen/draft-button"
 import { HierarchicalSelect } from "@kaizen/draft-hierarchical-select"
 import { Hierarchy, HierarchyNode } from "@kaizen/draft-hierarchical-menu"
+import { CATEGORIES } from "../../../storybook/constants"
 import {
   levelZero,
   levelOne,
@@ -64,7 +65,7 @@ const SelectionSummary = (props: {
 )
 
 export default {
-  title: "Components/Hierarchical Select",
+  title: `${CATEGORIES.components}/Hierarchical Select`,
   component: HierarchicalSelect,
   docs: {
     description: {

--- a/draft-packages/illustration/docs/IllustrationScene.stories.tsx
+++ b/draft-packages/illustration/docs/IllustrationScene.stories.tsx
@@ -57,6 +57,7 @@ import {
   BrandMomentError,
   BrandMomentStarterKit,
 } from ".."
+import { CATEGORIES, SUB_CATEGORIES } from "../../../storybook/constants"
 
 const withFixedWidth = Story => (
   <div style={{ width: "500px" }}>
@@ -65,7 +66,7 @@ const withFixedWidth = Story => (
 )
 
 export default {
-  title: "Components/Illustration/Scene",
+  title: `${CATEGORIES.components}/${SUB_CATEGORIES.illustration}/Scene`,
   component: ManagerLearningResilience,
   parameters: {
     docs: {

--- a/draft-packages/illustration/docs/IllustrationScene.stories.tsx
+++ b/draft-packages/illustration/docs/IllustrationScene.stories.tsx
@@ -65,7 +65,7 @@ const withFixedWidth = Story => (
 )
 
 export default {
-  title: "Illustration, Scene (React)",
+  title: "Components/Illustration/Scene",
   component: ManagerLearningResilience,
   parameters: {
     docs: {

--- a/draft-packages/illustration/docs/IllustrationSpot.stories.tsx
+++ b/draft-packages/illustration/docs/IllustrationSpot.stories.tsx
@@ -93,9 +93,10 @@ import {
   ValueAdd,
   Recommendation,
 } from ".."
+import { CATEGORIES, SUB_CATEGORIES } from "../../../storybook/constants"
 
 export default {
-  title: "Components/Illustration/Spot",
+  title: `${CATEGORIES.components}/${SUB_CATEGORIES.illustration}/Spot`,
   component: AccountBasics,
   parameters: {
     docs: {

--- a/draft-packages/illustration/docs/IllustrationSpot.stories.tsx
+++ b/draft-packages/illustration/docs/IllustrationSpot.stories.tsx
@@ -95,7 +95,7 @@ import {
 } from ".."
 
 export default {
-  title: "Illustration, Spot (React)",
+  title: "Components/Illustration/Spot",
   component: AccountBasics,
   parameters: {
     docs: {

--- a/draft-packages/likert-scale-legacy/docs/LikertScaleLegacy.stories.tsx
+++ b/draft-packages/likert-scale-legacy/docs/LikertScaleLegacy.stories.tsx
@@ -9,7 +9,7 @@ import { Heading } from "@kaizen/component-library"
 import { figmaEmbed } from "../../../storybook/helpers"
 
 export default {
-  title: "LikertScaleLegacy (React)",
+  title: "Components/Likert Scale",
   component: LikertScaleLegacy,
   parameters: {
     docs: {

--- a/draft-packages/likert-scale-legacy/docs/LikertScaleLegacy.stories.tsx
+++ b/draft-packages/likert-scale-legacy/docs/LikertScaleLegacy.stories.tsx
@@ -7,9 +7,10 @@ import {
 } from "@kaizen/draft-likert-scale-legacy"
 import { Heading } from "@kaizen/component-library"
 import { figmaEmbed } from "../../../storybook/helpers"
+import { CATEGORIES } from "../../../storybook/constants"
 
 export default {
-  title: "Components/Likert Scale",
+  title: `${CATEGORIES.components}/Likert Scale`,
   component: LikertScaleLegacy,
   parameters: {
     docs: {

--- a/draft-packages/loading-placeholder/docs/ElmLoadingPlaceholder.stories.tsx
+++ b/draft-packages/loading-placeholder/docs/ElmLoadingPlaceholder.stories.tsx
@@ -1,9 +1,10 @@
 import { loadElmStories } from "elm-storybook"
+import { CATEGORIES } from "../../../storybook/constants"
 
 const compiledElm = require("../ElmStories/LoadingPlaceholderStories.elm").Elm
   .ElmStories.LoadingPlaceholderStories
 
-loadElmStories("Elm/Loading Placeholder", module, compiledElm, [
+loadElmStories(`${CATEGORIES.elm}/Loading Placeholder`, module, compiledElm, [
   "Default, Multiple",
   "Default, Multiple, Inline",
   "Default, Multiple, Variable width",

--- a/draft-packages/loading-placeholder/docs/ElmLoadingPlaceholder.stories.tsx
+++ b/draft-packages/loading-placeholder/docs/ElmLoadingPlaceholder.stories.tsx
@@ -3,7 +3,7 @@ import { loadElmStories } from "elm-storybook"
 const compiledElm = require("../ElmStories/LoadingPlaceholderStories.elm").Elm
   .ElmStories.LoadingPlaceholderStories
 
-loadElmStories("LoadingPlaceholder (Elm)", module, compiledElm, [
+loadElmStories("Elm/Loading Placeholder", module, compiledElm, [
   "Default, Multiple",
   "Default, Multiple, Inline",
   "Default, Multiple, Variable width",

--- a/draft-packages/loading-placeholder/docs/LoadingPlaceholder.stories.tsx
+++ b/draft-packages/loading-placeholder/docs/LoadingPlaceholder.stories.tsx
@@ -2,6 +2,7 @@ import { Heading, Paragraph } from "@kaizen/component-library"
 import { LoadingPlaceholder } from "@kaizen/draft-loading-placeholder"
 import * as React from "react"
 import { withDesign } from "storybook-addon-designs"
+import { CATEGORIES } from "../../../storybook/constants"
 import { figmaEmbed } from "../../../storybook/helpers"
 
 import styles from "./LoadingPlaceholder.stories.scss"
@@ -11,7 +12,7 @@ const StoryContainer: React.FunctionComponent = ({ children }) => (
 )
 
 export default {
-  title: "Components/Loading Placeholder",
+  title: `${CATEGORIES.components}/Loading Placeholder`,
   component: LoadingPlaceholder,
   parameters: {
     docs: {

--- a/draft-packages/loading-placeholder/docs/LoadingPlaceholder.stories.tsx
+++ b/draft-packages/loading-placeholder/docs/LoadingPlaceholder.stories.tsx
@@ -11,7 +11,7 @@ const StoryContainer: React.FunctionComponent = ({ children }) => (
 )
 
 export default {
-  title: "LoadingPlaceholder (React)",
+  title: "Components/Loading Placeholder",
   component: LoadingPlaceholder,
   parameters: {
     docs: {

--- a/draft-packages/loading-spinner/docs/LoadingSpinner.stories.tsx
+++ b/draft-packages/loading-spinner/docs/LoadingSpinner.stories.tsx
@@ -7,7 +7,7 @@ import colorTokens from "@kaizen/design-tokens/tokens/color.json"
 import { figmaEmbed } from "../../../storybook/helpers"
 
 export default {
-  title: "LoadingSpinner (React)",
+  title: "Components/Loading Spinner",
   component: LoadingSpinner,
   parameters: {
     docs: {

--- a/draft-packages/loading-spinner/docs/LoadingSpinner.stories.tsx
+++ b/draft-packages/loading-spinner/docs/LoadingSpinner.stories.tsx
@@ -5,9 +5,10 @@ import { Box, Paragraph } from "@kaizen/component-library"
 import { withDesign } from "storybook-addon-designs"
 import colorTokens from "@kaizen/design-tokens/tokens/color.json"
 import { figmaEmbed } from "../../../storybook/helpers"
+import { CATEGORIES } from "../../../storybook/constants"
 
 export default {
-  title: "Components/Loading Spinner",
+  title: `${CATEGORIES.components}/Loading Spinner`,
   component: LoadingSpinner,
   parameters: {
     docs: {

--- a/draft-packages/menu/docs/Menu.stories.tsx
+++ b/draft-packages/menu/docs/Menu.stories.tsx
@@ -84,7 +84,7 @@ const MenuInstance: React.FunctionComponent = () => (
 )
 
 export default {
-  title: "Menu (React)",
+  title: "Components/Menu",
   component: Menu,
   parameters: {
     docs: {

--- a/draft-packages/menu/docs/Menu.stories.tsx
+++ b/draft-packages/menu/docs/Menu.stories.tsx
@@ -19,6 +19,7 @@ import {
   MenuSeparator,
   StatelessMenu,
 } from ".."
+import { CATEGORIES } from "../../../storybook/constants"
 
 const MenuInstance: React.FunctionComponent = () => (
   <MenuContent>
@@ -84,7 +85,7 @@ const MenuInstance: React.FunctionComponent = () => (
 )
 
 export default {
-  title: "Components/Menu",
+  title: `${CATEGORIES.components}/Menu`,
   component: Menu,
   parameters: {
     docs: {

--- a/draft-packages/modal/docs/ElmModal.stories.tsx
+++ b/draft-packages/modal/docs/ElmModal.stories.tsx
@@ -3,7 +3,7 @@ import { loadElmStories } from "elm-storybook"
 const compiledElm = require("../ElmStories/ModalStories.elm").Elm.ElmStories
   .ModalStories
 
-loadElmStories("Modal (Elm)", module, compiledElm, [
+loadElmStories("Elm/Modal", module, compiledElm, [
   "Confirmation (cautionary), shown by default",
   "Generic, shown by default",
   "Confirmation (informative), shown by default",

--- a/draft-packages/modal/docs/ElmModal.stories.tsx
+++ b/draft-packages/modal/docs/ElmModal.stories.tsx
@@ -1,9 +1,10 @@
 import { loadElmStories } from "elm-storybook"
+import { CATEGORIES } from "../../../storybook/constants"
 
 const compiledElm = require("../ElmStories/ModalStories.elm").Elm.ElmStories
   .ModalStories
 
-loadElmStories("Elm/Modal", module, compiledElm, [
+loadElmStories(`${CATEGORIES.elm}/Modal`, module, compiledElm, [
   "Confirmation (cautionary), shown by default",
   "Generic, shown by default",
   "Confirmation (informative), shown by default",

--- a/draft-packages/modal/docs/Modal.stories.tsx
+++ b/draft-packages/modal/docs/Modal.stories.tsx
@@ -75,7 +75,7 @@ class ModalStateContainer extends React.Component<
 }
 
 export default {
-  title: "Modal (React)",
+  title: "Components/Modal",
   component: ConfirmationModal,
   parameters: {
     docs: {

--- a/draft-packages/modal/docs/Modal.stories.tsx
+++ b/draft-packages/modal/docs/Modal.stories.tsx
@@ -27,6 +27,7 @@ import { withDesign } from "storybook-addon-designs"
 import { Negative, ExecutiveReportSharing } from "@kaizen/draft-illustration"
 import { figmaEmbed } from "../../../storybook/helpers"
 
+import { CATEGORIES } from "../../../storybook/constants"
 import styles from "./Modal.stories.scss"
 
 // Add additional height to the stories when running in Chromatic only.
@@ -75,7 +76,7 @@ class ModalStateContainer extends React.Component<
 }
 
 export default {
-  title: "Components/Modal",
+  title: `${CATEGORIES.components}/Modal`,
   component: ConfirmationModal,
   parameters: {
     docs: {

--- a/draft-packages/page-layout/docs/PageLayout.stories.tsx
+++ b/draft-packages/page-layout/docs/PageLayout.stories.tsx
@@ -7,7 +7,7 @@ import { figmaEmbed } from "../../../storybook/helpers"
 import styles from "./PageLayout.stories.scss"
 
 export default {
-  title: "PageLayout (React)",
+  title: "Components/Page Layout",
   component: Container,
   parameters: {
     docs: {

--- a/draft-packages/page-layout/docs/PageLayout.stories.tsx
+++ b/draft-packages/page-layout/docs/PageLayout.stories.tsx
@@ -4,10 +4,11 @@ import { NavigationTab, TitleBlockZen } from "@kaizen/draft-title-block-zen"
 import { withDesign } from "storybook-addon-designs"
 import { Container, Content, Skirt, SkirtCard } from ".."
 import { figmaEmbed } from "../../../storybook/helpers"
+import { CATEGORIES } from "../../../storybook/constants"
 import styles from "./PageLayout.stories.scss"
 
 export default {
-  title: "Components/Page Layout",
+  title: `${CATEGORIES.components}/Page Layout`,
   component: Container,
   parameters: {
     docs: {

--- a/draft-packages/popover/docs/ElmPopover.stories.tsx
+++ b/draft-packages/popover/docs/ElmPopover.stories.tsx
@@ -1,8 +1,9 @@
 import { loadElmStories } from "elm-storybook"
+import { CATEGORIES } from "../../../storybook/constants"
 const compiledElm = require("../ElmStories/PopoverStories.elm").Elm.ElmStories
   .PopoverStories
 
-loadElmStories("Elm/Popover", module, compiledElm, [
+loadElmStories(`${CATEGORIES.elm}/Popover`, module, compiledElm, [
   "Default",
   "Informative",
   "Positive",

--- a/draft-packages/popover/docs/ElmPopover.stories.tsx
+++ b/draft-packages/popover/docs/ElmPopover.stories.tsx
@@ -2,7 +2,7 @@ import { loadElmStories } from "elm-storybook"
 const compiledElm = require("../ElmStories/PopoverStories.elm").Elm.ElmStories
   .PopoverStories
 
-loadElmStories("Popover (Elm)", module, compiledElm, [
+loadElmStories("Elm/Popover", module, compiledElm, [
   "Default",
   "Informative",
   "Positive",

--- a/draft-packages/popover/docs/Popover.stories.tsx
+++ b/draft-packages/popover/docs/Popover.stories.tsx
@@ -9,7 +9,7 @@ import { withDesign } from "storybook-addon-designs"
 import { figmaEmbed } from "../../../storybook/helpers"
 
 export default {
-  title: "Popover (React)",
+  title: "Components/Popover",
   component: PopoverRaw,
   parameters: {
     docs: {

--- a/draft-packages/popover/docs/Popover.stories.tsx
+++ b/draft-packages/popover/docs/Popover.stories.tsx
@@ -7,9 +7,10 @@ import * as React from "react"
 import guidanceIcon from "@kaizen/component-library/icons/guidance.icon.svg"
 import { withDesign } from "storybook-addon-designs"
 import { figmaEmbed } from "../../../storybook/helpers"
+import { CATEGORIES } from "../../../storybook/constants"
 
 export default {
-  title: "Components/Popover",
+  title: `${CATEGORIES.components}/Popover`,
   component: PopoverRaw,
   parameters: {
     docs: {

--- a/draft-packages/select/docs/ElmSelect.stories.tsx
+++ b/draft-packages/select/docs/ElmSelect.stories.tsx
@@ -1,11 +1,12 @@
 import { loadElmStories } from "elm-storybook"
+import { CATEGORIES } from "../../../storybook/constants"
 import Ports from "../KaizenDraft/Select/ports"
 
 const compiledElm = require("../ElmStories/SelectStories.elm").Elm.ElmStories
   .SelectStories
 
 loadElmStories(
-  "Elm/Select",
+  `${CATEGORIES.elm}/Select`,
   module,
   compiledElm,
   [

--- a/draft-packages/select/docs/ElmSelect.stories.tsx
+++ b/draft-packages/select/docs/ElmSelect.stories.tsx
@@ -5,7 +5,7 @@ const compiledElm = require("../ElmStories/SelectStories.elm").Elm.ElmStories
   .SelectStories
 
 loadElmStories(
-  "Select (Elm)",
+  "Elm/Select",
   module,
   compiledElm,
   [

--- a/draft-packages/select/docs/Select.stories.tsx
+++ b/draft-packages/select/docs/Select.stories.tsx
@@ -2,6 +2,7 @@ import * as colorTokens from "@kaizen/design-tokens/tokens/color.json"
 import { AsyncSelect, Select } from "@kaizen/draft-select"
 import * as React from "react"
 import { withDesign } from "storybook-addon-designs"
+import { CATEGORIES } from "../../../storybook/constants"
 import { figmaEmbed } from "../../../storybook/helpers"
 
 const StoryContainer = ({ children }: { children: React.ReactNode }) => (
@@ -62,7 +63,7 @@ const promiseOptions = (inputValue): Promise<any[]> =>
   })
 
 export default {
-  title: "Components/Select",
+  title: `${CATEGORIES.components}/Select`,
   component: Select,
   parameters: {
     docs: {

--- a/draft-packages/select/docs/Select.stories.tsx
+++ b/draft-packages/select/docs/Select.stories.tsx
@@ -62,7 +62,7 @@ const promiseOptions = (inputValue): Promise<any[]> =>
   })
 
 export default {
-  title: "Select (React)",
+  title: "Components/Select",
   component: Select,
   parameters: {
     docs: {

--- a/draft-packages/slider/docs/Slider.stories.tsx
+++ b/draft-packages/slider/docs/Slider.stories.tsx
@@ -3,7 +3,7 @@ import * as React from "react"
 import { Slider } from "@kaizen/draft-slider"
 
 export default {
-  title: "Slider (React)",
+  title: "Components/Form/Slider",
   component: Slider,
   parameters: {
     docs: {

--- a/draft-packages/slider/docs/Slider.stories.tsx
+++ b/draft-packages/slider/docs/Slider.stories.tsx
@@ -1,9 +1,10 @@
 import * as React from "react"
 
 import { Slider } from "@kaizen/draft-slider"
+import { CATEGORIES, SUB_CATEGORIES } from "../../../storybook/constants"
 
 export default {
-  title: "Components/Form/Slider",
+  title: `${CATEGORIES.components}/${SUB_CATEGORIES.form}/Slider`,
   component: Slider,
   parameters: {
     docs: {

--- a/draft-packages/split-button/docs/ElmSplitButton.stories.tsx
+++ b/draft-packages/split-button/docs/ElmSplitButton.stories.tsx
@@ -1,6 +1,9 @@
 import { loadElmStories } from "elm-storybook"
+import { CATEGORIES } from "../../../storybook/constants"
 
 const compiledElm = require("../ElmStories/SplitButtonStories.elm").Elm
   .ElmStories.SplitButtonStories
 
-loadElmStories("Elm/Split Button", module, compiledElm, ["Default"])
+loadElmStories(`${CATEGORIES.elm}/Split Button`, module, compiledElm, [
+  "Default",
+])

--- a/draft-packages/split-button/docs/ElmSplitButton.stories.tsx
+++ b/draft-packages/split-button/docs/ElmSplitButton.stories.tsx
@@ -3,4 +3,4 @@ import { loadElmStories } from "elm-storybook"
 const compiledElm = require("../ElmStories/SplitButtonStories.elm").Elm
   .ElmStories.SplitButtonStories
 
-loadElmStories("SplitButton (Elm)", module, compiledElm, ["Default"])
+loadElmStories("Elm/Split Button", module, compiledElm, ["Default"])

--- a/draft-packages/split-button/docs/SplitButton.stories.tsx
+++ b/draft-packages/split-button/docs/SplitButton.stories.tsx
@@ -15,7 +15,7 @@ const withBottomMargin = (Story: React.ComponentType) => (
 )
 
 export default {
-  title: "SplitButton (React)",
+  title: "Components/Split Button",
   component: SplitButton,
   argTypes: { onClick: { action: "clicked" } },
   parameters: {

--- a/draft-packages/split-button/docs/SplitButton.stories.tsx
+++ b/draft-packages/split-button/docs/SplitButton.stories.tsx
@@ -7,6 +7,7 @@ import duplicateIcon from "@kaizen/component-library/icons/duplicate.icon.svg"
 import editIcon from "@kaizen/component-library/icons/edit.icon.svg"
 import { figmaEmbed } from "../../../storybook/helpers"
 import { Box } from "../../../packages/component-library"
+import { CATEGORIES } from "../../../storybook/constants"
 
 const withBottomMargin = (Story: React.ComponentType) => (
   <Box mb={4}>
@@ -15,7 +16,7 @@ const withBottomMargin = (Story: React.ComponentType) => (
 )
 
 export default {
-  title: "Components/Split Button",
+  title: `${CATEGORIES.components}/Split Button`,
   component: SplitButton,
   argTypes: { onClick: { action: "clicked" } },
   parameters: {

--- a/draft-packages/table/docs/ElmTable.stories.tsx
+++ b/draft-packages/table/docs/ElmTable.stories.tsx
@@ -1,6 +1,7 @@
 import { loadElmStories } from "elm-storybook"
+import { CATEGORIES } from "../../../storybook/constants"
 
 const compiledElm = require("../ElmStories/TableStories.elm").Elm.ElmStories
   .TableStories
 
-loadElmStories("Elm/Table", module, compiledElm, ["Default"])
+loadElmStories(`${CATEGORIES.elm}/Table`, module, compiledElm, ["Default"])

--- a/draft-packages/table/docs/ElmTable.stories.tsx
+++ b/draft-packages/table/docs/ElmTable.stories.tsx
@@ -3,4 +3,4 @@ import { loadElmStories } from "elm-storybook"
 const compiledElm = require("../ElmStories/TableStories.elm").Elm.ElmStories
   .TableStories
 
-loadElmStories("Table (Elm)", module, compiledElm, ["Default"])
+loadElmStories("Elm/Table", module, compiledElm, ["Default"])

--- a/draft-packages/table/docs/Table.stories.tsx
+++ b/draft-packages/table/docs/Table.stories.tsx
@@ -15,6 +15,7 @@ import {
   TableRowCell,
 } from ".."
 import { figmaEmbed } from "../../../storybook/helpers"
+import { CATEGORIES } from "../../../storybook/constants"
 import styles from "./Table.stories.scss"
 
 const Container: React.FunctionComponent<{
@@ -121,7 +122,7 @@ const ExampleTableRow = ({
 )
 
 export default {
-  title: "Components/Table",
+  title: `${CATEGORIES.components}/Table`,
   component: TableCard,
   parameters: {
     docs: {

--- a/draft-packages/table/docs/Table.stories.tsx
+++ b/draft-packages/table/docs/Table.stories.tsx
@@ -121,7 +121,7 @@ const ExampleTableRow = ({
 )
 
 export default {
-  title: "Table (React)",
+  title: "Components/Table",
   component: TableCard,
   parameters: {
     docs: {

--- a/draft-packages/tabs/docs/Tabs.stories.tsx
+++ b/draft-packages/tabs/docs/Tabs.stories.tsx
@@ -9,7 +9,7 @@ import { figmaEmbed } from "../../../storybook/helpers"
 import { ExampleLayout } from "./ExampleLayout"
 
 export default {
-  title: "Tabs (React)",
+  title: "Components/Tabs",
   component: Tabs,
   parameters: {
     docs: {

--- a/draft-packages/tabs/docs/Tabs.stories.tsx
+++ b/draft-packages/tabs/docs/Tabs.stories.tsx
@@ -6,10 +6,11 @@ import classnames from "classnames"
 import * as React from "react"
 import { withDesign } from "storybook-addon-designs"
 import { figmaEmbed } from "../../../storybook/helpers"
+import { CATEGORIES } from "../../../storybook/constants"
 import { ExampleLayout } from "./ExampleLayout"
 
 export default {
-  title: "Components/Tabs",
+  title: `${CATEGORIES.components}/Tabs`,
   component: Tabs,
   parameters: {
     docs: {

--- a/draft-packages/tag/docs/ElmTag.stories.tsx
+++ b/draft-packages/tag/docs/ElmTag.stories.tsx
@@ -1,9 +1,10 @@
 import { loadElmStories } from "elm-storybook"
+import { CATEGORIES } from "../../../storybook/constants"
 
 const compiledElm = require("../ElmStories/TagStories.elm").Elm.ElmStories
   .TagStories
 
-loadElmStories("Elm/Tag", module, compiledElm, [
+loadElmStories(`${CATEGORIES.elm}/Tag`, module, compiledElm, [
   "Default - Medium",
   "Default - Small",
   "Sentiment - Positive",

--- a/draft-packages/tag/docs/ElmTag.stories.tsx
+++ b/draft-packages/tag/docs/ElmTag.stories.tsx
@@ -3,7 +3,7 @@ import { loadElmStories } from "elm-storybook"
 const compiledElm = require("../ElmStories/TagStories.elm").Elm.ElmStories
   .TagStories
 
-loadElmStories("Tag (Elm)", module, compiledElm, [
+loadElmStories("Elm/Tag", module, compiledElm, [
   "Default - Medium",
   "Default - Small",
   "Sentiment - Positive",

--- a/draft-packages/tag/docs/Tag.stories.tsx
+++ b/draft-packages/tag/docs/Tag.stories.tsx
@@ -10,7 +10,7 @@ const StoryContainer = ({ children }: { children: React.ReactNode }) => (
 )
 
 export default {
-  title: "Tag (React)",
+  title: "Components/Tag",
   component: Tag,
   parameters: {
     docs: {

--- a/draft-packages/tag/docs/Tag.stories.tsx
+++ b/draft-packages/tag/docs/Tag.stories.tsx
@@ -1,6 +1,7 @@
 import { Tag } from "@kaizen/draft-tag"
 import * as React from "react"
 import { withDesign } from "storybook-addon-designs"
+import { CATEGORIES } from "../../../storybook/constants"
 import { figmaEmbed } from "../../../storybook/helpers"
 
 const StoryContainer = ({ children }: { children: React.ReactNode }) => (
@@ -10,7 +11,7 @@ const StoryContainer = ({ children }: { children: React.ReactNode }) => (
 )
 
 export default {
-  title: "Components/Tag",
+  title: `${CATEGORIES.components}/Tag`,
   component: Tag,
   parameters: {
     docs: {

--- a/draft-packages/tile/docs/Tile.stories.tsx
+++ b/draft-packages/tile/docs/Tile.stories.tsx
@@ -15,7 +15,7 @@ import bookmarkIcon from "@kaizen/component-library/icons/bookmark-off.icon.svg"
 import { figmaEmbed } from "../../../storybook/helpers"
 
 export default {
-  title: "Tile (React)",
+  title: "Components/Tile",
   component: MultiActionTile,
   subcomponents: { InformationTile, TileGrid },
   parameters: {

--- a/draft-packages/tile/docs/Tile.stories.tsx
+++ b/draft-packages/tile/docs/Tile.stories.tsx
@@ -13,9 +13,10 @@ import { Paragraph } from "@kaizen/component-library"
 import { withDesign } from "storybook-addon-designs"
 import bookmarkIcon from "@kaizen/component-library/icons/bookmark-off.icon.svg"
 import { figmaEmbed } from "../../../storybook/helpers"
+import { CATEGORIES } from "../../../storybook/constants"
 
 export default {
-  title: "Components/Tile",
+  title: `${CATEGORIES.components}/Tile`,
   component: MultiActionTile,
   subcomponents: { InformationTile, TileGrid },
   parameters: {

--- a/draft-packages/title-block-zen/docs/TitleBlockZen.stories.tsx
+++ b/draft-packages/title-block-zen/docs/TitleBlockZen.stories.tsx
@@ -15,7 +15,7 @@ import { figmaEmbed } from "../../../storybook/helpers"
 import styles from "./TitleBlockZen.stories.scss"
 
 export default {
-  title: "TitleBlockZen (React)",
+  title: "Components/Title Block",
   parameters: {
     docs: {
       description: {

--- a/draft-packages/title-block-zen/docs/TitleBlockZen.stories.tsx
+++ b/draft-packages/title-block-zen/docs/TitleBlockZen.stories.tsx
@@ -12,10 +12,11 @@ import { Args, Story } from "@storybook/react"
 import { NavigationTab, TitleBlockZen } from ".."
 import { figmaEmbed } from "../../../storybook/helpers"
 
+import { CATEGORIES } from "../../../storybook/constants"
 import styles from "./TitleBlockZen.stories.scss"
 
 export default {
-  title: "Components/Title Block",
+  title: `${CATEGORIES.components}/Title Block`,
   parameters: {
     docs: {
       description: {

--- a/draft-packages/tooltip/docs/ElmTooltip.stories.tsx
+++ b/draft-packages/tooltip/docs/ElmTooltip.stories.tsx
@@ -3,7 +3,7 @@ import { loadElmStories } from "elm-storybook"
 const compiledElm = require("../ElmStories/TooltipStories.elm").Elm.ElmStories
   .TooltipStories
 
-loadElmStories("Tooltip (Elm)", module, compiledElm, [
+loadElmStories("Elm/Tooltip", module, compiledElm, [
   "Default - Below",
   "Default - Above",
   "Default - dontTakeUpSpaceWhenHiddenQuickFix",

--- a/draft-packages/tooltip/docs/ElmTooltip.stories.tsx
+++ b/draft-packages/tooltip/docs/ElmTooltip.stories.tsx
@@ -1,9 +1,10 @@
 import { loadElmStories } from "elm-storybook"
+import { CATEGORIES } from "../../../storybook/constants"
 
 const compiledElm = require("../ElmStories/TooltipStories.elm").Elm.ElmStories
   .TooltipStories
 
-loadElmStories("Elm/Tooltip", module, compiledElm, [
+loadElmStories(`${CATEGORIES.elm}/Tooltip`, module, compiledElm, [
   "Default - Below",
   "Default - Above",
   "Default - dontTakeUpSpaceWhenHiddenQuickFix",

--- a/draft-packages/tooltip/docs/Tooltip.stories.tsx
+++ b/draft-packages/tooltip/docs/Tooltip.stories.tsx
@@ -21,7 +21,7 @@ const openTooltipInChromatic = (story, config) => {
 }
 
 export default {
-  title: "Tooltip (React)",
+  title: "Components/Tooltip",
   component: Tooltip,
   parameters: {
     docs: {

--- a/draft-packages/tooltip/docs/Tooltip.stories.tsx
+++ b/draft-packages/tooltip/docs/Tooltip.stories.tsx
@@ -9,6 +9,7 @@ import { Button } from "@kaizen/draft-button"
 import { Tooltip } from "@kaizen/draft-tooltip"
 import isChromatic from "chromatic/isChromatic"
 import { figmaEmbed } from "../../../storybook/helpers"
+import { CATEGORIES } from "../../../storybook/constants"
 
 /**
  * We should not be running visual regressions on these tooltip stories
@@ -21,7 +22,7 @@ const openTooltipInChromatic = (story, config) => {
 }
 
 export default {
-  title: "Components/Tooltip",
+  title: `${CATEGORIES.components}/Tooltip`,
   component: Tooltip,
   parameters: {
     docs: {

--- a/draft-packages/vertical-progress-step/docs/VerticalProgressIndicator.stories.tsx
+++ b/draft-packages/vertical-progress-step/docs/VerticalProgressIndicator.stories.tsx
@@ -1,4 +1,5 @@
 import * as React from "react"
+import { CATEGORIES } from "../../../storybook/constants"
 // eslint-disable-next-line max-len
 import { VerticalProgressIndicator } from "../KaizenDraft/VerticalProgressStep/VerticalProgressIndicator"
 
@@ -16,7 +17,7 @@ const RelativePositionBlock = ({ children }: { children: React.ReactNode }) => (
 )
 
 export default {
-  title: "Deprecated/Vertical Progress Indicator",
+  title: `${CATEGORIES.deprecated}/Vertical Progress Indicator`,
   component: VerticalProgressIndicator,
   parameters: {
     docs: {

--- a/draft-packages/vertical-progress-step/docs/VerticalProgressIndicator.stories.tsx
+++ b/draft-packages/vertical-progress-step/docs/VerticalProgressIndicator.stories.tsx
@@ -16,7 +16,7 @@ const RelativePositionBlock = ({ children }: { children: React.ReactNode }) => (
 )
 
 export default {
-  title: "VerticalProgressIndicator (React)",
+  title: "Deprecated/Vertical Progress Indicator",
   component: VerticalProgressIndicator,
   parameters: {
     docs: {

--- a/draft-packages/vertical-progress-step/docs/VerticalProgressStep.stories.tsx
+++ b/draft-packages/vertical-progress-step/docs/VerticalProgressStep.stories.tsx
@@ -3,7 +3,7 @@ import { VerticalProgressStep } from "@kaizen/draft-vertical-progress-step"
 import * as React from "react"
 
 export default {
-  title: "VerticalProgressStep (React)",
+  title: "Deprecated/Vertical Progress Step",
   component: VerticalProgressStep.CurrentStep,
   parameters: {
     docs: {

--- a/draft-packages/vertical-progress-step/docs/VerticalProgressStep.stories.tsx
+++ b/draft-packages/vertical-progress-step/docs/VerticalProgressStep.stories.tsx
@@ -1,9 +1,10 @@
 import { Paragraph } from "@kaizen/component-library"
 import { VerticalProgressStep } from "@kaizen/draft-vertical-progress-step"
 import * as React from "react"
+import { CATEGORIES } from "../../../storybook/constants"
 
 export default {
-  title: "Deprecated/Vertical Progress Step",
+  title: `${CATEGORIES.deprecated}/Vertical Progress Step`,
   component: VerticalProgressStep.CurrentStep,
   parameters: {
     docs: {

--- a/draft-packages/well/docs/ElmWell.stories.tsx
+++ b/draft-packages/well/docs/ElmWell.stories.tsx
@@ -2,7 +2,7 @@ import { loadElmStories } from "elm-storybook"
 const compiledElm = require("../ElmStories/WellStories.elm").Elm.ElmStories
   .WellStories
 
-loadElmStories("Well (Elm)", module, compiledElm, [
+loadElmStories("Elm/Well", module, compiledElm, [
   "Default with solid border",
   "Default with dashed border",
   "Default without border",

--- a/draft-packages/well/docs/ElmWell.stories.tsx
+++ b/draft-packages/well/docs/ElmWell.stories.tsx
@@ -1,8 +1,9 @@
 import { loadElmStories } from "elm-storybook"
+import { CATEGORIES } from "../../../storybook/constants"
 const compiledElm = require("../ElmStories/WellStories.elm").Elm.ElmStories
   .WellStories
 
-loadElmStories("Elm/Well", module, compiledElm, [
+loadElmStories(`${CATEGORIES.elm}/Well`, module, compiledElm, [
   "Default with solid border",
   "Default with dashed border",
   "Default without border",

--- a/draft-packages/well/docs/Well.stories.tsx
+++ b/draft-packages/well/docs/Well.stories.tsx
@@ -3,6 +3,7 @@ import { TextField } from "@kaizen/draft-form"
 import { Well } from "@kaizen/draft-well"
 import * as React from "react"
 import { withDesign } from "storybook-addon-designs"
+import { CATEGORIES } from "../../../storybook/constants"
 import { figmaEmbed } from "../../../storybook/helpers"
 
 const ExampleContent = () => (
@@ -26,7 +27,7 @@ const ExampleContent = () => (
 )
 
 export default {
-  title: "Components/Well",
+  title: `${CATEGORIES.components}/Well`,
   component: Well,
   parameters: {
     docs: {

--- a/draft-packages/well/docs/Well.stories.tsx
+++ b/draft-packages/well/docs/Well.stories.tsx
@@ -26,7 +26,7 @@ const ExampleContent = () => (
 )
 
 export default {
-  title: "Well (React)",
+  title: "Components/Well",
   component: Well,
   parameters: {
     docs: {

--- a/draft-packages/zen-navigation-bar/docs/ZenNavigationBar.stories.tsx
+++ b/draft-packages/zen-navigation-bar/docs/ZenNavigationBar.stories.tsx
@@ -13,7 +13,7 @@ import academyIcon from "@kaizen/component-library/icons/academy.icon.svg"
 import supportIcon from "@kaizen/component-library/icons/support.icon.svg"
 
 export default {
-  title: "ZenNavigationBar (React) (deprecated)",
+  title: "Deprecated/Navigation Bar",
 }
 
 const handleNavigationChange = (event: { preventDefault: () => void }) => {

--- a/draft-packages/zen-navigation-bar/docs/ZenNavigationBar.stories.tsx
+++ b/draft-packages/zen-navigation-bar/docs/ZenNavigationBar.stories.tsx
@@ -11,9 +11,10 @@ import { ColorScheme } from "@kaizen/draft-zen-navigation-bar/KaizenDraft/ZenNav
 import caIcon from "@kaizen/component-library/icons/ca-monogram.icon.svg"
 import academyIcon from "@kaizen/component-library/icons/academy.icon.svg"
 import supportIcon from "@kaizen/component-library/icons/support.icon.svg"
+import { CATEGORIES } from "../../../storybook/constants"
 
 export default {
-  title: "Deprecated/Navigation Bar",
+  title: `${CATEGORIES.deprecated}/Navigation Bar`,
 }
 
 const handleNavigationChange = (event: { preventDefault: () => void }) => {

--- a/legacy-packages/title-block/docs/ElmTitleBlock.stories.tsx
+++ b/legacy-packages/title-block/docs/ElmTitleBlock.stories.tsx
@@ -2,7 +2,7 @@ import { loadElmStories } from "elm-storybook"
 const compiledElm = require("../ElmStories/TitleBlockStories.elm").Elm
   .ElmStories.TitleBlockStories
 
-loadElmStories("Titleblock (Elm) (deprecated)", module, compiledElm, [
+loadElmStories("Elm/Title Block (deprecated)", module, compiledElm, [
   "Admin, with breadcrumb",
   "Admin, with navigation buttons",
   "Reversed",

--- a/legacy-packages/title-block/docs/ElmTitleBlock.stories.tsx
+++ b/legacy-packages/title-block/docs/ElmTitleBlock.stories.tsx
@@ -1,9 +1,11 @@
 import { loadElmStories } from "elm-storybook"
+import { CATEGORIES } from "../../../storybook/constants"
 const compiledElm = require("../ElmStories/TitleBlockStories.elm").Elm
   .ElmStories.TitleBlockStories
 
-loadElmStories("Elm/Title Block (deprecated)", module, compiledElm, [
-  "Admin, with breadcrumb",
-  "Admin, with navigation buttons",
-  "Reversed",
-])
+loadElmStories(
+  `${CATEGORIES.elm}/Title Block (deprecated)`,
+  module,
+  compiledElm,
+  ["Admin, with breadcrumb", "Admin, with navigation buttons", "Reversed"]
+)

--- a/legacy-packages/title-block/docs/TitleBlock.stories.tsx
+++ b/legacy-packages/title-block/docs/TitleBlock.stories.tsx
@@ -34,7 +34,7 @@ const stickyContainerStyle = {
 }
 
 export default {
-  title: "TitleBlock (React) (deprecated)",
+  title: "Deprecated/Title Block",
   component: TitleBlock,
   parameters: {
     info: {

--- a/legacy-packages/title-block/docs/TitleBlock.stories.tsx
+++ b/legacy-packages/title-block/docs/TitleBlock.stories.tsx
@@ -1,6 +1,7 @@
 import { Button } from "@kaizen/draft-button"
 import { TitleBlock } from "@kaizen/draft-title-block"
 import * as React from "react"
+import { CATEGORIES } from "../../../storybook/constants"
 
 require("./TitleBlock.stories.scss")
 
@@ -34,7 +35,7 @@ const stickyContainerStyle = {
 }
 
 export default {
-  title: "Deprecated/Title Block",
+  title: `${CATEGORIES.deprecated}/Title Block`,
   component: TitleBlock,
   parameters: {
     info: {

--- a/packages/brand-moment/docs/BrandMoment.stories.tsx
+++ b/packages/brand-moment/docs/BrandMoment.stories.tsx
@@ -11,6 +11,7 @@ import mailIcon from "@kaizen/component-library/icons/email.icon.svg"
 import feedbackClassifyIcon from "@kaizen/component-library/icons/feedback-classify.icon.svg"
 import { Box, Paragraph } from "@kaizen/component-library"
 import { BrandMoment } from "@kaizen/brand-moment"
+import { CATEGORIES } from "../../../storybook/constants"
 import {
   MinimalBasic,
   MinimalCustomerFocused,
@@ -18,7 +19,7 @@ import {
 } from "./ExampleHeaders"
 
 export default {
-  title: "Components/Brand Moment",
+  title: `${CATEGORIES.components}/Brand Moment`,
   component: BrandMoment,
   parameters: {
     docs: {

--- a/packages/brand-moment/docs/BrandMoment.stories.tsx
+++ b/packages/brand-moment/docs/BrandMoment.stories.tsx
@@ -18,7 +18,7 @@ import {
 } from "./ExampleHeaders"
 
 export default {
-  title: "Brand Moment (React)",
+  title: "Components/Brand Moment",
   component: BrandMoment,
   parameters: {
     docs: {

--- a/packages/brand/docs/Brand.stories.tsx
+++ b/packages/brand/docs/Brand.stories.tsx
@@ -1,9 +1,10 @@
 import React from "react"
+import { CATEGORIES } from "../../../storybook/constants"
 import { figmaEmbed } from "../../../storybook/helpers/figmaEmbed"
 import { Brand } from "../src/Brand/Brand"
 
 export default {
-  title: "Components/Brand",
+  title: `${CATEGORIES.components}/Brand`,
   component: Brand,
   parameters: {
     docs: {

--- a/packages/brand/docs/Brand.stories.tsx
+++ b/packages/brand/docs/Brand.stories.tsx
@@ -3,7 +3,7 @@ import { figmaEmbed } from "../../../storybook/helpers/figmaEmbed"
 import { Brand } from "../src/Brand/Brand"
 
 export default {
-  title: "Brand (React)",
+  title: "Components/Brand",
   component: Brand,
   parameters: {
     docs: {

--- a/packages/component-library/stories/Box.stories.tsx
+++ b/packages/component-library/stories/Box.stories.tsx
@@ -1,8 +1,9 @@
 import * as React from "react"
+import { CATEGORIES } from "../../../storybook/constants"
 import { Box } from "../components/Box"
 
 export default {
-  title: "Components/Box",
+  title: `${CATEGORIES.components}/Box`,
   component: Box,
   parameters: {
     docs: {

--- a/packages/component-library/stories/Box.stories.tsx
+++ b/packages/component-library/stories/Box.stories.tsx
@@ -2,7 +2,7 @@ import * as React from "react"
 import { Box } from "../components/Box"
 
 export default {
-  title: "Box (React)",
+  title: "Components/Box",
   component: Box,
   parameters: {
     docs: {

--- a/packages/component-library/stories/ElmBox.stories.tsx
+++ b/packages/component-library/stories/ElmBox.stories.tsx
@@ -1,9 +1,10 @@
 import { loadElmStories } from "elm-storybook"
+import { CATEGORIES } from "../../../storybook/constants"
 
 const compiledElm = require("../ElmStories/BoxStories.elm").Elm.ElmStories
   .BoxStories
 
-loadElmStories("Elm/Box", module, compiledElm, [
+loadElmStories(`${CATEGORIES.elm}/Box`, module, compiledElm, [
   "Box Default",
   "Box With Margin",
   "Box With Padding",

--- a/packages/component-library/stories/ElmBox.stories.tsx
+++ b/packages/component-library/stories/ElmBox.stories.tsx
@@ -3,7 +3,7 @@ import { loadElmStories } from "elm-storybook"
 const compiledElm = require("../ElmStories/BoxStories.elm").Elm.ElmStories
   .BoxStories
 
-loadElmStories("Box (Elm)", module, compiledElm, [
+loadElmStories("Elm/Box", module, compiledElm, [
   "Box Default",
   "Box With Margin",
   "Box With Padding",

--- a/packages/component-library/stories/ElmGlobalNotification.stories.tsx
+++ b/packages/component-library/stories/ElmGlobalNotification.stories.tsx
@@ -3,7 +3,7 @@ import { loadElmStories } from "elm-storybook"
 const compiledElm = require("../ElmStories/GlobalNotificationStories.elm").Elm
   .ElmStories.GlobalNotificationStories
 
-loadElmStories("GlobalNotification (Elm)", module, compiledElm, [
+loadElmStories("Elm/Global Notification", module, compiledElm, [
   "Positive",
   "Informative",
   "Cautionary",

--- a/packages/component-library/stories/ElmGlobalNotification.stories.tsx
+++ b/packages/component-library/stories/ElmGlobalNotification.stories.tsx
@@ -1,9 +1,10 @@
 import { loadElmStories } from "elm-storybook"
+import { CATEGORIES } from "../../../storybook/constants"
 
 const compiledElm = require("../ElmStories/GlobalNotificationStories.elm").Elm
   .ElmStories.GlobalNotificationStories
 
-loadElmStories("Elm/Global Notification", module, compiledElm, [
+loadElmStories(`${CATEGORIES.elm}/Global Notification`, module, compiledElm, [
   "Positive",
   "Informative",
   "Cautionary",

--- a/packages/component-library/stories/ElmHeading.stories.tsx
+++ b/packages/component-library/stories/ElmHeading.stories.tsx
@@ -1,9 +1,10 @@
 import { loadElmStories } from "elm-storybook"
+import { CATEGORIES } from "../../../storybook/constants"
 
 const compiledElm = require("../ElmStories/HeadingStories.elm").Elm.ElmStories
   .HeadingStories
 
-loadElmStories("Elm/Heading", module, compiledElm, [
+loadElmStories(`${CATEGORIES.elm}/Heading`, module, compiledElm, [
   "Display0",
   "Heading1",
   "Heading2",

--- a/packages/component-library/stories/ElmHeading.stories.tsx
+++ b/packages/component-library/stories/ElmHeading.stories.tsx
@@ -3,7 +3,7 @@ import { loadElmStories } from "elm-storybook"
 const compiledElm = require("../ElmStories/HeadingStories.elm").Elm.ElmStories
   .HeadingStories
 
-loadElmStories("Heading (Elm)", module, compiledElm, [
+loadElmStories("Elm/Heading", module, compiledElm, [
   "Display0",
   "Heading1",
   "Heading2",

--- a/packages/component-library/stories/ElmIcon.stories.tsx
+++ b/packages/component-library/stories/ElmIcon.stories.tsx
@@ -3,7 +3,7 @@ import { loadElmStories } from "elm-storybook"
 const compiledElm = require("../ElmStories/IconStories.elm").Elm.ElmStories
   .IconStories
 
-loadElmStories("Icon (Elm)", module, compiledElm, [
+loadElmStories("Elm/Icon", module, compiledElm, [
   "Meaningful",
   "Presentational",
   "Inherit Size",

--- a/packages/component-library/stories/ElmIcon.stories.tsx
+++ b/packages/component-library/stories/ElmIcon.stories.tsx
@@ -1,9 +1,10 @@
 import { loadElmStories } from "elm-storybook"
+import { CATEGORIES } from "../../../storybook/constants"
 
 const compiledElm = require("../ElmStories/IconStories.elm").Elm.ElmStories
   .IconStories
 
-loadElmStories("Elm/Icon", module, compiledElm, [
+loadElmStories(`${CATEGORIES.elm}/Icon`, module, compiledElm, [
   "Meaningful",
   "Presentational",
   "Inherit Size",

--- a/packages/component-library/stories/ElmInlineNotification.stories.tsx
+++ b/packages/component-library/stories/ElmInlineNotification.stories.tsx
@@ -1,9 +1,10 @@
 import { loadElmStories } from "elm-storybook"
+import { CATEGORIES } from "../../../storybook/constants"
 
 const compiledElm = require("../ElmStories/InlineNotificationStories.elm").Elm
   .ElmStories.InlineNotificationStories
 
-loadElmStories("Elm/Inline Notification", module, compiledElm, [
+loadElmStories(`${CATEGORIES.elm}/Inline Notification`, module, compiledElm, [
   "Dismissible, Positive",
   "Dismissible, Informative",
   "Dismissible, Cautionary",

--- a/packages/component-library/stories/ElmInlineNotification.stories.tsx
+++ b/packages/component-library/stories/ElmInlineNotification.stories.tsx
@@ -3,7 +3,7 @@ import { loadElmStories } from "elm-storybook"
 const compiledElm = require("../ElmStories/InlineNotificationStories.elm").Elm
   .ElmStories.InlineNotificationStories
 
-loadElmStories("InlineNotification (Elm)", module, compiledElm, [
+loadElmStories("Elm/Inline Notification", module, compiledElm, [
   "Dismissible, Positive",
   "Dismissible, Informative",
   "Dismissible, Cautionary",

--- a/packages/component-library/stories/ElmParagraph.stories.tsx
+++ b/packages/component-library/stories/ElmParagraph.stories.tsx
@@ -1,8 +1,9 @@
 import { loadElmStories } from "elm-storybook"
+import { CATEGORIES } from "../../../storybook/constants"
 const compiledElm = require("../ElmStories/ParagraphStories.elm").Elm.ElmStories
   .ParagraphStories
 
-loadElmStories("Elm/Paragraph", module, compiledElm, [
+loadElmStories(`${CATEGORIES.elm}/Paragraph`, module, compiledElm, [
   "IntroLede",
   "Body",
   "Body Dark Reduced Opacity",

--- a/packages/component-library/stories/ElmParagraph.stories.tsx
+++ b/packages/component-library/stories/ElmParagraph.stories.tsx
@@ -2,7 +2,7 @@ import { loadElmStories } from "elm-storybook"
 const compiledElm = require("../ElmStories/ParagraphStories.elm").Elm.ElmStories
   .ParagraphStories
 
-loadElmStories("Paragraph (Elm)", module, compiledElm, [
+loadElmStories("Elm/Paragraph", module, compiledElm, [
   "IntroLede",
   "Body",
   "Body Dark Reduced Opacity",

--- a/packages/component-library/stories/ElmText.stories.tsx
+++ b/packages/component-library/stories/ElmText.stories.tsx
@@ -1,9 +1,10 @@
 import { loadElmStories } from "elm-storybook"
+import { CATEGORIES } from "../../../storybook/constants"
 
 const compiledElm = require("../ElmStories/TextStories.elm").Elm.ElmStories
   .TextStories
 
-loadElmStories("Elm/Text (deprecated)", module, compiledElm, [
+loadElmStories(`${CATEGORIES.elm}/Text (deprecated)`, module, compiledElm, [
   "h1",
   "h2",
   "h3",

--- a/packages/component-library/stories/ElmText.stories.tsx
+++ b/packages/component-library/stories/ElmText.stories.tsx
@@ -3,7 +3,7 @@ import { loadElmStories } from "elm-storybook"
 const compiledElm = require("../ElmStories/TextStories.elm").Elm.ElmStories
   .TextStories
 
-loadElmStories("Text (Elm) (deprecated)", module, compiledElm, [
+loadElmStories("Elm/Text (deprecated)", module, compiledElm, [
   "h1",
   "h2",
   "h3",

--- a/packages/component-library/stories/ElmToastNotification.stories.tsx
+++ b/packages/component-library/stories/ElmToastNotification.stories.tsx
@@ -3,7 +3,7 @@ import { loadElmStories } from "elm-storybook"
 const compiledElm = require("../ElmStories/ToastNotificationStories.elm").Elm
   .ElmStories.ToastNotificationStories
 
-loadElmStories("ToastNotification (Elm)", module, compiledElm, [
+loadElmStories("Elm/Toast Notification", module, compiledElm, [
   "Positive",
   "Informative",
   "Cautionary",

--- a/packages/component-library/stories/ElmToastNotification.stories.tsx
+++ b/packages/component-library/stories/ElmToastNotification.stories.tsx
@@ -1,9 +1,10 @@
 import { loadElmStories } from "elm-storybook"
+import { CATEGORIES } from "../../../storybook/constants"
 
 const compiledElm = require("../ElmStories/ToastNotificationStories.elm").Elm
   .ElmStories.ToastNotificationStories
 
-loadElmStories("Elm/Toast Notification", module, compiledElm, [
+loadElmStories(`${CATEGORIES.elm}/Toast Notification`, module, compiledElm, [
   "Positive",
   "Informative",
   "Cautionary",

--- a/packages/component-library/stories/GlobalNotification.stories.tsx
+++ b/packages/component-library/stories/GlobalNotification.stories.tsx
@@ -5,7 +5,7 @@ import { withDesign } from "storybook-addon-designs"
 import { figmaEmbed } from "../../../storybook/helpers"
 
 export default {
-  title: "GlobalNotification (React)",
+  title: "Components/Notification/Global Notification",
   component: GlobalNotification,
   parameters: {
     docs: {

--- a/packages/component-library/stories/GlobalNotification.stories.tsx
+++ b/packages/component-library/stories/GlobalNotification.stories.tsx
@@ -3,9 +3,10 @@ import * as React from "react"
 import { GlobalNotification } from "@kaizen/component-library"
 import { withDesign } from "storybook-addon-designs"
 import { figmaEmbed } from "../../../storybook/helpers"
+import { CATEGORIES, SUB_CATEGORIES } from "../../../storybook/constants"
 
 export default {
-  title: "Components/Notification/Global Notification",
+  title: `${CATEGORIES.components}/${SUB_CATEGORIES.notification}/Global Notification`,
   component: GlobalNotification,
   parameters: {
     docs: {

--- a/packages/component-library/stories/Heading.stories.tsx
+++ b/packages/component-library/stories/Heading.stories.tsx
@@ -1,8 +1,9 @@
 import * as React from "react"
+import { CATEGORIES, SUB_CATEGORIES } from "../../../storybook/constants"
 import { Heading } from "../components/Heading"
 
 export default {
-  title: "Components/Typography/Heading",
+  title: `${CATEGORIES.components}/${SUB_CATEGORIES.typography}/Heading`,
   component: Heading,
   parameters: {
     docs: {

--- a/packages/component-library/stories/Heading.stories.tsx
+++ b/packages/component-library/stories/Heading.stories.tsx
@@ -1,9 +1,8 @@
-import * as colorTokens from "@kaizen/design-tokens/tokens/color.json"
 import * as React from "react"
 import { Heading } from "../components/Heading"
 
 export default {
-  title: "Heading (React)",
+  title: "Components/Typography/Heading",
   component: Heading,
   parameters: {
     docs: {

--- a/packages/component-library/stories/Icon.stories.tsx
+++ b/packages/component-library/stories/Icon.stories.tsx
@@ -2,9 +2,10 @@ import * as React from "react"
 
 import { Icon } from "@kaizen/component-library"
 import configureIcon from "@kaizen/component-library/icons/configure.icon.svg"
+import { CATEGORIES } from "../../../storybook/constants"
 
 export default {
-  title: "Components/Icon",
+  title: `${CATEGORIES.components}/Icon`,
   component: Icon,
   parameters: {
     docs: {

--- a/packages/component-library/stories/Icon.stories.tsx
+++ b/packages/component-library/stories/Icon.stories.tsx
@@ -4,7 +4,7 @@ import { Icon } from "@kaizen/component-library"
 import configureIcon from "@kaizen/component-library/icons/configure.icon.svg"
 
 export default {
-  title: "Icon (React)",
+  title: "Components/Icon",
   component: Icon,
   parameters: {
     docs: {

--- a/packages/component-library/stories/InlineNotification.stories.tsx
+++ b/packages/component-library/stories/InlineNotification.stories.tsx
@@ -3,6 +3,7 @@ import * as React from "react"
 import { InlineNotification } from "@kaizen/component-library"
 import { withDesign } from "storybook-addon-designs"
 import { figmaEmbed } from "../../../storybook/helpers"
+import { CATEGORIES, SUB_CATEGORIES } from "../../../storybook/constants"
 
 const multilineText = (
   <>
@@ -25,7 +26,7 @@ const withContentBelow = (Story: React.FunctionComponent) => (
 )
 
 export default {
-  title: "Components/Notification/Inline Notification",
+  title: `${CATEGORIES.components}/${SUB_CATEGORIES.notification}/Inline Notification`,
   component: InlineNotification,
   parameters: {
     docs: {

--- a/packages/component-library/stories/InlineNotification.stories.tsx
+++ b/packages/component-library/stories/InlineNotification.stories.tsx
@@ -25,7 +25,7 @@ const withContentBelow = (Story: React.FunctionComponent) => (
 )
 
 export default {
-  title: "InlineNotification (React)",
+  title: "Components/Notification/Inline Notification",
   component: InlineNotification,
   parameters: {
     docs: {

--- a/packages/component-library/stories/Paragraph.stories.tsx
+++ b/packages/component-library/stories/Paragraph.stories.tsx
@@ -3,7 +3,7 @@ import * as React from "react"
 import { Paragraph } from "../components/Paragraph"
 
 export default {
-  title: "Paragraph",
+  title: "Components/Typography/Paragraph",
   component: Paragraph,
   parameters: {
     docs: {

--- a/packages/component-library/stories/Paragraph.stories.tsx
+++ b/packages/component-library/stories/Paragraph.stories.tsx
@@ -1,9 +1,10 @@
 import * as colorTokens from "@kaizen/design-tokens/tokens/color.json"
 import * as React from "react"
+import { CATEGORIES, SUB_CATEGORIES } from "../../../storybook/constants"
 import { Paragraph } from "../components/Paragraph"
 
 export default {
-  title: "Components/Typography/Paragraph",
+  title: `${CATEGORIES.components}/${SUB_CATEGORIES.typography}/Paragraph`,
   component: Paragraph,
   parameters: {
     docs: {

--- a/packages/component-library/stories/Text.stories.tsx
+++ b/packages/component-library/stories/Text.stories.tsx
@@ -2,7 +2,7 @@ import { Text } from "@kaizen/component-library"
 import * as React from "react"
 
 export default {
-  title: "Text (deprecated) (React)",
+  title: "Deprecated/Text",
   component: Text,
   parameters: {
     info: {

--- a/packages/component-library/stories/Text.stories.tsx
+++ b/packages/component-library/stories/Text.stories.tsx
@@ -1,8 +1,9 @@
 import { Text } from "@kaizen/component-library"
 import * as React from "react"
+import { CATEGORIES } from "../../../storybook/constants"
 
 export default {
-  title: "Deprecated/Text",
+  title: `${CATEGORIES.deprecated}/Text`,
   component: Text,
   parameters: {
     info: {

--- a/packages/component-library/stories/ToastNotification.stories.tsx
+++ b/packages/component-library/stories/ToastNotification.stories.tsx
@@ -14,6 +14,7 @@ import { ToastNotificationWithOptionals } from "@kaizen/component-library/compon
 import { withDesign } from "storybook-addon-designs"
 import { v4 } from "uuid"
 import { figmaEmbed } from "../../../storybook/helpers"
+import { CATEGORIES, SUB_CATEGORIES } from "../../../storybook/constants"
 import styles from "./ToastNotification.stories.scss"
 
 const withNavigation = (Story: React.FunctionComponent) => (
@@ -88,7 +89,7 @@ const Triggers = ({
 }
 
 export default {
-  title: "Components/Notification/Toast Notification",
+  title: `${CATEGORIES.components}/${SUB_CATEGORIES.notification}/Toast Notification`,
   component: ToastNotification,
   parameters: {
     docs: {

--- a/packages/component-library/stories/ToastNotification.stories.tsx
+++ b/packages/component-library/stories/ToastNotification.stories.tsx
@@ -88,7 +88,7 @@ const Triggers = ({
 }
 
 export default {
-  title: "ToastNotification (React)",
+  title: "Components/Notification/Toast Notification",
   component: ToastNotification,
   parameters: {
     docs: {

--- a/packages/responsive/docs/useMediaQueries.stories.tsx
+++ b/packages/responsive/docs/useMediaQueries.stories.tsx
@@ -2,7 +2,7 @@ import React from "react"
 import { useMediaQueries } from "../"
 
 export default {
-  title: "useMediaQueries (React)",
+  title: "Helpers/Responsive/useMediaQueries",
   component: useMediaQueries,
   parameters: {
     docs: {

--- a/packages/responsive/docs/useMediaQueries.stories.tsx
+++ b/packages/responsive/docs/useMediaQueries.stories.tsx
@@ -1,8 +1,9 @@
 import React from "react"
 import { useMediaQueries } from "../"
+import { CATEGORIES, SUB_CATEGORIES } from "../../../storybook/constants"
 
 export default {
-  title: "Helpers/Responsive/useMediaQueries",
+  title: `${CATEGORIES.helpers}/${SUB_CATEGORIES.responsive}/useMediaQueries`,
   component: useMediaQueries,
   parameters: {
     docs: {

--- a/storybook/constants.ts
+++ b/storybook/constants.ts
@@ -1,0 +1,16 @@
+export const CATEGORIES = {
+  components: "Components",
+  helpers: "Helpers",
+  designTokens: "Design Tokens",
+  elm: "Elm",
+  deprecated: "Deprecated",
+}
+
+export const SUB_CATEGORIES = {
+  button: "Button",
+  form: "Form",
+  illustration: "Illustration",
+  notification: "Notification",
+  typography: "Typography",
+  responsive: "Responsive",
+}

--- a/storybook/preview.tsx
+++ b/storybook/preview.tsx
@@ -14,6 +14,7 @@ import {
   THEME_CHANGE_EVENT_TYPE,
   THEME_KEY_STORE_KEY,
 } from "./theme-switcher-addon/constants"
+import { CATEGORIES } from "./constants"
 // Polyfill for :focus-visible pseudo-selector
 // See: https://github.com/WICG/focus-visible
 require("focus-visible")
@@ -32,7 +33,13 @@ addParameters({
   options: {
     storySort: {
       method: "alphabetical",
-      order: ["Components", "Helpers", "Design Tokens", "Elm", "Deprecated"],
+      order: [
+        CATEGORIES.components,
+        CATEGORIES.helpers,
+        CATEGORIES.designTokens,
+        CATEGORIES.elm,
+        CATEGORIES.deprecated,
+      ],
     },
   },
   docs: {

--- a/storybook/preview.tsx
+++ b/storybook/preview.tsx
@@ -30,7 +30,10 @@ addParameters({
     values: backgrounds,
   },
   options: {
-    storySort: (a, b) => a[1].id.localeCompare(b[1].id),
+    storySort: {
+      method: "alphabetical",
+      order: ["Components", "Helpers", "Design Tokens", "Elm", "Deprecated"],
+    },
   },
   docs: {
     extractComponentDescription: (component, { notes }) => {


### PR DESCRIPTION
# Objective
Adds some grouping/hierarchy to our Storybook menu.

See https://storybook.js.org/docs/react/writing-stories/naming-components-and-hierarchy

# Motivation and Context
The navigation on our Storybook is quite messy and difficult to scan for things. This will make it easier for folks that aren't super familiar with our components to easily scan and browse through components.

# Screenshots

Before:
![image](https://user-images.githubusercontent.com/1811583/127797522-fe7cb9fd-664c-4a9d-8a18-99a03c1428ec.png)

After:
![image](https://user-images.githubusercontent.com/1811583/127797362-957a6926-c522-478a-9872-f89dffa4bd90.png)