### PR TITLE
fix: Tag dismiss button accessibility + uplift

### DIFF
--- a/draft-packages/tag/KaizenDraft/Tag/Tag.elm
+++ b/draft-packages/tag/KaizenDraft/Tag/Tag.elm
@@ -349,7 +349,7 @@ viewClear config =
                 , Maybe.map mouseleave config.onMouseleave
                 ]
     in
-    span ([ styles.class .dismissIcon ] ++ events)
+    Html.button ([ styles.class .dismissButton ] ++ events)
         [ div [ styles.class .iconWrapper ]
             [ Icon.view (Icon.presentation |> Icon.inheritSize True)
                 (svgAsset "@kaizen/component-library/icons/clear.icon.svg")
@@ -379,7 +379,7 @@ styles =
         , small = "small"
         , inline = "inline"
         , dismissible = "dismissible"
-        , dismissIcon = "dismissIcon"
+        , dismissButton = "dismissButton"
         , validationIcon = "validationIcon"
         , truncate = "truncate"
         , textContent = "textContent"

--- a/draft-packages/tag/KaizenDraft/Tag/Tag.scss
+++ b/draft-packages/tag/KaizenDraft/Tag/Tag.scss
@@ -4,10 +4,20 @@
 @import "~@kaizen/design-tokens/sass/typography-vars";
 @import "~@kaizen/design-tokens/sass/variable-identifiers";
 @import "~@kaizen/deprecated-component-library-helpers/styles/layout";
-@import "~@kaizen/deprecated-component-library-helpers/styles/type";
 
 $medium: calc(#{$kz-var-spacing-md} * 1.25);
 $small: $kz-var-spacing-md;
+
+// reset user agent styles for button element type
+@mixin button-reset {
+  appearance: none;
+  background: transparent;
+  border: none;
+  font: inherit;
+  margin: 0;
+  padding: 0;
+  transition: none; // override Murmur global styles :(
+}
 
 .root {
   @include ca-margin($end: calc(#{$kz-var-spacing-md} * 0.5));
@@ -46,6 +56,7 @@ $small: $kz-var-spacing-md;
 }
 
 .dismissIcon {
+  @include button-reset;
   position: relative;
   display: flex;
   height: 100%;

--- a/draft-packages/tag/KaizenDraft/Tag/Tag.scss
+++ b/draft-packages/tag/KaizenDraft/Tag/Tag.scss
@@ -55,7 +55,7 @@ $small: $kz-var-spacing-md;
   margin-top: -1px;
 }
 
-.dismissIcon {
+.dismissButton {
   @include button-reset;
   position: relative;
   display: flex;
@@ -88,6 +88,30 @@ $small: $kz-var-spacing-md;
   svg {
     position: relative;
   }
+
+  :global(.js-focus-visible) & {
+    outline: none;
+
+    // show custom focus ring when :focus-visible
+    &:global(.focus-visible) .iconWrapper {
+      color: var($kz-var-id-color-wisteria-800, $kz-var-color-wisteria-700);
+
+      &::after {
+        $focus-ring-offset: calc((#{$kz-var-border-focus-ring-border-width}));
+        content: "";
+        position: absolute;
+        background: transparent;
+        border-radius: 50%;
+        border-width: $kz-var-border-focus-ring-border-width;
+        border-style: $kz-var-border-focus-ring-border-style;
+        border-color: $kz-var-color-cluny-500;
+        top: calc(-1 * #{$focus-ring-offset});
+        left: calc(-1 * #{$focus-ring-offset});
+        right: calc(-1 * #{$focus-ring-offset});
+        bottom: calc(-1 * #{$focus-ring-offset});
+      }
+    }
+  }
 }
 
 .background {
@@ -105,6 +129,7 @@ $small: $kz-var-spacing-md;
 }
 
 .iconWrapper {
+  position: relative;
   height: 16px;
   width: 16px;
 }

--- a/draft-packages/tag/KaizenDraft/Tag/Tag.scss
+++ b/draft-packages/tag/KaizenDraft/Tag/Tag.scss
@@ -129,51 +129,27 @@ $small: $kz-var-spacing-md;
 
 .default {
   background-color: var($kz-var-id-color-ash, $kz-var-color-wisteria-200);
-
-  &.dismissible:hover {
-    border-color: var($kz-var-id-color-iron, $kz-var-color-wisteria-300);
-  }
 }
 
 .sentimentPositive {
   background-color: $kz-var-color-seedling-100;
-
-  &.dismissible:hover {
-    border-color: $kz-var-color-seedling-200;
-  }
 }
 
 .sentimentNeutral {
   background-color: $kz-var-color-ash;
-
-  &.dismissible:hover {
-    border-color: var($kz-var-id-color-iron, $kz-var-color-wisteria-300);
-  }
 }
 
 .sentimentNegative {
   background-color: $kz-var-color-coral-100;
-
-  &.dismissible:hover {
-    border-color: $kz-var-color-coral-200;
-  }
 }
 
 .sentimentNone {
   background-color: $kz-var-color-white;
   border-color: var($kz-var-id-color-ash, $kz-var-color-wisteria-200);
-
-  &.dismissible:hover {
-    border-color: var($kz-var-id-color-iron, $kz-var-color-wisteria-300);
-  }
 }
 
 .validationPositive {
   background-color: $kz-var-color-seedling-100;
-
-  &.dismissible:hover {
-    border-color: $kz-var-color-seedling-200;
-  }
 
   .validationIcon {
     color: $kz-var-color-seedling-300;
@@ -183,10 +159,6 @@ $small: $kz-var-spacing-md;
 .validationInformative {
   background-color: $kz-var-color-cluny-100;
 
-  &.dismissible:hover {
-    border-color: $kz-var-color-cluny-300;
-  }
-
   .validationIcon {
     color: $kz-var-color-cluny-500;
   }
@@ -195,10 +167,6 @@ $small: $kz-var-spacing-md;
 .validationNegative {
   background-color: $kz-var-color-coral-100;
 
-  &.dismissible:hover {
-    border-color: $kz-var-color-coral-200;
-  }
-
   .validationIcon {
     color: $kz-var-color-coral-500;
   }
@@ -206,10 +174,6 @@ $small: $kz-var-spacing-md;
 
 .validationCautionary {
   background-color: $kz-var-color-yuzu-100;
-
-  &.dismissible:hover {
-    border-color: $kz-var-color-yuzu-300;
-  }
 
   .validationIcon {
     color: $kz-var-color-yuzu-500;

--- a/draft-packages/tag/KaizenDraft/Tag/Tag.tsx
+++ b/draft-packages/tag/KaizenDraft/Tag/Tag.tsx
@@ -117,7 +117,7 @@ const Tag = (props: TagProps) => {
         {dismissible && (
           <>
             <button
-              className={styles.dismissIcon}
+              className={styles.dismissButton}
               onClick={onDismiss}
               onMouseDown={onMouseDown}
               onMouseLeave={onMouseLeave}

--- a/draft-packages/tag/KaizenDraft/Tag/Tag.tsx
+++ b/draft-packages/tag/KaizenDraft/Tag/Tag.tsx
@@ -116,7 +116,7 @@ const Tag = (props: TagProps) => {
         </span>
         {dismissible && (
           <>
-            <span
+            <button
               className={styles.dismissIcon}
               onClick={onDismiss}
               onMouseDown={onMouseDown}
@@ -126,7 +126,7 @@ const Tag = (props: TagProps) => {
               <div className={styles.iconWrapper}>
                 <Icon icon={clearIcon} inheritSize role="img" title="Dismiss" />
               </div>
-            </span>
+            </button>
           </>
         )}
         {variant === "statusLive" && (

--- a/draft-packages/tag/docs/Tag.stories.tsx
+++ b/draft-packages/tag/docs/Tag.stories.tsx
@@ -215,7 +215,12 @@ export const Inline = () => (
 
 export const InlineDismissible = () => (
   <StoryContainer>
-    <Tag variant="default" inline dismissible>
+    <Tag
+      variant="default"
+      inline
+      dismissible
+      onDismiss={() => alert("dismissed action fired")}
+    >
       Inline
     </Tag>
     <Tag
@@ -226,7 +231,12 @@ export const InlineDismissible = () => (
     >
       Inline
     </Tag>
-    <Tag variant="validationPositive" inline dismissible>
+    <Tag
+      variant="validationPositive"
+      inline
+      dismissible
+      onDismiss={() => alert("dismissed action fired")}
+    >
       Inline
     </Tag>
   </StoryContainer>

--- a/draft-packages/tag/docs/Tag.stories.tsx
+++ b/draft-packages/tag/docs/Tag.stories.tsx
@@ -218,7 +218,12 @@ export const InlineDismissible = () => (
     <Tag variant="default" inline dismissible>
       Inline
     </Tag>
-    <Tag variant="sentimentPositive" inline dismissible>
+    <Tag
+      variant="sentimentPositive"
+      inline
+      dismissible
+      onDismiss={() => alert("dismissed action fired")}
+    >
       Inline
     </Tag>
     <Tag variant="validationPositive" inline dismissible>


### PR DESCRIPTION
# Objective
The dismiss button of the Tag component is completely inaccessible.

- It should support keyboard and screen reader accessibility (which can easily be achieved by making it a `button` element instead of a `span`
- it should have a focus ring as per the latest Heart styles
- the border of the entire component should not change colour when focussed or hovered (because only the dismiss button is interactive + this is not in the latest Heart design)


# Motivation and Context

https://github.com/cultureamp/kaizen-design-system/issues/1797

# Screenshots (if appropriate)

As well as some non-visual accessibility improvements (works with keyboard and screen readers), there are some visual improvements:

## states

### default
before
![image](https://user-images.githubusercontent.com/702885/127442666-19494cd4-f636-4d6f-afda-3b1db26c53cc.png)
after
![image](https://user-images.githubusercontent.com/702885/127441851-854e9cb6-641f-41a9-8efa-78a57aba3afd.png)

### hover
before
![image](https://user-images.githubusercontent.com/702885/127442748-a52bb448-ab20-4da9-91bd-c8363c63324a.png)
after
![image](https://user-images.githubusercontent.com/702885/127441952-c56b6656-7d93-4a8b-87bf-685a6d06a604.png)

### focus
before
![image](https://user-images.githubusercontent.com/702885/127442880-72b2a9ec-d51d-45f0-a8b9-2e15f9fcf309.png)
after
![image](https://user-images.githubusercontent.com/702885/127441980-3e27a51f-09a6-4ca1-861c-36c2b92ec02f.png)





# Checklist
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] If this contains visual changes, has it been reviewed by a designer?
- [ ] If this introduces either a new component or a breaking change to an existing component, has it been reviewed by an advocate? (Ask in #prod_design_systems)
- [ ] I have considered likely risks of these changes and got someone else to QA as appropriate
- [ ] I have or will communicate these changes to the front end practice

# Additional Considerations
- Does there need to be right-to-left (RTL) options for localization and internationalization?
- Has the test suite been updated?
- Have you done cross-browser testing for our [supported browsers](https://academy.cultureamp.com/hc/en-us/articles/204539569-Supported-browsers-for-Participants)?
- Have you updated any relevant documentation or left useful comments in the code?
- Have you reviewed Culture Amp's Web Accessibility guide [Current Compliance, Going Forward, Statement and Answers for Customers](https://cultureamp.atlassian.net/wiki/spaces/Prod/pages/428572998/Web+Accessibility)?
- If this contains substantial visual changes, especially far reaching ones, have you unlocked the Chromatic step in the pipeline?
- Have Storybook stories been updated?

**If you're new to Kaizen, please ask #prod_design_systems to set up an onboarding session to get you up to speed.** If you have an urgent PR to merge before that happens, it is safest to ask in #prod_design_systems to have a design system advocate review the PR to catch any issues.
