### PR TITLE
fix: Exclude spec files from being compiled and published

### DIFF
--- a/packages/design-tokens/package.json
+++ b/packages/design-tokens/package.json
@@ -19,7 +19,8 @@
     "src",
     "react",
     "dist",
-    "elm"
+    "elm",
+    "!**/*.spec.*"
   ],
   "types": "dist/**/*.d.ts",
   "main": "dist/index.js",

--- a/packages/design-tokens/tsconfig.dist.json
+++ b/packages/design-tokens/tsconfig.dist.json
@@ -10,5 +10,6 @@
     "target": "es5",
     "module": "CommonJS"
   },
-  "include": ["index.ts"]
+  "include": ["index.ts"],
+  "exclude": ["**/*.spec.ts"]
 }


### PR DESCRIPTION
# Objective
This has caused the following issue in Buildkite:
```
[error] No parser could be inferred for file: sass/tokens.spec.js.map
```

# Checklist
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] If this contains visual changes, has it been reviewed by a designer?
- [ ] If this introduces either a new component or a breaking change to an existing component, has it been reviewed by an advocate? (Ask in #prod_design_systems)
- [ ] I have considered likely risks of these changes and got someone else to QA as appropriate
- [ ] I have or will communicate these changes to the front end practice

**If you're new to Kaizen, please ask #prod_design_systems to set up an onboarding session to get you up to speed.** If you have an urgent PR to merge before that happens, it is safest to ask in #prod_design_systems to have a design system advocate review the PR to catch any issues.
