### PR TITLE
fix: show tooltips in chromatic tests

### DIFF
--- a/draft-packages/tooltip/KaizenDraft/Tooltip/Tooltip.tsx
+++ b/draft-packages/tooltip/KaizenDraft/Tooltip/Tooltip.tsx
@@ -36,6 +36,11 @@ export type TooltipProps = {
    * `overflow: scroll` or `overflow: hidden` element.
    */
   portalSelector?: string
+  /**
+   * Should the tooltip be visible on the first render. Useful for visual
+   * regression testing.
+   */
+  isInitiallyVisible?: boolean
 }
 
 // Sync with Tooltip.scss
@@ -119,8 +124,9 @@ const Tooltip = ({
   position = "above",
   classNameAndIHaveSpokenToDST,
   portalSelector,
+  isInitiallyVisible = false,
 }: TooltipProps) => {
-  const [isHover, setIsHover] = useState(false)
+  const [isHover, setIsHover] = useState(isInitiallyVisible)
   const [isFocus, setIsFocus] = useState(false)
   const [
     referenceElement,

--- a/draft-packages/tooltip/docs/Tooltip.stories.tsx
+++ b/draft-packages/tooltip/docs/Tooltip.stories.tsx
@@ -15,9 +15,9 @@ import { figmaEmbed } from "../../../storybook/helpers"
  * until there is a clean way to trigger open states for the snapshots. See:
  * https://github.com/cultureamp/kaizen-design-system/issues/1375
  */
-const excludeFromChromatic = Story => {
-  if (!isChromatic()) return <Story />
-  return null
+const openTooltipInChromatic = (story, config) => {
+  if (isChromatic()) config.args.isInitiallyVisible = true
+  return story()
 }
 
 export default {
@@ -33,12 +33,12 @@ export default {
       "https://www.figma.com/file/GMxm8rvDCbj0Xw3TQWBZ8b/UI-Kit-Zen?node-id=14473%3A90872"
     ),
   },
-  decorators: [withDesign, excludeFromChromatic],
+  decorators: [withDesign, openTooltipInChromatic],
 }
 
-export const DefaultBelowKaizenSiteDemo = () => (
+export const DefaultBelowKaizenSiteDemo = props => (
   <div style={{ display: "flex", justifyContent: "center" }}>
-    <Tooltip position="below" text="This is below the tooltip">
+    <Tooltip {...props} position="below" text="This is below the tooltip">
       {/* Using buttons, as so we can test the focus state.
          ie. the tooltip should show when any child is focused. */}
       <Button label="Below" />
@@ -47,8 +47,6 @@ export const DefaultBelowKaizenSiteDemo = () => (
 )
 
 DefaultBelowKaizenSiteDemo.storyName = "Default - Below (Kaizen Site Demo)"
-DefaultBelowKaizenSiteDemo.component = Tooltip
-
 DefaultBelowKaizenSiteDemo.parameters = {
   info: {
     text: `
@@ -57,12 +55,12 @@ DefaultBelowKaizenSiteDemo.parameters = {
   },
 }
 
-export const DefaultAbove = () => (
+export const DefaultAbove = props => (
   <div
     style={{ marginTop: "100px", display: "flex", justifyContent: "center" }}
   >
     <div style={{ display: "inline-block", position: "relative" }}>
-      <Tooltip position="above" text="This is above the tooltip">
+      <Tooltip {...props} position="above" text="This is above the tooltip">
         {/* Using buttons, as so we can test the focus state.
          ie. the tooltip should show when any child is focused. */}
         <Button label="Above" />
@@ -70,10 +68,9 @@ export const DefaultAbove = () => (
     </div>
   </div>
 )
-
 DefaultAbove.storyName = "Default - Above"
 
-export const Inline = () => (
+export const Inline = props => (
   <div
     style={{
       margin: "100px",
@@ -86,12 +83,16 @@ export const Inline = () => (
       <Paragraph variant="body">
         Lorem ipsum dolor sit amet consectetur adipisicing elit. Ratione nulla
         quas corporis? Perspiciatis, ratione voluptas{" "}
-        <Tooltip display="inline-block" text="This is above the tooltip">
+        <Tooltip
+          {...props}
+          display="inline-block"
+          text="This is above the tooltip"
+        >
           <Tag>ad veniam sapiente</Tag>
         </Tooltip>{" "}
         Maxime harum, ducimus maiores itaque pariatur quod vel porro mollitia.
         Lorem ipsum dolor sit{" "}
-        <Tooltip display="inline" text="Open in new tab">
+        <Tooltip {...props} display="inline" text="Open in new tab">
           <a href="#">
             amet consectetur adipisicing elit Itaque obcaecati maxime molestiae
             blanditiis pariatur
@@ -100,6 +101,7 @@ export const Inline = () => (
         . Magni perspiciatis assumenda in adipisci, eaque commodi quidem dolore,
         tempore provident animi{" "}
         <Tooltip
+          {...props}
           display="inline-block"
           text="This is below the tooltip"
           position="below"
@@ -113,10 +115,11 @@ export const Inline = () => (
 
 Inline.storyName = "Inline"
 
-export const ArrowPositioning = () => (
+export const ArrowPositioning = props => (
   <div>
     <div style={{ position: "absolute", top: 0, left: 0 }}>
       <Tooltip
+        {...props}
         position="above"
         text="This is below the tooltip, despite it being set to position=above. This is because there is not enough room. Also note that the arrow is correctly positioned."
       >
@@ -125,6 +128,7 @@ export const ArrowPositioning = () => (
     </div>
     <div style={{ position: "absolute", bottom: 0, right: 0 }}>
       <Tooltip
+        {...props}
         position="below"
         text="This is above the tooltip, despite it being set to position=below. This is because there is not enough room. Also note that the arrow is correctly positioned."
       >
@@ -136,11 +140,12 @@ export const ArrowPositioning = () => (
 
 ArrowPositioning.storyName = "Arrow positioning"
 
-export const OverflowScroll = () => (
+export const OverflowScroll = props => (
   <div>
     <div style={{ overflowX: "scroll", width: "200px", height: "100px" }}>
       <div style={{ width: "500px", textAlign: "center" }}>
         <Tooltip
+          {...props}
           position="below"
           display="inline-block"
           text="This should not get cropped"
@@ -162,7 +167,7 @@ export const OverflowScroll = () => (
 
 OverflowScroll.storyName = "overflow: scroll"
 
-export const TooltipAboveDropdown = () => (
+export const TooltipAboveDropdown = props => (
   <>
     <div>
       <SplitButton
@@ -180,6 +185,7 @@ export const TooltipAboveDropdown = () => (
     </div>
     <div style={{ paddingTop: "50px" }}>
       <Tooltip
+        {...props}
         position="above"
         display="inline-block"
         text="Text to appear above the button dropdown text"


### PR DESCRIPTION

# Objective
<!-- Describe what this change achieves, and the details of how it works. -->

The visual regression tests around the tooltip component render the button that triggers the tooltip, but not the tooltip itself. This means that these tests provide little value, unless we can get the tooltip into the test.

The ideal way to do this would be to trigger a hover event in chromatic before the screenshot is captured, but the current chromatic API doesn't support any interaction or events. Instead, we are putting a new prop into the component to signal that the tooltip should be visible on the first render. This seems like it will only be useful for testing, but someone may find a valid use for it, so it hasn't been named obtusely (a name like `chromaticTestVisibility` would send a signal that this is the only valid usage)


# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
closes #1375 

# Screenshots (if appropriate)
<img width="517" alt="Screen Shot 2021-07-30 at 9 36 02 am" src="https://user-images.githubusercontent.com/899827/127578653-70b2be08-a4c1-4725-8383-84590eb2e92f.png">


# Checklist
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] If this contains visual changes, has it been reviewed by a designer?
- [ ] If this introduces either a new component or a breaking change to an existing component, has it been reviewed by an advocate? (Ask in #prod_design_systems)
- [ ] I have considered likely risks of these changes and got someone else to QA as appropriate
- [ ] I have or will communicate these changes to the front end practice

# Additional Considerations
- Does there need to be right-to-left (RTL) options for localization and internationalization?
- Has the test suite been updated?
- Have you done cross-browser testing for our [supported browsers](https://academy.cultureamp.com/hc/en-us/articles/204539569-Supported-browsers-for-Participants)?
- Have you updated any relevant documentation or left useful comments in the code?
- Have you reviewed Culture Amp's Web Accessibility guide [Current Compliance, Going Forward, Statement and Answers for Customers](https://cultureamp.atlassian.net/wiki/spaces/Prod/pages/428572998/Web+Accessibility)?
- If this contains substantial visual changes, especially far reaching ones, have you unlocked the Chromatic step in the pipeline?
- Have Storybook stories been updated?

**If you're new to Kaizen, please ask #prod_design_systems to set up an onboarding session to get you up to speed.** If you have an urgent PR to merge before that happens, it is safest to ask in #prod_design_systems to have a design system advocate review the PR to catch any issues.
