### PR TITLE
fix: Update Storybook background colour references

### DIFF
--- a/draft-packages/badge/docs/Badge.stories.tsx
+++ b/draft-packages/badge/docs/Badge.stories.tsx
@@ -112,7 +112,7 @@ export const Reversed = () => (
 Reversed.storyName = "Reversed"
 Reversed.parameters = {
   backgrounds: {
-    default: "Wisteria 700",
+    default: "Purple 700",
   },
 }
 
@@ -135,7 +135,7 @@ export const ReversedActive = () => (
 ReversedActive.storyName = "Reversed, Active"
 ReversedActive.parameters = {
   backgrounds: {
-    default: "Wisteria 700",
+    default: "Purple 700",
   },
 }
 

--- a/draft-packages/button/docs/Button.stories.tsx
+++ b/draft-packages/button/docs/Button.stories.tsx
@@ -31,7 +31,7 @@ export default {
 
 const reversedBg = {
   backgrounds: {
-    default: "Wisteria 700",
+    default: "Purple 700",
   },
 }
 

--- a/draft-packages/button/docs/IconButton.stories.tsx
+++ b/draft-packages/button/docs/IconButton.stories.tsx
@@ -63,7 +63,7 @@ export const Reversed = () => (
 )
 Reversed.parameters = {
   backgrounds: {
-    default: "Wisteria 700",
+    default: "Purple 700",
   },
 }
 
@@ -79,7 +79,7 @@ export const ReversedDisabled = () => (
 ReversedDisabled.storyName = "Reversed, Disabled"
 ReversedDisabled.parameters = {
   backgrounds: {
-    default: "Wisteria 700",
+    default: "Purple 700",
   },
 }
 

--- a/draft-packages/card/docs/Card.stories.tsx
+++ b/draft-packages/card/docs/Card.stories.tsx
@@ -40,5 +40,5 @@ export const CardWithSpace = () => (
 CardWithSpace.storyName = "Card, custom spacing with Box"
 
 CardWithSpace.parameters = {
-  backgrounds: { default: "Stone" },
+  backgrounds: { default: "Gray 100" },
 }

--- a/draft-packages/collapsible/docs/Collapsible.stories.tsx
+++ b/draft-packages/collapsible/docs/Collapsible.stories.tsx
@@ -22,7 +22,7 @@ export default {
   title: "Collapsible (React)",
   component: Collapsible,
   parameters: {
-    backgrounds: { default: "Stone" },
+    backgrounds: { default: "Gray 100" },
     docs: {
       description: {
         component:

--- a/draft-packages/divider/docs/Divider.stories.tsx
+++ b/draft-packages/divider/docs/Divider.stories.tsx
@@ -7,7 +7,7 @@ import { figmaEmbed } from "../../../storybook/helpers"
 
 const reversedBg = {
   backgrounds: {
-    default: "Wisteria 700",
+    default: "Purple 700",
   },
 }
 

--- a/draft-packages/form/docs/TextAreaField.stories.tsx
+++ b/draft-packages/form/docs/TextAreaField.stories.tsx
@@ -48,7 +48,7 @@ const ExampleContainer: React.FunctionComponent = ({ children }) => (
 
 const reversedBg = {
   backgrounds: {
-    default: "Wisteria 700",
+    default: "Purple 700",
   },
 }
 

--- a/draft-packages/form/docs/TextField.stories.tsx
+++ b/draft-packages/form/docs/TextField.stories.tsx
@@ -15,7 +15,7 @@ const ExampleContainer: React.FunctionComponent = ({ children }) => (
 
 const ReversedBg = {
   backgrounds: {
-    default: "Wisteria 700",
+    default: "Purple 700",
   },
 }
 

--- a/draft-packages/guidance-block/docs/GuidanceBlock.stories.tsx
+++ b/draft-packages/guidance-block/docs/GuidanceBlock.stories.tsx
@@ -17,7 +17,7 @@ export default {
           'import { GuidanceBlock } from "@kaizen/draft-guidance-block";',
       },
     },
-    backgrounds: { default: "Stone" },
+    backgrounds: { default: "Gray 100" },
     ...figmaEmbed(
       "https://www.figma.com/file/GMxm8rvDCbj0Xw3TQWBZ8b/UI-Kit-Zen?node-id=1929%3A39077"
     ),

--- a/draft-packages/likert-scale-legacy/docs/LikertScaleLegacy.stories.tsx
+++ b/draft-packages/likert-scale-legacy/docs/LikertScaleLegacy.stories.tsx
@@ -93,4 +93,4 @@ export const Reversed = () => {
 }
 
 Reversed.storyName = "Reversed"
-Reversed.parameters = { backgrounds: { default: "Wisteria 700" } }
+Reversed.parameters = { backgrounds: { default: "Purple 700" } }

--- a/draft-packages/loading-placeholder/docs/LoadingPlaceholder.stories.tsx
+++ b/draft-packages/loading-placeholder/docs/LoadingPlaceholder.stories.tsx
@@ -248,7 +248,7 @@ export const ReversedDefault = () => (
 ReversedDefault.storyName = "Reversed, Default"
 ReversedDefault.parameters = {
   backgrounds: {
-    default: "Wisteria 700",
+    default: "Purple 700",
   },
 }
 

--- a/draft-packages/menu/docs/Menu.stories.tsx
+++ b/draft-packages/menu/docs/Menu.stories.tsx
@@ -138,7 +138,7 @@ export const LabelAndIconReversed = () => (
 LabelAndIconReversed.storyName = "Label and Icon (reversed)"
 LabelAndIconReversed.parameters = {
   backgrounds: {
-    default: "Wisteria 700",
+    default: "Purple 700",
   },
 }
 

--- a/draft-packages/select/docs/Select.stories.tsx
+++ b/draft-packages/select/docs/Select.stories.tsx
@@ -199,7 +199,7 @@ export const SingleSecondarySmall = () => (
 SingleSecondarySmall.storyName = "Single, Secondary-Small, Reversed"
 SingleSecondarySmall.parameters = {
   backgrounds: {
-    default: "Wisteria 700",
+    default: "Purple 700",
   },
 }
 
@@ -232,7 +232,7 @@ export const SingleSecondaryReversed = () => (
 SingleSecondaryReversed.storyName = "Single, Secondary, Reversed"
 SingleSecondaryReversed.parameters = {
   backgrounds: {
-    default: "Wisteria 700",
+    default: "Purple 700",
   },
 }
 
@@ -262,7 +262,7 @@ export const SingleSecondaryWithEllipsis = () => {
 SingleSecondaryWithEllipsis.storyName = "Single Secondary with ellipsis"
 SingleSecondaryWithEllipsis.parameters = {
   backgrounds: {
-    default: "Wisteria 700",
+    default: "Purple 700",
   },
 }
 
@@ -283,6 +283,6 @@ SingleSecondaryReversedDisabled.storyName =
   "Single Secondary Reversed (disabled)"
 SingleSecondaryReversedDisabled.parameters = {
   backgrounds: {
-    default: "Wisteria 700",
+    default: "Purple 700",
   },
 }

--- a/draft-packages/table/docs/Table.stories.tsx
+++ b/draft-packages/table/docs/Table.stories.tsx
@@ -199,7 +199,7 @@ export const Reversed = () => (
 Reversed.storyName = "Reversed"
 Reversed.parameters = {
   backgrounds: {
-    default: "Wisteria 700",
+    default: "Purple 700",
   },
 }
 

--- a/draft-packages/tabs/docs/Tabs.stories.tsx
+++ b/draft-packages/tabs/docs/Tabs.stories.tsx
@@ -311,7 +311,7 @@ export const WithLayoutVerticalLTR = () => {
 WithLayoutVerticalLTR.storyName = "(Example) Layout LTR (Vertical)"
 
 WithLayoutVerticalLTR.parameters = {
-  backgrounds: { default: "Wisteria 700" },
+  backgrounds: { default: "Purple 700" },
 }
 
 export const WithLayoutVerticalRTL = () => {
@@ -342,7 +342,7 @@ export const WithLayoutVerticalRTL = () => {
 WithLayoutVerticalRTL.storyName = "(Example) Layout RTL (Vertical)"
 
 WithLayoutVerticalRTL.parameters = {
-  backgrounds: { default: "Stone" },
+  backgrounds: { default: "Gray 100" },
 }
 
 export const WithHeading = () => {
@@ -386,7 +386,7 @@ export const WithHeading = () => {
 WithHeading.storyName = "(Example) Layout With heading"
 
 WithHeading.parameters = {
-  backgrounds: { default: "Stone" },
+  backgrounds: { default: "Gray 100" },
 }
 
 export const ExampleContentTab = () => {
@@ -420,5 +420,5 @@ export const ExampleContentTab = () => {
 ExampleContentTab.storyName = "(Example) Content Tab in Content Area"
 
 ExampleContentTab.parameters = {
-  backgrounds: { default: "Stone" },
+  backgrounds: { default: "Gray 100" },
 }

--- a/packages/brand/docs/Brand.stories.tsx
+++ b/packages/brand/docs/Brand.stories.tsx
@@ -16,7 +16,7 @@ export default {
 
 const reversedBg = {
   backgrounds: {
-    default: "Wisteria 700",
+    default: "Purple 700",
   },
 }
 

--- a/packages/component-library/stories/Heading.stories.tsx
+++ b/packages/component-library/stories/Heading.stories.tsx
@@ -77,13 +77,13 @@ export const Heading3Negative = () => (
 Heading1White.storyName = "Heading 1 White"
 
 Heading1White.parameters = {
-  backgrounds: { default: "Wisteria 700" },
+  backgrounds: { default: "Purple 700" },
 }
 
 Heading1WhiteReducedOpacity.storyName = "Heading 1 White Reduced Opacity"
 
 Heading1WhiteReducedOpacity.parameters = {
-  backgrounds: { default: "Wisteria 700" },
+  backgrounds: { default: "Purple 700" },
 }
 
 export {

--- a/packages/component-library/stories/Paragraph.stories.tsx
+++ b/packages/component-library/stories/Paragraph.stories.tsx
@@ -56,7 +56,7 @@ export const BodyWhite = () => (
 BodyWhite.storyName = "Body White"
 
 BodyWhite.parameters = {
-  backgrounds: { default: "Wisteria 700" },
+  backgrounds: { default: "Purple 700" },
 }
 
 export const BodyPositive = () => (


### PR DESCRIPTION
These names changed in https://github.com/cultureamp/kaizen-design-system/pull/1741/files#diff-b3e4a28d9c367ace4d3bc1ebf576bc4ee1bb1927a3d141a2cf4386224dde60c0L8, but the stories weren't updated. This updates the references to the updated background colour names in our stories.
