### PR TITLE
fix: Wrong background-color for the checkbox after transition from mixed to off state

### DIFF
--- a/draft-packages/form/KaizenDraft/Form/Primitives/Checkbox/Checkbox.tsx
+++ b/draft-packages/form/KaizenDraft/Form/Primitives/Checkbox/Checkbox.tsx
@@ -74,8 +74,8 @@ const Input: Input = ({
       disabled={disabled}
       value={value || checkedStatus}
       ref={node => {
-        if (node && checkedStatus === "mixed") {
-          node.indeterminate = true
+        if (node) {
+          node.indeterminate = checkedStatus === "mixed"
         }
       }}
     />

--- a/draft-packages/form/docs/CheckboxGroup.stories.tsx
+++ b/draft-packages/form/docs/CheckboxGroup.stories.tsx
@@ -284,3 +284,69 @@ export const WithoutBottomMargin = () => (
 )
 
 WithoutBottomMargin.storyName = "without bottom margin"
+
+export const ConditionallyChecked = () => {
+  const [selectedOptions, setSelectedOptions] = React.useState<number[]>([])
+
+  const onCheckHandler = (state: string, value: number) => {
+    if (state === "off") {
+      setSelectedOptions(prev => [...prev, value])
+    } else {
+      setSelectedOptions(selectedOptions.filter(val => val !== value))
+    }
+  }
+
+  const checkAllCheckboxOnCheckHandler = (
+    event: React.ChangeEvent<HTMLInputElement>
+  ) => {
+    const state = event.currentTarget.value
+    if (state === "off" || state === "mixed") {
+      setSelectedOptions([1, 2, 3])
+    } else {
+      setSelectedOptions([])
+    }
+  }
+
+  const allCheckboxState = React.useMemo(() => {
+    if (selectedOptions.length === 3) {
+      return "on"
+    }
+    if (selectedOptions.length === 0) {
+      return "off"
+    }
+    return "mixed"
+  }, [selectedOptions])
+
+  return (
+    <div>
+      <CheckboxGroup noBottomMargin labelText="Checkbox Group Label">
+        <CheckboxField
+          id="checkbox-all"
+          checkedStatus={allCheckboxState}
+          labelText="All"
+          onCheck={checkAllCheckboxOnCheckHandler}
+        />
+        <CheckboxField
+          id="checkbox-1"
+          checkedStatus={selectedOptions.includes(1) ? "on" : "off"}
+          labelText="Label"
+          onCheck={e => onCheckHandler(e.currentTarget.value, 1)}
+        />
+        <CheckboxField
+          id="checkbox-2"
+          checkedStatus={selectedOptions.includes(2) ? "on" : "off"}
+          labelText="Label"
+          onCheck={e => onCheckHandler(e.currentTarget.value, 2)}
+        />
+        <CheckboxField
+          id="checkbox-3"
+          checkedStatus={selectedOptions.includes(3) ? "on" : "off"}
+          labelText="Label"
+          onCheck={e => onCheckHandler(e.currentTarget.value, 3)}
+        />
+      </CheckboxGroup>
+    </div>
+  )
+}
+
+ConditionallyChecked.storyName = "Conditionally checked"

--- a/draft-packages/form/docs/CheckboxGroup.stories.tsx
+++ b/draft-packages/form/docs/CheckboxGroup.stories.tsx
@@ -285,7 +285,7 @@ export const WithoutBottomMargin = () => (
 
 WithoutBottomMargin.storyName = "without bottom margin"
 
-export const ConditionallyChecked = () => {
+export const NestedCheckboxGroup = () => {
   const [selectedOptions, setSelectedOptions] = React.useState<number[]>([])
 
   const onCheckHandler = (state: string, value: number) => {
@@ -349,4 +349,4 @@ export const ConditionallyChecked = () => {
   )
 }
 
-ConditionallyChecked.storyName = "Conditionally checked"
+NestedCheckboxGroup.storyName = "Nested Checkbox Group"


### PR DESCRIPTION
# Objective
<!-- Describe what this change achieves, and the details of how it works. -->
Fix the checkbox background not change back to white when the state of the checkbox is no longer `mixed`

Fix #1599 

# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

https://github.com/cultureamp/kaizen-design-system/issues/1599

# Screenshots (if appropriate)

# Checklist
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] If this contains visual changes, has it been reviewed by a designer?
- [ ] If this introduces either a new component or a breaking change to an existing component, has it been reviewed by an advocate? (Ask in #prod_design_systems)
- [ ] I have considered likely risks of these changes and got someone else to QA as appropriate
- [ ] I have or will communicate these changes to the front end practice

# Additional Considerations
- Does there need to be right-to-left (RTL) options for localization and internationalization?
- Has the test suite been updated?
- Have you done cross-browser testing for our [supported browsers](https://academy.cultureamp.com/hc/en-us/articles/204539569-Supported-browsers-for-Participants)?
- Have you updated any relevant documentation or left useful comments in the code?
- Have you reviewed Culture Amp's Web Accessibility guide [Current Compliance, Going Forward, Statement and Answers for Customers](https://cultureamp.atlassian.net/wiki/spaces/Prod/pages/428572998/Web+Accessibility)?
- If this contains substantial visual changes, especially far reaching ones, have you unlocked the Chromatic step in the pipeline?
- Have Storybook stories been updated?

**If you're new to Kaizen, please ask #prod_design_systems to set up an onboarding session to get you up to speed.** If you have an urgent PR to merge before that happens, it is safest to ask in #prod_design_systems to have a design system advocate review the PR to catch any issues.
