### PR TITLE
fix: Stylelint plugin code polish

### DIFF
--- a/packages/stylelint-plugin/src/rules/lib/fixAlphaModificationFunctions.ts
+++ b/packages/stylelint-plugin/src/rules/lib/fixAlphaModificationFunctions.ts
@@ -39,7 +39,7 @@ const parsePercentageOrDecimal = (
 const parsePercentage = (value: string): number | "NaN" => {
   // Add-alpha can be used without a percentage sign, that won't fly.
   // Fix the percentage sign, then convert to a decimal for usage in RGBA
-  const parsed = parseInt(value.replace(/\%/, ""), 10)
+  const parsed = parseFloat(value.replace(/\%/, ""))
   if (isNaN(parsed)) {
     return "NaN"
   }

--- a/packages/stylelint-plugin/src/stylelintPlugin.spec.ts
+++ b/packages/stylelint-plugin/src/stylelintPlugin.spec.ts
@@ -541,11 +541,21 @@ const testExamples: TestExample[] = [
   },
   {
     language: "scss",
-    testName: "weird add-alpha alpha parameter is fixed",
+    testName: "add-alpha percentage parameter is normalised",
     input:
       '@import "~@kaizen/design-tokens/sass/color"; .foo { color: add-alpha($kz-color-wisteria-800, 70) }',
     expectedOutput:
       '@import "~@kaizen/design-tokens/sass/color"; .foo { color: rgba($color-purple-800-rgb, 0.7) }',
+    expectedWarnings: 0,
+  },
+  {
+    language: "scss",
+    testName:
+      "add-alpha percentage parameter is normalised and supports floats",
+    input:
+      '@import "~@kaizen/design-tokens/sass/color"; .foo { color: add-alpha($kz-color-wisteria-800, 70.1234) }',
+    expectedOutput:
+      '@import "~@kaizen/design-tokens/sass/color"; .foo { color: rgba($color-purple-800-rgb, 0.701234) }',
     expectedWarnings: 0,
   },
   {

--- a/packages/stylelint-plugin/src/stylelintPlugin.spec.ts
+++ b/packages/stylelint-plugin/src/stylelintPlugin.spec.ts
@@ -165,7 +165,7 @@ const testExamples: TestExample[] = [
   {
     language: "scss",
     testName:
-      "knows not change a token to a CSS variable within a function that doesn't support them",
+      "knows not to change a token to a CSS variable within a function that doesn't support them",
     input: `
       @import "~@kaizen/design-tokens/sass/color";
       .foo {
@@ -905,7 +905,7 @@ const testExamples: TestExample[] = [
   },
   {
     testName:
-      "tokens within functions can be replaced when the replacement is not a CSS variable",
+      "tokens within functions can be safely replaced when the current/existing token is a CSS variable",
     language: "scss",
     input:
       '@import "~@kaizen/design-tokens/sass/spacing-vars"; .test { padding: ca-padding($kz-var-spacing-md) }',

--- a/packages/stylelint-plugin/src/stylelintPlugin.ts
+++ b/packages/stylelint-plugin/src/stylelintPlugin.ts
@@ -45,7 +45,7 @@ export default rules.map(rule =>
             stylelint.utils.report({
               ruleName: `kaizen/${rule.name}`,
               message: `${message}${
-                autofixAvailable ? "(autofix avaialable)" : ""
+                autofixAvailable ? " (autofix available)" : ""
               }`,
               node,
               result,


### PR DESCRIPTION
# Objective
Make some code polish changes based on some remaining comments from https://github.com/cultureamp/kaizen-design-system/pull/1743.

- parseFloat instead of parseInt for add-alpha parsePercentage
- test/spec names needed some amending
- typo in lint rule message

# Screenshots (if appropriate)

# Checklist
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] If this contains visual changes, has it been reviewed by a designer?
- [ ] If this introduces either a new component or a breaking change to an existing component, has it been reviewed by an advocate? (Ask in #prod_design_systems)
- [ ] I have considered likely risks of these changes and got someone else to QA as appropriate
- [ ] I have or will communicate these changes to the front end practice

# Additional Considerations
- Does there need to be right-to-left (RTL) options for localization and internationalization?
- Has the test suite been updated?
- Have you done cross-browser testing for our [supported browsers](https://academy.cultureamp.com/hc/en-us/articles/204539569-Supported-browsers-for-Participants)?
- Have you updated any relevant documentation or left useful comments in the code?
- Have you reviewed Culture Amp's Web Accessibility guide [Current Compliance, Going Forward, Statement and Answers for Customers](https://cultureamp.atlassian.net/wiki/spaces/Prod/pages/428572998/Web+Accessibility)?
- If this contains substantial visual changes, especially far reaching ones, have you unlocked the Chromatic step in the pipeline?
- Have Storybook stories been updated?

**If you're new to Kaizen, please ask #prod_design_systems to set up an onboarding session to get you up to speed.** If you have an urgent PR to merge before that happens, it is safest to ask in #prod_design_systems to have a design system advocate review the PR to catch any issues.
