### PR TITLE
feat: Remove reversed color prop

### DIFF
--- a/draft-packages/button/KaizenDraft/Button/Button.elm
+++ b/draft-packages/button/KaizenDraft/Button/Button.elm
@@ -1,6 +1,5 @@
 module KaizenDraft.Button.Button exposing
-    ( BrandColor(..)
-    , ButtonType(..)
+    ( ButtonType(..)
     , Config
     , IconPosition(..)
     , automationId
@@ -24,7 +23,6 @@ module KaizenDraft.Button.Button exposing
     , onMouseDown
     , preventKeydownOn
     , primary
-    , reverseColor
     , reversed
     , secondary
     , view
@@ -64,11 +62,6 @@ view (Config config) label =
                 , ( .destructive, config.variant == Destructive )
                 , ( .form, config.form )
                 , ( .reversed, config.reversed )
-                , ( .reverseColorCluny, config.reverseColor == Just Cluny )
-                , ( .reverseColorPeach, config.reverseColor == Just Peach )
-                , ( .reverseColorSeedling, config.reverseColor == Just Seedling )
-                , ( .reverseColorWisteria, config.reverseColor == Just Wisteria )
-                , ( .reverseColorYuzu, config.reverseColor == Just Yuzu )
                 , ( .destructiveModifier, config.destructive == True )
                 ]
             ]
@@ -276,11 +269,6 @@ styles =
         , secondaryDestructive = "secondaryDestructive"
         , form = "form"
         , reversed = "reversed"
-        , reverseColorCluny = "reverseColorCluny"
-        , reverseColorPeach = "reverseColorPeach"
-        , reverseColorSeedling = "reverseColorSeedling"
-        , reverseColorWisteria = "reverseColorWisteria"
-        , reverseColorYuzu = "reverseColorYuzu"
         , content = "content"
         , label = "label"
         , fullWidth = "fullWidth"
@@ -305,7 +293,6 @@ type alias ConfigValue msg =
     , disabled : Bool
     , form : Bool
     , reversed : Bool
-    , reverseColor : Maybe BrandColor
     , onClick : Maybe msg
     , onFocus : Maybe msg
     , onBlur : Maybe msg
@@ -333,14 +320,6 @@ type IconPosition
     | End
 
 
-type BrandColor
-    = Cluny
-    | Peach
-    | Seedling
-    | Wisteria
-    | Yuzu
-
-
 default : Config msg
 default =
     Config defaults
@@ -355,7 +334,6 @@ defaults =
     , disabled = False
     , form = False
     , reversed = False
-    , reverseColor = Nothing
     , onClick = Nothing
     , onFocus = Nothing
     , onBlur = Nothing
@@ -428,11 +406,6 @@ reversed value (Config config) =
 fullWidth : Bool -> Config msg -> Config msg
 fullWidth value (Config config) =
     Config { config | fullWidth = value }
-
-
-reverseColor : BrandColor -> Config msg -> Config msg
-reverseColor value (Config config) =
-    Config { config | reverseColor = Just value }
 
 
 onClick : msg -> Config msg -> Config msg

--- a/draft-packages/button/KaizenDraft/Button/components/GenericButton.module.scss
+++ b/draft-packages/button/KaizenDraft/Button/components/GenericButton.module.scss
@@ -36,26 +36,6 @@
   @extend %caButtonReversed;
 }
 
-.reverseColorCluny {
-  @extend %caButtonReverseColorCluny;
-}
-
-.reverseColorPeach {
-  @extend %caButtonReverseColorPeach;
-}
-
-.reverseColorSeedling {
-  @extend %caButtonReverseColorSeedling;
-}
-
-.reverseColorWisteria {
-  @extend %caButtonReverseColorWisteria;
-}
-
-.reverseColorYuzu {
-  @extend %caButtonReverseColorYuzu;
-}
-
 .content {
   @extend %caButtonContent;
 }

--- a/draft-packages/button/KaizenDraft/Button/components/GenericButton.tsx
+++ b/draft-packages/button/KaizenDraft/Button/components/GenericButton.tsx
@@ -54,7 +54,6 @@ type LabelPropsGeneric = {
   iconPosition?: "start" | "end"
   primary?: boolean
   secondary?: boolean
-  reverseColor?: "cluny" | "peach" | "seedling" | "wisteria" | "yuzu"
 }
 
 type WorkingProps = {
@@ -247,11 +246,6 @@ const buttonClass = (props: Props) => {
     [styles.form]: props.form,
     [styles.reversed]: props.reversed,
     [styles.iconButton]: props.iconButton,
-    [styles.reverseColorCluny]: props.reverseColor === "cluny",
-    [styles.reverseColorPeach]: props.reverseColor === "peach",
-    [styles.reverseColorSeedling]: props.reverseColor === "seedling",
-    [styles.reverseColorWisteria]: props.reverseColor === "wisteria",
-    [styles.reverseColorYuzu]: props.reverseColor === "yuzu",
     [styles.working]: !props.iconButton && props.working,
   })
 }

--- a/draft-packages/button/KaizenDraft/Button/styles.scss
+++ b/draft-packages/button/KaizenDraft/Button/styles.scss
@@ -304,26 +304,6 @@ $caButton-verticalPaddingForm: calc(
       border-color: $kz-var-border-borderless-border-color;
       color: $kz-var-color-wisteria-800;
 
-      &%caButtonReverseColorCluny {
-        color: $kz-var-color-cluny-500;
-      }
-
-      &%caButtonReverseColorPeach {
-        color: $kz-var-color-peach-500;
-      }
-
-      &%caButtonReverseColorSeedling {
-        color: $kz-var-color-seedling-500;
-      }
-
-      &%caButtonReverseColorWisteria {
-        color: $kz-var-color-wisteria-500;
-      }
-
-      &%caButtonReverseColorYuzu {
-        color: $kz-var-color-yuzu-500;
-      }
-
       &:hover {
         background: $kz-var-color-seedling-400;
       }


### PR DESCRIPTION
BREAKING CHANGE: reverseColor prop removed from Button.
This prop was only changing the font color under certain circumstances.
Color will return to expected color for button (e.g. reversed / not reversed).

# Objective
<!-- Describe what this change achieves, and the details of how it works. -->

# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

# Screenshots (if appropriate)

# Checklist
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] If this contains visual changes, has it been reviewed by a designer?
- [ ] If this introduces either a new component or a breaking change to an existing component, has it been reviewed by an advocate? (Ask in #prod_design_systems)
- [ ] I have considered likely risks of these changes and got someone else to QA as appropriate
- [ ] I have or will communicate these changes to the front end practice

# Additional Considerations
- Does there need to be right-to-left (RTL) options for localization and internationalization?
- Has the test suite been updated?
- Have you done cross-browser testing for our [supported browsers](https://academy.cultureamp.com/hc/en-us/articles/204539569-Supported-browsers-for-Participants)?
- Have you updated any relevant documentation or left useful comments in the code?
- Have you reviewed Culture Amp's Web Accessibility guide [Current Compliance, Going Forward, Statement and Answers for Customers](https://cultureamp.atlassian.net/wiki/spaces/Prod/pages/428572998/Web+Accessibility)?
- If this contains substantial visual changes, especially far reaching ones, have you unlocked the Chromatic step in the pipeline?
- Have Storybook stories been updated?

**If you're new to Kaizen, please ask #prod_design_systems to set up an onboarding session to get you up to speed.** If you have an urgent PR to merge before that happens, it is safest to ask in #prod_design_systems to have a design system advocate review the PR to catch any issues.
