### PR TITLE
fix: update text field error styles

### DIFF
--- a/draft-packages/form/KaizenDraft/Form/Primitives/FieldMessage/FieldMessage.tsx
+++ b/draft-packages/form/KaizenDraft/Form/Primitives/FieldMessage/FieldMessage.tsx
@@ -2,8 +2,8 @@ import classnames from "classnames"
 import * as React from "react"
 import exclamationIcon from "@kaizen/component-library/icons/exclamation.icon.svg"
 
-import styles from "./styles.scss"
 import { Icon, Paragraph } from "@kaizen/component-library"
+import styles from "./styles.scss"
 
 export type FieldMessageStatus = "default" | "success" | "error"
 export type FieldMessageProps = {
@@ -47,7 +47,7 @@ const FieldMessage: FieldMessage = ({
       [styles.positionTop]: position === "top",
     })}
   >
-    {warningIcon}
+    {status === "error" && warningIcon}
     <div className={styles.message}>
       <Paragraph variant="small">{message}</Paragraph>
     </div>

--- a/draft-packages/form/KaizenDraft/Form/Primitives/FieldMessage/FieldMessage.tsx
+++ b/draft-packages/form/KaizenDraft/Form/Primitives/FieldMessage/FieldMessage.tsx
@@ -1,7 +1,9 @@
 import classnames from "classnames"
 import * as React from "react"
+import exclamationIcon from "@kaizen/component-library/icons/exclamation.icon.svg"
 
 import styles from "./styles.scss"
+import { Icon, Paragraph } from "@kaizen/component-library"
 
 export type FieldMessageStatus = "default" | "success" | "error"
 export type FieldMessageProps = {
@@ -14,6 +16,17 @@ export type FieldMessageProps = {
 }
 
 type FieldMessage = React.SFC<FieldMessageProps>
+
+const warningIcon = (
+  <span className={styles.warningIcon}>
+    <Icon
+      icon={exclamationIcon}
+      title="Error message"
+      role="img"
+      inheritSize={false}
+    />
+  </span>
+)
 
 const FieldMessage: FieldMessage = ({
   id,
@@ -34,7 +47,10 @@ const FieldMessage: FieldMessage = ({
       [styles.positionTop]: position === "top",
     })}
   >
-    {message}
+    {warningIcon}
+    <div className={styles.message}>
+      <Paragraph variant="small">{message}</Paragraph>
+    </div>
   </div>
 )
 

--- a/draft-packages/form/KaizenDraft/Form/Primitives/FieldMessage/FieldMessage.tsx
+++ b/draft-packages/form/KaizenDraft/Form/Primitives/FieldMessage/FieldMessage.tsx
@@ -49,7 +49,12 @@ const FieldMessage: FieldMessage = ({
   >
     {status === "error" && warningIcon}
     <div className={styles.message}>
-      <Paragraph variant="small">{message}</Paragraph>
+      <Paragraph
+        variant="small"
+        color={reversed ? "white-reduced-opacity" : "dark-reduced-opacity"}
+      >
+        {message}
+      </Paragraph>
     </div>
   </div>
 )

--- a/draft-packages/form/KaizenDraft/Form/Primitives/FieldMessage/FieldMessage.tsx
+++ b/draft-packages/form/KaizenDraft/Form/Primitives/FieldMessage/FieldMessage.tsx
@@ -35,28 +35,32 @@ const FieldMessage: FieldMessage = ({
   status = "default",
   reversed = false,
   position = "bottom",
-}) => (
-  <div
-    id={id}
-    data-automation-id={automationId}
-    className={classnames(styles.message, {
-      [styles.reversed]: reversed,
-      [styles.default]: status === "default",
-      [styles.error]: status === "error",
-      [styles.positionBottom]: position === "bottom",
-      [styles.positionTop]: position === "top",
-    })}
-  >
-    {status === "error" && warningIcon}
-    <div className={styles.message}>
-      <Paragraph
-        variant="small"
-        color={reversed ? "white-reduced-opacity" : "dark-reduced-opacity"}
-      >
-        {message}
-      </Paragraph>
+}) => {
+  const textColor = reversed
+    ? status === "error"
+      ? "dark-reduced-opacity"
+      : "white-reduced-opacity"
+    : "dark-reduced-opacity"
+  return (
+    <div
+      id={id}
+      data-automation-id={automationId}
+      className={classnames(styles.message, {
+        [styles.reversed]: reversed,
+        [styles.default]: status === "default",
+        [styles.error]: status === "error",
+        [styles.positionBottom]: position === "bottom",
+        [styles.positionTop]: position === "top",
+      })}
+    >
+      {status === "error" && warningIcon}
+      <div className={styles.message}>
+        <Paragraph variant="small" color={textColor}>
+          {message}
+        </Paragraph>
+      </div>
     </div>
-  </div>
-)
+  )
+}
 
 export default FieldMessage

--- a/draft-packages/form/KaizenDraft/Form/Primitives/FieldMessage/styles.scss
+++ b/draft-packages/form/KaizenDraft/Form/Primitives/FieldMessage/styles.scss
@@ -5,8 +5,9 @@
 @import "../../decision-tokens.scss";
 
 .message {
-  @include kz-typography-paragraph-small;
-  @include ca-inherit-baseline;
+  display: flex;
+  align-items: center;
+  gap: $ca-grid * 0.25;
 }
 
 .default {
@@ -29,4 +30,10 @@
 
 .positionTop {
   margin-bottom: $spacing-xs;
+}
+
+.warningIcon {
+  display: flex;
+  align-items: center;
+  color: $color-red-500;
 }

--- a/draft-packages/form/KaizenDraft/Form/Primitives/FieldMessage/styles.scss
+++ b/draft-packages/form/KaizenDraft/Form/Primitives/FieldMessage/styles.scss
@@ -22,6 +22,10 @@
   color: $dt-color-form-text-color;
   border-radius: $border-solid-border-radius;
   background: $color-red-100;
+
+  &.reversed {
+    background: $color-red-300;
+  }
 }
 
 .positionBottom {
@@ -36,4 +40,8 @@
   display: flex;
   align-items: center;
   color: $color-red-500;
+
+  .reversed & {
+    color: $color-purple-800;
+  }
 }

--- a/draft-packages/form/KaizenDraft/Form/Primitives/FieldMessage/styles.scss
+++ b/draft-packages/form/KaizenDraft/Form/Primitives/FieldMessage/styles.scss
@@ -20,7 +20,7 @@
   padding: $ca-grid / 2;
   color: $dt-color-form-text-color;
   border-radius: $border-solid-border-radius;
-  background: $color-red-300;
+  background: $color-red-100;
 }
 
 .positionBottom {

--- a/draft-packages/form/KaizenDraft/Form/Primitives/Input/styles.scss
+++ b/draft-packages/form/KaizenDraft/Form/Primitives/Input/styles.scss
@@ -221,7 +221,7 @@ $input-disabled-border-alpha: 50%;
   }
 
   &.error:not(:focus) {
-    border-color: $ca-palette-input-validation-negative;
+    border-color: $color-red-500;
   }
 }
 

--- a/draft-packages/form/KaizenDraft/Form/TextField/TextField.tsx
+++ b/draft-packages/form/KaizenDraft/Form/TextField/TextField.tsx
@@ -109,16 +109,11 @@ const TextField: TextField = ({
           )
         }
         endIconAdornment={
-          (status === "success" && (
+          status === "success" && (
             <div className={styles.success}>
               <Icon icon={successIcon} role="presentation" />
             </div>
-          )) ||
-          (status === "error" && (
-            <div className={styles.error}>
-              <Icon icon={exclamationIcon} role="presentation" />
-            </div>
-          ))
+          )
         }
       />
 

--- a/draft-packages/form/docs/TextField.stories.tsx
+++ b/draft-packages/form/docs/TextField.stories.tsx
@@ -588,19 +588,18 @@ export const DefaultWithHtmlDescription = () => {
 
 DefaultWithHtmlDescription.storyName = "Default w HTML description"
 
-export const DefaultWithHtmlDescriptionAndErrorMessage = () => (
+export const DefaultWithDescriptionAndErrorMessage = () => (
   <ExampleContainer>
     <TextField
-      id="default-with-html-description"
-      labelText="This a text field with a HTML description"
-      description={
-        "The description may contain a link to further details - we recommended opening the link in a new tab with an"
-      }
-      validationMessage="my cool validation message"
+      id="email"
       status="error"
+      inputValue="testing 1 2 3"
+      labelText="Label"
+      validationMessage="A cool validation message"
+      description="This is a description"
     />
   </ExampleContainer>
 )
 
-DefaultWithHtmlDescriptionAndErrorMessage.storyName =
-  "Default w HTML description and error message"
+DefaultWithDescriptionAndErrorMessage.storyName =
+  "Default w description and error message"

--- a/draft-packages/form/docs/TextField.stories.tsx
+++ b/draft-packages/form/docs/TextField.stories.tsx
@@ -184,12 +184,27 @@ export const DefaultError = () => (
       placeholder="Please enter your email"
       onChange={() => undefined}
       status="error"
-      validationMessage="Your email address looks like it’s from 1996"
+      validationMessage="Your email address looks like it’s from 1996."
     />
   </ExampleContainer>
 )
-
 DefaultError.storyName = "Default, Error"
+
+export const DefaultErrorLong = () => (
+  <ExampleContainer>
+    <TextField
+      id="email"
+      inputType="email"
+      inputValue="super_cool999@hotmail.com"
+      labelText="Email"
+      placeholder="Please enter your email"
+      onChange={() => undefined}
+      status="error"
+      validationMessage="Your email address looks like it’s from 1996. This is a long error message for testing purposes."
+    />
+  </ExampleContainer>
+)
+DefaultErrorLong.storyName = "Default, Error, long"
 
 export const DefaultErrorIcon = () => (
   <ExampleContainer>

--- a/draft-packages/form/docs/TextField.stories.tsx
+++ b/draft-packages/form/docs/TextField.stories.tsx
@@ -424,6 +424,24 @@ export const ReversedError = () => (
 ReversedError.storyName = "Reversed, Error"
 ReversedError.parameters = { ...ReversedBg }
 
+export const ReversedDescription = () => (
+  <ExampleContainer>
+    <TextField
+      id="email"
+      inputType="email"
+      inputValue="hello@hello.hello"
+      labelText="Email"
+      placeholder="Please enter your email"
+      onChange={() => undefined}
+      reversed={true}
+      description="Valid email addresses must have an @ and a suffix"
+    />
+  </ExampleContainer>
+)
+
+ReversedDescription.storyName = "Reversed, Description"
+ReversedDescription.parameters = { ...ReversedBg }
+
 export const ReversedErrorIcon = () => (
   <ExampleContainer>
     <TextField

--- a/draft-packages/form/docs/TextField.stories.tsx
+++ b/draft-packages/form/docs/TextField.stories.tsx
@@ -587,3 +587,20 @@ export const DefaultWithHtmlDescription = () => {
 }
 
 DefaultWithHtmlDescription.storyName = "Default w HTML description"
+
+export const DefaultWithHtmlDescriptionAndErrorMessage = () => (
+  <ExampleContainer>
+    <TextField
+      id="default-with-html-description"
+      labelText="This a text field with a HTML description"
+      description={
+        "The description may contain a link to further details - we recommended opening the link in a new tab with an"
+      }
+      validationMessage="my cool validation message"
+      status="error"
+    />
+  </ExampleContainer>
+)
+
+DefaultWithHtmlDescriptionAndErrorMessage.storyName =
+  "Default w HTML description and error message"


### PR DESCRIPTION
# Objective
Update the form input (TextField and TextAreaField fields) error message styling 

** in scope **
- background color, border color and warning icon for standard and reversed

** out of scope **
- padding and margins. These aren't quite the same as in the heart designs and haven't been updated. I think a refactor needs to be done first: rather than re-use a single `FieldMessage` component between the error message and description elements, just have completely separate implementations, as they are completely different things with very different styling. It's very fiddly trying to make it work for both. We ran out of time for this in our pairing session.


# Motivation and Context
https://github.com/cultureamp/kaizen-design-system/issues/1786

# Screenshots (if appropriate)

## before

![image](https://user-images.githubusercontent.com/702885/130400816-062ada8c-e236-42d4-83a0-855ed83d0fad.png)

![image](https://user-images.githubusercontent.com/702885/130403015-50a2a2be-0b20-4e0d-b368-60c46f6e4151.png)

![image](https://user-images.githubusercontent.com/702885/130403209-cbfad6bc-addd-4341-85c7-76b6568bae80.png)


![image](https://user-images.githubusercontent.com/702885/130403157-5fe1d758-a609-45f9-85cc-c40c58be5649.png)



## after

![image](https://user-images.githubusercontent.com/702885/130400744-086019e4-9465-432a-af46-2cf4cae6b84f.png)

![image](https://user-images.githubusercontent.com/702885/130403064-db47879d-0632-4e38-9490-d0962758a17d.png)

![image](https://user-images.githubusercontent.com/702885/130403339-c842d7bc-ba66-44c4-956e-cd75e2f8847c.png)

![image](https://user-images.githubusercontent.com/702885/130403265-16ab5679-4402-4cba-8113-bceca494592b.png)




# Checklist
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] If this contains visual changes, has it been reviewed by a designer?
- [ ] If this introduces either a new component or a breaking change to an existing component, has it been reviewed by an advocate? (Ask in #prod_design_systems)
- [ ] I have considered likely risks of these changes and got someone else to QA as appropriate
- [ ] I have or will communicate these changes to the front end practice

# Additional Considerations
- Does there need to be right-to-left (RTL) options for localization and internationalization?
- Has the test suite been updated?
- Have you done cross-browser testing for our [supported browsers](https://academy.cultureamp.com/hc/en-us/articles/204539569-Supported-browsers-for-Participants)?
- Have you updated any relevant documentation or left useful comments in the code?
- Have you reviewed Culture Amp's Web Accessibility guide [Current Compliance, Going Forward, Statement and Answers for Customers](https://cultureamp.atlassian.net/wiki/spaces/Prod/pages/428572998/Web+Accessibility)?
- If this contains substantial visual changes, especially far reaching ones, have you unlocked the Chromatic step in the pipeline?
- Have Storybook stories been updated?

**If you're new to Kaizen, please ask #prod_design_systems to set up an onboarding session to get you up to speed.** If you have an urgent PR to merge before that happens, it is safest to ask in #prod_design_systems to have a design system advocate review the PR to catch any issues.
