### PR TITLE
fix: Support design-tokens v3 in stylelint plugin

### DIFF
--- a/packages/stylelint-plugin/src/messages.ts
+++ b/packages/stylelint-plugin/src/messages.ts
@@ -6,7 +6,7 @@ export const unnecessaryKaizenImport = (path: string) =>
 export const deprecatedTokenUsageMessage = (oldName: string, newName: string) =>
   `Deprecated Kaizen token "${oldName}" should be migrated to "${newName}".`
 
-export const genericContainsDeprecatedKaizenTokenMessage = (name: string) =>
+export const containsDeprecatedKaizenTokenWithNoReplacement = (name: string) =>
   `Deprecated Kaizen token ${name} detected`
 
 export const deprecatedTokenUsageWithoutReplacementMessage = (

--- a/packages/stylelint-plugin/src/messages.ts
+++ b/packages/stylelint-plugin/src/messages.ts
@@ -6,12 +6,13 @@ export const unnecessaryKaizenImport = (path: string) =>
 export const deprecatedTokenUsageMessage = (oldName: string, newName: string) =>
   `Deprecated Kaizen token "${oldName}" should be migrated to "${newName}".`
 
-export const genericContainsDeprecatedKaizenTokenMessage =
-  "Deprecated Kaizen token detected"
+export const genericContainsDeprecatedKaizenTokenMessage = (name: string) =>
+  `Deprecated Kaizen token ${name} detected`
 
 export const deprecatedTokenUsageWithoutReplacementMessage = (
   deprecatedTokenName: string
 ) => `${deprecatedTokenName} is deprecated and should not be used anymore.`
+
 export const invalidRgbaUsage = (replacementVariable: string) =>
   `Invalid parameter to rgba or add-alpha function. Expected '-rgb' suffixed replacement: ${replacementVariable}.`
 
@@ -22,7 +23,7 @@ export const tokenNotInterpolatedInCalcMessage =
   "Invalid expression within calc() function. You must wrap variables in a string interpolation, e.g. #{$kz-var-spacing-md}."
 
 export const kaizenVariableUsedNextToOperatorMessage =
-  "Kaizen variable used next to math operator."
+  "Kaizen CSS variable token used next to math operator."
 
 export const noMatchingRgbParamsVariableMessage = (tokenName: string) =>
   `No matching -rgb variable found for ${tokenName}.`

--- a/packages/stylelint-plugin/src/rules/no-invalid-use-of-tokens.ts
+++ b/packages/stylelint-plugin/src/rules/no-invalid-use-of-tokens.ts
@@ -7,7 +7,7 @@ import {
   deprecatedTokenInVariableMessage,
   deprecatedTokenUsageMessage,
   deprecatedTokenUsageWithoutReplacementMessage,
-  genericContainsDeprecatedKaizenTokenMessage,
+  genericContainsDeprecatedKaizenTokenMessage as containsDeprecatedKaizenTokenWithNoReplacement,
   invalidEquationContainingKaizenTokenMessage,
   replacementCssVariableUsedWithinUnsupportedFunction,
 } from "../messages"
@@ -24,10 +24,10 @@ import { fixAlphaModificationFunctions } from "./lib/fixAlphaModificationFunctio
 import { containsEquationThatDoesntWorkWithCSSVariables } from "./no-invalid-use-of-var-tokens-in-equations"
 
 const deprecatedKaizenTokenPattern = new RegExp(
-  Array.from(deprecatedTokenReplacements.keys()).join("|")
+  `(${Array.from(deprecatedTokenReplacements.keys()).join("|")})`
 )
-function stringContainsDeprecatedKaizenToken(value: string) {
-  return deprecatedKaizenTokenPattern.test(value)
+function getDeprecatedKaizenTokenPatternMatches(value: string) {
+  return value.match(deprecatedKaizenTokenPattern)
 }
 
 // Most CSS standard functions are allowed to contain CSS variables.
@@ -316,9 +316,14 @@ function detectAndFixInvalidTokens(
     and would silently cause a style regression when upgrading to v3 of design tokens if left unchanged.
   */
   if (!reported) {
-    if (stringContainsDeprecatedKaizenToken(newValue)) {
+    const deprecatedTokenMatches = getDeprecatedKaizenTokenPatternMatches(
+      newValue
+    )
+    if (deprecatedTokenMatches) {
       options.reporter({
-        message: genericContainsDeprecatedKaizenTokenMessage,
+        message: containsDeprecatedKaizenTokenWithNoReplacement(
+          deprecatedTokenMatches[1]
+        ),
         autofixAvailable: false,
         node: postcssNode,
       })

--- a/packages/stylelint-plugin/src/rules/no-invalid-use-of-tokens.ts
+++ b/packages/stylelint-plugin/src/rules/no-invalid-use-of-tokens.ts
@@ -138,8 +138,9 @@ function detectAndFixInvalidTokens(
     return
   }
 
-  const fixAlphaModificationFunctionsResult =
-    fixAlphaModificationFunctions(nodeValue)
+  const fixAlphaModificationFunctionsResult = fixAlphaModificationFunctions(
+    nodeValue
+  )
 
   if (fixAlphaModificationFunctionsResult.errors.length) {
     fixAlphaModificationFunctionsResult.errors.forEach(error =>
@@ -321,8 +322,9 @@ function detectAndFixInvalidTokens(
     and would silently cause a style regression when upgrading to v3 of design tokens if left unchanged.
   */
   if (!reported) {
-    const deprecatedTokenMatches =
-      getDeprecatedKaizenTokenPatternMatches(newValue)
+    const deprecatedTokenMatches = getDeprecatedKaizenTokenPatternMatches(
+      newValue
+    )
     if (deprecatedTokenMatches) {
       options.reporter({
         message: containsDeprecatedKaizenTokenWithNoReplacement(

--- a/packages/stylelint-plugin/src/rules/no-invalid-use-of-tokens.ts
+++ b/packages/stylelint-plugin/src/rules/no-invalid-use-of-tokens.ts
@@ -7,7 +7,7 @@ import {
   deprecatedTokenInVariableMessage,
   deprecatedTokenUsageMessage,
   deprecatedTokenUsageWithoutReplacementMessage,
-  genericContainsDeprecatedKaizenTokenMessage as containsDeprecatedKaizenTokenWithNoReplacement,
+  containsDeprecatedKaizenTokenWithNoReplacement,
   invalidEquationContainingKaizenTokenMessage,
   replacementCssVariableUsedWithinUnsupportedFunction,
 } from "../messages"

--- a/packages/stylelint-plugin/src/rules/no-invalid-use-of-tokens.ts
+++ b/packages/stylelint-plugin/src/rules/no-invalid-use-of-tokens.ts
@@ -26,7 +26,13 @@ import { containsEquationThatDoesntWorkWithCSSVariables } from "./no-invalid-use
 const deprecatedKaizenTokenPattern = new RegExp(
   `(${Array.from(deprecatedTokenReplacements.keys()).join("|")})`
 )
-function getDeprecatedKaizenTokenPatternMatches(value: string) {
+
+/**
+ * Determine if any deprecated token strings show up within the input, and return the pattern matches, allowing you to determine which ones they were.
+ */
+function getDeprecatedKaizenTokenPatternMatches(
+  value: string
+): RegExpMatchArray | null {
   return value.match(deprecatedKaizenTokenPattern)
 }
 
@@ -132,9 +138,8 @@ function detectAndFixInvalidTokens(
     return
   }
 
-  const fixAlphaModificationFunctionsResult = fixAlphaModificationFunctions(
-    nodeValue
-  )
+  const fixAlphaModificationFunctionsResult =
+    fixAlphaModificationFunctions(nodeValue)
 
   if (fixAlphaModificationFunctionsResult.errors.length) {
     fixAlphaModificationFunctionsResult.errors.forEach(error =>
@@ -316,9 +321,8 @@ function detectAndFixInvalidTokens(
     and would silently cause a style regression when upgrading to v3 of design tokens if left unchanged.
   */
   if (!reported) {
-    const deprecatedTokenMatches = getDeprecatedKaizenTokenPatternMatches(
-      newValue
-    )
+    const deprecatedTokenMatches =
+      getDeprecatedKaizenTokenPatternMatches(newValue)
     if (deprecatedTokenMatches) {
       options.reporter({
         message: containsDeprecatedKaizenTokenWithNoReplacement(

--- a/packages/stylelint-plugin/src/rules/no-invalid-use-of-var-tokens-in-equations.spec.ts
+++ b/packages/stylelint-plugin/src/rules/no-invalid-use-of-var-tokens-in-equations.spec.ts
@@ -16,7 +16,7 @@ describe("no-invalid-use-of-var-tokens-in-equations rule", () => {
     return expect(reported === 0)
   }
 
-  test("Equations valid regardless of whether they are deprecated", () => {
+  test("Equations are valid regardless of whether they are deprecated", () => {
     expectEquationIsValid("$kz-layout-breakpoints-large * 5").toBe(true)
   })
   test("Equations are valid when their values are not CSS variables", () => {
@@ -25,17 +25,17 @@ describe("no-invalid-use-of-var-tokens-in-equations rule", () => {
     ).toBe(true)
   })
   test("Equations are invalid if not wrapped in calc", () => {
-    expectEquationIsValid("$kz-var-color-wisteria-800 * 5").toBe(false)
+    expectEquationIsValid("$color-purple-800 * 5").toBe(false)
   })
 
   test("Valid equations in space separated values are supported", () => {
     // The token is a separate value in a space-separated list.
     // The actual equation has no token.
-    expectEquationIsValid("$kz-var-spacing-md 5px - 2px").toBe(true)
+    expectEquationIsValid("$spacing-md 5px - 2px").toBe(true)
   })
 
   test("Invalid equations in space separated values are detected", () => {
-    expectEquationIsValid("solid 1px + $kz-var-spacing-md black").toBe(false)
+    expectEquationIsValid("solid 1px + $spacing-md black").toBe(false)
   })
 
   test("Our rule does not test/change unknown variables", () => {
@@ -43,26 +43,26 @@ describe("no-invalid-use-of-var-tokens-in-equations rule", () => {
   })
 
   test("Interpolation is needed inside calc()", () => {
-    expectEquationIsValid("calc($kz-var-spacing-md + 5px)").toBe(false)
+    expectEquationIsValid("calc($spacing-md + 5px)").toBe(false)
   })
 
   test("Interpolation within calc() is valid", () => {
-    expectEquationIsValid("calc(#{$kz-var-spacing-md} + 5px)").toBe(true)
+    expectEquationIsValid("calc(#{$spacing-md} + 5px)").toBe(true)
   })
 
   test("Negative values are invalid (needs to be calc)", () => {
-    expectEquationIsValid("-$kz-var-spacing-md").toBe(false)
+    expectEquationIsValid("-$spacing-md").toBe(false)
   })
 
   test("Negating values with calc() is valid", () => {
-    expectEquationIsValid("calc(#{$kz-var-spacing-md} * -1)").toBe(true)
+    expectEquationIsValid("calc(#{$spacing-md} * -1)").toBe(true)
   })
 
   test("Multiplying by a negative is valid", () => {
-    expectEquationIsValid("calc(#{$kz-var-spacing-md} * -5rem)").toBe(true)
+    expectEquationIsValid("calc(#{$spacing-md} * -5rem)").toBe(true)
   })
 
   test("Multiplying by a negative, without interpolation, is invalid", () => {
-    expectEquationIsValid("calc($kz-var-spacing-md * -5px)").toBe(false)
+    expectEquationIsValid("calc($spacing-md * -5px)").toBe(false)
   })
 })

--- a/packages/stylelint-plugin/src/rules/no-invalid-use-of-var-tokens-in-equations.ts
+++ b/packages/stylelint-plugin/src/rules/no-invalid-use-of-var-tokens-in-equations.ts
@@ -70,7 +70,8 @@ const noInvalidEquations = (
           options.reporter({
             message: negatedKaizenVariableMessage,
             node: postcssNode,
-            autofixAvailable: !isVariable(postcssNode),
+            autofixAvailable:
+              !isVariable(postcssNode) && options.language === "scss",
           })
         }
 

--- a/packages/stylelint-plugin/src/stylelintPlugin.spec.ts
+++ b/packages/stylelint-plugin/src/stylelintPlugin.spec.ts
@@ -6,6 +6,7 @@ import {
   kaizenVariableUsedNextToOperatorMessage,
   negatedKaizenVariableMessage,
   replacementCssVariableUsedWithinUnsupportedFunction,
+  deprecatedTokenInVariableMessage,
 } from "./messages"
 import { Language } from "./types"
 jest.setTimeout(10000)
@@ -256,11 +257,17 @@ const testExamples: TestExample[] = [
   {
     language: "scss",
     testName: "doesn't fix tokens within variables",
-    input:
-      '@import "~@kaizen/design-tokens/sass/color"; $foo: $color-purple-800;',
+    input: "$foo: $kz-color-wisteria-800;",
+    // Take the import out in the expectedOutput when breaking design-tokens. Imports for deprecated tokens are not automatically added.
     expectedOutput:
-      '@import "~@kaizen/design-tokens/sass/color"; $foo: $color-purple-800;',
-    expectedWarningMessages: [],
+      '@import "~@kaizen/design-tokens/sass/color"; $foo: $kz-color-wisteria-800;',
+    expectedWarningMessages: [
+      // Note that this warning message may change when breaking design tokens, and `kz-color-wisteria-800` ceases to exist.
+      deprecatedTokenInVariableMessage(
+        "kz-color-wisteria-800",
+        "color-purple-800"
+      ),
+    ],
   },
   {
     language: "scss",
@@ -932,7 +939,7 @@ const testExamples: TestExample[] = [
     input: "$foo: $kz-var-color-wisteria-100",
     expectedOutput:
       '@import "~@kaizen/design-tokens/sass/color"; $foo: $color-purple-100',
-    expectedWarnings: 0,
+    expectedWarningMessages: [],
   },
   /*
   Delete the above test and replace it with this one when removing deprecated tokens from design-tokens
@@ -1011,7 +1018,6 @@ const testExamples: TestExample[] = [
         "kz-var-color-wisteria-100"
       ),
     ],
-    only: true,
   },
 ]
 

--- a/packages/stylelint-plugin/src/stylelintPlugin.spec.ts
+++ b/packages/stylelint-plugin/src/stylelintPlugin.spec.ts
@@ -96,14 +96,22 @@ const testExamples: TestExample[] = [
     language: "scss",
     testName: "doesn't fix variables when used as equation terms",
     input: ".foo { padding: $kz-spacing-md * 2; }",
-    expectedOutput: ".foo { padding: $kz-spacing-md * 2; }",
+    // Take the import out in the expectedOutput when breaking design-tokens. Imports for deprecated tokens are not automatically added.
+    expectedOutput: `
+      @import "~@kaizen/design-tokens/sass/spacing";
+      .foo { padding: $kz-spacing-md * 2; }
+    `,
     expectedWarningMessages: [invalidEquationContainingKaizenTokenMessage],
   },
   {
     language: "less",
     testName: "doesn't fix variables when used as equation terms",
     input: ".foo { padding: @kz-spacing-md * 2; }",
-    expectedOutput: ".foo { padding: @kz-spacing-md * 2; }",
+    // Take the import out in the expectedOutput when breaking design-tokens. Imports for deprecated tokens are not automatically added.
+    expectedOutput: `
+      @import "~@kaizen/design-tokens/less/spacing";
+      .foo { padding: @kz-spacing-md * 2; }
+    `,
     expectedWarningMessages: [invalidEquationContainingKaizenTokenMessage],
   },
   {
@@ -182,7 +190,9 @@ const testExamples: TestExample[] = [
       .foo {
         background-color: darken($kz-color-cluny-700, 0.8);
       }`,
+    // Take the import out in the expectedOutput when breaking design-tokens. Imports for deprecated tokens are not automatically added.
     expectedOutput: `
+      @import "~@kaizen/design-tokens/sass/color";
       .foo {
         background-color: darken($kz-color-cluny-700, 0.8);
       }`,
@@ -486,7 +496,9 @@ const testExamples: TestExample[] = [
         color: desaturate($kz-color-wisteria-800, $amount);
       }
     `,
+    // Take the import out in the expectedOutput when breaking design-tokens. Imports for deprecated tokens are not automatically added.
     expectedOutput: `
+    @import \"~@kaizen/design-tokens/sass/color\";
     $white: white;
     $amount: 80%;
     .mix {
@@ -915,12 +927,23 @@ const testExamples: TestExample[] = [
     expectedWarnings: 0,
   },
   {
-    testName: "removed tokens are warned about within variables",
+    testName:
+      "tokens within variable definitions can be replaced when such a token is already a CSS variable",
+    language: "scss",
+    input: "$foo: $kz-var-color-wisteria-100",
+    expectedOutput:
+      '@import "~@kaizen/design-tokens/sass/color"; $foo: $color-purple-100',
+    expectedWarnings: 0,
+  },
+  /*
+  Delete the above test and replace it with this one when removing deprecated tokens from design-tokens
+  {
+    testName: "removed tokens are warned about within variables but not replaced",
     language: "scss",
     input: "$foo: $kz-var-color-wisteria-100",
     expectedOutput: "$foo: $kz-var-color-wisteria-100",
     expectedWarnings: 1,
-  },
+  }, */
   {
     testName:
       "tokens within variable definitions can be replaced when the replacement is not a CSS variable",

--- a/packages/stylelint-plugin/src/stylelintPlugin.spec.ts
+++ b/packages/stylelint-plugin/src/stylelintPlugin.spec.ts
@@ -1,8 +1,7 @@
 import { lint } from "stylelint"
 import {
+  containsDeprecatedKaizenTokenWithNoReplacement,
   cssVariableUsedWithinUnsupportedFunction,
-  deprecatedTokenUsageWithoutReplacementMessage,
-  genericContainsDeprecatedKaizenTokenMessage,
   invalidEquationContainingKaizenTokenMessage,
   kaizenVariableUsedNextToOperatorMessage,
   negatedKaizenVariableMessage,
@@ -993,6 +992,26 @@ const testExamples: TestExample[] = [
       @include ca-margin($start: $spacing-sm);
     }`,
     expectedWarnings: 0,
+  },
+  {
+    testName: "reports on deprecated tokens in CSS variable identifiers",
+    language: "scss",
+    input: `
+      .test {
+        color: var(--kz-var-color-wisteria-100);
+      }
+    `,
+    expectedOutput: `
+      .test {
+        color: var(--kz-var-color-wisteria-100);
+      }
+    `,
+    expectedWarningMessages: [
+      containsDeprecatedKaizenTokenWithNoReplacement(
+        "kz-var-color-wisteria-100"
+      ),
+    ],
+    only: true,
   },
 ]
 

--- a/packages/stylelint-plugin/src/util/kaizenTokens.ts
+++ b/packages/stylelint-plugin/src/util/kaizenTokens.ts
@@ -1,4 +1,4 @@
-import { Utils } from "@kaizen/design-tokens"
+import { mapLeafsOfObject } from "@kaizen/design-tokens/src/utils"
 import flatmap from "lodash.flatmap"
 import kebabCase from "lodash.kebabcase"
 import postcssValueParser from "postcss-value-parser"
@@ -30,7 +30,7 @@ import { CSSVariable, KaizenToken } from "../types"
 export const getCSSVarsFromJson = (json: Record<any, any>) => {
   const variables = {} as Record<string, string>
 
-  Utils.mapLeafsOfObject(json, (path, value) => {
+  mapLeafsOfObject(json, (path, value) => {
     const key = path.map(kebabCase).join("-")
     variables[key] = `${value}`
   })
@@ -44,7 +44,18 @@ export const getCSSVarsFromJson = (json: Record<any, any>) => {
 const getVarsFromKaizenModule = (moduleName: string) => {
   const sassModulePath = `@kaizen/design-tokens/sass/${moduleName}`
   const lessModulePath = `@kaizen/design-tokens/less/${moduleName}`
-  const source = require(`@kaizen/design-tokens/tokens/${moduleName}.json`)
+
+  let source: any
+  try {
+    source = require(`@kaizen/design-tokens/tokens/${moduleName}.json`)
+  } catch (e) {
+    return {
+      moduleName,
+      variables: {},
+      sassModulePath,
+      lessModulePath,
+    }
+  }
 
   const variables = getCSSVarsFromJson(source)
   return {

--- a/packages/stylelint-plugin/src/util/kaizenTokens.ts
+++ b/packages/stylelint-plugin/src/util/kaizenTokens.ts
@@ -1,4 +1,4 @@
-import { mapLeafsOfObject } from "@kaizen/design-tokens/src/utils"
+import { Utils } from "@kaizen/design-tokens"
 import flatmap from "lodash.flatmap"
 import kebabCase from "lodash.kebabcase"
 import postcssValueParser from "postcss-value-parser"
@@ -30,7 +30,7 @@ import { CSSVariable, KaizenToken } from "../types"
 export const getCSSVarsFromJson = (json: Record<any, any>) => {
   const variables = {} as Record<string, string>
 
-  mapLeafsOfObject(json, (path, value) => {
+  Utils.mapLeafsOfObject(json, (path, value) => {
     const key = path.map(kebabCase).join("-")
     variables[key] = `${value}`
   })


### PR DESCRIPTION
This change improves the no-invalid-use-of-tokens rule to handle both version 2 and 3 of design-tokens, by allowing for the possibility that a token might not exist anymore within it (but still existing in the deprecated tokens list). To do this we had to also slightly modify how `fixAlphaModificationFunctions` worked (as its ability was predicated on Kaizen tokens existing).
We also improve the way we test the stylelint plugin by allowing test cases to supply a `expectedWarningMessages` field, which causes a more specific assertion to made over what warning message texts are reported, rather than just a number of them.

**NOTE** that this branch was developed as a branch off https://github.com/cultureamp/kaizen-design-system/pull/1833 which contains the breaking change of design-tokens. This was done to further assert that the plugin is prepared for version 3 of design-tokens, and that no tests would break within #1833.
It was then rebased onto master.

# Screenshots (if appropriate)

# Checklist
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] If this contains visual changes, has it been reviewed by a designer?
- [ ] If this introduces either a new component or a breaking change to an existing component, has it been reviewed by an advocate? (Ask in #prod_design_systems)
- [ ] I have considered likely risks of these changes and got someone else to QA as appropriate
- [ ] I have or will communicate these changes to the front end practice

# Additional Considerations
- Does there need to be right-to-left (RTL) options for localization and internationalization?
- Has the test suite been updated?
- Have you done cross-browser testing for our [supported browsers](https://academy.cultureamp.com/hc/en-us/articles/204539569-Supported-browsers-for-Participants)?
- Have you updated any relevant documentation or left useful comments in the code?
- Have you reviewed Culture Amp's Web Accessibility guide [Current Compliance, Going Forward, Statement and Answers for Customers](https://cultureamp.atlassian.net/wiki/spaces/Prod/pages/428572998/Web+Accessibility)?
- If this contains substantial visual changes, especially far reaching ones, have you unlocked the Chromatic step in the pipeline?
- Have Storybook stories been updated?

**If you're new to Kaizen, please ask #prod_design_systems to set up an onboarding session to get you up to speed.** If you have an urgent PR to merge before that happens, it is safest to ask in #prod_design_systems to have a design system advocate review the PR to catch any issues.
