### PR TITLE
feat: Animate empty state illustration

### DIFF
--- a/draft-packages/empty-state/KaizenDraft/EmptyState/EmptyState.tsx
+++ b/draft-packages/empty-state/KaizenDraft/EmptyState/EmptyState.tsx
@@ -1,12 +1,12 @@
 import classnames from "classnames"
 import * as React from "react"
-import { useTheme } from "@kaizen/design-tokens"
 import {
   EmptyStatesAction,
   EmptyStatesInformative,
   EmptyStatesNegative,
   EmptyStatesNeutral,
   EmptyStatesPositive,
+  AnimatedProps,
 } from "@kaizen/draft-illustration"
 import styles from "./styles.scss"
 
@@ -38,7 +38,7 @@ export type EmptyStateProps = {
   // TODO: Heart Rebrand Cleanup > Deprecate or completely remove this prop once Heart is released.
   useZenStyles?: boolean
   children?: React.ReactNode
-}
+} & Pick<AnimatedProps, "isAnimated" | "loop">
 
 type EmptyState = React.FunctionComponent<EmptyStateProps>
 
@@ -52,8 +52,10 @@ const EmptyState: EmptyState = ({
   children,
   straightCorners,
   useZenStyles,
+  isAnimated = true,
+  loop = false,
 }) => {
-  const theme = useTheme()
+  const animationProps = isAnimated ? { isAnimated, loop } : {}
   return (
     <div
       className={classnames([
@@ -70,6 +72,7 @@ const EmptyState: EmptyState = ({
         {React.createElement(illustrations[illustrationType], {
           alt: illustrationType,
           classNameAndIHaveSpokenToDST: styles.illustration,
+          ...animationProps,
         })}
       </div>
       <div


### PR DESCRIPTION
- By default empty state components should animate and play once
- isAnimated and loop props exposed on EmptyState

# Screenshots (if appropriate)
https://dev.cultureamp.design/ally/animated-brand-moments/storybook/?path=/story/components-empty-state--neutral
