### PR TITLE
feat: Bump design-tokens in peer dependencies to v3

### DIFF
--- a/draft-packages/avatar/package.json
+++ b/draft-packages/avatar/package.json
@@ -38,7 +38,7 @@
     "react-textfit": "^1.1.0"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^3.0.0",
+    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/avatar/package.json
+++ b/draft-packages/avatar/package.json
@@ -38,7 +38,7 @@
     "react-textfit": "^1.1.0"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^2.10.3",
+    "@kaizen/design-tokens": "^3.0.0",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/badge/package.json
+++ b/draft-packages/badge/package.json
@@ -35,7 +35,7 @@
     "classnames": "^2.2.6"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^2.10.3",
+    "@kaizen/design-tokens": "^3.0.0",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/badge/package.json
+++ b/draft-packages/badge/package.json
@@ -35,7 +35,7 @@
     "classnames": "^2.2.6"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^3.0.0",
+    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/button/package.json
+++ b/draft-packages/button/package.json
@@ -42,7 +42,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^2.10.3",
+    "@kaizen/design-tokens": "^3.0.0",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/button/package.json
+++ b/draft-packages/button/package.json
@@ -42,7 +42,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^3.0.0",
+    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/card/package.json
+++ b/draft-packages/card/package.json
@@ -32,7 +32,7 @@
   "private": false,
   "license": "MIT",
   "peerDependencies": {
-    "@kaizen/design-tokens": "^3.0.0",
+    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/card/package.json
+++ b/draft-packages/card/package.json
@@ -32,7 +32,7 @@
   "private": false,
   "license": "MIT",
   "peerDependencies": {
-    "@kaizen/design-tokens": "^2.10.3",
+    "@kaizen/design-tokens": "^3.0.0",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/collapsible/package.json
+++ b/draft-packages/collapsible/package.json
@@ -42,7 +42,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^2.10.3",
+    "@kaizen/design-tokens": "^3.0.0",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/collapsible/package.json
+++ b/draft-packages/collapsible/package.json
@@ -42,7 +42,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^3.0.0",
+    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/divider/package.json
+++ b/draft-packages/divider/package.json
@@ -35,7 +35,7 @@
     "classnames": "^2.2.6"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^2.10.3",
+    "@kaizen/design-tokens": "^3.0.0",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/divider/package.json
+++ b/draft-packages/divider/package.json
@@ -35,7 +35,7 @@
     "classnames": "^2.2.6"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^3.0.0",
+    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/dropdown/package.json
+++ b/draft-packages/dropdown/package.json
@@ -42,7 +42,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^2.10.3",
+    "@kaizen/design-tokens": "^3.0.0",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/dropdown/package.json
+++ b/draft-packages/dropdown/package.json
@@ -42,7 +42,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^3.0.0",
+    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/empty-state/package.json
+++ b/draft-packages/empty-state/package.json
@@ -42,7 +42,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^2.10.3",
+    "@kaizen/design-tokens": "^3.0.0",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/empty-state/package.json
+++ b/draft-packages/empty-state/package.json
@@ -42,7 +42,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^3.0.0",
+    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/events/package.json
+++ b/draft-packages/events/package.json
@@ -41,7 +41,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^3.0.0",
+    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/events/package.json
+++ b/draft-packages/events/package.json
@@ -41,7 +41,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^2.10.3",
+    "@kaizen/design-tokens": "^3.0.0",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/filter-menu-button/package.json
+++ b/draft-packages/filter-menu-button/package.json
@@ -38,7 +38,7 @@
     "classnames": "^2.2.6"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^3.0.0",
+    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/filter-menu-button/package.json
+++ b/draft-packages/filter-menu-button/package.json
@@ -38,7 +38,7 @@
     "classnames": "^2.2.6"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^2.10.3",
+    "@kaizen/design-tokens": "^3.0.0",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/form/package.json
+++ b/draft-packages/form/package.json
@@ -42,7 +42,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^2.10.3",
+    "@kaizen/design-tokens": "^3.0.0",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/form/package.json
+++ b/draft-packages/form/package.json
@@ -42,7 +42,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^3.0.0",
+    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/guidance-block/package.json
+++ b/draft-packages/guidance-block/package.json
@@ -45,7 +45,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^2.10.3",
+    "@kaizen/design-tokens": "^3.0.0",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/guidance-block/package.json
+++ b/draft-packages/guidance-block/package.json
@@ -45,7 +45,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^3.0.0",
+    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/hero-card/package.json
+++ b/draft-packages/hero-card/package.json
@@ -42,7 +42,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^2.10.3",
+    "@kaizen/design-tokens": "^3.0.0",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/hero-card/package.json
+++ b/draft-packages/hero-card/package.json
@@ -42,7 +42,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^3.0.0",
+    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/hierarchical-menu/package.json
+++ b/draft-packages/hierarchical-menu/package.json
@@ -40,7 +40,7 @@
     "react-transition-group": "^4.4.1"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^2.10.3",
+    "@kaizen/design-tokens": "^3.0.0",
     "react": "^16.13.1"
   }
 }

--- a/draft-packages/hierarchical-menu/package.json
+++ b/draft-packages/hierarchical-menu/package.json
@@ -40,7 +40,7 @@
     "react-transition-group": "^4.4.1"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^3.0.0",
+    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0",
     "react": "^16.13.1"
   }
 }

--- a/draft-packages/hierarchical-select/package.json
+++ b/draft-packages/hierarchical-select/package.json
@@ -38,7 +38,7 @@
     "@kaizen/draft-hierarchical-menu": "^2.1.0"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^2.10.3",
+    "@kaizen/design-tokens": "^3.0.0",
     "react": "^16.13.1"
   }
 }

--- a/draft-packages/hierarchical-select/package.json
+++ b/draft-packages/hierarchical-select/package.json
@@ -38,7 +38,7 @@
     "@kaizen/draft-hierarchical-menu": "^2.1.0"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^3.0.0",
+    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0",
     "react": "^16.13.1"
   }
 }

--- a/draft-packages/illustration/package.json
+++ b/draft-packages/illustration/package.json
@@ -43,7 +43,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^3.0.0",
+    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/illustration/package.json
+++ b/draft-packages/illustration/package.json
@@ -43,7 +43,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^2.10.3",
+    "@kaizen/design-tokens": "^3.0.0",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/likert-scale-legacy/package.json
+++ b/draft-packages/likert-scale-legacy/package.json
@@ -36,7 +36,7 @@
     "classnames": "^2.2.6"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^2.10.3",
+    "@kaizen/design-tokens": "^3.0.0",
     "react": "^16.9.0"
   },
   "devDependencies": {

--- a/draft-packages/likert-scale-legacy/package.json
+++ b/draft-packages/likert-scale-legacy/package.json
@@ -36,7 +36,7 @@
     "classnames": "^2.2.6"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^3.0.0",
+    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0",
     "react": "^16.9.0"
   },
   "devDependencies": {

--- a/draft-packages/loading-placeholder/package.json
+++ b/draft-packages/loading-placeholder/package.json
@@ -41,7 +41,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^3.0.0",
+    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/loading-placeholder/package.json
+++ b/draft-packages/loading-placeholder/package.json
@@ -41,7 +41,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^2.10.3",
+    "@kaizen/design-tokens": "^3.0.0",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/loading-spinner/package.json
+++ b/draft-packages/loading-spinner/package.json
@@ -32,7 +32,7 @@
   "private": false,
   "license": "MIT",
   "peerDependencies": {
-    "@kaizen/design-tokens": "^3.0.0",
+    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/loading-spinner/package.json
+++ b/draft-packages/loading-spinner/package.json
@@ -32,7 +32,7 @@
   "private": false,
   "license": "MIT",
   "peerDependencies": {
-    "@kaizen/design-tokens": "^2.10.3",
+    "@kaizen/design-tokens": "^3.0.0",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/menu/package.json
+++ b/draft-packages/menu/package.json
@@ -44,7 +44,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^3.0.0",
+    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0",
     "react": "^16.9.0",
     "react-dom": "^16.9.0"
   }

--- a/draft-packages/menu/package.json
+++ b/draft-packages/menu/package.json
@@ -44,7 +44,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^2.10.3",
+    "@kaizen/design-tokens": "^3.0.0",
     "react": "^16.9.0",
     "react-dom": "^16.9.0"
   }

--- a/draft-packages/modal/package.json
+++ b/draft-packages/modal/package.json
@@ -50,7 +50,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^3.0.0",
+    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/modal/package.json
+++ b/draft-packages/modal/package.json
@@ -50,7 +50,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^2.10.3",
+    "@kaizen/design-tokens": "^3.0.0",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/page-layout/package.json
+++ b/draft-packages/page-layout/package.json
@@ -38,7 +38,7 @@
     "resize-observer-polyfill": "^1.5.1"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^2.10.3",
+    "@kaizen/design-tokens": "^3.0.0",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/page-layout/package.json
+++ b/draft-packages/page-layout/package.json
@@ -38,7 +38,7 @@
     "resize-observer-polyfill": "^1.5.1"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^3.0.0",
+    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/popover/package.json
+++ b/draft-packages/popover/package.json
@@ -44,7 +44,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^3.0.0",
+    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/popover/package.json
+++ b/draft-packages/popover/package.json
@@ -44,7 +44,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^2.10.3",
+    "@kaizen/design-tokens": "^3.0.0",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/select/package.json
+++ b/draft-packages/select/package.json
@@ -47,7 +47,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^3.0.0",
+    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/select/package.json
+++ b/draft-packages/select/package.json
@@ -47,7 +47,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^2.10.3",
+    "@kaizen/design-tokens": "^3.0.0",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/slider/package.json
+++ b/draft-packages/slider/package.json
@@ -37,7 +37,7 @@
     "lodash": "^4.17.20"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^3.0.0",
+    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/slider/package.json
+++ b/draft-packages/slider/package.json
@@ -37,7 +37,7 @@
     "lodash": "^4.17.20"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^2.10.3",
+    "@kaizen/design-tokens": "^3.0.0",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/split-button/package.json
+++ b/draft-packages/split-button/package.json
@@ -42,7 +42,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^2.10.3",
+    "@kaizen/design-tokens": "^3.0.0",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/split-button/package.json
+++ b/draft-packages/split-button/package.json
@@ -42,7 +42,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^3.0.0",
+    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/table/package.json
+++ b/draft-packages/table/package.json
@@ -43,7 +43,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^3.0.0",
+    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/table/package.json
+++ b/draft-packages/table/package.json
@@ -43,7 +43,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^2.10.3",
+    "@kaizen/design-tokens": "^3.0.0",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/tabs/package.json
+++ b/draft-packages/tabs/package.json
@@ -42,7 +42,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^2.10.3",
+    "@kaizen/design-tokens": "^3.0.0",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/tabs/package.json
+++ b/draft-packages/tabs/package.json
@@ -42,7 +42,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^3.0.0",
+    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/tag/package.json
+++ b/draft-packages/tag/package.json
@@ -42,7 +42,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^2.10.3",
+    "@kaizen/design-tokens": "^3.0.0",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/tag/package.json
+++ b/draft-packages/tag/package.json
@@ -42,7 +42,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^3.0.0",
+    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/tile/package.json
+++ b/draft-packages/tile/package.json
@@ -32,7 +32,7 @@
   "private": false,
   "license": "MIT",
   "peerDependencies": {
-    "@kaizen/design-tokens": "^2.10.3",
+    "@kaizen/design-tokens": "^3.0.0",
     "react": "^16.9.0"
   },
   "dependencies": {

--- a/draft-packages/tile/package.json
+++ b/draft-packages/tile/package.json
@@ -32,7 +32,7 @@
   "private": false,
   "license": "MIT",
   "peerDependencies": {
-    "@kaizen/design-tokens": "^3.0.0",
+    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0",
     "react": "^16.9.0"
   },
   "dependencies": {

--- a/draft-packages/title-block-zen/package.json
+++ b/draft-packages/title-block-zen/package.json
@@ -47,7 +47,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^3.0.0",
+    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/title-block-zen/package.json
+++ b/draft-packages/title-block-zen/package.json
@@ -47,7 +47,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^2.10.3",
+    "@kaizen/design-tokens": "^3.0.0",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/tooltip/package.json
+++ b/draft-packages/tooltip/package.json
@@ -46,7 +46,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^2.10.3",
+    "@kaizen/design-tokens": "^3.0.0",
     "react": "^16.9.0",
     "react-dom": "^16.9.0"
   }

--- a/draft-packages/tooltip/package.json
+++ b/draft-packages/tooltip/package.json
@@ -46,7 +46,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^3.0.0",
+    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0",
     "react": "^16.9.0",
     "react-dom": "^16.9.0"
   }

--- a/draft-packages/user-interactions/package.json
+++ b/draft-packages/user-interactions/package.json
@@ -41,7 +41,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^3.0.0",
+    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/user-interactions/package.json
+++ b/draft-packages/user-interactions/package.json
@@ -41,7 +41,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^2.10.3",
+    "@kaizen/design-tokens": "^3.0.0",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/vertical-progress-step/package.json
+++ b/draft-packages/vertical-progress-step/package.json
@@ -41,7 +41,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^3.0.0",
+    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/vertical-progress-step/package.json
+++ b/draft-packages/vertical-progress-step/package.json
@@ -41,7 +41,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^2.10.3",
+    "@kaizen/design-tokens": "^3.0.0",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/well/package.json
+++ b/draft-packages/well/package.json
@@ -41,7 +41,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^3.0.0",
+    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/well/package.json
+++ b/draft-packages/well/package.json
@@ -41,7 +41,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^2.10.3",
+    "@kaizen/design-tokens": "^3.0.0",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/zen-navigation-bar/package.json
+++ b/draft-packages/zen-navigation-bar/package.json
@@ -46,7 +46,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^2.10.3",
+    "@kaizen/design-tokens": "^3.0.0",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/zen-navigation-bar/package.json
+++ b/draft-packages/zen-navigation-bar/package.json
@@ -46,7 +46,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^3.0.0",
+    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0",
     "react": "^16.9.0"
   }
 }

--- a/legacy-packages/title-block/package.json
+++ b/legacy-packages/title-block/package.json
@@ -45,7 +45,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^2.10.3",
+    "@kaizen/design-tokens": "^3.0.0",
     "react": "^16.9.0"
   }
 }

--- a/legacy-packages/title-block/package.json
+++ b/legacy-packages/title-block/package.json
@@ -45,7 +45,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^3.0.0",
+    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0",
     "react": "^16.9.0"
   }
 }

--- a/packages/brand-moment/package.json
+++ b/packages/brand-moment/package.json
@@ -46,7 +46,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^2.10.3",
+    "@kaizen/design-tokens": "^3.0.0",
     "react": "^16.9.0"
   }
 }

--- a/packages/brand-moment/package.json
+++ b/packages/brand-moment/package.json
@@ -46,7 +46,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^3.0.0",
+    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0",
     "react": "^16.9.0"
   }
 }

--- a/packages/component-library/package.json
+++ b/packages/component-library/package.json
@@ -26,7 +26,7 @@
   "private": false,
   "license": "MIT",
   "peerDependencies": {
-    "@kaizen/design-tokens": "^2.10.3",
+    "@kaizen/design-tokens": "^3.0.0",
     "focus-visible": "4.x || 5.x",
     "react": "^16.9.0",
     "react-dom": "^16.9.0"

--- a/packages/component-library/package.json
+++ b/packages/component-library/package.json
@@ -26,7 +26,7 @@
   "private": false,
   "license": "MIT",
   "peerDependencies": {
-    "@kaizen/design-tokens": "^3.0.0",
+    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0",
     "focus-visible": "4.x || 5.x",
     "react": "^16.9.0",
     "react-dom": "^16.9.0"

--- a/packages/deprecated-component-library-helpers/package.json
+++ b/packages/deprecated-component-library-helpers/package.json
@@ -16,6 +16,6 @@
   "private": false,
   "license": "MIT",
   "peerDependencies": {
-    "@kaizen/design-tokens": "^2.10.3"
+    "@kaizen/design-tokens": "^3.0.0"
   }
 }

--- a/packages/deprecated-component-library-helpers/package.json
+++ b/packages/deprecated-component-library-helpers/package.json
@@ -16,6 +16,6 @@
   "private": false,
   "license": "MIT",
   "peerDependencies": {
-    "@kaizen/design-tokens": "^3.0.0"
+    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0"
   }
 }

--- a/packages/responsive/package.json
+++ b/packages/responsive/package.json
@@ -35,7 +35,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^2.10.3",
+    "@kaizen/design-tokens": "^3.0.0",
     "react": "^16.9.0"
   }
 }

--- a/packages/responsive/package.json
+++ b/packages/responsive/package.json
@@ -35,7 +35,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^3.0.0",
+    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0",
     "react": "^16.9.0"
   }
 }

--- a/packages/stylelint-plugin/package.json
+++ b/packages/stylelint-plugin/package.json
@@ -26,7 +26,7 @@
     "stylelint": "^13.10.0"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^2.10.3"
+    "@kaizen/design-tokens": "^3.0.0"
   },
   "devDependencies": {
     "@types/lodash.kebabcase": "^4.1.6",

--- a/packages/stylelint-plugin/package.json
+++ b/packages/stylelint-plugin/package.json
@@ -26,7 +26,7 @@
     "stylelint": "^13.10.0"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^3.0.0"
+    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0"
   },
   "devDependencies": {
     "@types/lodash.kebabcase": "^4.1.6",


### PR DESCRIPTION
Change each peer dependency **on** design-tokens to v3.

# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

# Screenshots (if appropriate)

# Checklist
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] If this contains visual changes, has it been reviewed by a designer?
- [ ] If this introduces either a new component or a breaking change to an existing component, has it been reviewed by an advocate? (Ask in #prod_design_systems)
- [ ] I have considered likely risks of these changes and got someone else to QA as appropriate
- [ ] I have or will communicate these changes to the front end practice

# Additional Considerations
- Does there need to be right-to-left (RTL) options for localization and internationalization?
- Has the test suite been updated?
- Have you done cross-browser testing for our [supported browsers](https://academy.cultureamp.com/hc/en-us/articles/204539569-Supported-browsers-for-Participants)?
- Have you updated any relevant documentation or left useful comments in the code?
- Have you reviewed Culture Amp's Web Accessibility guide [Current Compliance, Going Forward, Statement and Answers for Customers](https://cultureamp.atlassian.net/wiki/spaces/Prod/pages/428572998/Web+Accessibility)?
- If this contains substantial visual changes, especially far reaching ones, have you unlocked the Chromatic step in the pipeline?
- Have Storybook stories been updated?

**If you're new to Kaizen, please ask #prod_design_systems to set up an onboarding session to get you up to speed.** If you have an urgent PR to merge before that happens, it is safest to ask in #prod_design_systems to have a design system advocate review the PR to catch any issues.
