### PR TITLE
chore: add tests for textarea and toggleswitch

### DIFF
--- a/draft-packages/form/KaizenDraft/Form/Primitives/TextArea/TextArea.spec.tsx
+++ b/draft-packages/form/KaizenDraft/Form/Primitives/TextArea/TextArea.spec.tsx
@@ -18,9 +18,18 @@ const renderTextArea = (props?: TextAreaProps) => {
 }
 
 describe("<TextArea />", () => {
-  it("should render a value", () => {
+  it("should render a value when component is controlled", () => {
     const { queryByText } = renderTextArea()
     expect(queryByText(defaultTextAreaProps.value)).toBeTruthy()
+  })
+
+  it("should render a default value when component is uncontrolled", () => {
+    const { queryByText } = renderTextArea({
+      defaultValue: "default value",
+      value: undefined,
+    })
+    expect(queryByText(defaultTextAreaProps.value)).toBeFalsy()
+    expect(queryByText("default value")).toBeTruthy()
   })
 
   it("should call the `onChange` event when the value is updated", () => {

--- a/draft-packages/form/KaizenDraft/Form/Primitives/TextArea/TextArea.spec.tsx
+++ b/draft-packages/form/KaizenDraft/Form/Primitives/TextArea/TextArea.spec.tsx
@@ -1,0 +1,56 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react"
+import * as React from "react"
+import { TextAreaProps } from "./TextArea"
+import { TextArea } from "."
+
+afterEach(cleanup)
+
+const defaultTextAreaProps = {
+  id: "someTextAreaId",
+  value: "Some field value",
+  onChange: jest.fn(),
+}
+
+const renderTextArea = (props?: TextAreaProps) => {
+  const mergedTextAreaProps = { ...defaultTextAreaProps, ...props }
+
+  return render(<TextArea {...mergedTextAreaProps} />)
+}
+
+describe("<TextArea />", () => {
+  it("should render a value", () => {
+    const { queryByText } = renderTextArea()
+    expect(queryByText(defaultTextAreaProps.value)).toBeTruthy()
+  })
+
+  it("should call the `onChange` event when the value is updated", () => {
+    renderTextArea()
+
+    fireEvent.change(screen.getByRole("textbox"), {
+      target: { value: "Hello" },
+    })
+
+    expect(defaultTextAreaProps.onChange).toBeCalledTimes(1)
+  })
+
+  it("should render an `data-automation-id` attribute", () => {
+    const automationId = "someTextAreaAutomationId"
+
+    const { container } = renderTextArea({ automationId })
+    expect(
+      container.querySelector(`[data-automation-id="${automationId}"]`)
+    ).toBeTruthy()
+  })
+
+  it("should render an `id` attribute", () => {
+    const { container } = renderTextArea()
+    expect(
+      container.querySelector(`[id="${defaultTextAreaProps.id}"]`)
+    ).toBeTruthy()
+  })
+
+  it("should render a reversed text area", () => {
+    const { container } = renderTextArea({ reversed: true })
+    expect(container.querySelector(".reversed")).toBeTruthy()
+  })
+})

--- a/draft-packages/form/KaizenDraft/Form/Primitives/TextArea/TextArea.spec.tsx
+++ b/draft-packages/form/KaizenDraft/Form/Primitives/TextArea/TextArea.spec.tsx
@@ -42,22 +42,6 @@ describe("<TextArea />", () => {
     expect(defaultTextAreaProps.onChange).toBeCalledTimes(1)
   })
 
-  it("should render an `data-automation-id` attribute", () => {
-    const automationId = "someTextAreaAutomationId"
-
-    const { container } = renderTextArea({ automationId })
-    expect(
-      container.querySelector(`[data-automation-id="${automationId}"]`)
-    ).toBeTruthy()
-  })
-
-  it("should render an `id` attribute", () => {
-    const { container } = renderTextArea()
-    expect(
-      container.querySelector(`[id="${defaultTextAreaProps.id}"]`)
-    ).toBeTruthy()
-  })
-
   it("should render a reversed text area", () => {
     const { container } = renderTextArea({ reversed: true })
     expect(container.querySelector(".reversed")).toBeTruthy()

--- a/draft-packages/form/KaizenDraft/Form/Primitives/ToggleSwitch/ToggleSwitch.spec.tsx
+++ b/draft-packages/form/KaizenDraft/Form/Primitives/ToggleSwitch/ToggleSwitch.spec.tsx
@@ -1,0 +1,43 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react"
+import * as React from "react"
+import { ToggleSwitchProps } from "./ToggleSwitch"
+import { ToggleSwitch } from "."
+
+afterEach(cleanup)
+
+const defaultToggleSwitchProps = {
+  id: "someToggleSwitchId",
+  value: "Some field value",
+  onToggle: jest.fn(),
+}
+
+const renderToggleSwitch = (props?: ToggleSwitchProps) => {
+  const mergedToggleSwitchProps = { ...defaultToggleSwitchProps, ...props }
+
+  return render(<ToggleSwitch {...mergedToggleSwitchProps} />)
+}
+
+describe("<ToggleSwitch />", () => {
+  it("should render an `data-automation-id` attribute", () => {
+    const automationId = "someToggleSwitchAutomationId"
+
+    const { container } = renderToggleSwitch({ automationId })
+    expect(
+      container.querySelector(`[data-automation-id="${automationId}"]`)
+    ).toBeTruthy()
+  })
+
+  it("should render an `id` attribute", () => {
+    const { container } = renderToggleSwitch()
+    expect(
+      container.querySelector(`[id="${defaultToggleSwitchProps.id}"]`)
+    ).toBeTruthy()
+  })
+
+  it("should call onToggle when toggle is changed", () => {
+    renderToggleSwitch()
+
+    fireEvent.click(screen.getByRole("checkbox"))
+    expect(defaultToggleSwitchProps.onToggle).toHaveBeenCalledTimes(1)
+  })
+})

--- a/draft-packages/form/KaizenDraft/Form/Primitives/ToggleSwitch/ToggleSwitch.spec.tsx
+++ b/draft-packages/form/KaizenDraft/Form/Primitives/ToggleSwitch/ToggleSwitch.spec.tsx
@@ -9,7 +9,6 @@ afterEach(cleanup)
 const defaultToggleSwitchProps = {
   id: "someToggleSwitchId",
   onToggle: jest.fn(),
-  toggledStatus: ToggledStatus.OFF,
 }
 
 const renderToggleSwitch = (props?: ToggleSwitchProps) => {
@@ -26,9 +25,18 @@ describe("<ToggleSwitch />", () => {
     expect(defaultToggleSwitchProps.onToggle).toHaveBeenCalledTimes(1)
   })
 
-  it("should show toggledStatus when passed through", async () => {
-    renderToggleSwitch()
-    expect(defaultToggleSwitchProps.toggledStatus).toEqual("off")
+  it("should show toggledStatus class when status is passed through", async () => {
+    const { container } = renderToggleSwitch({
+      toggledStatus: ToggledStatus.ON,
+    })
+    expect(container.querySelector(".on")).toBeTruthy()
+  })
+
+  it("should show toggledStatus class when status is passed through", async () => {
+    const { container } = renderToggleSwitch({
+      toggledStatus: ToggledStatus.OFF,
+    })
+    expect(container.querySelector(".off")).toBeTruthy()
   })
 
   it("has disabled attribute when disabled prop passed in", async () => {

--- a/draft-packages/form/KaizenDraft/Form/Primitives/ToggleSwitch/ToggleSwitch.spec.tsx
+++ b/draft-packages/form/KaizenDraft/Form/Primitives/ToggleSwitch/ToggleSwitch.spec.tsx
@@ -1,13 +1,15 @@
 import { cleanup, fireEvent, render, screen } from "@testing-library/react"
 import * as React from "react"
-import { ToggleSwitchProps } from "./ToggleSwitch"
+import { ToggledStatus, ToggleSwitchProps } from "./ToggleSwitch"
 import { ToggleSwitch } from "."
+import "@testing-library/jest-dom"
 
 afterEach(cleanup)
 
 const defaultToggleSwitchProps = {
   id: "someToggleSwitchId",
   onToggle: jest.fn(),
+  toggledStatus: ToggledStatus.OFF,
 }
 
 const renderToggleSwitch = (props?: ToggleSwitchProps) => {
@@ -17,26 +19,20 @@ const renderToggleSwitch = (props?: ToggleSwitchProps) => {
 }
 
 describe("<ToggleSwitch />", () => {
-  it("should render an `data-automation-id` attribute", () => {
-    const automationId = "someToggleSwitchAutomationId"
-
-    const { container } = renderToggleSwitch({ automationId })
-    expect(
-      container.querySelector(`[data-automation-id="${automationId}"]`)
-    ).toBeTruthy()
-  })
-
-  it("should render an `id` attribute", () => {
-    const { container } = renderToggleSwitch()
-    expect(
-      container.querySelector(`[id="${defaultToggleSwitchProps.id}"]`)
-    ).toBeTruthy()
-  })
-
   it("should call onToggle when toggle is changed", () => {
     renderToggleSwitch()
 
     fireEvent.click(screen.getByRole("checkbox"))
     expect(defaultToggleSwitchProps.onToggle).toHaveBeenCalledTimes(1)
+  })
+
+  it("should show toggledStatus when passed through", async () => {
+    renderToggleSwitch()
+    expect(defaultToggleSwitchProps.toggledStatus).toEqual("off")
+  })
+
+  it("has disabled attribute when disabled prop passed in", async () => {
+    const { container } = renderToggleSwitch({ disabled: true })
+    expect(container.querySelector("[disabled]")).toBeTruthy()
   })
 })

--- a/draft-packages/form/KaizenDraft/Form/Primitives/ToggleSwitch/ToggleSwitch.spec.tsx
+++ b/draft-packages/form/KaizenDraft/Form/Primitives/ToggleSwitch/ToggleSwitch.spec.tsx
@@ -7,7 +7,6 @@ afterEach(cleanup)
 
 const defaultToggleSwitchProps = {
   id: "someToggleSwitchId",
-  value: "Some field value",
   onToggle: jest.fn(),
 }
 


### PR DESCRIPTION
# Objective
- Add tests to the TextArea and ToggleSwitch components

# Motivation and Context
- Future-proofs our components
- Closes this: https://github.com/cultureamp/kaizen-design-system/issues/911