### PR TITLE
fix: Check for existing toast-notification-manager-portal before creating

### DIFF
--- a/packages/component-library/components/Notification/ToastNotificationManager.tsx
+++ b/packages/component-library/components/Notification/ToastNotificationManager.tsx
@@ -46,13 +46,18 @@ const createToastNotificationManager = (): ToastNotificationApi => {
   let setNotifications:
     | React.Dispatch<React.SetStateAction<ToastNotification[]>>
     | undefined
+  const automationId = "toast-notification-manager-portal"
   if (portal === undefined && typeof window !== "undefined") {
-    portal = document.createElement("div")
-    portal.setAttribute(
-      "data-automation-id",
-      "toast-notification-manager-portal"
+    const existingPortal = document.querySelector(
+      `[data-automation-id="${automationId}"]`
     )
-    document.body.appendChild(portal)
+    if (existingPortal !== null) {
+      portal = existingPortal as HTMLDivElement
+    } else {
+      portal = document.createElement("div")
+      portal.setAttribute("data-automation-id", automationId)
+      document.body.appendChild(portal)
+    }
   }
 
   const state: {


### PR DESCRIPTION
Closes https://github.com/cultureamp/kaizen-design-system/issues/1835

**BREAKING CHANGE**: This will break snapshot tests with multiple toast-notification-manager-portal divs, these will need to be refreshed.

# Objective
Checks for an existing `toast-notification-manager-portal` div before creating one.

# Motivation and Context
See https://github.com/cultureamp/kaizen-design-system/issues/1835

