### PR TITLE
docs: Update demoStoryIds after grouping change to stories

### DIFF
--- a/draft-packages/button/KaizenDraft/Button/README.mdx
+++ b/draft-packages/button/KaizenDraft/Button/README.mdx
@@ -7,7 +7,7 @@ needToKnow:
 - Buttons perform actions.
 - If it needs to navigate somewhere and can be opened in a new tab, use a link instead.
 headerImage: button
-demoStoryId: button-zen-react--default-kaizen-site-demo
+demoStoryId: components-button-button--default-kaizen-site-demo
 health:
   designed: true
   documented: true

--- a/draft-packages/collapsible/docs/README.mdx
+++ b/draft-packages/collapsible/docs/README.mdx
@@ -6,7 +6,7 @@ tags: ["Expandable", "Accordion", "Show and hide", "Reveal", "Disclosure"]
 needToKnow:
   - "We usually start collapsibles in a collapsed position by default so that users can see what's available."
   - "We often avoid accordions, which are a specific type of collapsible that allows only 1 section open at a time and is often an annoying constraint on user interaction."
-demoStoryId: collapsible-react--single-collapsible-kaizen-site-demo
+demoStoryId: components-collapsible--single-collapsible-kaizen-site-demo
 health:
   designed: true
   documented: true

--- a/draft-packages/empty-state/KaizenDraft/EmptyState/README.mdx
+++ b/draft-packages/empty-state/KaizenDraft/EmptyState/README.mdx
@@ -6,7 +6,7 @@ tags: ["Zero State", "Empty well", "Starter content", "Educational content"]
 needToKnow:
 - Empty states communicate the current state, allowing users to feel in control of the system, take appropriate actions to reach their goal, and ultimately trust the brand.
 - Without an empty state, people are confused about what to do next.
-demoStoryId: emptystate-react--default-kaizen-site-demo
+demoStoryId: components-empty-state--default-kaizen-site-demo
 health:
   designed: true
   documented: true

--- a/draft-packages/form/KaizenDraft/Form/CheckboxField/README.mdx
+++ b/draft-packages/form/KaizenDraft/Form/CheckboxField/README.mdx
@@ -5,7 +5,7 @@ summaryParagraph: A checkbox field includes a checkable input and its label. Che
 tags: ["Checkbox", "Tick box", "Check item", "Option button", "Choice", "Selection"]
 needToKnow:
 - Lets a user choose to select or unselect a single item. When used in a Checkbox Group, a checkbox lets a user select zero or more items from a set, which are all visible at the same time.
-demoStoryId: checkboxfield-react--interactive-kaizen-site-demo
+demoStoryId: components-form-checkbox-field--interactive-kaizen-site-demo
 headerImage: checkbox-field
 health:
   designed: true

--- a/draft-packages/form/KaizenDraft/Form/CheckboxGroup/README.mdx
+++ b/draft-packages/form/KaizenDraft/Form/CheckboxGroup/README.mdx
@@ -7,7 +7,7 @@ needToKnow:
 - Prefer vertical (stacked) checkboxes to easily scan and compare options.
 - When choices are mutually exclusive, use a radio instead.
 - For settings that are immediately applied, consider using a toggle switch instead.
-demoStoryId: checkboxgroup-react--interactive-kaizen-site-demo
+demoStoryId: components-form-checkbox-group--interactive-kaizen-site-demo
 headerImage: checkbox-group
 health:
   designed: true

--- a/draft-packages/form/KaizenDraft/Form/RadioField/README.mdx
+++ b/draft-packages/form/KaizenDraft/Form/RadioField/README.mdx
@@ -5,7 +5,7 @@ summaryParagraph: A radio includes a radio input and its label. Radios are used 
 tags: ["Radio button", "Radio group", "Option button", "Choice", "Selection", "Disc", "Radio input"]
 needToKnow:
 - Radios are only used in radio groups to let people select exactly one option from a set.
-demoStoryId: radio-react--interactive-kaizen-site-demo
+demoStoryId: components-form-radio-field--interactive-kaizen-site-demo
 headerImage: radio
 health:
   designed: true

--- a/draft-packages/form/KaizenDraft/Form/RadioGroup/README.mdx
+++ b/draft-packages/form/KaizenDraft/Form/RadioGroup/README.mdx
@@ -7,7 +7,7 @@ needToKnow:
 - Prefer vertical (stacked) radios to easily scan and compare options.
 - When there’s only two options, consider if a single checkbox would be better.
 - For settings that are immediately applied, consider using a toggle switch instead.
-demoStoryId: radiogroup-react--default-kaizen-site-demo
+demoStoryId: components-form-radio-group--default-kaizen-site-demo
 headerImage: radio-group
 health:
   designed: true

--- a/draft-packages/form/KaizenDraft/Form/TextAreaField/README.mdx
+++ b/draft-packages/form/KaizenDraft/Form/TextAreaField/README.mdx
@@ -5,7 +5,7 @@ summaryParagraph: A text area includes a label and a longer area you can type mu
 tags: ["Text area", "Textarea", "Multiline text field", "Textarea Autosize"]
 needToKnow:
 - "For sizing, consider likely text input and use existing data where possible."
-demoStoryId: textareafield-react--default-kaizen-site-demo
+demoStoryId: components-form-text-area-field--default-kaizen-site-demo
 health:
   designed: true
   documented: true

--- a/draft-packages/form/KaizenDraft/Form/TextField/README.mdx
+++ b/draft-packages/form/KaizenDraft/Form/TextField/README.mdx
@@ -5,7 +5,7 @@ summaryParagraph: A text field includes a label and an input field you can type 
 tags: ["Input", "Form field", "Text input", "Email input", "Password"]
 needToKnow:
 - "Pre-fill the Text Field input with good defaults wherever possible."
-demoStoryId: textfield-react--default-kaizen-site-demo
+demoStoryId: components-form-text-field--default-kaizen-site-demo
 headerImage: text-field
 health:
   designed: true

--- a/draft-packages/form/KaizenDraft/Form/ToggleSwitchField/README.mdx
+++ b/draft-packages/form/KaizenDraft/Form/ToggleSwitchField/README.mdx
@@ -6,7 +6,7 @@ tags: ["Toggle button", "Switch", "Toggle"]
 needToKnow:
 - Toggle Switch labels must include a verb. E.g. Show translations
 - The label should never be on both sides (e.g. On/Off).
-demoStoryId: toggleswitchfield-react--on-kaizen-site-demo
+demoStoryId: components-form-toggle-switch-field--on-kaizen-site-demo
 health:
   designed: true
   documented: true

--- a/draft-packages/hero-card/KaizenDraft/HeroCard/README.mdx
+++ b/draft-packages/hero-card/KaizenDraft/HeroCard/README.mdx
@@ -7,7 +7,7 @@ needToKnow:
 - The badge contains a number, ideally 1 character, showing a micro bit of information such as a step.
 - For the image, use a graphic illustration that supports what's going on in the rest of the card.
 - For the title, aim for 1 line of text.
-demoStoryId: herocard-react--default-kaizen-site-demo
+demoStoryId: components-hero-card--default-kaizen-site-demo
 health:
   designed: true
   documented: true

--- a/draft-packages/loading-placeholder/KaizenDraft/LoadingPlaceholder/README.mdx
+++ b/draft-packages/loading-placeholder/KaizenDraft/LoadingPlaceholder/README.mdx
@@ -5,7 +5,7 @@ summaryParagraph: A single loading placeholder element used in a loading skeleto
 tags: ["Skeleton", "Stencil", "Placeholder UI"]
 needToKnow:
   - "Only use loading placeholders with loading skeletons."
-demoStoryId: loadingplaceholder-react--default-multiple-kaizen-site-demo
+demoStoryId: components-loading-placeholder--default-multiple-kaizen-site-demo
 health:
   designed: true
   documented: true

--- a/draft-packages/menu/KaizenDraft/Menu/README.mdx
+++ b/draft-packages/menu/KaizenDraft/Menu/README.mdx
@@ -5,7 +5,7 @@ summaryParagraph: A menu contains links to places or button actions. It does NOT
 tags: ["Menu list", "Context menu", "Menubar"]
 needToKnow:
 - If a menu dropdown contains a mix of links and buttons, separate them with a content divider with links at the top and buttons at the bottom.
-demoStoryId: menu-react--label-and-icon
+demoStoryId: components-menu--label-and-icon
 demoStoryHeight: 456px
 health:
   designed: true

--- a/draft-packages/modal/KaizenDraft/Modal/README.mdx
+++ b/draft-packages/modal/KaizenDraft/Modal/README.mdx
@@ -8,7 +8,7 @@ needToKnow:
 - "Modals need an overlay behind them and over the page."
 - "Choose your type (confirmation, input-edit or context)."
 - "Use sparingly."
-demoStoryId: modal-react--confirmation-positive-kaizen-site-demo
+demoStoryId: components-modal--confirmation-positive-kaizen-site-demo
 demoStoryHeight: 500px
 headerImage: modal-informative
 health:

--- a/draft-packages/page-layout/README.mdx
+++ b/draft-packages/page-layout/README.mdx
@@ -5,7 +5,7 @@ summaryParagraph:
   Content limits the width its content to the maximum allowed width for any
   given screen size, and centres it within the viewport.
 tags: ["Content", "Structure"]
-demoStoryId: Content-react--default
+demoStoryId: components-page-layout--default-story
 health:
   designed: true
   documented: true

--- a/draft-packages/popover/KaizenDraft/Popover/README.mdx
+++ b/draft-packages/popover/KaizenDraft/Popover/README.mdx
@@ -8,7 +8,7 @@ needToKnow:
 - Unlike a tooltip, a user can interact with popover content.
 - Trigger popovers from Interactive elements (Buttons, Links, Icon buttons) or Non-interactive elements (Icons, Abbreviations, Truncated text)—be mindful of keyboard accessibility
 - Use sparingly.
-demoStoryId: popover-react--default-kaizen-site-demo
+demoStoryId: components-popover--default-kaizen-site-demo
 demoStoryHeight: 160px
 health:
   designed: true

--- a/draft-packages/select/KaizenDraft/Select/README.mdx
+++ b/draft-packages/select/KaizenDraft/Select/README.mdx
@@ -5,7 +5,7 @@ summaryParagraph: A select lets you choose options from an option menu. A single
 tags: ["Select", "Select menu", "Select dropdown", "Dropdown", "Select input"]
 needToKnow:
 - Use for 4+ options when you need to conserve space and provide a pre-selected good default. There are single- and multi-select variants.
-demoStoryId: select-elm--single-kaizen-site-demo
+demoStoryId: components-select--single
 demoStoryHeight: 300px
 health:
   designed: true

--- a/draft-packages/table/KaizenDraft/Table/README.mdx
+++ b/draft-packages/table/KaizenDraft/Table/README.mdx
@@ -6,7 +6,7 @@ tags: ["Tabular data", "data table", "Values", "Resource list"]
 needToKnow:
 - All tables have headers, rows, and columns.
 - Don’t use a table when you can use a data visualization.
-demoStoryId: table-react--default-kaizen-site-demo
+demoStoryId: components-table--default-kaizen-site-demo
 health:
   designed: true
   documented: true

--- a/draft-packages/tag/KaizenDraft/Tag/README.mdx
+++ b/draft-packages/tag/KaizenDraft/Tag/README.mdx
@@ -8,7 +8,7 @@ needToKnow:
   - Tags help categorize and organize.
   - Use sentiment labels only for sentiment or other employee feedback data.
   - Tags may be persistent or dismissible. Dismissible tags can be added or removed by users.
-demoStoryId: tag-react--default-medium-kaizen-site-demo
+demoStoryId: components-tag--default-medium-kaizen-site-demo
 health:
   designed: true
   documented: true

--- a/draft-packages/tooltip/KaizenDraft/Tooltip/README.mdx
+++ b/draft-packages/tooltip/KaizenDraft/Tooltip/README.mdx
@@ -9,7 +9,7 @@ needToKnow:
 - Tooltips must be accessible via hover, focus or click.
 - Trigger tooltips from Interactive elements (Buttons, Links, Icon buttons) or Non-interactive elements (Icons, Abbreviations, Truncated text)—be mindful of keyboard accessibility
 - Use sparingly. Tooltips innately hide information. Consider exposing it immediately without a tooltip or removing it completely.
-demoStoryId: tooltip-react--default-below-kaizen-site-demo
+demoStoryId: components-tooltip--default-below-kaizen-site-demo
 demoStoryHeight: 100px
 health:
   designed: true

--- a/draft-packages/well/README.mdx
+++ b/draft-packages/well/README.mdx
@@ -6,7 +6,7 @@ tags: ["Placeholder", "Content area", "Frame", "Card", "Group", "Box", "Containe
 needToKnow:
 - "For primary content, use a Card instead."
 - "Usually, wells are used in other components, such as Empty States and drag and drop file upload, instead of independently."
-demoStoryId: well-react--default-with-solid-border-kaizen-site-demo
+demoStoryId: components-well--default-with-solid-border-kaizen-site-demo
 health:
   designed: true
   documented: true

--- a/packages/component-library/components/Icon/README.mdx
+++ b/packages/component-library/components/Icon/README.mdx
@@ -5,7 +5,7 @@ summaryParagraph: The Icon component displays meaningful and presentational icon
 needToKnow:
 - "This component shows a single icon that can be meaningful or presentational."
 - "To control the icon's color, set the color property on the icon's parent element."
-demoStoryId: icon-react--meaningful-kaizen-site-demo
+demoStoryId: components-icon--meaningful-kaizen-site-demo
 health:
   designed: true
   documented: true

--- a/site/docs/components/avatar.mdx
+++ b/site/docs/components/avatar.mdx
@@ -8,7 +8,7 @@ needToKnow:
 - Use an avatar to help a user in the platform efficiently identify another person or an organization.
 - Use a profile avatar to represent an individual and an account avatar for an organization.
 - When an avatar photo is unavailable, fall back to initials or first initial.
-demoStoryId: avatar-react--default-user
+demoStoryId: components-avatar--default-user
 headerImage: avatar
 health:
   designed: true

--- a/site/docs/components/badge.mdx
+++ b/site/docs/components/badge.mdx
@@ -6,7 +6,7 @@ tags: ["Tag", "Chip", "Label", "Pill", "Lozenge"]
 needToKnow:
 - For numerical counts, use a badge.
 - Use a “pop” animation style when badge numbers increase.
-demoStoryId: badge-react--default-story
+demoStoryId: components-badge--default-story
 headerImage: badge
 health:
   designed: true

--- a/site/docs/components/card.mdx
+++ b/site/docs/components/card.mdx
@@ -6,7 +6,7 @@ tags: ["Wells", "Panels", "Slats", "Rows", "List Rows", "Tiles", "Container", "C
 needToKnow:
 - Meaningful content—such as data, images, or paragraphs (but not headings)—sit on cards.
 headerImage: card
-demoStoryId: card-react--default-story
+demoStoryId: components-card--default-story
 health:
   designed: true
   documented: true

--- a/site/docs/components/commentary.mdx
+++ b/site/docs/components/commentary.mdx
@@ -3,7 +3,6 @@ title: Commentary
 navTitle: Commentary
 summaryParagraph: A user-created note that provides additional context to shared information.
 tags: ["Annotation", "Banner", "Note", "Communications", "Memo", "Monologue", "Context", "Commentaries", "Commentary", "Message", "Summary"]
-demoStoryId:  <%= componentName %>-react--default-kaizen-site-demo
 needToKnow:
 - Mackenzie hesitates about auto-sharing reports that do not contain context for their audience.  
 - A commentary is used to communicate additional context. It is often a one-way monologue / memo intended for a shared audience.

--- a/site/docs/components/divider.mdx
+++ b/site/docs/components/divider.mdx
@@ -3,7 +3,7 @@ title: "Divider"
 navTitle: "Divider"
 summaryParagraph: Dividers are thin lines that group content in lists and layouts, or separate blocks of content.
 tags: ["Horizontal rules", "HR", "Lines", "Stroke"]
-demoStoryId: divider-react--default-story
+demoStoryId: components-divider--default-story
 needToKnow: 
 - Content dividers are used to separate content within a card, table, or any white content area.
 - Canvas dividers are used on the canvas (not cards) to separate large blocks of content.

--- a/site/docs/components/filter-menu.mdx
+++ b/site/docs/components/filter-menu.mdx
@@ -5,7 +5,7 @@ summaryParagraph: A filter drawer contains filters. It controls filtering of an 
 tags: ["Filter menu", "Filter drawer", "Filter", "Filterable list"]
 needToKnow:
 - Use rows or columns to clearly define groups of filter components.
-demoStoryId:  filtermenubutton-react--default-story
+demoStoryId: components-filter-menu--default-story
 demoStoryHeight: 400px
 health:
   designed: false

--- a/site/docs/components/global-notification.mdx
+++ b/site/docs/components/global-notification.mdx
@@ -5,7 +5,7 @@ summaryParagraph: A global notification is a message object used for system-leve
 tags: ["Banner", "Confirmation", "Acknowledgment", "Message", "Alert"]
 needToKnow:
 - A Global notification is always positioned at the top of the screen (above the Navigation Bar) and stretches the full width of the viewport.
-demoStoryId: globalnotification-react--positive-kaizen-site-demo
+demoStoryId: components-notification-global-notification--positive-kaizen-site-demo
 health:
   designed: true
   documented: true

--- a/site/docs/components/icon-button.mdx
+++ b/site/docs/components/icon-button.mdx
@@ -9,7 +9,7 @@ needToKnow:
   - Use a Primary icon button when it's the most important action to take.
   - Use a Destructive icon button when the action will result in data loss, cannot be undone, or otherwise have significant consequences.
   - Breadcrumb icon buttons use link elements to navigate and must show a destination as text on hover/focus.
-demoStoryId: iconbutton-react--default-kaizen-site-demo
+demoStoryId: components-button-icon-button--default-kaizen-site-demo
 health:
   designed: true
   documented: true

--- a/site/docs/components/illustration.mdx
+++ b/site/docs/components/illustration.mdx
@@ -6,7 +6,7 @@ tags: ["Illustration", "Hero illustration", "Spot illustration", "Imagery", "Gra
 needToKnow:
 - "Scene illustrations tell a rich story to set the scene for users and let them know what's possible."
 - "Spot illustrations are simple, informational visuals that assist users in their task."
-demoStoryId: illustration-scene-react--default-site-demo
+demoStoryId: components-illustration-spot--spot-story-for-kaizen-site
 demoStoryHeight: 400px
 health:
   designed: true

--- a/site/docs/components/inline-notification.mdx
+++ b/site/docs/components/inline-notification.mdx
@@ -5,7 +5,7 @@ summaryParagraph: An inline notification is a message object that presents timel
 tags: ["Banner", "Confirmation", "Acknowledgement", "Message", "Alert"]
 needToKnow: 
 - An inline notification is a message object that presents timely information within content areas as close as possible to the thing that it’s about.
-demoStoryId: inlinenotification-react--dismissible-positive-kaizen-site-demo
+demoStoryId: components-notification-inline-notification--dismissible-positive-kaizen-site-demo
 health:
   designed: true
   documented: true

--- a/site/docs/components/loading-spinner.mdx
+++ b/site/docs/components/loading-spinner.mdx
@@ -7,7 +7,7 @@ needToKnow:
 - "Center the loading spinner in the available space."
 - "Avoid showing multiple Loading Spinners on a single page."
 - "Give people an idea of what’s happening when a small content/data item takes less than 10s to load."
-demoStoryId: loadingspinner-react--default-story
+demoStoryId: components-loading-spinner--default-story
 health:
   designed: true
   documented: true

--- a/site/docs/components/progress-stepper.mdx
+++ b/site/docs/components/progress-stepper.mdx
@@ -8,10 +8,11 @@ needToKnow:
 - Progress steppers may be gated or ungated.
 - A step may show validation feedback.
 - Aim for 3–4 steps.
+demoStoryId: deprecated-vertical-progress-step--completed-step
 health:
   designed: true
   documented: true
-  implemented: false
+  implemented: true
   latestDesign: false
   allVariants: false
   responsive: false

--- a/site/docs/components/progress-stepper.mdx
+++ b/site/docs/components/progress-stepper.mdx
@@ -8,7 +8,6 @@ needToKnow:
 - Progress steppers may be gated or ungated.
 - A step may show validation feedback.
 - Aim for 3–4 steps.
-demoStoryId: verticalprogressstep-react--completed-step
 health:
   designed: true
   documented: true

--- a/site/docs/components/search-field.mdx
+++ b/site/docs/components/search-field.mdx
@@ -9,7 +9,6 @@ needToKnow:
 - 'Ensure the search input is wide enough to fit the majority of search queries informed by analytics or user research.'
 - 'Design for loading, empty, and zero states.'
 - '"Search" describes the general behavior and, informally, the search field. "Search field" describes the main search component (label and input).'
-demoStoryId:  searchbox-react--default-story
 demoStoryHeight: 300px
 health:
   designed: true

--- a/site/docs/components/split-button.mdx
+++ b/site/docs/components/split-button.mdx
@@ -7,7 +7,7 @@ needToKnow:
 - Avoid split buttons where separated buttons and icon buttons will do.
 - Only include related actions in the dropdown.
 - Don’t use links in the dropdown.
-demoStoryId: splitbutton-react--default-kaizen-site-demo
+demoStoryId: components-split-button--default-kaizen-site-demo
 health:
   designed: true
   documented: true

--- a/site/docs/components/tabs.mdx
+++ b/site/docs/components/tabs.mdx
@@ -6,7 +6,7 @@ tags: ["Tab list", "Tab group", "Tab panel", "Content tabs", "Nav bar", "Vertica
 needToKnow:
 - Navigation tabs are always used for global navigation at the top of the page or inside an offscreen menu on small screens.
 - Content tabs are used for chunking content, allowing movement between content within a single page.
-demoStoryId: tabs-react--active-tab
+demoStoryId: components-tabs--active-tab
 health:
   designed: true
   documented: true

--- a/site/docs/components/toast-notification.mdx
+++ b/site/docs/components/toast-notification.mdx
@@ -5,7 +5,7 @@ summaryParagraph: A toast notification is a message object that presents timely 
 tags: ["Toasts", "Snackbars", "Pop-up notifications", "Drawer notification", "Banner", "Confirmation", "Acknowledgement", "Message", "Alert"]
 needToKnow:
 - Use toast notifications immediately after a specific event such as a user action that does not relate to an object on the page.
-demoStoryId: toastnotification-react--positive-kaizen-site-demo
+demoStoryId: components-notification-toast-notification--positive-kaizen-site-demo
 demoStoryHeight: 250px
 health:
   designed: true


### PR DESCRIPTION
# Objective
Fixes a bunch of broken story paths in component documentation

# Motivation and Context
These all changed in https://github.com/cultureamp/kaizen-design-system/pull/1794 and broke our embeds on the site component documentation.