### PR TITLE
docs: remove reference of draft in main readme

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,10 +74,6 @@ To update a component in code:
 
 See the [design tokens](https://github.com/cultureamp/kaizen-design-system/tree/master/packages/generator) package.
 
-### Building a new draft component
-
-See the [draft package generator](https://github.com/cultureamp/kaizen-design-system/tree/master/packages/generator) package.
-
 ### Browser and device support
 
 To learn more about what browsers and devices we support in Kaizen Component Library, Culture Amp employees can see [the Browser Support wiki page](https://cultureamp.atlassian.net/wiki/spaces/Prod/pages/1572948/Browser+Support+and+Stats).
@@ -86,7 +82,7 @@ To learn more about what browsers and devices we support in Kaizen Component Lib
 
 To strengthen the Kaizen Design System, we encourage engineers to take a component-first development approach. By concentrating on developing Kaizen components in Storybook, we are likely to improve the API design and achieve good separation of concerns, avoiding components tightly coupled to specific applications. If, however, you want to test a component in the context of another front-end codebase, you can [yarn link](https://yarnpkg.com/lang/en/docs/cli/link/) your local version of `@kaizen/component-library` with your other front-end codebase.
 
-#### For core, non-draft components
+#### For core components
 
 **Step 1**: Make your local copy of `@kaizen/component-library` available.
 
@@ -120,43 +116,6 @@ When you are done, unlink the package from your front-end codebase:
 `yarn unlink @kaizen/component-library`
 
 You can also clean up generated files in your `@kaizen/component-library` repo:
-
-`yarn clean`
-
-#### For draft components
-
-**Step 1**: Make your local copy of the relevant `@kaizen/draft-*` module available (the code below uses the `@kaizen/draft-modal` component as an example).
-
-```sh
-# Navigate to code source
-$ cd ./draft-packages/modal
-
-# Register package for linking
-$ yarn link
-
-# Build in watch mode
-$ yarn build:watch
-```
-
-**Step 2**: Link `@kaizen/draft-modal` to your other front-end codebase.
-
-```sh
-# Navigate to code source
-$ cd <your_code>/cultureamp/YOUR_FRONT_END_CODEBASE
-
-# Link repo to locally registered package
-$ yarn link @kaizen/draft-modal
-```
-
-Your local Kaizen changes will now show in your other front-end codebase.
-
-**Step 3**: Unlink
-
-When you are done, unlink the package from your front-end codebase:
-
-`yarn unlink @kaizen/draft-modal`
-
-You can also clean up generated files in your `@kaizen/draft-*` repo:
 
 `yarn clean`
 


### PR DESCRIPTION
# Objective
- As we're not using the draft packages implementation anymore, I've removed it from the contributing readme.

# Motivation and Context
- As a part of making the general guidelines to using Kaizen smoother, we are trying to update as many docs as possible. 
