### PR TITLE
docs: adding labels to each component to tie our open issues that are labelled to our gatsby docs

### DIFF
--- a/draft-packages/button/KaizenDraft/Button/README.mdx
+++ b/draft-packages/button/KaizenDraft/Button/README.mdx
@@ -3,6 +3,7 @@ title: Button
 navTitle: Button
 summaryParagraph: Buttons perform actions.
 tags: ["Link button", "Primary action", "Secondary action", "Default action", "Destructive action"]
+githubLabels: ["component:button"]
 needToKnow:
 - Buttons perform actions.
 - If it needs to navigate somewhere and can be opened in a new tab, use a link instead.

--- a/draft-packages/collapsible/docs/README.mdx
+++ b/draft-packages/collapsible/docs/README.mdx
@@ -3,6 +3,7 @@ title: "Collapsible"
 navTitle: "Collapsible"
 summaryParagraph: Collapsibles are used to collapse and expand content inline on a page. This lets users progressively disclose information as desired.
 tags: ["Expandable", "Accordion", "Show and hide", "Reveal", "Disclosure"]
+githubLabels: ["component:collapsible"]
 needToKnow:
   - "We usually start collapsibles in a collapsed position by default so that users can see what's available."
   - "We often avoid accordions, which are a specific type of collapsible that allows only 1 section open at a time and is often an annoying constraint on user interaction."

--- a/draft-packages/empty-state/KaizenDraft/EmptyState/README.mdx
+++ b/draft-packages/empty-state/KaizenDraft/EmptyState/README.mdx
@@ -3,6 +3,7 @@ title: "Empty State"
 navTitle: "Empty State"
 summaryParagraph: Empty states tell users that there’s no content to display—and what they can do next.
 tags: ["Zero State", "Empty well", "Starter content", "Educational content"]
+githubLabels: ["component:empty-state"]
 needToKnow:
 - Empty states communicate the current state, allowing users to feel in control of the system, take appropriate actions to reach their goal, and ultimately trust the brand.
 - Without an empty state, people are confused about what to do next.

--- a/draft-packages/form/KaizenDraft/Form/CheckboxField/README.mdx
+++ b/draft-packages/form/KaizenDraft/Form/CheckboxField/README.mdx
@@ -3,6 +3,7 @@ title: Checkbox Field
 navTitle: Checkbox Field
 summaryParagraph: A checkbox field includes a checkable input and its label. Checkbox fields are used in checkbox groups that let people select zero or more options from a set.
 tags: ["Checkbox", "Tick box", "Check item", "Option button", "Choice", "Selection"]
+githubLabels: ["component:checkbox", "component:form"]
 needToKnow:
 - Lets a user choose to select or unselect a single item. When used in a Checkbox Group, a checkbox lets a user select zero or more items from a set, which are all visible at the same time.
 demoStoryId: components-form-checkbox-field--interactive-kaizen-site-demo

--- a/draft-packages/form/KaizenDraft/Form/CheckboxGroup/README.mdx
+++ b/draft-packages/form/KaizenDraft/Form/CheckboxGroup/README.mdx
@@ -3,6 +3,7 @@ title: Checkbox Group
 navTitle: Checkbox Group
 summaryParagraph: A checkbox group contains checkbox fields that let people select zero or more options from a set.
 tags: ["Choice list", "Radio button", "Option button", "Choice", "Selection"]
+githubLabels: ["component:checkbox", "component:form"]
 needToKnow:
 - Prefer vertical (stacked) checkboxes to easily scan and compare options.
 - When choices are mutually exclusive, use a radio instead.

--- a/draft-packages/form/KaizenDraft/Form/RadioField/README.mdx
+++ b/draft-packages/form/KaizenDraft/Form/RadioField/README.mdx
@@ -3,6 +3,7 @@ title: Radio Field
 navTitle: Radio Field
 summaryParagraph: A radio includes a radio input and its label. Radios are used in radio groups that let people select exactly one option from a set.
 tags: ["Radio button", "Radio group", "Option button", "Choice", "Selection", "Disc", "Radio input"]
+githubLabels: ["component:radio", "component:form"]
 needToKnow:
 - Radios are only used in radio groups to let people select exactly one option from a set.
 demoStoryId: components-form-radio-field--interactive-kaizen-site-demo

--- a/draft-packages/form/KaizenDraft/Form/RadioGroup/README.mdx
+++ b/draft-packages/form/KaizenDraft/Form/RadioGroup/README.mdx
@@ -3,6 +3,7 @@ title: Radio Group
 navTitle: Radio Group
 summaryParagraph: Radio groups include a set of radios that let people select exactly one option in a set.
 tags: ["Choice list", "Radio button", "Radio button group", "Option button", "Choice", "Selection"]
+githubLabels: ["component:radio", "component:form"]
 needToKnow:
 - Prefer vertical (stacked) radios to easily scan and compare options.
 - When there’s only two options, consider if a single checkbox would be better.

--- a/draft-packages/form/KaizenDraft/Form/TextAreaField/README.mdx
+++ b/draft-packages/form/KaizenDraft/Form/TextAreaField/README.mdx
@@ -3,6 +3,7 @@ title: Text Area Field
 navTitle: Text Area Field
 summaryParagraph: A text area includes a label and a longer area you can type multiple lines of text into.
 tags: ["Text area", "Textarea", "Multiline text field", "Textarea Autosize"]
+githubLabels: ["component:text-area", "component:form"]
 needToKnow:
 - "For sizing, consider likely text input and use existing data where possible."
 demoStoryId: components-form-text-area-field--default-kaizen-site-demo

--- a/draft-packages/form/KaizenDraft/Form/TextField/README.mdx
+++ b/draft-packages/form/KaizenDraft/Form/TextField/README.mdx
@@ -3,6 +3,7 @@ title: Text Field
 navTitle: Text Field
 summaryParagraph: A text field includes a label and an input field you can type text into.
 tags: ["Input", "Form field", "Text input", "Email input", "Password"]
+githubLabels: ["component:text-input", "component:form"]
 needToKnow:
 - "Pre-fill the Text Field input with good defaults wherever possible."
 demoStoryId: components-form-text-field--default-kaizen-site-demo

--- a/draft-packages/form/KaizenDraft/Form/ToggleSwitchField/README.mdx
+++ b/draft-packages/form/KaizenDraft/Form/ToggleSwitchField/README.mdx
@@ -3,6 +3,7 @@ title: Toggle Switch Field
 navTitle: Toggle Switch Field
 summaryParagraph: A Toggle Switch lets people turn a single setting on or off immediately.
 tags: ["Toggle button", "Switch", "Toggle"]
+githubLabels: ["component:toggle-switch", "component:form"]
 needToKnow:
 - Toggle Switch labels must include a verb. E.g. Show translations
 - The label should never be on both sides (e.g. On/Off).

--- a/draft-packages/guidance-block/KaizenDraft/GuidanceBlock/README.mdx
+++ b/draft-packages/guidance-block/KaizenDraft/GuidanceBlock/README.mdx
@@ -3,6 +3,7 @@ title: Guidance Block
 navTitle: Guidance Block
 summaryParagraph: A Guidance Block provides a familiar layout that is visually prominent to draw attention to related content and encourage people to take an action. It guides people to new actions they haven't done before or connects them to relevant content and action they can take on another page.
 tags: ["Callout", "Callout card", "Media card", "Promos", "Campaign", "Notice", "Notification"]
+githubLabels: ["component:guidance-block"]
 needToKnow:
 - Use a Guidance Block to encourage action on another page.
 health:

--- a/draft-packages/hero-card/KaizenDraft/HeroCard/README.mdx
+++ b/draft-packages/hero-card/KaizenDraft/HeroCard/README.mdx
@@ -3,6 +3,7 @@ title: Hero Card
 navTitle: Hero Card
 summaryParagraph: Hero Cards are a large structural component for organizing primary content. They are used to create visual interest and draw attention.
 tags: ["Panel", "Card", "Container", "Box", "Table"]
+githubLabels: ["component:hero-card"]
 needToKnow:
 - The badge contains a number, ideally 1 character, showing a micro bit of information such as a step.
 - For the image, use a graphic illustration that supports what's going on in the rest of the card.

--- a/draft-packages/likert-scale-legacy/docs/README.mdx
+++ b/draft-packages/likert-scale-legacy/docs/README.mdx
@@ -3,6 +3,7 @@ title: Likert Scale Legacy
 navTitle: Likert Scale Legacy
 summaryParagraph: Likert scale radio buttons let people select one option in a Likert scale ranging from strongly disagree to strongly agree.
 tags: ["Likert", "Rating scale", "Scale"]
+githubLabels: ["component:likert-scale"]
 needToKnow:
 - This was copied over from murmur's RatingScale component under `ca-capture`.
 - When in doubt, talk to a people scientist.

--- a/draft-packages/loading-placeholder/KaizenDraft/LoadingPlaceholder/README.mdx
+++ b/draft-packages/loading-placeholder/KaizenDraft/LoadingPlaceholder/README.mdx
@@ -3,6 +3,7 @@ title: Loading Placeholder
 navTitle: Loading Placeholder
 summaryParagraph: A single loading placeholder element used in a loading skeleton to visually communicate that piece of content.
 tags: ["Skeleton", "Stencil", "Placeholder UI"]
+githubLabels: ["component:loading"]
 needToKnow:
   - "Only use loading placeholders with loading skeletons."
 demoStoryId: components-loading-placeholder--default-multiple-kaizen-site-demo

--- a/draft-packages/menu/KaizenDraft/Menu/README.mdx
+++ b/draft-packages/menu/KaizenDraft/Menu/README.mdx
@@ -3,6 +3,7 @@ title: Menu
 navTitle: Menu
 summaryParagraph: A menu contains links to places or button actions. It does NOT show a selected item at all and the menu button text never changes.
 tags: ["Menu list", "Context menu", "Menubar"]
+githubLabels: ["component:menu"]
 needToKnow:
 - If a menu dropdown contains a mix of links and buttons, separate them with a content divider with links at the top and buttons at the bottom.
 demoStoryId: components-menu--label-and-icon

--- a/draft-packages/modal/KaizenDraft/Modal/README.mdx
+++ b/draft-packages/modal/KaizenDraft/Modal/README.mdx
@@ -3,6 +3,7 @@ title: "Modal"
 navTitle: "Modal"
 summaryParagraph: A modal shows additional content in a layer above the page with a backdrop overlay covering the page behind. Use sparingly.
 tags: ["Modal window", "Dialog", "Pop up", "Alert", "Lightbox", "Overlay"]
+githubLabels: ["component:modal"]
 needToKnow:
 - "Modals need a trigger to open like a button."
 - "Modals need an overlay behind them and over the page."

--- a/draft-packages/page-layout/README.mdx
+++ b/draft-packages/page-layout/README.mdx
@@ -15,6 +15,8 @@ health:
   responsive: true
   internationalized: true
   accessible: true
+githubLabels: ["component:page-layout"]
+demoStoryId: Content-react--default
 ---
 
 import WhenToUseAndWhenNotToUse from "docs-components/WhenToUseAndWhenNotToUse"

--- a/draft-packages/page-layout/README.mdx
+++ b/draft-packages/page-layout/README.mdx
@@ -16,7 +16,6 @@ health:
   internationalized: true
   accessible: true
 githubLabels: ["component:page-layout"]
-demoStoryId: Content-react--default
 ---
 
 import WhenToUseAndWhenNotToUse from "docs-components/WhenToUseAndWhenNotToUse"

--- a/draft-packages/popover/KaizenDraft/Popover/README.mdx
+++ b/draft-packages/popover/KaizenDraft/Popover/README.mdx
@@ -3,6 +3,7 @@ title: Popover
 navTitle: Popover
 summaryParagraph: A popover displays rich content in a non-modal dialog to describe or add additional information when users hover over, focus on, or click an interactive element. User can interact with popover content, including selecting text or clicking links. Use sparingly.
 tags: ["Tooltip", "Data viz tooltip", "Coach mark"]
+githubLabels: ["component:popover"]
 needToKnow:
 - A popover contains rich content, such as headings, links, and data.
 - Unlike a tooltip, a user can interact with popover content.

--- a/draft-packages/select/KaizenDraft/Select/README.mdx
+++ b/draft-packages/select/KaizenDraft/Select/README.mdx
@@ -3,6 +3,7 @@ title: Select
 navTitle: Select
 summaryParagraph: A select lets you choose options from an option menu. A single-select lets you choose one option while a multi-select lets you choose multiple options.
 tags: ["Select", "Select menu", "Select dropdown", "Dropdown", "Select input"]
+githubLabels: ["component:select"]
 needToKnow:
 - Use for 4+ options when you need to conserve space and provide a pre-selected good default. There are single- and multi-select variants.
 demoStoryId: components-select--single

--- a/draft-packages/table/KaizenDraft/Table/README.mdx
+++ b/draft-packages/table/KaizenDraft/Table/README.mdx
@@ -3,6 +3,7 @@ title: Table
 navTitle: Table
 summaryParagraph: A table displays rows of data, including all data in a set, making it efficient to look up values.
 tags: ["Tabular data", "data table", "Values", "Resource list"]
+githubLabels: ["component:table"]
 needToKnow:
 - All tables have headers, rows, and columns.
 - Don’t use a table when you can use a data visualization.

--- a/draft-packages/tag/KaizenDraft/Tag/README.mdx
+++ b/draft-packages/tag/KaizenDraft/Tag/README.mdx
@@ -4,6 +4,7 @@ navTitle: Tag
 summaryParagraph: |
   Tags help users quickly recognize important information about items that organize and categorize them. They visually label items with small amounts of information or the item’s status, usually with keywords that help organize and categorize the items.
 tags: ['Badge', 'Pill', 'Chip', 'Label', 'Lozenge', 'Input tag']
+githubLabels: ["component:tag"]
 needToKnow:
   - Tags help categorize and organize.
   - Use sentiment labels only for sentiment or other employee feedback data.
@@ -84,6 +85,7 @@ import WhenNotToUse from "docs-components/WhenNotToUse"
 ## External links
 
 Here are some examples of existing design system tags:
+githubLabels: ["component:*"]
 
 - [Ant Design: tag](https://ant.design/components/tag/).
 - [Polaris: tag](https://polaris.shopify.com/components/forms/tag#navigation).

--- a/draft-packages/tag/KaizenDraft/Tag/README.mdx
+++ b/draft-packages/tag/KaizenDraft/Tag/README.mdx
@@ -85,7 +85,6 @@ import WhenNotToUse from "docs-components/WhenNotToUse"
 ## External links
 
 Here are some examples of existing design system tags:
-githubLabels: ["component:*"]
 
 - [Ant Design: tag](https://ant.design/components/tag/).
 - [Polaris: tag](https://polaris.shopify.com/components/forms/tag#navigation).

--- a/draft-packages/tooltip/KaizenDraft/Tooltip/README.mdx
+++ b/draft-packages/tooltip/KaizenDraft/Tooltip/README.mdx
@@ -3,6 +3,7 @@ title: Tooltip
 navTitle: Tooltip
 summaryParagraph: Tooltips are floating labels to describe or add additional information when users hover over, focus on, or click an interactive element. Use sparingly.
 tags: ["Popover", "Data viz tooltip"]
+githubLabels: ["component:tooltip"]
 needToKnow:
 - Tooltips are used to provide additional information when space is tight.
 - Tooltips should be concise but can be rendered with one or more lines of text.

--- a/draft-packages/well/README.mdx
+++ b/draft-packages/well/README.mdx
@@ -3,6 +3,7 @@ title: "Well"
 navTitle: "Well"
 summaryParagraph: Wells are used as a visual container around secondary content.
 tags: ["Placeholder", "Content area", "Frame", "Card", "Group", "Box", "Container"]
+githubLabels: ["component:well"]
 needToKnow:
 - "For primary content, use a Card instead."
 - "Usually, wells are used in other components, such as Empty States and drag and drop file upload, instead of independently."

--- a/packages/component-library/components/Dropdown/README.mdx
+++ b/packages/component-library/components/Dropdown/README.mdx
@@ -3,6 +3,7 @@ title: Dropdown
 navTitle: Dropdown
 summaryParagraph: A dropdown is the bit that drops down, and contains links or actions, NOT selected values.
 tags: ["Select menu", "Select dropdown", "Multi-select", "Select input"]
+githubLabels: ["component:dropdown"]
 needToKnow:
 ---
 

--- a/packages/component-library/components/Icon/README.mdx
+++ b/packages/component-library/components/Icon/README.mdx
@@ -6,6 +6,7 @@ needToKnow:
 - "This component shows a single icon that can be meaningful or presentational."
 - "To control the icon's color, set the color property on the icon's parent element."
 demoStoryId: components-icon--meaningful-kaizen-site-demo
+githubLabels: ["component:icon"]
 health:
   designed: true
   documented: true

--- a/packages/generator/generators/draft/templates/README.mdx
+++ b/packages/generator/generators/draft/templates/README.mdx
@@ -3,6 +3,7 @@ title: "<%= componentName %>"
 navTitle: "<%= componentName %>"
 summaryParagraph: <%= componentName %> lets the user...
 tags: ["Common alternative name", "Another example"]
+githubLabels: ["component:*"]
 demoStoryId:  <%= componentName %>-react--default-kaizen-site-demo
 ---
 

--- a/site/docs/components/autocomplete.mdx
+++ b/site/docs/components/autocomplete.mdx
@@ -3,6 +3,7 @@ title: Autocomplete
 navTitle: Autocomplete (not built)
 summaryParagraph: Autocomplete automatically completes typed user input with matching results from a larger data set. Autosuggest breaks beyond the input provided to suggest alternative, relevant answers.
 tags: ["Autosuggest", "Live filter", "Filters", "Search", "Top bar", "Text input"]
+githubLabels: ["component:autocomplete"]
 needToKnow:
 - "Search and autocomplete are separated into distinct components, because search may be used in a way that doesn't show autocompleted results."
 - 'Unlike a Select (single- or multi-) that lets you select options from an options menu, the Autocomplete component has other behavior beyond choosing an option as the value for a setting, such as linking to other content.'

--- a/site/docs/components/badge.mdx
+++ b/site/docs/components/badge.mdx
@@ -3,6 +3,7 @@ title: Badge
 navTitle: Badge
 summaryParagraph: Badges show the count of some adjacent data. A dot badge notifies the user that something is new or updated without showing a count.
 tags: ["Tag", "Chip", "Label", "Pill", "Lozenge"]
+githubLabels: ["component:badge"]
 needToKnow:
 - For numerical counts, use a badge.
 - Use a “pop” animation style when badge numbers increase.

--- a/site/docs/components/button-group.mdx
+++ b/site/docs/components/button-group.mdx
@@ -3,6 +3,7 @@ title: Button Group
 navTitle: Button Group (not built)
 summaryParagraph: Button Groups contain buttons that perform related actions.
 tags: ["Toggle Buttons", "Radio Button Groups", "Switchers"]
+githubLabels: ["component:button"]
 needToKnow:
 - Button Groups contain buttons that perform related actions.
 - Default button groups contain connected default buttons that immediately perform actions.

--- a/site/docs/components/card.mdx
+++ b/site/docs/components/card.mdx
@@ -3,6 +3,7 @@ title: "Card"
 navTitle: "Card"
 summaryParagraph: Cards are a structural component to contain primary content.
 tags: ["Wells", "Panels", "Slats", "Rows", "List Rows", "Tiles", "Container", "Content area", "Box", "Rectangle"]
+githubLabels: ["component:card"]
 needToKnow:
 - Meaningful content—such as data, images, or paragraphs (but not headings)—sit on cards.
 headerImage: card

--- a/site/docs/components/commentary.mdx
+++ b/site/docs/components/commentary.mdx
@@ -3,6 +3,9 @@ title: Commentary
 navTitle: Commentary
 summaryParagraph: A user-created note that provides additional context to shared information.
 tags: ["Annotation", "Banner", "Note", "Communications", "Memo", "Monologue", "Context", "Commentaries", "Commentary", "Message", "Summary"]
+githubLabels: ["component:commentary"]
+demoStoryId:  <%= componentName %>-react--default-kaizen-site-demo
+
 needToKnow:
 - Mackenzie hesitates about auto-sharing reports that do not contain context for their audience.  
 - A commentary is used to communicate additional context. It is often a one-way monologue / memo intended for a shared audience.

--- a/site/docs/components/date-picker.mdx
+++ b/site/docs/components/date-picker.mdx
@@ -3,6 +3,7 @@ title: "Date Picker"
 navTitle: "Date Picker (not built)"
 summaryParagraph: A Date Picker lets users select a date or range of dates. It uses a text field and a visual calendar in a popover.
 tags: ["Calendar", "Time"]
+githubLabels: ["component:date-picker"]
 needToKnow:
 - Date Pickers might include a single date or a date range.
 - Date Pickers often require validation for the user's input.

--- a/site/docs/components/divider.mdx
+++ b/site/docs/components/divider.mdx
@@ -3,7 +3,8 @@ title: "Divider"
 navTitle: "Divider"
 summaryParagraph: Dividers are thin lines that group content in lists and layouts, or separate blocks of content.
 tags: ["Horizontal rules", "HR", "Lines", "Stroke"]
-demoStoryId: components-divider--default-story
+githubLabels: ["component:divider"]
+demoStoryId: divider-react--default-story
 needToKnow: 
 - Content dividers are used to separate content within a card, table, or any white content area.
 - Canvas dividers are used on the canvas (not cards) to separate large blocks of content.

--- a/site/docs/components/drawer.mdx
+++ b/site/docs/components/drawer.mdx
@@ -3,6 +3,7 @@ title: Drawer
 navTitle: Drawer
 summaryParagraph: A drawer is a temporary workspace that allows users to complete tasks without navigating to a new page.
 tags: ["Modal", "Modal window", "Slide-out modal", "Menu", "Compartment", "Dossier", "Overlay", "Lightbox"]
+githubLabels: ["component:drawer"]
 needToKnow:
 - Drawers come in two sizes, Small (375px max-width) and Medium (600px max-width). Choose the right one for your needs. The horizontal width of content should always fit the drawer. Users should never be able to scroll horizontally within a drawer. 
 - Drawers can have overlays or can appear in parallel with page content. An overlay drawer is useful when you want to focus the user on a specific task. A parallel drawer can provide additional context or information during a task. 

--- a/site/docs/components/filter-menu.mdx
+++ b/site/docs/components/filter-menu.mdx
@@ -3,6 +3,7 @@ title: Filter Menu
 navTitle: Filter Menu
 summaryParagraph: A filter drawer contains filters. It controls filtering of an entire page.
 tags: ["Filter menu", "Filter drawer", "Filter", "Filterable list"]
+githubLabels: ["component:filter-menu"]
 needToKnow:
 - Use rows or columns to clearly define groups of filter components.
 demoStoryId: components-filter-menu--default-story

--- a/site/docs/components/global-notification.mdx
+++ b/site/docs/components/global-notification.mdx
@@ -3,6 +3,7 @@ title: Global Notification
 navTitle: Global Notification
 summaryParagraph: A global notification is a message object used for system-level notifications that inform the user about system status such as logging in and background processes like data imports.
 tags: ["Banner", "Confirmation", "Acknowledgment", "Message", "Alert"]
+githubLabels: ["component:global-notification"]
 needToKnow:
 - A Global notification is always positioned at the top of the screen (above the Navigation Bar) and stretches the full width of the viewport.
 demoStoryId: components-notification-global-notification--positive-kaizen-site-demo

--- a/site/docs/components/icon-button.mdx
+++ b/site/docs/components/icon-button.mdx
@@ -4,6 +4,7 @@ navTitle: Icon Button
 summaryParagraph: |
   Icon buttons are buttons without visible text labels by default.
 tags: ['Breadcrumb button', 'Button', 'Icon']
+githubLabels: ["component:button", "component:icon-button"]
 needToKnow:
   - Default icon buttons perform actions using action icons without labels.
   - Use a Primary icon button when it's the most important action to take.

--- a/site/docs/components/illustration.mdx
+++ b/site/docs/components/illustration.mdx
@@ -3,6 +3,7 @@ title: Illustration
 navTitle: Illustration
 summaryParagraph: An illustration communicates and expresses our personality through visuals.
 tags: ["Illustration", "Hero illustration", "Spot illustration", "Imagery", "Graphics"]
+githubLabels: ["component:illustration"]
 needToKnow:
 - "Scene illustrations tell a rich story to set the scene for users and let them know what's possible."
 - "Spot illustrations are simple, informational visuals that assist users in their task."

--- a/site/docs/components/infinite-scroll.mdx
+++ b/site/docs/components/infinite-scroll.mdx
@@ -3,6 +3,7 @@ title: Infinite Scroll with a “View more” button
 navTitle: Infinite Scroll (not built)
 summaryParagraph: Infinite Scroll separates large bodies of content into separate sections. You can access each extra section via a "View more" button.
 tags: ["Infinite scrolling", "Continuous scroll", "Load more", "Async loading"]
+githubLabels: ["component:infinite-scroll"]
 needToKnow:
   - Perform usability testing to decide where to split content into pages (that is, how much content to show per page).
   - This has been designed but not built.

--- a/site/docs/components/inline-notification.mdx
+++ b/site/docs/components/inline-notification.mdx
@@ -3,6 +3,7 @@ title: Inline Notification
 navTitle: Inline Notification
 summaryParagraph: An inline notification is a message object that presents timely information within content areas as close as possible to the thing that it’s about. 
 tags: ["Banner", "Confirmation", "Acknowledgement", "Message", "Alert"]
+githubLabels: ["component:notification"]
 needToKnow: 
 - An inline notification is a message object that presents timely information within content areas as close as possible to the thing that it’s about.
 demoStoryId: components-notification-inline-notification--dismissible-positive-kaizen-site-demo

--- a/site/docs/components/loading-skeleton.mdx
+++ b/site/docs/components/loading-skeleton.mdx
@@ -3,6 +3,7 @@ title: Loading Skeleton
 navTitle: Loading Skeleton (not built)
 summaryParagraph: A collection of loading placeholders that display a non-interactive preview of the app’s actual UI to visually communicate that content is in the process of loading.
 tags: ["Skeleton", "Stencil", "Loading Placeholders", "Placeholder UI"]
+githubLabels: ["component:loading-skeleton"]
 needToKnow:
 - "Give people an idea of what’s about to come and what’s happening (it's currently loading) when a page full of content/data takes more than 300ms to load."
 health:

--- a/site/docs/components/loading-spinner.mdx
+++ b/site/docs/components/loading-spinner.mdx
@@ -3,6 +3,7 @@ title: Loading Spinner
 navTitle: Loading Spinner
 summaryParagraph: An animated element that indicates loading is in process and where it will appear when loading data is slow.
 tags: ["Spinner", "Loader", "Progress indicators", "Circular indicators", "Indeterminate indicators"]
+githubLabels: ["component:loading-spinner"]
 needToKnow:
 - "Center the loading spinner in the available space."
 - "Avoid showing multiple Loading Spinners on a single page."

--- a/site/docs/components/progress-bar.mdx
+++ b/site/docs/components/progress-bar.mdx
@@ -3,6 +3,7 @@ title: Progress Bar
 navTitle: Progress Bar (not built)
 summaryParagraph: Progress bars show continuous progress through a process, such as a percentage value. They show how much progress is complete and how much remains.
 tags: ["Progress", "Progress bar", "Progress indicator", "Progress tracker", "Loading bar", "Loader"]
+githubLabels: ["component:progress-bar"]
 needToKnow:
 - Give people feedback about progress.
 - A static progress bar shows current progress through a process that will not progress without user interaction.

--- a/site/docs/components/progress-stepper.mdx
+++ b/site/docs/components/progress-stepper.mdx
@@ -3,6 +3,7 @@ title: Progress Stepper
 navTitle: Progress Stepper
 summaryParagraph: Progress steppers show discrete progress through a process, such as numbers 1–4. They show how much progress is complete and how much remains, divided into equal steps.
 tags: ["Progress bar", "Progress tracker", "Progress indicator"]
+githubLabels: ["component:progress-stepper"]
 needToKnow:
 - Progress steppers may be vertical or horizontal.
 - Progress steppers may be gated or ungated.

--- a/site/docs/components/rich-text-editor.mdx
+++ b/site/docs/components/rich-text-editor.mdx
@@ -3,6 +3,7 @@ title: Rich Text Editor
 navTitle: Rich Text Editor
 summaryParagraph: A text area with additional capabilities for users to format the input text.
 tags: ["WYSIWYG editor", "HTML editor"]
+githubLabels: ["component:rich-text-editor"]
 needToKnow:
 - Used to create & publish content for other users, where control over the look & feel of the content is important (e.g. survey communications)
  or users need to structure text to make it more readable (e.g. performance reviews & manager 1:1s).

--- a/site/docs/components/search-field.mdx
+++ b/site/docs/components/search-field.mdx
@@ -3,6 +3,7 @@ title: Search Field
 navTitle: Search Field
 summaryParagraph: Search lets users quickly find relevant content. A search field allows a user to type a word or phrase to filter a large amount of data down to a known piece of content or to a narrower list of relevant content without navigation.
 tags: ["Search", "Searchbox", "Forms", "Text input", "Top bar", "Filters", "Autocomplete", "Autosuggest", "Live filter"]
+githubLabels: ["component:search", "component:form"]
 needToKnow:
 - "All form elements including search must have a label, whether it's visually displayed or hidden."
 - 'We separate Autocomplete into a separate component.'

--- a/site/docs/components/slider.mdx
+++ b/site/docs/components/slider.mdx
@@ -3,6 +3,7 @@ title: Slider
 navTitle: Slider
 summaryParagraph: Sliders are an input that allows users to make an imprecise selection from a range of values.
 tags: ["Range", "Range input", "Range slider"]
+githubLabels: ["component:slider"]
 needToKnow:
 - Avoid sliders when choosing a precise value is important.
 health:

--- a/site/docs/components/split-button.mdx
+++ b/site/docs/components/split-button.mdx
@@ -3,6 +3,7 @@ title: Split Button
 navTitle: Split Button
 summaryParagraph: Split buttons let you immediately perform an action or choose additional options from a dropdown.
 tags: ["Button with dropdown", "Dropdown", "Segmented button"]
+githubLabels: ["component:button", "component:split-button"]
 needToKnow:
 - Avoid split buttons where separated buttons and icon buttons will do.
 - Only include related actions in the dropdown.

--- a/site/docs/components/tabs.mdx
+++ b/site/docs/components/tabs.mdx
@@ -3,6 +3,7 @@ title: Tabs
 navTitle: Tabs
 summaryParagraph: Tabs organize content by grouping similar information into containers that are shown and hidden through navigation.
 tags: ["Tab list", "Tab group", "Tab panel", "Content tabs", "Nav bar", "Vertical tabs", "Horizontal tabs"]
+githubLabels: ["component:tabs"]
 needToKnow:
 - Navigation tabs are always used for global navigation at the top of the page or inside an offscreen menu on small screens.
 - Content tabs are used for chunking content, allowing movement between content within a single page.

--- a/site/docs/components/tile-grid.mdx
+++ b/site/docs/components/tile-grid.mdx
@@ -3,6 +3,7 @@ title: Tile Grid
 navTitle: Tile Grid
 summaryParagraph: A wrapper component that makes it easy to lay out Tiles in a way that is responsive.
 tags: ["Tile", "Grid item"]
+githubLabels: ["component:tile-grid"]
 needToKnow:
 - Only takes Tile component as children
 - Max width is 1392px

--- a/site/docs/components/tile.mdx
+++ b/site/docs/components/tile.mdx
@@ -3,6 +3,7 @@ title: Tile
 navTitle: Tile
 summaryParagraph: A visually interesting item in a list consisting of a card, visual, title metadata, and call to action.
 tags: ["Card", "Grid item", "Featured item"]
+githubLabels: ["component:tile"]
 needToKnow:
 - Tiles draw attention to featured items.
 - All tiles have a title.

--- a/site/docs/components/toast-notification.mdx
+++ b/site/docs/components/toast-notification.mdx
@@ -3,6 +3,7 @@ title: Toast Notification
 navTitle: Toast Notification
 summaryParagraph: A toast notification is a message object that presents timely information, including confirmation of actions, alerts, and errors.
 tags: ["Toasts", "Snackbars", "Pop-up notifications", "Drawer notification", "Banner", "Confirmation", "Acknowledgement", "Message", "Alert"]
+githubLabels: ["component:notification"]
 needToKnow:
 - Use toast notifications immediately after a specific event such as a user action that does not relate to an object on the page.
 demoStoryId: components-notification-toast-notification--positive-kaizen-site-demo


### PR DESCRIPTION
# Objective
- Adding labels to each component to tie our open issues that are labelled to our gatsby docs

# Motivation and Context
- This is the second part of [this PR](https://github.com/cultureamp/kaizen-design-system/pull/1850) which setup the fetching and displaying. This now just adds the labels which Ally did (and I did another once over and then added all those added into Github)

# Screenshots (if appropriate)

See this working below and linked in this issue: https://github.com/cultureamp/kaizen-design-system/issues/1857

<img width="936" alt="Screen Shot 2021-08-19 at 10 36 33 am" src="https://user-images.githubusercontent.com/18339250/129989555-2c566ca1-6ff9-4830-998b-abc4036f8d5a.png">

Here's a screenshot of some of the new ones (50 component labels in total now)
<img width="1382" alt="Screen Shot 2021-08-19 at 10 41 54 am" src="https://user-images.githubusercontent.com/18339250/129989919-0ec348fe-9858-4c16-bddb-39b9395ee38a.png">

