### PR TITLE
Add a forceUpdate method to usePopper in Popover

### DIFF
--- a/draft-packages/popover/KaizenDraft/Popover/Popover.tsx
+++ b/draft-packages/popover/KaizenDraft/Popover/Popover.tsx
@@ -38,6 +38,7 @@ export type PopoverProps = {
    Please avoid using a custom icon unless you have a very good reason to do so. **/
   readonly customIcon?: React.SVGAttributes<SVGSymbolElement>
   readonly referenceElement: HTMLElement | null
+  readonly isForceUpdate?: boolean
 }
 
 type PopoverModernType = React.FunctionComponent<PopoverProps>
@@ -58,12 +59,13 @@ export const Popover: PopoverModernType = ({
   singleLine = false,
   customIcon,
   referenceElement,
+  isForceUpdate,
 }: PopoverProps) => {
   const [popperElement, setPopperElement] = useState<HTMLDivElement | null>(
     null
   )
   const [arrowElement, setArrowElement] = useState<HTMLDivElement | null>(null)
-  const { styles: popperStyles, attributes } = usePopper(
+  const { styles: popperStyles, attributes, forceUpdate } = usePopper(
     referenceElement,
     popperElement,
     {
@@ -95,6 +97,10 @@ export const Popover: PopoverModernType = ({
       placement,
     }
   )
+
+  if (isForceUpdate && forceUpdate) {
+    forceUpdate()
+  }
 
   return (
     <div
@@ -170,7 +176,8 @@ type PopoverPropsWithoutRef = Omit<PopoverProps, "referenceElement">
  */
 export const usePopover = (): [
   (element: HTMLElement | null) => void,
-  React.FunctionComponent<PopoverPropsWithoutRef>
+  React.FunctionComponent<PopoverPropsWithoutRef>,
+  HTMLElement | null
 ] => {
   const [referenceElement, setReferenceElement] = useState<HTMLElement | null>(
     null
@@ -188,5 +195,5 @@ export const usePopover = (): [
     [referenceElement]
   )
 
-  return [setReferenceElement, PopoverWithRef]
+  return [setReferenceElement, PopoverWithRef, referenceElement]
 }

--- a/draft-packages/popover/KaizenDraft/Popover/Popover.tsx
+++ b/draft-packages/popover/KaizenDraft/Popover/Popover.tsx
@@ -100,15 +100,10 @@ export const Popover: PopoverModernType = ({
   )
 
   useEffect(() => {
-    console.log("Popover useEffect triggered because isForceUpdate changed")
-    if (isForceUpdate && forceUpdate) {
+    if (typeof isForceUpdate !== "undefined" && forceUpdate) {
       forceUpdate()
     }
   }, [isForceUpdate])
-
-  // setTimeout(() => {
-  //   forceUpdate && forceUpdate()
-  // }, 6000)
 
   return (
     <div

--- a/draft-packages/popover/KaizenDraft/Popover/Popover.tsx
+++ b/draft-packages/popover/KaizenDraft/Popover/Popover.tsx
@@ -3,7 +3,8 @@ import { Icon } from "@kaizen/component-library"
 import closeIcon from "@kaizen/component-library/icons/close.icon.svg"
 
 import classNames from "classnames"
-import React, { useMemo, useState } from "react"
+import React, { useMemo, useState, useEffect } from "react"
+
 import styles from "./styles.scss"
 import { Size, Variant } from "./types"
 import {
@@ -98,9 +99,16 @@ export const Popover: PopoverModernType = ({
     }
   )
 
-  if (isForceUpdate && forceUpdate) {
-    forceUpdate()
-  }
+  useEffect(() => {
+    console.log("Popover useEffect triggered because isForceUpdate changed")
+    if (isForceUpdate && forceUpdate) {
+      forceUpdate()
+    }
+  }, [isForceUpdate])
+
+  // setTimeout(() => {
+  //   forceUpdate && forceUpdate()
+  // }, 6000)
 
   return (
     <div

--- a/draft-packages/popover/docs/Popover.stories.tsx
+++ b/draft-packages/popover/docs/Popover.stories.tsx
@@ -254,6 +254,7 @@ PlacementStart.storyName = "Placement start"
 
 export const PlacementEnd = () => {
   const [referenceElementRef, Popover] = usePopover()
+
   return (
     <Container>
       <div style={{ marginTop: "1.5rem" }}>
@@ -268,3 +269,47 @@ export const PlacementEnd = () => {
 }
 
 PlacementEnd.storyName = "Placement end"
+
+export const MoveableTargetElement = () => {
+  const [setReferenceElement, PopoverWithRef, referenceElement] = usePopover()
+  let paddingOnButton = "2rem"
+  setTimeout(() => {
+    paddingOnButton = "5rem"
+  }, 5000)
+
+  // detect changes in the button component
+  // if the button component changes, then trigger update on the popover
+  // via setReferenceElement
+  const [isForceUpdate, setForceUpdate] = React.useState(false)
+
+  // Set a resize observer on the reference element.
+  const referenceElementObserver = React.useMemo(
+    () =>
+      new ResizeObserver(entries => {
+        setForceUpdate(true)
+        console.log("Resize detected")
+      }),
+    []
+  )
+  if (referenceElement) {
+    referenceElementObserver.observe(referenceElement)
+  }
+
+  return (
+    <div>
+      <button
+        id="ally-was-here"
+        ref={setReferenceElement}
+        style={{ backgroundColor: "red", padding: paddingOnButton }}
+      >
+        Click me!
+      </button>
+      <PopoverWithRef heading="Placement end" placement="bottom-start">
+        PopoverWithRef body that explains something useful, is optional, and not
+        critical to completing a task.
+      </PopoverWithRef>
+    </div>
+  )
+}
+
+MoveableTargetElement.storyName = "Moveable Target Element"

--- a/draft-packages/popover/docs/Popover.stories.tsx
+++ b/draft-packages/popover/docs/Popover.stories.tsx
@@ -272,14 +272,12 @@ export const PlacementEnd = () => {
 PlacementEnd.storyName = "Placement end"
 
 const useSize = target => {
-  const [size, setSize] = React.useState()
+  const [size, setSize] = React.useState<DOMRect>()
 
   React.useLayoutEffect(() => {
-    console.log("happening")
     setSize(target.current.getBoundingClientRect())
   }, [target])
 
-  // Where the magic happens
   useResizeObserver(target, entry => setSize(entry.contentRect))
   return size
 }
@@ -300,10 +298,7 @@ export const MoveableTargetElement = () => {
   const [isForceUpdate, setForceUpdate] = React.useState(false)
 
   React.useEffect(() => {
-    console.log(
-      "MoveableTargetElement useEffect triggered because the targetSize changed"
-    )
-    setForceUpdate(true)
+    setForceUpdate(!isForceUpdate)
   }, [targetSize])
 
   return (

--- a/draft-packages/popover/docs/Popover.stories.tsx
+++ b/draft-packages/popover/docs/Popover.stories.tsx
@@ -5,6 +5,7 @@ import {
 } from "@kaizen/draft-popover"
 import * as React from "react"
 import guidanceIcon from "@kaizen/component-library/icons/guidance.icon.svg"
+import useResizeObserver from "@react-hook/resize-observer"
 import { withDesign } from "storybook-addon-designs"
 import { figmaEmbed } from "../../../storybook/helpers"
 import { CATEGORIES } from "../../../storybook/constants"
@@ -270,9 +271,24 @@ export const PlacementEnd = () => {
 
 PlacementEnd.storyName = "Placement end"
 
+const useSize = target => {
+  const [size, setSize] = React.useState()
+
+  React.useLayoutEffect(() => {
+    console.log("happening")
+    setSize(target.current.getBoundingClientRect())
+  }, [target])
+
+  // Where the magic happens
+  useResizeObserver(target, entry => setSize(entry.contentRect))
+  return size
+}
+
 export const MoveableTargetElement = () => {
   const [setReferenceElement, PopoverWithRef, referenceElement] = usePopover()
   const [paddingAmount, setPaddingAmount] = React.useState("2rem")
+  const target = React.useRef(null)
+  const targetSize = useSize(target)
 
   setTimeout(() => {
     setPaddingAmount("5rem")
@@ -283,18 +299,15 @@ export const MoveableTargetElement = () => {
   // via setReferenceElement
   const [isForceUpdate, setForceUpdate] = React.useState(false)
 
-  // Set a resize observer on the reference element.
-  const referenceElementObserver = new ResizeObserver(entries => {
+  React.useEffect(() => {
+    console.log(
+      "MoveableTargetElement useEffect triggered because the targetSize changed"
+    )
     setForceUpdate(true)
-    console.log("Resize detected")
-  })
-
-  if (referenceElement) {
-    referenceElementObserver.observe(referenceElement)
-  }
+  }, [targetSize])
 
   return (
-    <div>
+    <div ref={target}>
       <button
         id="ally-was-here"
         ref={setReferenceElement}
@@ -302,10 +315,20 @@ export const MoveableTargetElement = () => {
       >
         Click me!
       </button>
-      <PopoverWithRef heading="Placement end" placement="bottom-start">
+      <PopoverWithRef
+        heading="Placement end"
+        placement="bottom-start"
+        isForceUpdate={isForceUpdate}
+      >
         PopoverWithRef body that explains something useful, is optional, and not
         critical to completing a task.
       </PopoverWithRef>
+      {targetSize &&
+        JSON.stringify(
+          { width: targetSize.width, height: targetSize.height },
+          null,
+          2
+        )}
     </div>
   )
 }

--- a/draft-packages/popover/docs/Popover.stories.tsx
+++ b/draft-packages/popover/docs/Popover.stories.tsx
@@ -272,9 +272,10 @@ PlacementEnd.storyName = "Placement end"
 
 export const MoveableTargetElement = () => {
   const [setReferenceElement, PopoverWithRef, referenceElement] = usePopover()
-  let paddingOnButton = "2rem"
+  const [paddingAmount, setPaddingAmount] = React.useState("2rem")
+
   setTimeout(() => {
-    paddingOnButton = "5rem"
+    setPaddingAmount("5rem")
   }, 5000)
 
   // detect changes in the button component
@@ -283,14 +284,11 @@ export const MoveableTargetElement = () => {
   const [isForceUpdate, setForceUpdate] = React.useState(false)
 
   // Set a resize observer on the reference element.
-  const referenceElementObserver = React.useMemo(
-    () =>
-      new ResizeObserver(entries => {
-        setForceUpdate(true)
-        console.log("Resize detected")
-      }),
-    []
-  )
+  const referenceElementObserver = new ResizeObserver(entries => {
+    setForceUpdate(true)
+    console.log("Resize detected")
+  })
+
   if (referenceElement) {
     referenceElementObserver.observe(referenceElement)
   }
@@ -300,7 +298,7 @@ export const MoveableTargetElement = () => {
       <button
         id="ally-was-here"
         ref={setReferenceElement}
-        style={{ backgroundColor: "red", padding: paddingOnButton }}
+        style={{ backgroundColor: "red", padding: paddingAmount }}
       >
         Click me!
       </button>

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "@babel/plugin-proposal-object-rest-spread": "^7.14.7",
     "@babel/preset-react": "^7.14.5",
     "@babel/preset-typescript": "^7.14.5",
+    "@react-hook/resize-observer": "^1.2.2",
     "@storybook/addon-a11y": "^6.3.4",
     "@storybook/addon-essentials": "^6.3.4",
     "@storybook/addon-links": "^6.3.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1836,6 +1836,11 @@
     "@types/yargs" "^15.0.0"
     chalk "^4.0.0"
 
+"@juggle/resize-observer@^3.3.1":
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/@juggle/resize-observer/-/resize-observer-3.3.1.tgz#b50a781709c81e10701004214340f25475a171a0"
+  integrity sha512-zMM9Ds+SawiUkakS7y94Ymqx+S0ORzpG3frZirN3l+UlXUmSUR7hF4wxCVqW+ei94JzV5kt0uXBcoOEAuiydrw==
+
 "@lerna/add@3.21.0":
   version "3.21.0"
   resolved "https://registry.yarnpkg.com/@lerna/add/-/add-3.21.0.tgz#27007bde71cc7b0a2969ab3c2f0ae41578b4577b"
@@ -2811,6 +2816,27 @@
     invariant "^2.2.3"
     prop-types "^15.6.1"
     react-lifecycles-compat "^3.0.4"
+
+"@react-hook/latest@^1.0.2":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@react-hook/latest/-/latest-1.0.3.tgz#c2d1d0b0af8b69ec6e2b3a2412ba0768ac82db80"
+  integrity sha512-dy6duzl+JnAZcDbNTfmaP3xHiKtbXYOaz3G51MGVljh548Y8MWzTr+PHLOfvpypEVW9zwvl+VyKjbWKEVbV1Rg==
+
+"@react-hook/passive-layout-effect@^1.2.0":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@react-hook/passive-layout-effect/-/passive-layout-effect-1.2.1.tgz#c06dac2d011f36d61259aa1c6df4f0d5e28bc55e"
+  integrity sha512-IwEphTD75liO8g+6taS+4oqz+nnroocNfWVHWz7j+N+ZO2vYrc6PV1q7GQhuahL0IOR7JccFTsFKQ/mb6iZWAg==
+
+"@react-hook/resize-observer@^1.2.2":
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/@react-hook/resize-observer/-/resize-observer-1.2.2.tgz#7eaf3151557a68f94fdcfd4666ada9948a45e743"
+  integrity sha512-F7ciucmLrF4vZM78sUpRquvMCSVJwu3ayxapsHKKzTOvixZtcwJZocDBOasQQIbd7DtXzD/sVEJCKJUC0X1MDA==
+  dependencies:
+    "@juggle/resize-observer" "^3.3.1"
+    "@react-hook/latest" "^1.0.2"
+    "@react-hook/passive-layout-effect" "^1.2.0"
+    "@types/raf-schd" "^4.0.0"
+    raf-schd "^4.0.2"
 
 "@samverschueren/stream-to-observable@^0.3.0":
   version "0.3.1"
@@ -4479,6 +4505,11 @@
   version "6.9.7"
   resolved "https://registry.yarnpkg.com/@types/qs/-/qs-6.9.7.tgz#63bb7d067db107cc1e457c303bc25d511febf6cb"
   integrity sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==
+
+"@types/raf-schd@^4.0.0":
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/@types/raf-schd/-/raf-schd-4.0.1.tgz#1f9e03736f277fe9c7b82102bf18570a6ee19f82"
+  integrity sha512-Ha+EnKHFIh9EKW0/XZJPUd3EGDFisEvauaBd4VVCRPKeOqUxNEc9TodiY2Zhk33XCgzJucoFEcaoNcBAPHTQ2A==
 
 "@types/reach__router@^1.3.3", "@types/reach__router@^1.3.7":
   version "1.3.7"
@@ -19127,6 +19158,11 @@ quick-lru@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-4.0.1.tgz#5b8878f113a58217848c6482026c73e1ba57727f"
   integrity sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==
+
+raf-schd@^4.0.2:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/raf-schd/-/raf-schd-4.0.3.tgz#5d6c34ef46f8b2a0e880a8fcdb743efc5bfdbc1a"
+  integrity sha512-tQkJl2GRWh83ui2DiPTJz9wEiMN20syf+5oKfB03yYP7ioZcJwsIK8FjrtLwH1m7C7e+Tt2yYBlrOpdT+dyeIQ==
 
 ramda@^0.21.0:
   version "0.21.0"


### PR DESCRIPTION
# Objective
<!-- Describe what this change achieves, and the details of how it works. -->
This change exposes the `forceUpdate` method of the `usePopper` hook, and adds a `resizeObserver` that detects when a reference element has changed size, and if so, calls the `forceUpdate` method. The resizeObserver is handled by the `useResizeObserver` npm package which ensures only one observer is added instead of one for each Popover

# Motivation and Context
The Popover component can be in the wrong position if the element that triggers it has changed size after the Popover has been opened.
An example of this is when a `Textfield` component is used to display a `Datepicker` in performance ui. If the `Datepicker` has been closed, and an error is being displayed for the `Textfield`, and the user then opens the `Datepicker` again and selects a date, the error will be removed but the `Datepicker` is still displayed in the position it was when the error is shown- there is a large gap between the `Textfield` and the `Datepicker`. This video demonstrates the problem:


https://user-images.githubusercontent.com/1913338/129990913-23db11b2-dbd1-4963-881b-48a1ab4fcd3b.mov


# Screenshots (if appropriate)

# Checklist
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] If this contains visual changes, has it been reviewed by a designer?
- [ ] If this introduces either a new component or a breaking change to an existing component, has it been reviewed by an advocate? (Ask in #prod_design_systems)
- [ ] I have considered likely risks of these changes and got someone else to QA as appropriate
- [ ] I have or will communicate these changes to the front end practice

# Additional Considerations
- Does there need to be right-to-left (RTL) options for localization and internationalization?
- Has the test suite been updated?
- Have you done cross-browser testing for our [supported browsers](https://academy.cultureamp.com/hc/en-us/articles/204539569-Supported-browsers-for-Participants)?
- Have you updated any relevant documentation or left useful comments in the code?
- Have you reviewed Culture Amp's Web Accessibility guide [Current Compliance, Going Forward, Statement and Answers for Customers](https://cultureamp.atlassian.net/wiki/spaces/Prod/pages/428572998/Web+Accessibility)?
- If this contains substantial visual changes, especially far reaching ones, have you unlocked the Chromatic step in the pipeline?
- Have Storybook stories been updated?

**If you're new to Kaizen, please ask #prod_design_systems to set up an onboarding session to get you up to speed.** If you have an urgent PR to merge before that happens, it is safest to ask in #prod_design_systems to have a design system advocate review the PR to catch any issues.
