### PR TITLE
docs: Heart theme on Kaizen site

### DIFF
--- a/site/src/components/Layout.tsx
+++ b/site/src/components/Layout.tsx
@@ -3,10 +3,10 @@
 import classnames from "classnames"
 import * as React from "react"
 import "../styles/global.scss"
+import { useSSRHeartTheme } from "../utils/useSSRHeartTheme"
 import Footer from "./Footer"
 import Head from "./Head"
 import MainNav from "./MainNav"
-
 import styles from "./Layout.scss"
 
 type LayoutProps = {
@@ -27,42 +27,43 @@ const Layout: React.SFC<LayoutProps> = ({
   fullWidthContent = false,
   trimBottomOfCardToContent = false,
   footer,
-}) => (
-  <>
-    <Head pageTitle={pageTitle} />
-    <div className={styles.root}>
-      <div className={styles.navigationBarContainer}>
-        <MainNav currentPath={currentPath} />
+}) =>
+  useSSRHeartTheme(
+    <>
+      <Head pageTitle={pageTitle} />
+      <div className={styles.root}>
+        <div className={styles.navigationBarContainer}>
+          <MainNav currentPath={currentPath} />
+        </div>
+        <div
+          className={classnames({
+            [styles.page]: true,
+            [styles.noBottomPadding]: fullWidthContent,
+            [styles.noPageHeader]: !pageHeader,
+          })}
+        >
+          <main>
+            {pageHeader}
+            {fullWidthContent ? (
+              children
+            ) : (
+              <div
+                className={classnames({
+                  [styles.fullWidthContent]: true,
+                  [styles.contentContainer]: true,
+                  [styles.trimBottomOfCardToContent]: trimBottomOfCardToContent,
+                })}
+              >
+                <div className={styles.content}>{children}</div>
+              </div>
+            )}
+          </main>
+        </div>
+        <footer>
+          <div className={styles.footerContainer}>{footer}</div>
+        </footer>
       </div>
-      <div
-        className={classnames({
-          [styles.page]: true,
-          [styles.noBottomPadding]: fullWidthContent,
-          [styles.noPageHeader]: !pageHeader,
-        })}
-      >
-        <main>
-          {pageHeader}
-          {fullWidthContent ? (
-            children
-          ) : (
-            <div
-              className={classnames({
-                [styles.fullWidthContent]: true,
-                [styles.contentContainer]: true,
-                [styles.trimBottomOfCardToContent]: trimBottomOfCardToContent,
-              })}
-            >
-              <div className={styles.content}>{children}</div>
-            </div>
-          )}
-        </main>
-      </div>
-      <footer>
-        <div className={styles.footerContainer}>{footer}</div>
-      </footer>
-    </div>
-  </>
-)
+    </>
+  )
 
 export default Layout

--- a/site/src/components/PageHeader.scss
+++ b/site/src/components/PageHeader.scss
@@ -6,7 +6,7 @@
 .pageHeader {
   display: grid;
   justify-items: center;
-  background: $color-purple-700;
+  background: $color-purple-600;
   padding: calc(var(--ca-grid) * 3.5) var(--ca-grid);
   color: white;
 

--- a/site/src/utils/useSSRHeartTheme.tsx
+++ b/site/src/utils/useSSRHeartTheme.tsx
@@ -1,0 +1,20 @@
+import React from "react"
+import { heartTheme, ThemeManager, ThemeProvider } from "@kaizen/design-tokens"
+
+/**
+ * Use this hook to enable the Heart theme, and for it to work with server side rendering
+ */
+export function useSSRHeartTheme(
+  wrappedElement: React.ReactElement
+): React.ReactElement {
+  const [themeManager, setThemeManager] = React.useState<ThemeManager>()
+
+  // This effect will only occur when rendering in the browser, and not on the server.
+  // We want this instantiation deferred because ThemeManager accesses the document, which isn't allowed during SSR.
+  React.useEffect(() => {
+    setThemeManager(new ThemeManager(heartTheme))
+  }, [])
+  return themeManager ? (
+    <ThemeProvider themeManager={themeManager}>{wrappedElement}</ThemeProvider>
+  ) : null
+}


### PR DESCRIPTION
Uses a delayed instantiation of ThemeManager by utilising the fact that React.useEffect is only run in the browser, not the server.
Also it was abstracted away within a React hook.

# Checklist
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] If this contains visual changes, has it been reviewed by a designer?
- [ ] If this introduces either a new component or a breaking change to an existing component, has it been reviewed by an advocate? (Ask in #prod_design_systems)
- [ ] I have considered likely risks of these changes and got someone else to QA as appropriate
- [ ] I have or will communicate these changes to the front end practice

# Additional Considerations
- Does there need to be right-to-left (RTL) options for localization and internationalization?
- Has the test suite been updated?
- Have you done cross-browser testing for our [supported browsers](https://academy.cultureamp.com/hc/en-us/articles/204539569-Supported-browsers-for-Participants)?
- Have you updated any relevant documentation or left useful comments in the code?
- Have you reviewed Culture Amp's Web Accessibility guide [Current Compliance, Going Forward, Statement and Answers for Customers](https://cultureamp.atlassian.net/wiki/spaces/Prod/pages/428572998/Web+Accessibility)?
- If this contains substantial visual changes, especially far reaching ones, have you unlocked the Chromatic step in the pipeline?
- Have Storybook stories been updated?

**If you're new to Kaizen, please ask #prod_design_systems to set up an onboarding session to get you up to speed.** If you have an urgent PR to merge before that happens, it is safest to ask in #prod_design_systems to have a design system advocate review the PR to catch any issues.
