### PR TITLE
feat: add github action for closing stale prs

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,17 @@
+name: "Handle stale PRs"
+on:
+  schedule:
+    - cron: "30 7 * * 1-5"
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v4
+        with:
+          only: pulls
+          stale-pr-message: "This PR hasn't seen activity in two months! Should it be merged, closed, or worked on further? If you want to keep it open, post a comment or remove the `stale` label – otherwise this will be closed in a fortnight."
+          close-pr-message: "This PR was closed due to 2 months of inactivity. Feel free to reopen it if still relevant."
+          days-before-pr-stale: 60
+          days-before-pr-close: 14
+          stale-pr-label: stale


### PR DESCRIPTION
# Objective
- To keep on top of our open PRs and to nudge those that may have left them hanging.

# Motivation and Context
- As discussed, the more of these tasks that are automated, the easier it is to manage and spend time helping others contribute to the library. This is just a step for PRs and is _very_ open to what people think about the durations. Once we decide on something, I'll do the same with issues (this may be harder as there could be issues we have that need fixing but no capacity to do so).