### PR TITLE
feat: add ability to have first line underneath the heading

### DIFF
--- a/packages/component-library/components/Notification/InlineNotification.tsx
+++ b/packages/component-library/components/Notification/InlineNotification.tsx
@@ -14,6 +14,7 @@ type Props = {
   onHide?: () => void
   automationId?: string
   noBottomMargin?: boolean
+  forceMultiline?: boolean
 }
 
 const InlineNotification = ({

--- a/packages/component-library/components/Notification/_styles.scss
+++ b/packages/component-library/components/Notification/_styles.scss
@@ -231,6 +231,10 @@ $ca-notification-slide-right: transform $ca-duration-fast ease-out;
     // Fading the higher-contrast text out at, as well as the whole container, makes for a smoother animation.
     transition: $ca-notification-fade-out;
   }
+
+  &%ca-notification---forceMultiline {
+    flex-direction: column;
+  }
 }
 
 %ca-notification__title {

--- a/packages/component-library/components/Notification/components/GenericNotification.module.scss
+++ b/packages/component-library/components/Notification/components/GenericNotification.module.scss
@@ -77,3 +77,7 @@
 .noBottomMargin {
   @extend %ca-notification---noBottomMargin;
 }
+
+.forceMultiline {
+  @extend %ca-notification---forceMultiline;
+}

--- a/packages/component-library/components/Notification/components/GenericNotification.tsx
+++ b/packages/component-library/components/Notification/components/GenericNotification.tsx
@@ -26,6 +26,7 @@ type Props = {
   onHide?: () => void
   automationId?: string
   noBottomMargin?: boolean
+  forceMultiline?: boolean
 }
 
 type State = {
@@ -105,7 +106,7 @@ class GenericNotification extends React.Component<Props, State> {
         <div className={styles.icon}>
           <Icon icon={this.iconType()} role="presentation" inheritSize />
         </div>
-        <div className={styles.textContainer}>
+        <div className={this.textContainerClassName()}>
           {this.props.title && (
             <h6 className={styles.title}>{this.props.title}</h6>
           )}
@@ -128,6 +129,12 @@ class GenericNotification extends React.Component<Props, State> {
         [styles.noBottomMargin]: this.props.noBottomMargin,
       }
     )
+  }
+
+  textContainerClassName(): string {
+    return classnames(styles.textContainer, {
+      [styles.forceMultiline]: this.props.forceMultiline,
+    })
   }
 
   marginTop(): string {

--- a/packages/component-library/stories/InlineNotification.stories.tsx
+++ b/packages/component-library/stories/InlineNotification.stories.tsx
@@ -18,6 +18,17 @@ const multilineText = (
     this can fit into one line of text on an average screen...
   </>
 )
+
+const forceMultilineText = (
+  <>
+    This is a short line which we want to see underneath the notification
+    heading.
+    <ol>
+      <li>Contact support</li>
+      <li>Contact your admin</li>
+    </ol>
+  </>
+)
 const withContentBelow = (Story: React.FunctionComponent) => (
   <>
     <Story />
@@ -136,6 +147,19 @@ export const DismissibleMultiline = () => (
 
 DismissibleMultiline.storyName = "Dismissible, Multiline"
 
+export const DismissibleForcedMultiline = () => (
+  <InlineNotification
+    type="negative"
+    title="Negative"
+    automationId="notification1"
+    forceMultiline
+  >
+    {forceMultilineText}
+  </InlineNotification>
+)
+
+DismissibleForcedMultiline.storyName = "Dismissible, Forced Multiline"
+
 export const DismissibleSlim = () => (
   <InlineNotification
     type="affirmative"
@@ -214,6 +238,20 @@ export const PersistentMultiline = () => (
 )
 
 PersistentMultiline.storyName = "Persistent, Multiline"
+
+export const PersistentForcedMultiline = () => (
+  <InlineNotification
+    type="negative"
+    title="Negative"
+    persistent
+    automationId="notification1"
+    forceMultiline
+  >
+    {forceMultilineText}
+  </InlineNotification>
+)
+
+PersistentForcedMultiline.storyName = "Persistent, Forced Multiline"
 
 export const PersistentSlim = () => (
   <InlineNotification


### PR DESCRIPTION
# Objective
- Adding a new prop to make InlineNotification have it's first line of text underneath the notification heading

# Motivation and Context
- Closes this PR https://github.com/cultureamp/kaizen-design-system/issues/1843

# Screenshots (if appropriate)
### Non-dismissable
<img width="1340" alt="Screen Shot 2021-08-24 at 10 55 44 am" src="https://user-images.githubusercontent.com/18339250/130538451-4080d785-065c-4835-a514-8d4e6ec351db.png">


### Dismissable
<img width="1334" alt="Screen Shot 2021-08-24 at 10 55 51 am" src="https://user-images.githubusercontent.com/18339250/130538449-aeb86086-88c9-47d8-bfe6-dedff04b4af8.png">



# Checklist
- [ ] If this contains visual changes, has it been reviewed by a designer?
- [ ] I have considered likely risks of these changes and got someone else to QA as appropriate
- [ ] I have or will communicate these changes to the front end practice

# Additional Considerations
- Does there need to be right-to-left (RTL) options for localization and internationalization?
- Has the test suite been updated?
- Have you done cross-browser testing for our [supported browsers](https://academy.cultureamp.com/hc/en-us/articles/204539569-Supported-browsers-for-Participants)?
- Have you updated any relevant documentation or left useful comments in the code?
- Have you reviewed Culture Amp's Web Accessibility guide [Current Compliance, Going Forward, Statement and Answers for Customers](https://cultureamp.atlassian.net/wiki/spaces/Prod/pages/428572998/Web+Accessibility)?
- If this contains substantial visual changes, especially far reaching ones, have you unlocked the Chromatic step in the pipeline?
- Have Storybook stories been updated?

**If you're new to Kaizen, please ask #prod_design_systems to set up an onboarding session to get you up to speed.** If you have an urgent PR to merge before that happens, it is safest to ask in #prod_design_systems to have a design system advocate review the PR to catch any issues.
