### PR TITLE
docs: Remove the "not built" string in documenation pages

### DIFF
--- a/site/docs/components/autocomplete.mdx
+++ b/site/docs/components/autocomplete.mdx
@@ -1,6 +1,6 @@
 ---
 title: Autocomplete
-navTitle: Autocomplete (not built)
+navTitle: Autocomplete
 summaryParagraph: Autocomplete automatically completes typed user input with matching results from a larger data set. Autosuggest breaks beyond the input provided to suggest alternative, relevant answers.
 tags: ["Autosuggest", "Live filter", "Filters", "Search", "Top bar", "Text input"]
 githubLabels: ["component:autocomplete"]

--- a/site/docs/components/button-group.mdx
+++ b/site/docs/components/button-group.mdx
@@ -1,6 +1,6 @@
 ---
 title: Button Group
-navTitle: Button Group (not built)
+navTitle: Button Group
 summaryParagraph: Button Groups contain buttons that perform related actions.
 tags: ["Toggle Buttons", "Radio Button Groups", "Switchers"]
 githubLabels: ["component:button"]

--- a/site/docs/components/date-picker.mdx
+++ b/site/docs/components/date-picker.mdx
@@ -1,6 +1,6 @@
 ---
-title: "Date Picker"
-navTitle: "Date Picker (not built)"
+title: Date Picker
+navTitle: Date Picker
 summaryParagraph: A Date Picker lets users select a date or range of dates. It uses a text field and a visual calendar in a popover.
 tags: ["Calendar", "Time"]
 githubLabels: ["component:date-picker"]

--- a/site/docs/components/infinite-scroll.mdx
+++ b/site/docs/components/infinite-scroll.mdx
@@ -1,12 +1,11 @@
 ---
 title: Infinite Scroll with a “View more” button
-navTitle: Infinite Scroll (not built)
+navTitle: Infinite Scroll
 summaryParagraph: Infinite Scroll separates large bodies of content into separate sections. You can access each extra section via a "View more" button.
 tags: ["Infinite scrolling", "Continuous scroll", "Load more", "Async loading"]
 githubLabels: ["component:infinite-scroll"]
 needToKnow:
   - Perform usability testing to decide where to split content into pages (that is, how much content to show per page).
-  - This has been designed but not built.
 health:
   designed: false
   documented: true

--- a/site/docs/components/loading-skeleton.mdx
+++ b/site/docs/components/loading-skeleton.mdx
@@ -1,11 +1,11 @@
 ---
 title: Loading Skeleton
-navTitle: Loading Skeleton (not built)
+navTitle: Loading Skeleton
 summaryParagraph: A collection of loading placeholders that display a non-interactive preview of the app’s actual UI to visually communicate that content is in the process of loading.
 tags: ["Skeleton", "Stencil", "Loading Placeholders", "Placeholder UI"]
 githubLabels: ["component:loading-skeleton"]
 needToKnow:
-- "Give people an idea of what’s about to come and what’s happening (it's currently loading) when a page full of content/data takes more than 300ms to load."
+- Give people an idea of what’s about to come and what’s happening (it's currently loading) when a page full of content/data takes more than 300ms to load.
 health:
   designed: true
   documented: true

--- a/site/docs/components/pagination.mdx
+++ b/site/docs/components/pagination.mdx
@@ -1,11 +1,10 @@
 ---
 title: Pagination
-navTitle: Pagination (not built)
+navTitle: Pagination
 summaryParagraph: Pagination separates large bodies of content into separate pages. You can access each page via a shared index of links.
 tags: ["Pages"]
 needToKnow:
   - Perform usability testing to decide where to split content into pages (that is, how much content to show per page).
-  - This has been designed but not built.
 health:
   designed: true
   documented: true

--- a/site/docs/components/progress-bar.mdx
+++ b/site/docs/components/progress-bar.mdx
@@ -1,6 +1,6 @@
 ---
 title: Progress Bar
-navTitle: Progress Bar (not built)
+navTitle: Progress Bar
 summaryParagraph: Progress bars show continuous progress through a process, such as a percentage value. They show how much progress is complete and how much remains.
 tags: ["Progress", "Progress bar", "Progress indicator", "Progress tracker", "Loading bar", "Loader"]
 githubLabels: ["component:progress-bar"]

--- a/site/docs/components/tile.mdx
+++ b/site/docs/components/tile.mdx
@@ -7,7 +7,7 @@ githubLabels: ["component:tile"]
 needToKnow:
 - Tiles draw attention to featured items.
 - All tiles have a title.
-- There are three types of tiles - InformationTile, MultiActionTile, SingleActionTile (not built)
+- There are three types of tiles - InformationTile, MultiActionTile, SingleActionTile
 ---
 
 import WhenToUseAndWhenNotToUse from "docs-components/WhenToUseAndWhenNotToUse"
@@ -20,7 +20,7 @@ import WhenNotToUse from "docs-components/WhenNotToUse"
 
 ## To keep in mind
 
-### SingleActionTile (not built)
+### SingleActionTile
 *   Entire tile is a single click zone for performing a single action.
 
 ### MultiActionTile

--- a/site/docs/guidelines/filtering.mdx
+++ b/site/docs/guidelines/filtering.mdx
@@ -19,7 +19,7 @@ needToKnow:
 
 These definitions are used throughout the subsequent guidance.
 
-*   A **Filter Bar (not built yet)** is a horizontal collection of filter components, such as Selects and Date Pickers for filtering that appears in a content area.
+*   A **Filter Bar** is a horizontal collection of filter components, such as Selects and Date Pickers for filtering that appears in a content area.
 *   A **Filter menu (not a component)** is a general term for a group of components available to apply filters.
 *   A **filter field** describes a specific group of data that you might have different options for, such as “Price”.
 *   A **filter value** describes a specific option for a value, such as “>$50”.


### PR DESCRIPTION
- This information is now encapsulated in the component health tags
- The single source of truth for the status of the component should be the component health indicators (Issues list, and component health tags). 

Before:
<img width="260" alt="Screen Shot 2021-08-24 at 11 34 04 am" src="https://user-images.githubusercontent.com/1621182/130541344-328ddb33-0572-42ee-a96c-495aec9cc1ce.png">

After:
<img width="260" alt="Screen Shot 2021-08-24 at 11 34 37 am" src="https://user-images.githubusercontent.com/1621182/130541346-2ac4b3cf-b673-4160-939c-2e4dad1b8087.png">