### PR TITLE
docs: Add API guidance to component overview page

### DIFF
--- a/site/docs/components/overview.mdx
+++ b/site/docs/components/overview.mdx
@@ -27,6 +27,23 @@ We strive to achieve the following quality attributes on all of our components:
 
 The status of these can be found on the documentation page for each component, or on the [Component health](/component-health) page, which shows the status of all components.
 
+### API
+- **Avoid language overloading**: Avoid prop names that are used in HTML, such as `type`.
+- **Lean on existing mental models**: Things like input `onChange` should not stray from the default behavior that React has defined.
+- **Encapsulation:** Components should only be concerned about their own form and function and not about how they appear in relation to other components.
+- **Favor composition**: This allows us to have a more succinct API that encourages code reuse.
+- **RTL support**: Avoid using left/right props or values, instead use start/end and support RTL automatically.
+- **Allowing ReactNode**: Favor allowing ReactNode values over strings where possible, for greater flexibility.
+
+#### Common props
+| Name | Description | Example |
+| --- | --- | --- |
+| `tag` | Specifies which HTML element the component should render as. | `<Heading tag="h2">` |
+| `mood` | Dictates the tone of the component, usually affecting colors. | `<BrandMoment mood="positive">` |
+| `primary` / `secondary` / `destructive` | Used to enable these common variants. | `<Button primary>` |
+| `reversed` | Enables a version of the component to be used on a dark background. | `<Button reversed>` |
+| `variant` | Only used if none of the above props makes sense.  | `<TextAreaField variant="prominent">` |
+
 ## Want to learn more about great components?
 
 - [Documenting Components by Nathan Curtis](https://medium.com/eightshapes-llc/documenting-components-9fe59b80c015).

--- a/site/docs/components/overview.mdx
+++ b/site/docs/components/overview.mdx
@@ -39,7 +39,7 @@ The status of these can be found on the documentation page for each component, o
 | Name | Description | Example |
 | --- | --- | --- |
 | `tag` | Specifies which HTML element the component should render as. | `<Heading tag="h2">` |
-| `mood` | Dictates the tone of the component, usually affecting colors. | `<BrandMoment mood="positive">` |
+| `mood` | [Dictates the tone of the component](https://dev.cultureamp.design/api-guidelines/guidelines/moods/), usually affecting colors. | `<BrandMoment mood="positive">` |
 | `primary` / `secondary` / `destructive` | Used to enable these common variants. | `<Button primary>` |
 | `reversed` | Enables a version of the component to be used on a dark background. | `<Button reversed>` |
 | `variant` | Only used if none of the above props makes sense.  | `<TextAreaField variant="prominent">` |

--- a/site/docs/components/overview.mdx
+++ b/site/docs/components/overview.mdx
@@ -29,7 +29,7 @@ The status of these can be found on the documentation page for each component, o
 
 ### API
 - **Avoid language overloading**: Avoid prop names that are used in HTML, such as `type`.
-- **Lean on existing mental models**: Things like input `onChange` should not stray from the default behavior that React has defined.
+- **Lean on existing mental models**: Lean into established naming conventions where it makes sense to do so. Things like input `onChange` should not stray from the default behavior that React has defined. 
 - **Encapsulation:** Components should only be concerned about their own form and function and not about how they appear in relation to other components.
 - **Favor composition**: This allows us to have a more succinct API that encourages code reuse.
 - **RTL support**: Avoid using left/right props or values, instead use start/end and support RTL automatically.

--- a/site/docs/components/overview.mdx
+++ b/site/docs/components/overview.mdx
@@ -28,7 +28,7 @@ We strive to achieve the following quality attributes on all of our components:
 The status of these can be found on the documentation page for each component, or on the [Component health](/component-health) page, which shows the status of all components.
 
 ### API
-- **Avoid language overloading**: Avoid prop names that are used in HTML, such as `type`.
+- **Avoid language overloading**: Choose names that are self-describing that continue to be clear in slightly different contexts. For example, `type`, has a specific meaning within the context of a form, but it could also be used to describe a different appearance of a component. A good rule of thumb is to avoid names that are used in HTML.
 - **Lean on existing mental models**: Lean into established naming conventions where it makes sense to do so. Things like input `onChange` should not stray from the default behavior that React has defined. 
 - **Encapsulation:** Components should only be concerned about their own form and function and not about how they appear in relation to other components.
 - **Favor composition**: This allows us to have a more succinct API that encourages code reuse.


### PR DESCRIPTION
# Objective
Adds a bit of guidance around component API to the site.

# Motivation and Context
There's not a lot of guidance around this at the moment. This idea has been floating around for a while and Ally wrote up a bunch of stuff here: https://cultureamp.atlassian.net/wiki/spaces/~316784077/pages/1001396888/DRAFT+Kaizen+Consistent+Component+API

This is a compressed version of that, that we can build on in a separate page at a future time if we like