### PR TITLE
docs: add an example of passing a name with non-latin characters to Avatar

### DIFF
--- a/draft-packages/avatar/docs/Avatar.stories.tsx
+++ b/draft-packages/avatar/docs/Avatar.stories.tsx
@@ -45,6 +45,18 @@ export const InitialsOthers = () => (
   </>
 )
 
+export const UnicodeInitials = () => (
+  <>
+    <Avatar isCurrentUser={false} size="xlarge" fullName="李存信" />
+    <br />
+    <Avatar isCurrentUser={false} size="large" fullName="李存信" />
+    <br />
+    <Avatar isCurrentUser={false} size="medium" fullName="李存信" />
+    <br />
+    <Avatar isCurrentUser={false} size="small" fullName="李存信" />
+  </>
+)
+
 export const DisabledInitials = () => (
   <>
     <Avatar


### PR DESCRIPTION
Fixes #1905 

(or more correctly, shows that unicode characters are supported, and the problem probably lies elsewhere).

# Objective
Add a story showing the use of unicode names in our Avatar component.

Note: this story illustrates that the desired behaviour isn't clear. In this example, the avatar component is showing just one of the names. The idea of "initials" doesn't necessarily make sense in this culture.

Storybook: https://dev.cultureamp.design/jasono/unicode-initials-example-in-avatar/storybook/?path=/story/components-avatar--unicode-initials
![image](https://user-images.githubusercontent.com/315158/131794056-4fee87eb-4f8b-4c3b-86c8-b2d23d9f4403.png)
