### PR TITLE
feat: Create titleTag prop on Tile components

### DIFF
--- a/draft-packages/tile/KaizenDraft/Tile/InformationTile.tsx
+++ b/draft-packages/tile/KaizenDraft/Tile/InformationTile.tsx
@@ -10,6 +10,7 @@ type InformationTile = React.FunctionComponent<InformationTileProps>
 
 const InformationTile: InformationTile = ({
   title,
+  titleTag,
   metadata,
   children,
   information,
@@ -17,6 +18,7 @@ const InformationTile: InformationTile = ({
 }) => (
   <GenericTile
     title={title}
+    titleTag={titleTag}
     metadata={metadata}
     information={information}
     footer={footer}

--- a/draft-packages/tile/KaizenDraft/Tile/MultiActionTile.tsx
+++ b/draft-packages/tile/KaizenDraft/Tile/MultiActionTile.tsx
@@ -32,6 +32,7 @@ const renderActions = (
 
 const MultiActionTile: MultiActionTile = ({
   title,
+  titleTag,
   metadata,
   children,
   primaryAction,
@@ -40,6 +41,7 @@ const MultiActionTile: MultiActionTile = ({
 }) => (
   <GenericTile
     title={title}
+    titleTag={titleTag}
     metadata={metadata}
     information={information}
     footer={renderActions(primaryAction, secondaryAction)}

--- a/draft-packages/tile/KaizenDraft/Tile/Tile.spec.tsx
+++ b/draft-packages/tile/KaizenDraft/Tile/Tile.spec.tsx
@@ -72,6 +72,22 @@ describe("<InformationTile />", () => {
 
       expect(container.firstChild).toMatchSnapshot()
     })
+
+    it("renders InformationTile with a custom title tag", () => {
+      const { getByText } = render(
+        <InformationTile
+          title="custom title"
+          titleTag="div"
+          metadata="Metadata"
+          footer={<div>Hello world</div>}
+          information={information}
+        >
+          <div>Child content</div>
+        </InformationTile>
+      )
+
+      expect(getByText("custom title").tagName).toEqual("DIV")
+    })
   })
 })
 
@@ -100,6 +116,20 @@ describe("<MultiActionTile />", () => {
       )
 
       expect(container.firstChild).toMatchSnapshot()
+    })
+
+    it("renders MultiActionTile with a custom title tag", () => {
+      const { getByText } = render(
+        <MultiActionTile
+          title="custom title"
+          titleTag="h6"
+          metadata="Metadata"
+          primaryAction={primaryAction}
+          secondaryAction={secondaryAction}
+        />
+      )
+
+      expect(getByText("custom title").tagName).toEqual("H6")
     })
   })
 })

--- a/draft-packages/tile/KaizenDraft/Tile/components/GenericTile.tsx
+++ b/draft-packages/tile/KaizenDraft/Tile/components/GenericTile.tsx
@@ -5,6 +5,7 @@ import classNames from "classnames"
 
 import informationIcon from "@kaizen/component-library/icons/information.icon.svg"
 import arrowBackwardIcon from "@kaizen/component-library/icons/arrow-backward.icon.svg"
+import { AllowedTags } from "@kaizen/component-library/components/Heading"
 import Action from "./Action"
 import styles from "./GenericTile.scss"
 
@@ -24,7 +25,8 @@ export interface TileInformation {
 }
 
 export interface GenericTileProps {
-  readonly title: string
+  readonly title: React.ReactNode
+  readonly titleTag?: AllowedTags
   readonly metadata?: string
   readonly children?: React.ReactNode
   readonly information?: TileInformation | React.ReactNode
@@ -39,6 +41,7 @@ type GenericTile = React.FunctionComponent<Props>
 const GenericTile: GenericTile = ({
   children,
   title,
+  titleTag = "h3",
   metadata,
   information,
   footer,
@@ -47,7 +50,9 @@ const GenericTile: GenericTile = ({
 
   const renderTitle = () => (
     <div className={styles.title}>
-      <Heading variant="heading-3">{title}</Heading>
+      <Heading variant="heading-3" tag={titleTag}>
+        {title}
+      </Heading>
       {metadata && (
         <Box pt={0.25}>
           <Paragraph variant="small" color="dark-reduced-opacity">

--- a/draft-packages/tile/docs/Tile.stories.tsx
+++ b/draft-packages/tile/docs/Tile.stories.tsx
@@ -98,6 +98,18 @@ export const MultiActionWithChildren = () => (
 
 MultiActionWithChildren.storyName = "Multi action tile with children"
 
+export const MultiActionWithCustomTitle = () => (
+  <MultiActionTile
+    title="Custom title"
+    primaryAction={primaryAction}
+    titleTag="div"
+  >
+    {children}
+  </MultiActionTile>
+)
+
+MultiActionWithCustomTitle.storyName = "Multi action tile with custom title tag"
+
 export const MultiActionWithInformation = () => (
   <MultiActionTile
     title="Tile heading"
@@ -151,6 +163,18 @@ export const InformationCustomInfoElement = () => (
 
 InformationCustomInfoElement.storyName =
   "Information tile (custom information element)"
+
+export const InformationCustomTitleTag = () => (
+  <InformationTile
+    title="Tile heading"
+    titleTag="div"
+    metadata="Metadata"
+    information={<Paragraph variant="body">Anything can go here</Paragraph>}
+    footer={<Tag variant="statusLive">Live</Tag>}
+  />
+)
+
+InformationCustomTitleTag.storyName = "Information tile (custom title tag)"
 
 export const TileGridWithTiles = () => (
   <TileGrid>


### PR DESCRIPTION
Closes https://github.com/cultureamp/kaizen-design-system/issues/1930

# Objective
Creates a new `titleTag` prop on our two Tile components (`InformationTile` and `MultiActionTile`) that allows consumers to change the tag that is rendered with the heading (currently hard-coded to `h3`).

Also changes `title` to accept a `ReactNode` rather than just a `string`.

# Motivation and Context
See https://github.com/cultureamp/kaizen-design-system/issues/1930

# Reasoning
@OliBridgman and I paired on this and explored a other options, before settling on this:
* Making the `title` prop optional and allow consumers to pass in their own heading via `children`
  * This didn't work so well because the title ended up vertically aligned.
* Allowing title to be `ReactNode`, while removing the `<Heading variant="heading-3">` wrapping when the title is *not a string*.
  * We decided this was too magical - how is a consumer meant to know that this switch happens based on whether they pass in a string or JSX?
* A render prop for title
  * We don't really like this pattern.

We also ruled out any options that would result in a breaking change, such as changing the `title` prop to be a `HeadingProps` object.

Ultimately we decided this new prop was the least evil of everything we tried, and it's not such a bad thing that we keep the heading styling locked to `heading-3`. It's not perfect, in an ideal world these components would be compositional, but there's a good chance that we'll be rewriting our Tile components at some point with the recent work the designers have done, so we didn't want to invest too much in our current ones.