### PR TITLE
fix: Add aria-hidden=true to Divider hr

### DIFF
--- a/draft-packages/divider/KaizenDraft/Divider/Divider.tsx
+++ b/draft-packages/divider/KaizenDraft/Divider/Divider.tsx
@@ -9,6 +9,7 @@ export interface DividerProps {
 
 export const Divider = ({ isReversed = false, variant }: DividerProps) => (
   <hr
+    aria-hidden="true"
     className={classNames(styles.wrapper, {
       [styles.reversed]: isReversed,
       [styles.content]: variant === "content",

--- a/draft-packages/divider/KaizenDraft/Divider/styles.module.scss
+++ b/draft-packages/divider/KaizenDraft/Divider/styles.module.scss
@@ -35,7 +35,7 @@ $dt-content-border-color: rgba(
     var(--dt-canvas-border-color-zen)
   );
 
-  border-top: 2px solid;
+  border-top: 1px solid;
   border-bottom: 1px solid;
   border-color: var(--dt-canvas-border-color);
 

--- a/site/docs/components/divider.mdx
+++ b/site/docs/components/divider.mdx
@@ -13,7 +13,7 @@ health:
   designed: true
   documented: true
   implemented: true
-  latestDesign: false
+  latestDesign: true
   allVariants: true
   responsive: true
   internationalized: true


### PR DESCRIPTION
Closes https://github.com/cultureamp/kaizen-design-system/issues/1920

Also makes a very small adjustment to the `canvas` variant of Divider to match the UI kit (3px height -> 2px height)