### PR TITLE
fix: Use IconButton for hamburger menu button instead of div

### DIFF
--- a/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/TitleBlockZen.scss
+++ b/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/TitleBlockZen.scss
@@ -1,3 +1,4 @@
+@import "~@kaizen/design-tokens/sass/spacing";
 @import "~@kaizen/design-tokens/sass/typography";
 @import "~@kaizen/design-tokens/sass/color";
 @import "~@kaizen/design-tokens/sass/layout";
@@ -234,38 +235,11 @@ $tab-container-height-medium-and-small-collapsed: $ca-grid * 0.75;
 
 .hamburger {
   display: none;
-  @include ca-margin($end: $ca-grid * 2/3);
-  color: $color-white;
-
-  &:hover {
-    cursor: pointer;
-  }
-
-  .educationVariant &,
-  .adminVariant & {
-    color: $color-purple-800;
-  }
+  @include ca-margin($end: $spacing-xs);
 
   @include title-block-medium-and-small {
     display: flex;
     align-items: center;
-    transform: translateY(-1px);
-  }
-
-  .hasSubtitle & {
-    @include title-block-under-1366 {
-      transform: translateY(-6px);
-    }
-
-    @include title-block-medium-and-small {
-      transform: translateY(-8px);
-    }
-  }
-
-  .hasPageSwitcherSelect & {
-    @include title-block-medium-and-small {
-      transform: translateY(-6px);
-    }
   }
 }
 

--- a/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/TitleBlockZen.tsx
+++ b/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/TitleBlockZen.tsx
@@ -1,7 +1,7 @@
 import { Heading, Icon } from "@kaizen/component-library"
 import * as layoutTokens from "@kaizen/design-tokens/tokens/layout.json"
 import { Avatar, AvatarProps as DraftAvatarProps } from "@kaizen/draft-avatar"
-import { ButtonProps } from "@kaizen/draft-button"
+import { IconButton, ButtonProps } from "@kaizen/draft-button"
 import { MenuItemProps } from "@kaizen/draft-menu"
 import { Select } from "@kaizen/draft-select"
 import { Tag } from "@kaizen/draft-tag"
@@ -542,14 +542,12 @@ const TitleBlockZen = ({
                   )}
                 <div className={styles.titleAndAdjacentNotBreadcrumb}>
                   {handleHamburgerClick && (
-                    <div
-                      className={styles.hamburger}
-                      onClick={handleHamburgerClick}
-                    >
-                      <Icon
+                    <div className={styles.hamburger}>
+                      <IconButton
+                        onClick={handleHamburgerClick}
                         icon={hamburgerIcon}
-                        role="presentation"
-                        title="Open menu"
+                        label="Open menu"
+                        reversed={isReversed(variant)}
                       />
                     </div>
                   )}


### PR DESCRIPTION
# Objective
Switches the 'hamburger' button that shows on mobile from a `<div onClick={}>` to an `<IconButton>` to make it keyboard and screen reader friendly. 

# Motivation and Context
Closes https://github.com/cultureamp/kaizen-design-system/issues/1928

# Screenshots

This pushes the hamburger button to the right a bit because IconButton has padding (I've included screenshots of hover so that you can see the full box)

<details>
  <summary>Default</summary>

  ### Before
  ![image](https://user-images.githubusercontent.com/1811583/132267724-8d58bbfd-42d7-426d-b263-19f8895ea21d.png)

  ### After
  ![image](https://user-images.githubusercontent.com/1811583/132267801-0b09e9de-e1d4-4a07-ae84-fde24280dfdc.png)

  ### After (hover)
  ![image](https://user-images.githubusercontent.com/1811583/132267773-97c344fd-1e30-4b34-ac72-eaaced43ad51.png)
</details>

<details>
  <summary>With report switcher</summary>

  ### Before
  ![image](https://user-images.githubusercontent.com/1811583/132268124-4e2eb48b-fe1b-442a-ad5a-c200fe43c1ea.png)

  ### After
  ![image](https://user-images.githubusercontent.com/1811583/132268152-b6789322-1b95-442a-bc61-9cf148423c8d.png)

  ### After (hover)
  ![image](https://user-images.githubusercontent.com/1811583/132268166-f751f16e-05ac-4f2c-8c38-0411faed108c.png)
</details>

<details>
  <summary>With subtitle</summary>
  
  ### Before
  ![image](https://user-images.githubusercontent.com/1811583/132268349-604659f2-f841-470c-89fd-75c7d8f1c157.png)

  ### After
  ![image](https://user-images.githubusercontent.com/1811583/132268305-06a3666e-2b7a-42dd-929d-89871fc2b1cf.png)

  ### After (hover)
  ![image](https://user-images.githubusercontent.com/1811583/132268320-f154c466-e071-4f0f-b540-cd954cd09347.png)
</details>
