### PR TITLE
fix: Use min-height:100vh on small viewport as well

### DIFF
--- a/packages/brand-moment/src/BrandMoment.scss
+++ b/packages/brand-moment/src/BrandMoment.scss
@@ -9,8 +9,8 @@ $breakpoint-xl: 1366px; // TODO: create an xl breakpoint in design-tokens and re
 // --------------------------------
 
 .body {
-  inline-size: 100%;
-  min-block-size: 100vh;
+  width: 100%;
+  min-height: 100vh;
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -33,7 +33,7 @@ $breakpoint-xl: 1366px; // TODO: create an xl breakpoint in design-tokens and re
 // --------------------------------
 
 .container {
-  max-inline-size: $layout-content-max-width;
+  max-width: $layout-content-max-width;
   margin: 0 auto;
   padding: 0 $spacing-md;
 }
@@ -101,8 +101,8 @@ $breakpoint-xl: 1366px; // TODO: create an xl breakpoint in design-tokens and re
 }
 
 .leftInner {
-  inline-size: 100%;
-  max-inline-size: 525px;
+  width: 100%;
+  max-width: 525px;
 }
 
 .right {
@@ -113,7 +113,7 @@ $breakpoint-xl: 1366px; // TODO: create an xl breakpoint in design-tokens and re
 }
 
 .rightInner {
-  max-inline-size: 543px;
+  max-width: 543px;
 }
 
 .secondaryAction {
@@ -174,7 +174,7 @@ $breakpoint-xl: 1366px; // TODO: create an xl breakpoint in design-tokens and re
   margin-inline-start: $spacing-xs;
 
   > img {
-    max-inline-size: 133px;
+    max-width: 133px;
   }
 }
 

--- a/packages/brand-moment/src/BrandMoment.scss
+++ b/packages/brand-moment/src/BrandMoment.scss
@@ -10,6 +10,7 @@ $breakpoint-xl: 1366px; // TODO: create an xl breakpoint in design-tokens and re
 
 .body {
   inline-size: 100%;
+  min-block-size: 100vh;
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -24,12 +25,6 @@ $breakpoint-xl: 1366px; // TODO: create an xl breakpoint in design-tokens and re
 
   &.negative {
     background: $color-red-100;
-  }
-}
-
-@media (min-width: $layout-breakpoints-large) {
-  .body {
-    min-block-size: 100vh;
   }
 }
 


### PR DESCRIPTION
# Objective
See the first commit for the main objective here - just makes the `min-height: 100vh` that was only on large and up now on smaller view ports as well.

The extra stuff I did here was just revert any use of the logical properties `inline-size` and `block-size` back to `width` and `height` because of our pseudo support for legacy Edge, and given we're probably not going to be supporting Mongolian anytime soon :)

# Motivation and Context
@lloydstubber ran into this while implementing a `BrandMoment` (note the blank white space at the bottom). This happens when your browser height is beyond the height of the content.
![image](https://user-images.githubusercontent.com/1811583/132605054-161c3cb7-5660-45f3-b38d-99c8da879ca8.png)

I don't think there was any good reason for limiting the `min-height:100vh` to large and up - I probably did it because I originally had it as `height` and not `min-height`