### PR TITLE
fix: Disable event listeners on legacy Edge

### DIFF
--- a/packages/responsive/src/useMediaQueries.tsx
+++ b/packages/responsive/src/useMediaQueries.tsx
@@ -28,6 +28,10 @@ export const useMediaQueries = (
 } => {
   const theme = useTheme()
 
+  // The `addEventListener` calls blow up legacy Edge (<= v18/pre chromium),
+  // so we disable the functionality of updating after page load.
+  const isLegacyEdge = navigator.userAgent.match(/Edge/)
+
   // ---------------------------------------
   // Create Kaizen breakpoint matches for initial state
   // ---------------------------------------
@@ -76,6 +80,10 @@ export const useMediaQueries = (
   // Create an event listener based on the medium breakpoint and update state whenever it changes
   // ---------------------------------------
   useEffect(() => {
+    if (isLegacyEdge) {
+      return
+    }
+
     const updateMatches = () => {
       const isSmallAfterUpdate = smallMatchMedia.matches || false
       const isMediumAfterUpdate = mediumMatchMedia.matches || false
@@ -118,6 +126,10 @@ export const useMediaQueries = (
   // Create an event listener for each custom query
   // ---------------------------------------
   useEffect(() => {
+    if (isLegacyEdge) {
+      return
+    }
+
     const updateCustomMatches = (
       matchMedia: MediaQueryList,
       queryName: string


### PR DESCRIPTION
# Objective
Stops legacy Edge blowing up when `useMediaQueries` is used.

Removes some functionality for legacy Edge as a result: it will no longer respond to changes after load. It's a legacy browser though so I don't think we care that much, and I wouldn't want to invest anymore in this. Having the values from page load gets you most of the way.

# Motivation and Context
We've noticed errors coming through: `"Object doesn't support property or method 'addEventListener'"`
https://cultureamp.slack.com/archives/C016N8Y1E10/p1630975772292000