### PR TITLE
chore: Revert "Enable Chromatic TurboSnap"

### DIFF
--- a/.buildkite/scripts/run-chromatic-build.sh
+++ b/.buildkite/scripts/run-chromatic-build.sh
@@ -11,5 +11,5 @@ export CHROMATIC_APP_CODE
 CHROMATIC_APP_CODE=$(get_secret "chromatic-app-code") || exit $?
 
 yarn install --frozen-lockfile
-yarn storybook:build --webpack-stats-json
-yarn chromatic --only-changed --exit-zero-on-changes --storybook-build-dir storybook/public
+yarn storybook:build
+yarn chromatic --exit-zero-on-changes --storybook-build-dir storybook/public


### PR DESCRIPTION
Reverts cultureamp/kaizen-design-system#1792

The `--only-changed` parameter started causing storybook builds to fail recently (eg: https://buildkite.com/culture-amp/kaizen-design-system/builds/19137#2ac7200d-3950-430f-b9ad-268e56d3e158/6-927). It looks like this has been disabled for accounts that have explicitly opted in the beta program. We are still on my personal Chromatic account for Kaizen (the key needs to be updated in the secrets settings for Github which I don't have access to). We can easily switch over to the Cultureamp Account, which I think has been opted into the beta turbosnap program, but in any case, there are still issues we're finding with Turbosnap, so it's better to disable it for now. We don't really need it with the manual workflow, as it doesn't get run very often (far far less than on every commit)

This will be superceded by https://github.com/cultureamp/kaizen-design-system/pull/1601 (using the Github workflow) when the outstanding issues are resolved.