### PR TITLE
feat: Remove all usages of var() in scss to provide Zen fallbacks

### DIFF
--- a/draft-packages/avatar/KaizenDraft/Avatar/decision-tokens.scss
+++ b/draft-packages/avatar/KaizenDraft/Avatar/decision-tokens.scss
@@ -1,10 +1,7 @@
 @import "~@kaizen/design-tokens/sass/color";
-@mixin avatar-theme-switching-tokens() {
-  --avatar--color-icon-color: rgba($color-purple-800-rgb, 0.7);
-}
 $dt-color-background-color: $color-gray-300;
 $dt-color-background-color-initials: $color-gray-300;
 $dt-color-background-color-personal: $color-orange-100;
 $dt-color-text-color: $color-purple-800;
 $dt-color-border-color: $color-white;
-$dt-color-icon-color: var(--avatar--color-icon-color);
+$dt-color-icon-color: rgba($color-purple-800-rgb, 0.7);

--- a/draft-packages/avatar/KaizenDraft/Avatar/decision-tokens.scss
+++ b/draft-packages/avatar/KaizenDraft/Avatar/decision-tokens.scss
@@ -1,16 +1,10 @@
 @import "~@kaizen/design-tokens/sass/color";
 @mixin avatar-theme-switching-tokens() {
-  --avatar--color-icon-color: rgba(var(#{$color-purple-800-rgb-id}), 0.7);
+  --avatar--color-icon-color: rgba($color-purple-800-rgb, 0.7);
 }
-$dt-color-background-color: var($color-gray-300-id, $color-gray-100);
-$dt-color-background-color-initials: var($color-gray-300-id, $color-purple-200);
-$dt-color-background-color-personal: var(
-  $color-orange-100-id,
-  $color-orange-200
-);
+$dt-color-background-color: $color-gray-300;
+$dt-color-background-color-initials: $color-gray-300;
+$dt-color-background-color-personal: $color-orange-100;
 $dt-color-text-color: $color-purple-800;
 $dt-color-border-color: $color-white;
-$dt-color-icon-color: var(
-  --avatar--color-icon-color,
-  rgba($color-purple-800-rgb, 0.3)
-);
+$dt-color-icon-color: var(--avatar--color-icon-color);

--- a/draft-packages/avatar/KaizenDraft/Avatar/styles.module.scss
+++ b/draft-packages/avatar/KaizenDraft/Avatar/styles.module.scss
@@ -4,7 +4,6 @@
 @import "./decision-tokens.scss";
 
 .wrapper {
-  @include avatar-theme-switching-tokens;
   background: $dt-color-background-color;
   border-radius: 100%;
   box-sizing: border-box;

--- a/draft-packages/badge/KaizenDraft/Badge/decision-tokens.scss
+++ b/draft-packages/badge/KaizenDraft/Badge/decision-tokens.scss
@@ -1,4 +1,3 @@
 @import "~@kaizen/design-tokens/sass/color";
-// if $kz-var-id-color-ash fails, the CSS property does not exist so assume a Zen theme
-// and fall back to $kz-var-color-wisteria-200 (which has a Zen fallback value included)
-$dt-color-background-default: var($color-gray-300-id, $color-purple-200);
+
+$dt-color-background-default: $color-gray-300;

--- a/draft-packages/button/KaizenDraft/Button/decision-tokens.scss
+++ b/draft-packages/button/KaizenDraft/Button/decision-tokens.scss
@@ -1,9 +1,9 @@
 @import "~@kaizen/design-tokens/sass/color";
-$dt-color-background-active: var($color-gray-100-id, $color-purple-100);
-$dt-color-background-focus: var($color-gray-100-id, $color-purple-100);
-$dt-color-background-hover: var($color-gray-100-id, $color-purple-100);
-$dt-color-border-color-base: var($color-gray-500-id, $color-purple-500);
-$dt-color-border-color-hover: var($color-gray-600-id, $color-purple-700);
-$dt-color-border-color-focus: var($color-gray-600-id, $color-purple-700);
-$dt-color-border-color-disabled: var($color-gray-500-id, $color-purple-500);
-$dt-color-color-disabled: var($color-purple-800-id, $color-purple-800);
+$dt-color-background-active: $color-gray-100;
+$dt-color-background-focus: $color-gray-100;
+$dt-color-background-hover: $color-gray-100;
+$dt-color-border-color-base: $color-gray-500;
+$dt-color-border-color-hover: $color-gray-600;
+$dt-color-border-color-focus: $color-gray-600;
+$dt-color-border-color-disabled: $color-gray-500;
+$dt-color-color-disabled: $color-purple-800;

--- a/draft-packages/divider/KaizenDraft/Divider/styles.module.scss
+++ b/draft-packages/divider/KaizenDraft/Divider/styles.module.scss
@@ -3,10 +3,7 @@
 
 // Use different tokens with different opacities across the Zen and Heart themes, by assuming that when Zen is applied there won't be any CSS variables declared.
 
-$dt-content-border-color: rgba(
-  var($color-gray-600-rgb-id, $color-purple-700-rgb),
-  0.1
-);
+$dt-content-border-color: rgba($color-gray-600-rgb, 0.1);
 
 .wrapper {
   width: 100%;
@@ -28,16 +25,9 @@ $dt-content-border-color: rgba(
 }
 
 .canvas {
-  --dt-canvas-border-color-zen: rgba(#{$color-purple-700-rgb}, 0.2);
-  --dt-canvas-border-color-heart: rgba(var(#{$color-gray-600-rgb-id}), 0.1);
-  --dt-canvas-border-color: var(
-    --dt-canvas-border-color-heart,
-    var(--dt-canvas-border-color-zen)
-  );
-
   border-top: 1px solid;
   border-bottom: 1px solid;
-  border-color: var(--dt-canvas-border-color);
+  border-color: rgba($color-gray-600-rgb, 0.1);
 
   &.reversed {
     border-color: rgba($color-white-rgb, 0.1);

--- a/draft-packages/empty-state/KaizenDraft/EmptyState/styles.scss
+++ b/draft-packages/empty-state/KaizenDraft/EmptyState/styles.scss
@@ -7,11 +7,6 @@
 @import "./responsive";
 
 .container {
-  --dt-border-zen: #{$border-solid-border-width} #{$border-solid-border-style} #{$color-purple-200};
-  --dt-border-heart: var(#{$border-solid-border-width-id})
-    var(#{$border-solid-border-style-id})
-    var(#{$border-borderless-border-color-id});
-
   display: flex;
   justify-content: space-around;
   width: 100%;
@@ -20,7 +15,8 @@
   padding-left: $spacing-md;
   padding-right: $spacing-md;
   color: $color-purple-800;
-  border: var(--dt-border-heart, var(--dt-border-zen));
+  border: $border-solid-border-width $border-solid-border-style
+    $border-borderless-border-color-id;
   border-radius: $border-solid-border-radius;
 
   @include small {
@@ -50,19 +46,19 @@
   }
 
   &.positive {
-    background-color: var($color-green-100-id, $color-gray-300);
+    background-color: $color-green-100;
   }
   &.negative {
-    background-color: var($color-red-100-id, $color-gray-300);
+    background-color: $color-red-100;
   }
   &.action {
-    background-color: var($color-orange-100-id, $color-gray-300);
+    background-color: $color-orange-100;
   }
   &.neutral {
-    background-color: var($color-purple-100-id, $color-gray-300);
+    background-color: $color-purple-100;
   }
   &.informative {
-    background-color: var($color-blue-100-id, $color-gray-300);
+    background-color: $color-blue-100;
   }
 }
 

--- a/draft-packages/form/KaizenDraft/Form/decision-tokens.scss
+++ b/draft-packages/form/KaizenDraft/Form/decision-tokens.scss
@@ -1,55 +1,28 @@
 @import "~@kaizen/design-tokens/sass/color";
 // General purpose tokens
-$dt-color-form-border-color: var($color-gray-500-id, $color-purple-500);
+$dt-color-form-border-color: $color-gray-500;
 $dt-color-form-border-color-focus: $color-blue-500;
-$dt-color-form-border-color-hover: var($color-gray-600-id, $color-purple-700);
+$dt-color-form-border-color-hover: $color-gray-600;
 $dt-color-form-border-color-reversed-focus: $color-blue-300;
 $dt-color-form-text-color: $color-purple-800;
 $dt-color-form-text-color-reversed: $color-white;
 $dt-color-form-text-color-label: rgba($color-purple-800-rgb, 0.75);
 $dt-color-form-text-color-label-reversed: rgba($color-white-rgb, 0.8);
-$dt-color-form-color-icon-reversed: var($color-gray-600-id, $color-purple-700);
+$dt-color-form-color-icon-reversed: $color-gray-600;
 $dt-color-form-text-color-placeholder: rgba($color-purple-800-rgb, 0.7);
 
 // component specific tokens
-$dt-color-checkbox-background-color-checked: var(
-  $color-gray-500-id,
-  $color-purple-500
-);
-$dt-color-checkbox-background-color-checked-focus: var(
-  $color-gray-600-id,
-  $color-purple-700
-);
-$dt-color-checkbox-background-color-unchecked-focus: var(
-  $color-gray-100-id,
-  $color-purple-100
-);
-$dt-color-checkbox-background-color-hover: var(
-  $color-gray-600-id,
-  $color-purple-700
-);
-$dt-color-checkbox-background-color-unchecked-hover: var(
-  $color-gray-100-id,
-  $color-purple-100
-);
-$dt-color-checkbox-border-color-checked-focus: var(
-  $color-gray-600-id,
-  $color-purple-700
-);
-$dt-color-checkbox-border-color-focus: var(
-  $color-gray-600-id,
-  $color-purple-700
-);
-$dt-color-checkbox-border-color-hover: var(
-  $color-gray-600-id,
-  $color-purple-700
-);
-$dt-color-radio-disc-color-base: var($color-gray-600-id, $color-purple-700);
-$dt-color-radio-background-color-hover: var(
-  $color-gray-100-id,
-  $color-purple-100
-);
-$dt-color-radio-border-color-focus: var($color-gray-600-id, $color-purple-700);
-$dt-color-toggle-background-color: var($color-gray-300-id, $color-purple-300);
+$dt-color-checkbox-background-color-checked: $color-gray-500;
+$dt-color-checkbox-background-color-checked-focus: $color-gray-600;
+$dt-color-checkbox-background-color-unchecked-focus: $color-gray-100;
+$dt-color-checkbox-background-color-hover: $color-gray-600;
+$dt-color-checkbox-background-color-unchecked-hover: $color-gray-100;
+$dt-color-checkbox-border-color-checked-focus: $color-gray-600;
+$dt-color-checkbox-border-color-focus: $color-gray-600;
+$dt-color-checkbox-border-color-hover: $color-gray-600;
+$dt-color-radio-disc-color-base: $color-gray-600;
+$dt-color-radio-background-color-hover: $color-gray-100;
+$dt-color-radio-border-color-focus: $color-gray-600;
+$dt-color-toggle-background-color: $color-gray-300;
 $dt-color-toggle-background-color-hover: $color-purple-500;
-$dt-color-toggle-background-color-hover: rgba(var($color-gray-500-rgb-id), 0.4);
+$dt-color-toggle-background-color-hover: rgba($color-gray-500-rgb, 0.4);

--- a/draft-packages/loading-placeholder/KaizenDraft/LoadingPlaceholder/decision-tokens.scss
+++ b/draft-packages/loading-placeholder/KaizenDraft/LoadingPlaceholder/decision-tokens.scss
@@ -1,27 +1,4 @@
 @import "~@kaizen/design-tokens/sass/color";
-// Setting these variables on our container allows us to use rgba() while allowing cascading fallbacks.
-// If the `--kz-var-*` variables exist, then our `--loading-placeholder--*` variables will use these colours with alpha added.
-// If the `--kz-var-*` variables do not exist, then our `--loading-placeholder--*` variables will also be invalid.
-// Therefore when we use `--loading-placeholder--*` they will either correctly have alpha added, or trigger a fallback.
-@mixin loading-placeholder-theme-switching-tokens() {
-  --loading-placeholder--color-background-default: rgba(
-    var(#{$color-gray-600-rgb-id}),
-    0.1
-  );
-  --loading-placeholder--color-background-reversed: rgba(
-    var(#{$color-white-rgb-id}),
-    0.1
-  );
-}
 
-// Decision tokens for background colours based on presence of CSS variables.
-// If the `--kz-var-*` variable is missing, our `--loading-placeholder--*` variables will be invalid, and the Zen tokens are used as a fallback.
-$dt-color-background-default: var(
-  --loading-placeholder--color-background-default,
-  $color-purple-200
-);
-
-$dt-color-background-reversed: var(
-  --loading-placeholder--color-background-reversed,
-  rgba($color-white-rgb, 0.65)
-);
+$dt-color-background-default: rgba($color-gray-600-rgb, 0.1);
+$dt-color-background-reversed: rgba($color-white-rgb, 0.1);

--- a/draft-packages/loading-placeholder/KaizenDraft/LoadingPlaceholder/styles.scss
+++ b/draft-packages/loading-placeholder/KaizenDraft/LoadingPlaceholder/styles.scss
@@ -7,9 +7,6 @@
 @import "./decision-tokens";
 
 .base {
-  // We need to set some CSS Custom Properties on our container for theme switching to work.
-  @include loading-placeholder-theme-switching-tokens;
-
   background-color: $dt-color-background-default;
   border-radius: calc(#{$border-solid-border-radius} * 3);
   position: relative;
@@ -45,7 +42,7 @@
 }
 
 .reversedOcean {
-  background-color: var($color-blue-200-id, $color-blue-300);
+  background-color: $color-blue-200;
 }
 
 .normal {

--- a/draft-packages/modal/KaizenDraft/Modal/Presets/ConfirmationModal.scss
+++ b/draft-packages/modal/KaizenDraft/Modal/Presets/ConfirmationModal.scss
@@ -5,16 +5,11 @@
 @import "~@kaizen/deprecated-component-library-helpers/styles/layout";
 @import "~@kaizen/component-library/styles/responsive";
 
-// Use different tokens for "Heart" theme with fallback values set to "Zen" theme.
-$dt-positive-header-background: var($color-green-100-id, $color-green-500);
-
-$dt-informative-header-background: var($color-blue-100-id, $color-blue-500);
-
-$dt-negative-header-background: var($color-red-100-id, $color-red-500);
-
-$dt-cautionary-header-background: var($color-yellow-100-id, $color-yellow-500);
-
-$dt-heading-text-color: var($color-purple-800-id, $color-white);
+$dt-positive-header-background: $color-green-100;
+$dt-informative-header-background: $color-blue-100;
+$dt-negative-header-background: $color-red-100;
+$dt-cautionary-header-background: $color-yellow-100;
+$dt-heading-text-color: $color-purple-800;
 $dt-cautionary-heading-text-color: $color-purple-800;
 
 .modal {

--- a/draft-packages/modal/KaizenDraft/Modal/Presets/RoadblockModal.scss
+++ b/draft-packages/modal/KaizenDraft/Modal/Presets/RoadblockModal.scss
@@ -5,8 +5,7 @@
 @import "~@kaizen/deprecated-component-library-helpers/styles/layout";
 @import "~@kaizen/component-library/styles/responsive";
 
-// Use Peach 100 for Heart theme, and Peach 500 for Zen (default fallback)
-$dt-roadblock-header-background: var($color-orange-100-id, $color-orange-500);
+$dt-roadblock-header-background: $color-orange-100;
 
 .modal {
   composes: genericModal from "../Primitives/GenericModal.scss";

--- a/draft-packages/page-layout/KaizenDraft/decision-tokens.scss
+++ b/draft-packages/page-layout/KaizenDraft/decision-tokens.scss
@@ -1,6 +1,3 @@
 @import "~@kaizen/design-tokens/sass/color";
-$dt-color-background-color-default: var(
-  $color-purple-600-id,
-  $color-purple-700
-);
-$dt-color-background-color-education: var($color-blue-100-id, $color-blue-200);
+$dt-color-background-color-default: $color-purple-600;
+$dt-color-background-color-education: $color-blue-100;

--- a/draft-packages/popover/KaizenDraft/Popover/styles.scss
+++ b/draft-packages/popover/KaizenDraft/Popover/styles.scss
@@ -50,8 +50,7 @@ $large-width: 450px;
 
 %box {
   background: white;
-  border: $border-solid-border-width $border-solid-border-style
-    var($color-gray-300-id, $color-purple-200);
+  border: $border-solid-border-width $border-solid-border-style $color-gray-300;
   filter: drop-shadow(0 0 7px rgba(0, 0, 0, 0.1));
   border-radius: $border-solid-border-radius;
   color: $color-purple-800;
@@ -63,10 +62,10 @@ $large-width: 450px;
 }
 
 .defaultArrow {
-  @include arrow(white, var($color-gray-300-id, $color-purple-200));
+  @include arrow(white, $color-gray-300);
 }
 
-$informative-box-border-color: var($color-blue-300-id, $color-blue-200);
+$informative-box-border-color: $color-blue-300;
 
 .informativeBox {
   @extend %box;
@@ -78,7 +77,7 @@ $informative-box-border-color: var($color-blue-300-id, $color-blue-200);
   @include arrow($color-blue-100, $informative-box-border-color);
 }
 
-$positive-box-border-color: var($color-green-300-id, $color-green-200);
+$positive-box-border-color: $color-green-300;
 
 .positiveBox {
   @extend %box;
@@ -90,7 +89,7 @@ $positive-box-border-color: var($color-green-300-id, $color-green-200);
   @include arrow($color-green-100, $positive-box-border-color);
 }
 
-$negative-box-border-color: var($color-red-300-id, $color-red-200);
+$negative-box-border-color: $color-red-300;
 
 .negativeBox {
   @extend %box;

--- a/draft-packages/select/KaizenDraft/Select/styles.elm.scss
+++ b/draft-packages/select/KaizenDraft/Select/styles.elm.scss
@@ -47,17 +47,14 @@ $control-height: $ca-grid * 2;
   min-height: $control-height;
   position: relative;
   box-sizing: border-box;
-  border: $border-solid-border-width $border-solid-border-style
-    var($color-gray-500-id, $color-purple-500);
+  border: $border-solid-border-width $border-solid-border-style $color-gray-500;
   border-radius: $border-solid-border-radius;
   /* Tech debt - this !important existed before Stylelint rules */
   outline: 0 !important; /* stylelint-disable-line declaration-no-important */
 
   &:not(.disabled):hover {
-    // Slate on Heart theme, Wisteria700 on Zen. Switching not needed when Zen is removed.
-    border-color: var($color-gray-600-id, $color-purple-700);
-    // Stone on Heart theme, Wisteria100 on Zen. Switching not needed when Zen is removed
-    background-color: var($color-gray-100-id, $color-purple-100);
+    border-color: $color-gray-600;
+    background-color: $color-gray-100;
   }
 
   &.isFocused {

--- a/draft-packages/select/KaizenDraft/Select/styles.react.scss
+++ b/draft-packages/select/KaizenDraft/Select/styles.react.scss
@@ -47,14 +47,12 @@ $focus-border-color: $color-blue-500;
     }
     min-height: $input-height;
     border: $border-solid-border-width $border-solid-border-style
-      var($color-gray-500-id, $color-purple-500);
+      $color-gray-500;
     border-radius: $border-solid-border-radius;
 
     &:hover {
-      // Slate on Heart theme, Wisteria700 on Zen. Switching not needed when Zen is removed.
-      border-color: var($color-gray-600-id, $color-purple-700);
-      // Stone on Heart theme, Wisteria100 on Zen. Switching not needed when Zen is removed.
-      background-color: var($color-gray-100-id, $color-purple-100);
+      border-color: $color-gray-600;
+      background-color: $color-gray-100;
       cursor: pointer;
     }
   }

--- a/draft-packages/slider/KaizenDraft/Slider/styles.module.scss
+++ b/draft-packages/slider/KaizenDraft/Slider/styles.module.scss
@@ -3,11 +3,11 @@
 @import "~@kaizen/deprecated-component-library-helpers/styles/layout";
 
 // The draghandle
-$thumb-color: var($color-blue-500-id, $color-purple-600);
+$thumb-color: $color-blue-500;
 $thumb-radius: 100%;
 $thumb-height: 26px;
 $thumb-width: 26px;
-$thumb-hover-shadow-color: var($color-blue-600-id, $color-purple-700);
+$thumb-hover-shadow-color: $color-blue-600;
 
 // The range
 $track-color: $color-gray-300;

--- a/draft-packages/split-button/KaizenDraft/SplitButton/styles.scss
+++ b/draft-packages/split-button/KaizenDraft/SplitButton/styles.scss
@@ -8,7 +8,7 @@
 @import "~@kaizen/component-library/styles/animation";
 
 $base-border: $border-solid-border-width $border-solid-border-style
-  var($color-gray-500-id, $color-purple-200);
+  $color-gray-500;
 $button-width: 124px;
 
 $side-padding: 3/4 * $ca-grid;
@@ -85,8 +85,8 @@ $side-padding: 3/4 * $ca-grid;
   height: 40px; // Set a fixed height to avoid expansion when dropdown is displayed
   position: relative;
 
-  --dt-heart-disabled-border-color: rgba(var(#{$color-gray-500-rgb-id}), 0.3);
-  --dt-heart-disabled-color: rgba(var(#{$color-purple-800-rgb-id}), 0.3);
+  --dt-heart-disabled-border-color: rgba($color-gray-500-rgb, 0.3);
+  --dt-heart-disabled-color: rgba($color-purple-800-rgb, 0.3);
 }
 
 .buttonReset {
@@ -104,33 +104,30 @@ $side-padding: 3/4 * $ca-grid;
 .buttonDefault {
   @include button-mixing(
     $background: $color-white,
-    $border-color: var($color-gray-500-id, $color-purple-200),
+    $border-color: $color-gray-500,
     $color: $color-purple-800,
     $hover-background: $color-gray-100,
-    $hover-border-color: var($color-gray-600-id, $color-purple-400),
-    $active-background: var($color-gray-100-id, $color-gray-300),
-    $active-border-color: var($color-gray-600-id, $color-purple-500),
+    $hover-border-color: $color-gray-600,
+    $active-background: $color-gray-100,
+    $active-border-color: $color-gray-600,
     $disabled-background: $color-white,
-    $disabled-border-color:
-      var(--dt-heart-disabled-border-color, $color-purple-200),
-    $disabled-color: var(--dt-heart-disabled-color, $color-purple-300)
+    $disabled-border-color: var(--dt-heart-disabled-border-color),
+    $disabled-color: var(--dt-heart-disabled-color)
   );
 }
 
 .buttonPrimary {
-  // #58b59a is equal to add-tint($ca-palette-seedling, 10%). Temporary until we remove Zen (Wisteria)
   @include button-mixing(
-    $background: var($color-green-300-id, #58b59a),
-    $border-color: var($color-green-300-id, #58b59a),
-    $color: var($color-purple-800-id, $color-white),
-    $hover-background: var($color-green-400-id, $color-green-500),
-    $hover-border-color: var($color-green-400-id, $color-green-500),
+    $background: $color-green-300,
+    $border-color: $color-green-300,
+    $color: $color-purple-800,
+    $hover-background: $color-green-400,
+    $hover-border-color: $color-green-400,
     $active-background: $color-green-500,
     $active-border-color: $color-green-500,
     $disabled-background: $color-white,
-    $disabled-border-color:
-      var(--dt-heart-disabled-border-color, $color-purple-100),
-    $disabled-color: var(--dt-heart-disabled-color, $color-purple-300)
+    $disabled-border-color: var(--dt-heart-disabled-border-color),
+    $disabled-color: var(--dt-heart-disabled-color)
   );
 }
 
@@ -243,19 +240,12 @@ $side-padding: 3/4 * $ca-grid;
 .dropdownButtonPrimary {
   composes: buttonReset buttonPrimary;
 
-  --dt-border-left-color-heart: rgba(var(#{$color-green-400-rgb-id}), 0.7);
-
-  // Making the left | right border white to separate the button with dropdown button
+  --dt-border-left-color-heart: rgba($color-green-400-rgb, 0.7);
   /* stylelint-disable declaration-no-important */
-  border-left-color: var(--dt-border-left-color-heart, $color-white) !important;
+  border-left-color: var(--dt-border-left-color-heart) !important;
 
   [dir="rtl"] & {
-    // equal to add-tint($ca-palette-seedling, 10%). Temporary until we remove Zen
-    border-left-color: #58b59a !important;
-    border-left-color: var(
-      --dt-border-left-color-heart,
-      $color-white
-    ) !important;
+    border-left-color: var(--dt-border-left-color-heart) !important;
   }
 
   &:active,

--- a/draft-packages/table/KaizenDraft/Table/styles.scss
+++ b/draft-packages/table/KaizenDraft/Table/styles.scss
@@ -176,10 +176,6 @@ $row-height-data-variant: 48px;
 }
 
 .expanded {
-  // We want to have NO background on Heart theme (when CSS variables are defined), but keep stone backgrond on Zen. Need to do this using 0 opacity.
-  // We also only want this switch for the expanded state. Non-expanded hovering will resort to stone background, as seen in .hasHoverState
-  --dt-hover-background-heart: rgba(var(#{$color-white-rgb-id}), 0);
-
   position: relative;
   z-index: 1;
   margin-left: calc(#{$spacing-sm} * -1);
@@ -195,10 +191,6 @@ $row-height-data-variant: 48px;
 
   &.expanded {
     width: calc(100% + #{$spacing-md});
-  }
-
-  &:hover {
-    background-color: var(--dt-hover-background-heart, $color-gray-100);
   }
 }
 

--- a/draft-packages/table/docs/Table.stories.scss
+++ b/draft-packages/table/docs/Table.stories.scss
@@ -12,7 +12,7 @@
 }
 
 .popoutExpandedFooter {
-  background: var($color-gray-100-id, $color-purple-100);
+  background: $color-gray-100;
   margin-left: -$ca-grid * 0.5;
   margin-right: -$ca-grid * 0.5;
   padding: $ca-grid * 0.5 ($ca-grid * 0.5 + $ca-grid * 0.8) $ca-grid;

--- a/draft-packages/tag/KaizenDraft/Tag/Tag.scss
+++ b/draft-packages/tag/KaizenDraft/Tag/Tag.scss
@@ -62,15 +62,11 @@ $small: $spacing-md;
   padding: 0 $spacing-xs;
   margin-right: -0.6625rem;
   margin-left: -0.225rem;
-
-  --dt-dismiss-icon-color-heart: rgba(var(#{$color-purple-800-rgb-id}), 0.7);
-  $dt-dismiss-icon-color: var(--dt-dismiss-icon-color-heart, $color-purple-600);
-
-  color: $dt-dismiss-icon-color;
+  color: rgba($color-purple-800-rgb, 0.7);
   cursor: pointer;
 
   &:hover {
-    color: var($color-purple-800-id, $color-purple-700);
+    color: $color-purple-800;
   }
 
   &:active {
@@ -86,7 +82,7 @@ $small: $spacing-md;
 
     // show custom focus ring when :focus-visible
     &:global(.focus-visible) .iconWrapper {
-      color: var($color-purple-800-id, $color-purple-700);
+      color: $color-purple-800;
 
       &::after {
         $focus-ring-offset: calc((#{$border-focus-ring-border-width}));
@@ -145,7 +141,7 @@ $small: $spacing-md;
 }
 
 .default {
-  background-color: var($color-gray-300-id, $color-purple-200);
+  background-color: $color-gray-300;
 }
 
 .sentimentPositive {
@@ -162,7 +158,7 @@ $small: $spacing-md;
 
 .sentimentNone {
   background-color: $color-white;
-  border-color: var($color-gray-300-id, $color-purple-200);
+  border-color: $color-gray-300;
 }
 
 .validationPositive {
@@ -203,12 +199,12 @@ $small: $spacing-md;
 }
 
 .statusDraft {
-  background-color: var($color-orange-100-id, $color-orange-200);
+  background-color: $color-orange-100;
   color: $color-purple-800;
 }
 
 .statusClosed {
-  background-color: var($color-red-100-id, $color-purple-200);
+  background-color: $color-red-100;
 }
 
 .statusAction {

--- a/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/decision-tokens.scss
+++ b/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/decision-tokens.scss
@@ -1,12 +1,9 @@
 @import "~@kaizen/design-tokens/sass/color";
 $dt-color-background-color-admin: $color-gray-100;
-$dt-color-background-color-eduction: var($color-blue-100-id, $color-blue-200);
-$dt-color-background-color-default: var(
-  $color-purple-600-id,
-  $color-purple-700
-);
+$dt-color-background-color-eduction: $color-blue-100;
+$dt-color-background-color-default: $color-purple-600;
 $dt-color-background-gradient: linear-gradient(
   0,
-  var($color-purple-600-id, $color-purple-700),
-  rgba(var($color-purple-600-rgb-id, $color-purple-700-rgb), 0)
+  $color-purple-600,
+  rgba($color-purple-600-rgb, 0)
 );

--- a/draft-packages/tooltip/KaizenDraft/Tooltip/Tooltip.scss
+++ b/draft-packages/tooltip/KaizenDraft/Tooltip/Tooltip.scss
@@ -9,8 +9,7 @@
 $arrow-height: 10px;
 $arrow-width: 20px;
 
-// Ash for Heart theme, Wisteria200 for Zen. Switching not needed when Zen is removed.
-$dt-tooltip-content-border: var($color-gray-300-id, $color-purple-200);
+$dt-tooltip-content-border: $color-gray-300;
 
 .tooltip {
   position: relative; // Make this a positioned element so z-index works. (Note: Popper overrides this to absolute.)

--- a/draft-packages/well/styles.scss
+++ b/draft-packages/well/styles.scss
@@ -50,10 +50,8 @@
 }
 
 .default {
-  // Slate 700 10% for Heart theme, Wisteria 300 for Zen theme (use Zen fallback when CSS variables aren't available).
-  --slate-700-10: rgba(var(#{$color-gray-600-rgb-id}), 0.1);
   background-color: $color-gray-300;
-  border-color: var(--slate-700-10, $color-purple-300);
+  border-color: rgba($color-gray-600-rgb, 0.1);
 }
 
 // Border Style Variations

--- a/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/decision-tokens.scss
+++ b/draft-packages/zen-navigation-bar/KaizenDraft/ZenNavigationBar/decision-tokens.scss
@@ -1,11 +1,8 @@
 @import "~@kaizen/design-tokens/sass/color";
 $dt-color-text: $color-purple-800;
 $dt-color-text-reversed: $color-white;
-$dt-color-background-color-default: var(
-  $color-purple-600-id,
-  $color-purple-700
-);
-$dt-color-background-color-content: var($color-blue-100-id, $color-blue-200);
+$dt-color-background-color-default: $color-purple-600;
+$dt-color-background-color-content: $color-blue-100;
 $dt-color-link: $color-purple-800;
 $dt-color-link-active: $color-blue-500;
 $dt-color-background-color-content-link: $color-blue-500;
@@ -16,8 +13,5 @@ $dt-color-badge-background-color-test: $color-purple-400;
 $dt-color-badge-background-color-local: $color-blue-300;
 $dt-color-badge-background-color-new: $color-green-200;
 $dt-color-indicator-color: $color-green-400;
-$dt-color-menu-background-color: var($color-purple-700-id, $color-purple-800);
-$dt-color-menu-background-color-active: var(
-  $color-purple-600-id,
-  $color-purple-700
-);
+$dt-color-menu-background-color: $color-purple-700;
+$dt-color-menu-background-color-active: $color-purple-600;

--- a/legacy-packages/title-block/KaizenDraft/TitleBlock/TitleBlock.scss
+++ b/legacy-packages/title-block/KaizenDraft/TitleBlock/TitleBlock.scss
@@ -391,12 +391,12 @@
 .reverseColorWisteria {
   @include title-block-desktop {
     .titleBlock {
-      background-color: var($color-purple-600-id, $color-purple-700);
+      background-color: $color-purple-600;
     }
   }
   @include title-block-mobile {
     .navContainer {
-      background-color: var($color-purple-600-id, $color-purple-700);
+      background-color: $color-purple-600;
     }
   }
 }
@@ -517,12 +517,12 @@
 .stickyColorWisteria {
   @include title-block-desktop {
     .titleBlock {
-      background-color: var($color-purple-600-id, $color-purple-700);
+      background-color: $color-purple-600;
     }
   }
   @include title-block-mobile {
     .navContainer {
-      background-color: var($color-purple-600-id, $color-purple-700);
+      background-color: $color-purple-600;
     }
   }
 }

--- a/packages/component-library/components/NavigationBar/decision-tokens.scss
+++ b/packages/component-library/components/NavigationBar/decision-tokens.scss
@@ -1,10 +1,7 @@
 @import "~@kaizen/design-tokens/sass/color";
 $dt-color-text: $color-purple-800;
-$dt-color-background-color-default: var(
-  $color-purple-600-id,
-  $color-purple-700
-);
-$dt-color-background-color-content: var($color-blue-100-id, $color-blue-200);
+$dt-color-background-color-default: $color-purple-600;
+$dt-color-background-color-content: $color-blue-100;
 $dt-color-link: $color-purple-800;
 $dt-color-link-active: $color-blue-500;
 $dt-color-background-color-content-link: $color-blue-500;
@@ -15,8 +12,5 @@ $dt-color-badge-background-color-test: $color-purple-400;
 $dt-color-badge-background-color-local: $color-blue-300;
 $dt-color-badge-background-color-new: $color-green-200;
 $dt-color-indicator-color: $color-green-400;
-$dt-color-menu-background-color: var($color-purple-700-id, $color-purple-800);
-$dt-color-menu-background-color-active: var(
-  $color-purple-600-id,
-  $color-purple-700
-);
+$dt-color-menu-background-color: $color-purple-700;
+$dt-color-menu-background-color-active: $color-purple-600;

--- a/packages/notification/src/_styles.scss
+++ b/packages/notification/src/_styles.scss
@@ -101,9 +101,7 @@ $ca-notification-slide-right: transform $ca-duration-fast ease-out;
     color: $color-purple-800;
 
     &%ca-notification---global {
-      // Yuzu200 for Heart theme, Yuzu300 for Zen theme. Switch not needed when Zen is removed.
-      // Use Yuzu200 for Heart theme, and Yuzu300 for zen (the default fallback)
-      background-color: var($color-yellow-200-id, $color-yellow-300);
+      background-color: $color-yellow-200;
     }
   }
 


### PR DESCRIPTION
# Objective
Removes all usages of `var()` in `scss` that were being used as a way of doing `var([heart_value], [zen_value])`.

# Motivation and Context
This was a method we used to switch tokens based on Zen or Heart, because we knew that no CSS vars existed for Zen, and it would use the fallback value.