### PR TITLE
fix: Add default value to variant to ensure description displays

### DIFF
--- a/draft-packages/form/KaizenDraft/Form/TextAreaField/TextAreaField.spec.tsx
+++ b/draft-packages/form/KaizenDraft/Form/TextAreaField/TextAreaField.spec.tsx
@@ -18,3 +18,15 @@ it("renders a description when provided", () => {
 
   expect(screen.getByText("Your reply will only be seen by you")).toBeTruthy()
 })
+
+it("renders a validation message when provided", () => {
+  render(
+    <TextAreaField
+      id="reply"
+      labelText="Your reply"
+      validationMessage="Incorrect message"
+    />
+  )
+
+  expect(screen.getByText("Incorrect message")).toBeTruthy()
+})

--- a/draft-packages/form/KaizenDraft/Form/TextAreaField/TextAreaField.spec.tsx
+++ b/draft-packages/form/KaizenDraft/Form/TextAreaField/TextAreaField.spec.tsx
@@ -1,0 +1,20 @@
+import React from "react"
+import { render, screen } from "@testing-library/react"
+import { TextAreaField } from "./"
+
+it("renders the label", () => {
+  render(<TextAreaField id="reply" labelText="Text area label" />)
+  expect(screen.getByText("Text area label")).toBeTruthy()
+})
+
+it("renders a description when provided", () => {
+  render(
+    <TextAreaField
+      id="reply"
+      labelText="Your reply"
+      description="Your reply will only be seen by you"
+    />
+  )
+
+  expect(screen.getByText("Your reply will only be seen by you")).toBeTruthy()
+})

--- a/draft-packages/form/KaizenDraft/Form/TextAreaField/TextAreaField.tsx
+++ b/draft-packages/form/KaizenDraft/Form/TextAreaField/TextAreaField.tsx
@@ -26,7 +26,7 @@ const TextAreaField: React.FunctionComponent<TextAreaFieldProps> = props => {
     description,
     inline,
     reversed,
-    variant,
+    variant = "default",
     maxLength,
     placeholder,
     textAreaRef,
@@ -37,6 +37,7 @@ const TextAreaField: React.FunctionComponent<TextAreaFieldProps> = props => {
     ...genericTextAreaProps
   } = props
 
+  const renderDescriptionOnTop = variant === "prominent"
   const renderDescription = (position: "top" | "bottom") => {
     if (!description) return null
     return (
@@ -64,7 +65,7 @@ const TextAreaField: React.FunctionComponent<TextAreaFieldProps> = props => {
         reversed={reversed}
         variant={variant}
       />
-      {variant === "prominent" && renderDescription("top")}
+      {renderDescriptionOnTop && renderDescription("top")}
       <TextArea
         id={`${id}-field-textarea`}
         automationId={`${id}-field-textarea`}
@@ -92,7 +93,7 @@ const TextAreaField: React.FunctionComponent<TextAreaFieldProps> = props => {
           reversed={reversed}
         />
       )}
-      {variant === "default" && renderDescription("bottom")}
+      {!renderDescriptionOnTop && renderDescription("bottom")}
     </FieldGroup>
   )
 }

--- a/draft-packages/form/KaizenDraft/Form/TextAreaField/TextAreaField.tsx
+++ b/draft-packages/form/KaizenDraft/Form/TextAreaField/TextAreaField.tsx
@@ -21,7 +21,7 @@ const TextAreaField: React.FunctionComponent<TextAreaFieldProps> = props => {
     value,
     defaultValue,
     validationMessage,
-    status,
+    status = "default",
     autogrow,
     description,
     inline,


### PR DESCRIPTION
# Objective
Adds a default value for the `variant` prop to fix the bug below. Also adds some tests to catch any regressions.

# Motivation and Context
Closes https://github.com/cultureamp/kaizen-design-system/issues/1929

