### PR TITLE
feat: Allow generic HTMLElement props on Heading and Paragraph

### DIFF
--- a/packages/component-library/components/Heading/Heading.tsx
+++ b/packages/component-library/components/Heading/Heading.tsx
@@ -1,6 +1,5 @@
-import { HTMLAttributes } from "react"
 import classNames from "classnames"
-import { createElement } from "react"
+import { createElement, HTMLAttributes } from "react"
 
 import styles from "./Heading.module.scss"
 
@@ -26,6 +25,7 @@ export type AllowedTags =
   | "h4"
   | "h5"
   | "h6"
+  | "label"
 
 export type AllowedColors =
   | "dark"

--- a/packages/component-library/components/Heading/Heading.tsx
+++ b/packages/component-library/components/Heading/Heading.tsx
@@ -1,3 +1,4 @@
+import { HTMLAttributes } from "react"
 import classNames from "classnames"
 import { createElement } from "react"
 
@@ -34,7 +35,8 @@ export type AllowedColors =
   | "positive"
   | "negative"
 
-export interface HeadingProps {
+export interface HeadingProps
+  extends Omit<HTMLAttributes<HTMLElement>, "className"> {
   /**
    * Not recommended. A short-circuit for overriding styles in a pinch
    * @default ""

--- a/packages/component-library/components/Paragraph/Paragraph.tsx
+++ b/packages/component-library/components/Paragraph/Paragraph.tsx
@@ -1,6 +1,5 @@
-import { HTMLAttributes } from "react"
 import classNames from "classnames"
-import { createElement } from "react"
+import { createElement, HTMLAttributes } from "react"
 
 import styles from "./Paragraph.module.scss"
 
@@ -17,6 +16,7 @@ export type AllowedTags =
   | "h4"
   | "h5"
   | "h6"
+  | "label"
 
 export type AllowedColors =
   | "dark"

--- a/packages/component-library/components/Paragraph/Paragraph.tsx
+++ b/packages/component-library/components/Paragraph/Paragraph.tsx
@@ -1,3 +1,4 @@
+import { HTMLAttributes } from "react"
 import classNames from "classnames"
 import { createElement } from "react"
 
@@ -25,7 +26,8 @@ export type AllowedColors =
   | "positive"
   | "negative"
 
-export interface ParagraphProps {
+export interface ParagraphProps
+  extends Omit<HTMLAttributes<HTMLElement>, "className"> {
   /**
    * Not recommended. A short-circuit for overriding styles in a pinch
    * @default ""

--- a/packages/component-library/stories/Heading.stories.tsx
+++ b/packages/component-library/stories/Heading.stories.tsx
@@ -17,7 +17,7 @@ export default {
 export const Display0 = () => <Heading variant="display-0">Display 0</Heading>
 
 export const Heading1 = () => (
-  <Heading data-automation-id="test" variant="heading-1">
+  <Heading data-automation-id="test" variant="heading-1" id="make-me-unique">
     Heading 1
   </Heading>
 )

--- a/packages/component-library/stories/Paragraph.stories.tsx
+++ b/packages/component-library/stories/Paragraph.stories.tsx
@@ -16,7 +16,9 @@ export default {
 }
 
 export const IntroLede = () => (
-  <Paragraph variant="intro-lede">Paragraph Intro Lede</Paragraph>
+  <Paragraph variant="intro-lede" id="make-me-unique">
+    Paragraph Intro Lede
+  </Paragraph>
 )
 
 export const Body = () => (


### PR DESCRIPTION
# Objective
Uses `extends Omit<HTMLAttributes<HTMLElement>, "className">` on our `Heading` and `Paragraph` components to allow native props like `id` on these components.

Additionally, adds `label` to the list of allowed tags for these components.

# Motivation and Context
Ran into this as part of https://github.com/cultureamp/kaizen-design-system/pull/1956, where we need to put an `id` on a `Paragraph` component.

Regarding the `label` as an allowed tag - that's also related to the new Slider - we have a case in 1-on-1s where we want a label with heading styling.