### PR TITLE
fix: a11Y change for aria label on hidden for undefined

### DIFF
--- a/packages/component-library/components/Dropdown/__snapshots__/Dropdown.spec.tsx.snap
+++ b/packages/component-library/components/Dropdown/__snapshots__/Dropdown.spec.tsx.snap
@@ -11,8 +11,6 @@ exports[`Dropdown renders control action dropdown 1`] = `
       class="dropdownIcon"
     >
       <svg
-        aria-hidden="false"
-        aria-labelledby="9bf7d107-5813-5af0-bab0-b86e615f8ec3"
         class="icon"
         focusable="false"
         role="img"
@@ -37,8 +35,6 @@ exports[`Dropdown renders control action dropdown 1`] = `
       class="chevronIcon"
     >
       <svg
-        aria-hidden="false"
-        aria-labelledby="9bf7d107-5813-5af0-bab0-b86e615f8ec3"
         class="icon"
         focusable="false"
         role="img"
@@ -68,8 +64,6 @@ exports[`Dropdown renders default view 1`] = `
       class="dropdownIcon"
     >
       <svg
-        aria-hidden="false"
-        aria-labelledby="9bf7d107-5813-5af0-bab0-b86e615f8ec3"
         class="icon"
         focusable="false"
         role="img"
@@ -99,8 +93,6 @@ exports[`Dropdown renders drop down with icon 1`] = `
       class="dropdownIcon"
     >
       <svg
-        aria-hidden="false"
-        aria-labelledby="9bf7d107-5813-5af0-bab0-b86e615f8ec3"
         class="icon"
         focusable="false"
         role="img"
@@ -131,8 +123,6 @@ exports[`Dropdown renders drop down with icon and label 1`] = `
       class="dropdownIcon"
     >
       <svg
-        aria-hidden="false"
-        aria-labelledby="9bf7d107-5813-5af0-bab0-b86e615f8ec3"
         class="icon"
         focusable="false"
         role="img"
@@ -184,8 +174,6 @@ exports[`Dropdown renders reversed color control action dropdown 1`] = `
       class="dropdownIcon"
     >
       <svg
-        aria-hidden="false"
-        aria-labelledby="9bf7d107-5813-5af0-bab0-b86e615f8ec3"
         class="icon"
         focusable="false"
         role="img"
@@ -210,8 +198,6 @@ exports[`Dropdown renders reversed color control action dropdown 1`] = `
       class="chevronIcon"
     >
       <svg
-        aria-hidden="false"
-        aria-labelledby="9bf7d107-5813-5af0-bab0-b86e615f8ec3"
         class="icon"
         focusable="false"
         role="img"

--- a/packages/component-library/components/Icon/Icon.spec.tsx
+++ b/packages/component-library/components/Icon/Icon.spec.tsx
@@ -65,16 +65,5 @@ describe("<Icon />", () => {
       )
       expect(queryByText(description)).toBeTruthy()
     })
-
-    it("should be visible to screen readers", () => {
-      const title = "My accessible title"
-      const description = "My accessible icon description"
-
-      const { container } = render(
-        <Icon title={title} desc={description} icon={svgIcon} role="img" />
-      )
-
-      expect(container.querySelector('[aria-hidden="false"]')).toBeTruthy()
-    })
   })
 })

--- a/packages/component-library/components/Icon/Icon.tsx
+++ b/packages/component-library/components/Icon/Icon.tsx
@@ -60,8 +60,7 @@ const Icon: Icon = ({
 
   const accessibilityProps = {
     role,
-    ["aria-hidden"]: !isMeaningfulImg,
-    ["aria-labelledby"]: isMeaningfulImg && labelledBy ? labelledBy : undefined,
+    ["aria-hidden"]: isMeaningfulImg ? undefined : true,
   }
 
   return (

--- a/packages/notification/src/__snapshots__/GlobalNotification.spec.tsx.snap
+++ b/packages/notification/src/__snapshots__/GlobalNotification.spec.tsx.snap
@@ -37,8 +37,6 @@ exports[`The basic notification renders correctly 1`] = `
       class="cancelInner"
     >
       <svg
-        aria-hidden="false"
-        aria-labelledby="faffea72-0fc0-5bc3-8038-936bd9f22ca8"
         class="icon"
         focusable="false"
         role="img"
@@ -98,8 +96,6 @@ exports[`You can change the type 1`] = `
       class="cancelInner"
     >
       <svg
-        aria-hidden="false"
-        aria-labelledby="faffea72-0fc0-5bc3-8038-936bd9f22ca8"
         class="icon"
         focusable="false"
         role="img"

--- a/packages/notification/src/__snapshots__/InlineNotification.spec.tsx.snap
+++ b/packages/notification/src/__snapshots__/InlineNotification.spec.tsx.snap
@@ -79,8 +79,6 @@ exports[`The basic notification renders correctly 1`] = `
       class="cancelInner"
     >
       <svg
-        aria-hidden="false"
-        aria-labelledby="faffea72-0fc0-5bc3-8038-936bd9f22ca8"
         class="icon"
         focusable="false"
         role="img"


### PR DESCRIPTION
# Objective
Update to the Icon following A11Y audit that requested we remove the `aria-labelledby` and the `aria-hidden` tag in certain circumstances.

# Motivation and Context
Going through the A11Y audit report and fixing issues that have been called out. Being done as part of Earthings Tickets.

https://cultureamp.atlassian.net/jira/software/c/projects/EARTH/boards/186?selectedIssue=EARTH-821&modal=detail&atlOrigin=eyJpIjoiZTc4ZWE5MjdkMTY3NDU1NWFiYjNlMTE4ZGZjNzhiYWYiLCJwIjoiaiJ9

