### PR TITLE
fix: add secondary destructive variant to IconButton

### DIFF
--- a/draft-packages/button/KaizenDraft/Button/IconButton.tsx
+++ b/draft-packages/button/KaizenDraft/Button/IconButton.tsx
@@ -10,6 +10,7 @@ IconButton.defaultProps = {
   destructive: false,
   disabled: false,
   reversed: false,
+  secondary: false,
 }
 
 IconButton.displayName = "IconButton"

--- a/draft-packages/button/KaizenDraft/Button/components/GenericButton.tsx
+++ b/draft-packages/button/KaizenDraft/Button/components/GenericButton.tsx
@@ -29,6 +29,7 @@ export type GenericProps = {
   id?: string
   label: string
   destructive?: boolean
+  secondary?: boolean
   disabled?: boolean
   form?: boolean
   reversed?: boolean
@@ -53,7 +54,6 @@ export type AdditionalContentProps = {
 type LabelPropsGeneric = {
   iconPosition?: "start" | "end"
   primary?: boolean
-  secondary?: boolean
 }
 
 type WorkingProps = {

--- a/draft-packages/button/KaizenDraft/Button/components/GenericButton.tsx
+++ b/draft-packages/button/KaizenDraft/Button/components/GenericButton.tsx
@@ -237,7 +237,10 @@ const renderLink = (props: Props, ref: Ref<HTMLAnchorElement>) => {
 
 const buttonClass = (props: Props) => {
   const variantClass =
-    (props.destructive && props.secondary && styles.secondaryDestructive) ||
+    (props.destructive &&
+      props.secondary &&
+      !props.reversed &&
+      styles.secondaryDestructive) ||
     (props.destructive && styles.destructive) ||
     (props.primary && styles.primary) ||
     (props.secondary && styles.secondary)

--- a/draft-packages/button/KaizenDraft/Button/styles.scss
+++ b/draft-packages/button/KaizenDraft/Button/styles.scss
@@ -32,7 +32,7 @@ $caButton-verticalPaddingForm: calc(
   pointer-events: none;
 }
 
-@mixin secondary-destructive {
+@mixin secondary {
   font-family: $typography-button-secondary-font-family;
   font-weight: $typography-button-secondary-font-weight;
   font-size: $typography-button-secondary-font-size;
@@ -42,6 +42,34 @@ $caButton-verticalPaddingForm: calc(
   &:not(:disabled) {
     background: transparent;
     border-color: $border-borderless-border-color;
+    color: $color-blue-500;
+
+    %caButtonLabel {
+      color: $color-blue-500;
+    }
+
+    &:hover,
+    &:active,
+    :global(.js-focus-visible) &:global(.focus-visible) {
+      color: $color-blue-500;
+      background: $color-blue-100;
+      border-color: $border-borderless-border-color;
+    }
+  }
+
+  &:disabled,
+  &.working {
+    @include working-state;
+    background: transparent;
+    border-color: $border-borderless-border-color;
+    color: $color-blue-500;
+  }
+}
+
+@mixin secondary-destructive {
+  @include secondary;
+
+  &:not(:disabled) {
     color: $color-red-600;
 
     %caButtonLabel {
@@ -53,15 +81,12 @@ $caButton-verticalPaddingForm: calc(
     :global(.js-focus-visible) &:global(.focus-visible) {
       color: $color-red-600;
       background: $color-red-100;
-      border-color: $border-borderless-border-color;
     }
   }
 
   &:disabled,
   &.working {
     @include working-state;
-    background: transparent;
-    border-color: $border-borderless-border-color;
     color: $color-red-600;
   }
 }
@@ -232,37 +257,7 @@ $caButton-verticalPaddingForm: calc(
 }
 
 %caButtonSecondary {
-  font-family: $typography-button-secondary-font-family;
-  font-weight: $typography-button-secondary-font-weight;
-  font-size: $typography-button-secondary-font-size;
-  line-height: $typography-button-secondary-line-height;
-  letter-spacing: $typography-button-secondary-letter-spacing;
-
-  &:not(:disabled) {
-    background: transparent;
-    border-color: $border-borderless-border-color;
-    color: $color-blue-500;
-
-    %caButtonLabel {
-      color: $color-blue-500;
-    }
-
-    &:hover,
-    &:active,
-    :global(.js-focus-visible) &:global(.focus-visible) {
-      color: $color-blue-500;
-      background: $color-blue-100;
-      border-color: $border-borderless-border-color;
-    }
-  }
-
-  &:disabled,
-  &.working {
-    @include working-state;
-    background: transparent;
-    border-color: $border-borderless-border-color;
-    color: $color-blue-500;
-  }
+  @include secondary;
 }
 
 %caButtonSecondaryDestructive {
@@ -467,8 +462,7 @@ $caButton-verticalPaddingForm: calc(
     &,
     &:hover,
     &:active,
-    &%caButtonPrimary,
-    &%caButtonSecondary {
+    &%caButtonPrimary {
       color: inherit;
       background: none;
       border-color: $border-borderless-border-color;
@@ -485,13 +479,16 @@ $caButton-verticalPaddingForm: calc(
     }
   }
 
+  &%caButtonSecondary {
+    @include secondary;
+  }
+
   &:not(:disabled) {
     cursor: pointer;
 
     &:hover,
     &:active,
     :global(.js-focus-visible) &:global(.focus-visible) {
-      color: $color-blue-500;
       background: $color-gray-200;
       border-color: $border-borderless-border-color;
     }
@@ -508,6 +505,14 @@ $caButton-verticalPaddingForm: calc(
         background: rgba($color-white-rgb, 0.1);
         border-color: $border-borderless-border-color;
       }
+    }
+
+    &:disabled,
+    &.working {
+      @include working-state;
+      opacity: 0.3;
+      color: $color-white;
+      background: transparent;
     }
   }
 

--- a/draft-packages/button/KaizenDraft/Button/styles.scss
+++ b/draft-packages/button/KaizenDraft/Button/styles.scss
@@ -32,6 +32,40 @@ $caButton-verticalPaddingForm: calc(
   pointer-events: none;
 }
 
+@mixin secondary-destructive {
+  font-family: $typography-button-secondary-font-family;
+  font-weight: $typography-button-secondary-font-weight;
+  font-size: $typography-button-secondary-font-size;
+  line-height: $typography-button-secondary-line-height;
+  letter-spacing: $typography-button-secondary-letter-spacing;
+
+  &:not(:disabled) {
+    background: transparent;
+    border-color: $border-borderless-border-color;
+    color: $color-red-600;
+
+    %caButtonLabel {
+      color: $color-red-600;
+    }
+
+    &:hover,
+    &:active,
+    :global(.js-focus-visible) &:global(.focus-visible) {
+      color: $color-red-600;
+      background: $color-red-100;
+      border-color: $border-borderless-border-color;
+    }
+  }
+
+  &:disabled,
+  &.working {
+    @include working-state;
+    background: transparent;
+    border-color: $border-borderless-border-color;
+    color: $color-red-600;
+  }
+}
+
 %caButtonContainer {
   display: inline-block;
 }
@@ -232,37 +266,7 @@ $caButton-verticalPaddingForm: calc(
 }
 
 %caButtonSecondaryDestructive {
-  font-family: $typography-button-secondary-font-family;
-  font-weight: $typography-button-secondary-font-weight;
-  font-size: $typography-button-secondary-font-size;
-  line-height: $typography-button-secondary-line-height;
-  letter-spacing: $typography-button-secondary-letter-spacing;
-
-  &:not(:disabled) {
-    background: transparent;
-    border-color: $border-borderless-border-color;
-    color: $color-red-600;
-
-    %caButtonLabel {
-      color: $color-red-600;
-    }
-
-    &:hover,
-    &:active,
-    :global(.js-focus-visible) &:global(.focus-visible) {
-      color: $color-red-600;
-      background: $color-red-100;
-      border-color: $border-borderless-border-color;
-    }
-  }
-
-  &:disabled,
-  &.working {
-    @include working-state;
-    background: transparent;
-    border-color: $border-borderless-border-color;
-    color: $color-red-600;
-  }
+  @include secondary-destructive;
 }
 
 %caButtonReversed {
@@ -559,6 +563,10 @@ $caButton-verticalPaddingForm: calc(
       background: $color-red-500;
       border-color: $color-red-500;
     }
+  }
+
+  &%caButtonSecondaryDestructive {
+    @include secondary-destructive;
   }
 }
 

--- a/draft-packages/button/docs/IconButton.stories.tsx
+++ b/draft-packages/button/docs/IconButton.stories.tsx
@@ -59,6 +59,29 @@ export const DestructiveDisabled = () => (
 
 DestructiveDisabled.storyName = "Destructive, Disabled"
 
+export const DestructiveSecondary = () => (
+  <IconButton
+    icon={configureIcon}
+    label="Label"
+    destructive={true}
+    secondary={true}
+  />
+)
+
+DestructiveSecondary.storyName = "Destructive, Secondary"
+
+export const DestructiveSecondaryDisabled = () => (
+  <IconButton
+    icon={configureIcon}
+    label="Label"
+    destructive={true}
+    secondary={true}
+    disabled={true}
+  />
+)
+
+DestructiveSecondaryDisabled.storyName = "Destructive, Secondary, Disabled"
+
 export const Reversed = () => (
   <IconButton icon={configureIcon} label="Label" reversed />
 )

--- a/draft-packages/button/docs/IconButton.stories.tsx
+++ b/draft-packages/button/docs/IconButton.stories.tsx
@@ -56,8 +56,21 @@ export const DestructiveDisabled = () => (
     disabled={true}
   />
 )
-
 DestructiveDisabled.storyName = "Destructive, Disabled"
+
+export const Secondary = () => (
+  <IconButton icon={configureIcon} label="Label" secondary={true} />
+)
+
+export const SecondaryDisabled = () => (
+  <IconButton
+    icon={configureIcon}
+    label="Label"
+    secondary={true}
+    disabled={true}
+  />
+)
+DestructiveDisabled.storyName = "Secondary, Disabled"
 
 export const DestructiveSecondary = () => (
   <IconButton
@@ -67,7 +80,6 @@ export const DestructiveSecondary = () => (
     secondary={true}
   />
 )
-
 DestructiveSecondary.storyName = "Destructive, Secondary"
 
 export const DestructiveSecondaryDisabled = () => (
@@ -79,7 +91,6 @@ export const DestructiveSecondaryDisabled = () => (
     disabled={true}
   />
 )
-
 DestructiveSecondaryDisabled.storyName = "Destructive, Secondary, Disabled"
 
 export const Reversed = () => (
@@ -99,9 +110,34 @@ export const ReversedDisabled = () => (
     disabled={true}
   />
 )
-
 ReversedDisabled.storyName = "Reversed, Disabled"
 ReversedDisabled.parameters = {
+  backgrounds: {
+    default: "Purple 700",
+  },
+}
+
+export const ReversedSecondary = () => (
+  <IconButton icon={configureIcon} label="Label" reversed secondary={true} />
+)
+ReversedSecondary.storyName = "Reversed, Secondary"
+ReversedSecondary.parameters = {
+  backgrounds: {
+    default: "Purple 700",
+  },
+}
+
+export const ReversedSecondaryDisabled = () => (
+  <IconButton
+    icon={configureIcon}
+    label="Label"
+    reversed
+    secondary={true}
+    disabled={true}
+  />
+)
+ReversedSecondaryDisabled.storyName = "Reversed, Secondary Disabled"
+ReversedSecondaryDisabled.parameters = {
   backgrounds: {
     default: "Purple 700",
   },
@@ -110,5 +146,4 @@ ReversedDisabled.parameters = {
 export const FormDiscouraged = () => (
   <IconButton icon={configureIcon} label="Label" form={true} />
 )
-
 FormDiscouraged.storyName = "Form (discouraged)"


### PR DESCRIPTION
# Objective
<!-- Describe what this change achieves, and the details of how it works. -->
`IconButton` needs secondary destructive variant now that destructive variant [has been fixed](https://github.com/cultureamp/kaizen-design-system/issues/1892) to match the latest design.

**Secondary destructive design:**
<img width="846" alt="Screen Shot 2021-09-28 at 4 40 17 pm" src="https://user-images.githubusercontent.com/22196200/135036202-bc05aa6f-efe8-4e36-bdc5-aebcbf7fc9e5.png">

We also need to make sure there cannot be the combination of secondary, destructive, and reversed as this does not exist the designs.

# Checklist
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] If this contains visual changes, has it been reviewed by a designer?
- [ ] If this introduces either a new component or a breaking change to an existing component, has it been reviewed by an advocate? (Ask in #prod_design_systems)
- [ ] I have considered likely risks of these changes and got someone else to QA as appropriate
- [ ] I have or will communicate these changes to the front end practice

# Additional Considerations
- Does there need to be right-to-left (RTL) options for localization and internationalization?
- Has the test suite been updated?
- Have you done cross-browser testing for our [supported browsers](https://academy.cultureamp.com/hc/en-us/articles/204539569-Supported-browsers-for-Participants)?
- Have you updated any relevant documentation or left useful comments in the code?
- Have you reviewed Culture Amp's Web Accessibility guide [Current Compliance, Going Forward, Statement and Answers for Customers](https://cultureamp.atlassian.net/wiki/spaces/Prod/pages/428572998/Web+Accessibility)?
- If this contains substantial visual changes, especially far reaching ones, have you unlocked the Chromatic step in the pipeline?
- Have Storybook stories been updated?

**If you're new to Kaizen, please ask #prod_design_systems to set up an onboarding session to get you up to speed.** If you have an urgent PR to merge before that happens, it is safest to ask in #prod_design_systems to have a design system advocate review the PR to catch any issues.
