### PR TITLE
feat: Change the primaryAction to be an optional prop

### DIFF
--- a/packages/brand-moment/src/BrandMoment.tsx
+++ b/packages/brand-moment/src/BrandMoment.tsx
@@ -12,7 +12,7 @@ type Props = {
   illustration: ReactElement<SceneProps>
   header: ReactNode
   body?: ReactNode
-  primaryAction: ButtonProps
+  primaryAction?: ButtonProps
   secondaryAction?: ButtonProps
   text: {
     title: ReactNode
@@ -66,11 +66,13 @@ export const BrandMoment = (props: Props) => {
                 )}
                 {props.body && <Box mb={1.5}>{props.body}</Box>}
                 <div className={styles.actions}>
-                  <Button
-                    primary
-                    fullWidth={queries.isSmall}
-                    {...props.primaryAction}
-                  />
+                  {props.primaryAction && (
+                    <Button
+                      primary
+                      fullWidth={queries.isSmall}
+                      {...props.primaryAction}
+                    />
+                  )}
                   {props.secondaryAction && (
                     <div className={styles.secondaryAction}>
                       <Button

--- a/packages/brand-moment/src/BrandMoment.tsx
+++ b/packages/brand-moment/src/BrandMoment.tsx
@@ -7,7 +7,7 @@ import { assetUrl } from "@kaizen/hosted-assets"
 import classnames from "classnames"
 import styles from "./BrandMoment.scss"
 
-type Props = {
+export interface BrandMomentProps {
   mood: "informative" | "positive" | "negative"
   illustration: ReactElement<SceneProps>
   header: ReactNode
@@ -22,7 +22,7 @@ type Props = {
   }
 }
 
-export const BrandMoment = (props: Props) => {
+export const BrandMoment = (props: BrandMomentProps) => {
   const { queries } = useMediaQueries()
 
   return (


### PR DESCRIPTION
# Objective
This PR makes the primary action prop optional. 

# Motivation and Context
Some Brand Moments, such as the new maintenance page, do not have any call to action within the Brand Moments. 
I've also exported the `BrandMomentProps` interface so that it's consistent with other Kaizen components. 

