### PR TITLE
fix: Add label to TiltleBlockZen overflow meatball IconButton

### DIFF
--- a/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/MainActions.tsx
+++ b/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/MainActions.tsx
@@ -156,7 +156,11 @@ const MainActions = ({
           <Menu
             align="right"
             button={
-              <IconButton label="" reversed={reversed} icon={meatballsIcon} />
+              <IconButton
+                label="Open secondary menu"
+                reversed={reversed}
+                icon={meatballsIcon}
+              />
             }
           >
             <MenuContent>


### PR DESCRIPTION
Issue: https://github.com/cultureamp/kaizen-design-system/issues/1916

Same thing as https://github.com/cultureamp/kaizen-design-system/pull/1938, but for the MainActions -> overflow button (basically the same button but only shows on smaller viewports). We didn't realise that there were two cases that needed this.