### PR TITLE
feat: add primary and primary reversed to icon button

### DIFF
--- a/draft-packages/button/KaizenDraft/Button/IconButton.tsx
+++ b/draft-packages/button/KaizenDraft/Button/IconButton.tsx
@@ -7,6 +7,7 @@ const IconButton: React.FunctionComponent<IconButtonProps> = (
 
 IconButton.defaultProps = {
   form: false,
+  primary: false,
   destructive: false,
   disabled: false,
   reversed: false,

--- a/draft-packages/button/KaizenDraft/Button/components/GenericButton.tsx
+++ b/draft-packages/button/KaizenDraft/Button/components/GenericButton.tsx
@@ -28,6 +28,7 @@ export type CustomButtonProps = {
 export type GenericProps = {
   id?: string
   label: string
+  primary?: boolean
   destructive?: boolean
   secondary?: boolean
   disabled?: boolean

--- a/draft-packages/button/KaizenDraft/Button/styles.scss
+++ b/draft-packages/button/KaizenDraft/Button/styles.scss
@@ -32,6 +32,62 @@ $caButton-verticalPaddingForm: calc(
   pointer-events: none;
 }
 
+@mixin primary {
+  &:not(:disabled) {
+    background: $color-blue-500;
+    border-color: $border-borderless-border-color;
+    color: $color-white;
+
+    &:hover {
+      background: $color-blue-600;
+      border-color: $color-blue-600;
+    }
+
+    &:active {
+      background: $color-blue-600;
+      border-color: $color-blue-600;
+    }
+
+    :global(.js-focus-visible) &:global(.focus-visible) {
+      background: $color-blue-600;
+      border-color: $color-blue-600;
+    }
+  }
+
+  &:disabled,
+  &.working {
+    @include working-state;
+    background: $color-blue-500;
+    color: $color-white;
+    border-color: $border-borderless-border-color;
+  }
+}
+
+@mixin primary-reversed {
+  &:not(:disabled) {
+    background: $color-green-300;
+    border-color: $border-borderless-border-color;
+    color: $color-purple-800;
+
+    &:hover {
+      background: $color-green-400;
+    }
+
+    :global(.js-focus-visible) &:global(.focus-visible) {
+      border-color: $border-borderless-border-color;
+      background: $color-green-400;
+    }
+  }
+
+  &:disabled,
+  &.working {
+    @include working-state;
+    background: $color-green-300;
+    border-color: $border-borderless-border-color;
+    color: $color-purple-800;
+  }
+}
+
 @mixin secondary {
   font-family: $typography-button-secondary-font-family;
   font-weight: $typography-button-secondary-font-weight;
@@ -195,34 +251,7 @@ $caButton-verticalPaddingForm: calc(
 }
 
 %caButtonPrimary {
-  &:not(:disabled) {
-    background: $color-blue-500;
-    border-color: $border-borderless-border-color;
-    color: $color-white;
-
-    &:hover {
-      background: $color-blue-600;
-      border-color: $color-blue-600;
-    }
-
-    &:active {
-      background: $color-blue-600;
-      border-color: $color-blue-600;
-    }
-
-    :global(.js-focus-visible) &:global(.focus-visible) {
-      background: $color-blue-600;
-      border-color: $color-blue-600;
-    }
-  }
-
-  &:disabled,
-  &.working {
-    @include working-state;
-    background: $color-blue-500;
-    color: $color-white;
-    border-color: $border-borderless-border-color;
-  }
+  @include primary;
 }
 
 %caButtonDestructive {
@@ -293,31 +322,6 @@ $caButton-verticalPaddingForm: calc(
     border-color: rgba($color-white-rgb, 0.5);
     color: $color-white;
     background: transparent;
-  }
-
-  &%caButtonPrimary {
-    &:not(:disabled) {
-      background: $color-green-300;
-      border-color: $border-borderless-border-color;
-      color: $color-purple-800;
-
-      &:hover {
-        background: $color-green-400;
-      }
-
-      :global(.js-focus-visible) &:global(.focus-visible) {
-        border-color: $border-borderless-border-color;
-        background: $color-green-400;
-      }
-    }
-
-    &:disabled,
-    &.working {
-      @include working-state;
-      background: $color-green-300;
-      border-color: $border-borderless-border-color;
-      color: $color-purple-800;
-    }
   }
 
   &%caButtonSecondary {
@@ -468,15 +472,19 @@ $caButton-verticalPaddingForm: calc(
       border-color: $border-borderless-border-color;
 
       &%caButtonReversed {
-        color: white;
+        color: $color-purple-800;
         &%caButtonPrimary {
           %caButtonContent {
-            color: white;
+            color: $color-purple-800;
             background: none;
           }
         }
       }
     }
+  }
+
+  &%caButtonPrimary {
+    @include primary;
   }
 
   &%caButtonSecondary {
@@ -513,6 +521,10 @@ $caButton-verticalPaddingForm: calc(
       opacity: 0.3;
       color: $color-white;
       background: transparent;
+    }
+
+    &%caButtonPrimary {
+      @include primary-reversed;
     }
   }
 

--- a/draft-packages/button/docs/IconButton.stories.tsx
+++ b/draft-packages/button/docs/IconButton.stories.tsx
@@ -44,6 +44,36 @@ export const Disabled = () => (
   <IconButton icon={configureIcon} label="Label" disabled={true} />
 )
 
+export const Primary = () => (
+  <IconButton icon={configureIcon} label="Label" primary />
+)
+Primary.storyName = "Primary"
+
+export const PrimaryDisabled = () => (
+  <IconButton icon={configureIcon} label="Label" primary disabled />
+)
+PrimaryDisabled.storyName = "Primary, Disabled"
+
+export const PrimaryReversed = () => (
+  <IconButton icon={configureIcon} label="Label" primary reversed />
+)
+PrimaryReversed.storyName = "Primary, Reversed"
+PrimaryReversed.parameters = {
+  backgrounds: {
+    default: "Purple 700",
+  },
+}
+
+export const PrimaryReversedDisabled = () => (
+  <IconButton icon={configureIcon} label="Label" primary reversed disabled />
+)
+PrimaryReversedDisabled.storyName = "Primary, Reversed, Disabled"
+PrimaryReversedDisabled.parameters = {
+  backgrounds: {
+    default: "Purple 700",
+  },
+}
+
 export const Destructive = () => (
   <IconButton icon={configureIcon} label="Label" destructive={true} />
 )


### PR DESCRIPTION
# Objective
- Add primary and primary reversed to IconButton

# Motivation and Context
- Closes this: https://github.com/cultureamp/kaizen-design-system/issues/1890


# Screenshots (if appropriate)
<img width="620" alt="Screen Shot 2021-10-06 at 1 33 25 pm" src="https://user-images.githubusercontent.com/18339250/136131614-eff7d8f0-1d7a-42d2-9f8c-dbf252f9d3c8.png">

<img width="608" alt="Screen Shot 2021-10-06 at 1 36 14 pm" src="https://user-images.githubusercontent.com/18339250/136131797-c07319c6-fca1-4d9f-81db-31a59e38d756.png">

# Checklist
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] If this contains visual changes, has it been reviewed by a designer?
- [ ] If this introduces either a new component or a breaking change to an existing component, has it been reviewed by an advocate? (Ask in #prod_design_systems)
- [ ] I have considered likely risks of these changes and got someone else to QA as appropriate
- [ ] I have or will communicate these changes to the front end practice

# Additional Considerations
- Does there need to be right-to-left (RTL) options for localization and internationalization?
- Has the test suite been updated?
- Have you done cross-browser testing for our [supported browsers](https://academy.cultureamp.com/hc/en-us/articles/204539569-Supported-browsers-for-Participants)?
- Have you updated any relevant documentation or left useful comments in the code?
- Have you reviewed Culture Amp's Web Accessibility guide [Current Compliance, Going Forward, Statement and Answers for Customers](https://cultureamp.atlassian.net/wiki/spaces/Prod/pages/428572998/Web+Accessibility)?
- If this contains substantial visual changes, especially far reaching ones, have you unlocked the Chromatic step in the pipeline?
- Have Storybook stories been updated?

**If you're new to Kaizen, please ask #prod_design_systems to set up an onboarding session to get you up to speed.** If you have an urgent PR to merge before that happens, it is safest to ask in #prod_design_systems to have a design system advocate review the PR to catch any issues.
