### PR TITLE
chore: Update renovate config to trigger a patch release when publishable packages...

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -21,13 +21,6 @@
       "matchPaths": ["packages/**", "draft-packages/**"],
       "semanticCommitType": "fix",
       "matchDepTypes": ["peerDependencies", "dependencies"]
-    },
-    {
-      // devDependencies of publishable packages should not trigger 
-      // a new release 
-      "matchPaths": ["packages/**", "draft-packages/**"],
-      "extends": [":semanticCommitTypeAll(chore)"],
-      "matchDepTypes": ["devDependencies"]
     }
   ]
 }


### PR DESCRIPTION
# Objective
Update renovate config to trigger a patch release when publishable packages receive a version change on a peerDependency or dependency.

# Motivation and Context
A sensible default for changes to dependencies within publishable packages is to trigger a patch release. This should be checked and verified by the merger of the PR. 

# Screenshots (if appropriate)
