### PR TITLE
fix: Avoid divs inside labels for valid HTML

### DIFF
--- a/draft-packages/form/KaizenDraft/Form/Primitives/Checkbox/Checkbox.tsx
+++ b/draft-packages/form/KaizenDraft/Form/Primitives/Checkbox/Checkbox.tsx
@@ -55,7 +55,7 @@ const Input: Input = ({
   tabIndex,
   value,
 }) => (
-  <div className={styles.container}>
+  <span className={styles.container}>
     <input
       type="checkbox"
       id={id}
@@ -79,8 +79,8 @@ const Input: Input = ({
         }
       }}
     />
-    <div className={styles.box}>{renderCheckOrMixedIcon(checkedStatus)}</div>
-  </div>
+    <span className={styles.box}>{renderCheckOrMixedIcon(checkedStatus)}</span>
+  </span>
 )
 
 export default Input

--- a/draft-packages/form/KaizenDraft/Form/Primitives/Checkbox/styles.scss
+++ b/draft-packages/form/KaizenDraft/Form/Primitives/Checkbox/styles.scss
@@ -34,6 +34,7 @@ $focus-ring-offset: 2px;
 }
 
 .box {
+  display: block;
   position: relative;
   pointer-events: none;
   background: $color-white;

--- a/draft-packages/form/KaizenDraft/Form/Primitives/Radio/Radio.tsx
+++ b/draft-packages/form/KaizenDraft/Form/Primitives/Radio/Radio.tsx
@@ -31,7 +31,7 @@ const Radio: Radio = ({
   onChange,
   disabled = false,
 }) => (
-  <div>
+  <span>
     <input
       type="radio"
       id={id}
@@ -45,8 +45,8 @@ const Radio: Radio = ({
       onChange={onChange}
       disabled={disabled}
     />
-    <div className={styles.box}>{renderSelected(selectedStatus)}</div>
-  </div>
+    <span className={styles.box}>{renderSelected(selectedStatus)}</span>
+  </span>
 )
 
 export default Radio

--- a/draft-packages/form/KaizenDraft/Form/Primitives/Radio/styles.scss
+++ b/draft-packages/form/KaizenDraft/Form/Primitives/Radio/styles.scss
@@ -25,6 +25,7 @@ $focus-ring-offset: 2px;
 }
 
 .box {
+  display: block;
   position: relative;
   background: $color-white;
   height: $radio-size;

--- a/draft-packages/form/KaizenDraft/Form/Primitives/ToggleSwitch/ToggleSwitch.tsx
+++ b/draft-packages/form/KaizenDraft/Form/Primitives/ToggleSwitch/ToggleSwitch.tsx
@@ -41,7 +41,7 @@ const ToggleSwitch: ToggleSwitch = ({
   const isOn = toggledStatus === ToggledStatus.ON
 
   return (
-    <div
+    <span
       className={classnames({
         [styles.on]: isOn,
         [styles.off]: !isOn,
@@ -59,14 +59,14 @@ const ToggleSwitch: ToggleSwitch = ({
         onBlur={onBlur}
         disabled={disabled}
       />
-      <div
+      <span
         className={classnames(styles.track, {
           [styles.freemium]: theme === ToggleTheme.FREEMIUM,
         })}
       >
-        <div className={styles.thumb} />
-      </div>
-    </div>
+        <span className={styles.thumb} />
+      </span>
+    </span>
   )
 }
 

--- a/draft-packages/form/KaizenDraft/Form/RadioGroup/__snapshots__/RadioGroup.spec.tsx.snap
+++ b/draft-packages/form/KaizenDraft/Form/RadioGroup/__snapshots__/RadioGroup.spec.tsx.snap
@@ -94,7 +94,7 @@ exports[`<RadioGroup />  snapshots renders RadioGroup with radios 1`] = `
       for="radio-1"
       id="radio-1-field-label"
     >
-      <div>
+      <span>
         <input
           class="radioInput needsclick"
           data-automation-id="radio-1-radio-input"
@@ -103,10 +103,10 @@ exports[`<RadioGroup />  snapshots renders RadioGroup with radios 1`] = `
           type="radio"
           value="radio-1"
         />
-        <div
+        <span
           class="box"
         />
-      </div>
+      </span>
       <span
         class="appendedLabel"
       >
@@ -123,7 +123,7 @@ exports[`<RadioGroup />  snapshots renders RadioGroup with radios 1`] = `
       for="radio-2"
       id="radio-2-field-label"
     >
-      <div>
+      <span>
         <input
           class="radioInput needsclick"
           data-automation-id="radio-2-radio-input"
@@ -132,10 +132,10 @@ exports[`<RadioGroup />  snapshots renders RadioGroup with radios 1`] = `
           type="radio"
           value="radio-2"
         />
-        <div
+        <span
           class="box"
         />
-      </div>
+      </span>
       <span
         class="appendedLabel"
       >

--- a/draft-packages/form/docs/CheckboxField.stories.tsx
+++ b/draft-packages/form/docs/CheckboxField.stories.tsx
@@ -34,16 +34,12 @@ class CheckboxFieldExample extends React.Component<Props> {
     const { render } = this.props
 
     return (
-      <div
-        style={{
-          paddingTop: 24,
-        }}
-      >
+      <>
         {render({
           checkedStatus: this.state.checkedStatus,
           onCheckHandler: this.onCheckHandler,
         })}
-      </div>
+      </>
     )
   }
 }
@@ -72,12 +68,12 @@ export const InteractiveKaizenSiteDemo = () => (
         id="checkbox-1"
         checkedStatus={checkedStatus as any}
         labelText={
-          <div>
+          <span>
             This is a label with a{" "}
             <a href="http://google.com" target="_blank">
               link
             </a>
-          </div>
+          </span>
         }
       />
     )}

--- a/draft-packages/form/docs/CheckboxGroup.stories.tsx
+++ b/draft-packages/form/docs/CheckboxGroup.stories.tsx
@@ -68,12 +68,12 @@ export const InteractiveKaizenSiteDemo = () => (
             id="checkbox-1"
             checkedStatus={checkedStatus as any}
             labelText={
-              <div>
+              <span>
                 This is a label with a{" "}
                 <a href="http://google.com" target="_blank">
                   link
                 </a>
-              </div>
+              </span>
             }
           />
         )}
@@ -85,12 +85,12 @@ export const InteractiveKaizenSiteDemo = () => (
             id="checkbox-2"
             checkedStatus={checkedStatus as any}
             labelText={
-              <div>
+              <span>
                 This is a label with a{" "}
                 <a href="http://google.com" target="_blank">
                   link
                 </a>
-              </div>
+              </span>
             }
           />
         )}
@@ -102,12 +102,12 @@ export const InteractiveKaizenSiteDemo = () => (
             id="checkbox-3"
             checkedStatus={checkedStatus as any}
             labelText={
-              <div>
+              <span>
                 This is a label with a{" "}
                 <a href="http://google.com" target="_blank">
                   link
                 </a>
-              </div>
+              </span>
             }
           />
         )}

--- a/draft-packages/form/docs/RadioField.stories.tsx
+++ b/draft-packages/form/docs/RadioField.stories.tsx
@@ -37,16 +37,12 @@ class RadioFieldExample extends React.Component<Props> {
     const { render } = this.props
 
     return (
-      <div
-        style={{
-          paddingTop: 24,
-        }}
-      >
+      <>
         {render({
           selectedStatus: this.state.selectedStatus,
           onChangeHandler: this.onChangeHandler,
         })}
-      </div>
+      </>
     )
   }
 }
@@ -77,12 +73,12 @@ export const InteractiveKaizenSiteDemo = () => (
         selectedStatus={selectedStatus as any}
         value="radio-1"
         labelText={
-          <div>
+          <span>
             This is a label with a{" "}
             <a href="http://google.com" target="_blank">
               link
             </a>
-          </div>
+          </span>
         }
       />
     )}

--- a/draft-packages/form/docs/TextField.stories.tsx
+++ b/draft-packages/form/docs/TextField.stories.tsx
@@ -43,12 +43,12 @@ export const DefaultKaizenSiteDemo = () => (
       inputType="email"
       inputValue=""
       labelText={
-        <div>
+        <span>
           This is a label with a{" "}
           <a href="http://google.com" target="_blank">
             link
           </a>
-        </div>
+        </span>
       }
       placeholder="Please enter your email"
       onChange={() => undefined}
@@ -529,12 +529,12 @@ export const DefaultFocusBlurEvents = () => (
       inputType="email"
       inputValue=""
       labelText={
-        <div>
+        <span>
           This is a label with a{" "}
           <a href="http://google.com" target="_blank">
             link
           </a>
-        </div>
+        </span>
       }
       placeholder="Please enter your email"
       onFocus={() => undefined}


### PR DESCRIPTION
# Objective
Replaces any `div`s living inside of a `label` with `span`s in Checkbox, Radio, and ToggleSwitch.

# Motivation and Context
Closes https://github.com/cultureamp/kaizen-design-system/issues/2083