### PR TITLE
fix: elm field description styles

### DIFF
--- a/draft-packages/form/KaizenDraft/Form/Primitives/FieldMessage/FieldMessage.elm
+++ b/draft-packages/form/KaizenDraft/Form/Primitives/FieldMessage/FieldMessage.elm
@@ -3,6 +3,7 @@ module KaizenDraft.Form.Primitives.FieldMessage.FieldMessage exposing (FieldMess
 import CssModules exposing (css)
 import Html exposing (..)
 import Html.Attributes
+import Paragraph.Paragraph as Paragraph exposing (TypeVariant(..))
 
 
 styles =
@@ -21,9 +22,12 @@ type FieldMessageStatus
     | Success
     | Error
 
+
 type FieldMessagePosition
     = Top
     | Bottom
+
+
 
 -- CONFIG
 
@@ -120,6 +124,11 @@ view (Config config) =
         attribs =
             idAttr
                 ++ automationIdAttr
+
+        descriptionParagraphConfig =
+            Paragraph.p
+                |> Paragraph.variant Small
+                |> Paragraph.color Paragraph.DarkReducedOpacity
     in
     div
         (attribs
@@ -139,8 +148,11 @@ view (Config config) =
                 -- we wanted to avoid a breaking change, so we need to deal with
                 -- nonsensical state where both are provided, so the html
                 -- aribitrarily wins out if both are supplied
-                html
+                [ Paragraph.view descriptionParagraphConfig html ]
 
             ( messageString, Nothing ) ->
-                [ text messageString ]
+                [ Paragraph.view
+                    descriptionParagraphConfig
+                    [ text messageString ]
+                ]
         )

--- a/draft-packages/form/KaizenDraft/Form/TextField/TextField.elm
+++ b/draft-packages/form/KaizenDraft/Form/TextField/TextField.elm
@@ -47,7 +47,6 @@ styles =
         , error = "error"
         , icon = "icon"
         , inline = "inline"
-        , description = "description"
         }
 
 
@@ -371,10 +370,7 @@ view (Config config) =
 
                 _ ->
                     div
-                        [ styles.classList
-                            [ ( .description, True )
-                            ]
-                        ]
+                        []
                         [ FieldMessage.view
                             (FieldMessage.default
                                 |> FieldMessage.id (idProp ++ "-field-description")


### PR DESCRIPTION
# Objective
A recent uplift to React 
( a css class was removed)

Rather than using css for styling text, we prefer the Paragraph component. So, `FieldMessage` has been updated to use Paragraph (and the latest Heart styles).

# Motivation and Context
It was just something I noticed after dong a dependency update. 

# Screenshots (if appropriate)

**before**

![image](https://user-images.githubusercontent.com/702885/138389680-e647572a-4622-45d4-8b7c-420a342e62a2.png)


**after**
![image](https://user-images.githubusercontent.com/702885/138389620-d34914c8-a781-4de2-b6cb-ccbc28031e17.png)


# Checklist
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] If this contains visual changes, has it been reviewed by a designer?
- [ ] If this introduces either a new component or a breaking change to an existing component, has it been reviewed by an advocate? (Ask in #prod_design_systems)
- [ ] I have considered likely risks of these changes and got someone else to QA as appropriate
- [ ] I have or will communicate these changes to the front end practice

# Additional Considerations
- Does there need to be right-to-left (RTL) options for localization and internationalization?
- Has the test suite been updated?
- Have you done cross-browser testing for our [supported browsers](https://academy.cultureamp.com/hc/en-us/articles/204539569-Supported-browsers-for-Participants)?
- Have you updated any relevant documentation or left useful comments in the code?
- Have you reviewed Culture Amp's Web Accessibility guide [Current Compliance, Going Forward, Statement and Answers for Customers](https://cultureamp.atlassian.net/wiki/spaces/Prod/pages/428572998/Web+Accessibility)?
- If this contains substantial visual changes, especially far reaching ones, have you unlocked the Chromatic step in the pipeline?
- Have Storybook stories been updated?

**If you're new to Kaizen, please ask #prod_design_systems to set up an onboarding session to get you up to speed.** If you have an urgent PR to merge before that happens, it is safest to ask in #prod_design_systems to have a design system advocate review the PR to catch any issues.
