### PR TITLE
fix: Update snapshots after removing IDs from Icon

### DIFF
--- a/packages/component-library/components/Dropdown/__snapshots__/Dropdown.spec.tsx.snap
+++ b/packages/component-library/components/Dropdown/__snapshots__/Dropdown.spec.tsx.snap
@@ -16,9 +16,7 @@ exports[`Dropdown renders control action dropdown 1`] = `
         role="img"
         viewBox="0 0 20 20"
       >
-        <title
-          id="9bf7d107-5813-5af0-bab0-b86e615f8ec3"
-        >
+        <title>
           Open menu
         </title>
         <use
@@ -39,9 +37,7 @@ exports[`Dropdown renders control action dropdown 1`] = `
         focusable="false"
         role="img"
       >
-        <title
-          id="9bf7d107-5813-5af0-bab0-b86e615f8ec3"
-        >
+        <title>
           Open menu
         </title>
         <use
@@ -68,9 +64,7 @@ exports[`Dropdown renders default view 1`] = `
         focusable="false"
         role="img"
       >
-        <title
-          id="9bf7d107-5813-5af0-bab0-b86e615f8ec3"
-        >
+        <title>
           Open menu
         </title>
         <use
@@ -98,9 +92,7 @@ exports[`Dropdown renders drop down with icon 1`] = `
         role="img"
         viewBox="0 0 20 20"
       >
-        <title
-          id="9bf7d107-5813-5af0-bab0-b86e615f8ec3"
-        >
+        <title>
           Open menu
         </title>
         <use
@@ -128,9 +120,7 @@ exports[`Dropdown renders drop down with icon and label 1`] = `
         role="img"
         viewBox="0 0 20 20"
       >
-        <title
-          id="9bf7d107-5813-5af0-bab0-b86e615f8ec3"
-        >
+        <title>
           Open menu
         </title>
         <use
@@ -179,9 +169,7 @@ exports[`Dropdown renders reversed color control action dropdown 1`] = `
         role="img"
         viewBox="0 0 20 20"
       >
-        <title
-          id="9bf7d107-5813-5af0-bab0-b86e615f8ec3"
-        >
+        <title>
           Open menu
         </title>
         <use
@@ -202,9 +190,7 @@ exports[`Dropdown renders reversed color control action dropdown 1`] = `
         focusable="false"
         role="img"
       >
-        <title
-          id="9bf7d107-5813-5af0-bab0-b86e615f8ec3"
-        >
+        <title>
           Open menu
         </title>
         <use

--- a/packages/notification/src/__snapshots__/GlobalNotification.spec.tsx.snap
+++ b/packages/notification/src/__snapshots__/GlobalNotification.spec.tsx.snap
@@ -41,9 +41,7 @@ exports[`The basic notification renders correctly 1`] = `
         focusable="false"
         role="img"
       >
-        <title
-          id="faffea72-0fc0-5bc3-8038-936bd9f22ca8"
-        >
+        <title>
           close notification
         </title>
         <use
@@ -100,9 +98,7 @@ exports[`You can change the type 1`] = `
         focusable="false"
         role="img"
       >
-        <title
-          id="faffea72-0fc0-5bc3-8038-936bd9f22ca8"
-        >
+        <title>
           close notification
         </title>
         <use

--- a/packages/notification/src/__snapshots__/InlineNotification.spec.tsx.snap
+++ b/packages/notification/src/__snapshots__/InlineNotification.spec.tsx.snap
@@ -83,9 +83,7 @@ exports[`The basic notification renders correctly 1`] = `
         focusable="false"
         role="img"
       >
-        <title
-          id="faffea72-0fc0-5bc3-8038-936bd9f22ca8"
-        >
+        <title>
           close notification
         </title>
         <use


### PR DESCRIPTION
Follow up to https://github.com/cultureamp/kaizen-design-system/pull/2124 which got auto merged with build failures. Just updates snapshots