### PR TITLE
chore: Add migration notes to CHANGELOGs after Menu refactor

### DIFF
--- a/draft-packages/filter-menu-button/CHANGELOG.md
+++ b/draft-packages/filter-menu-button/CHANGELOG.md
@@ -48,7 +48,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### BREAKING CHANGES
 
-Ignore this and look at v2.1 for migration instructions
+No impact on consumptions of FilterMenuButton
 
 
 

--- a/draft-packages/menu/CHANGELOG.md
+++ b/draft-packages/menu/CHANGELOG.md
@@ -10,6 +10,9 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 * Adjust Menu structure again to allow content separate from the list of items ([#2126](https://github.com/cultureamp/kaizen-design-system/issues/2126)) ([b56864b](https://github.com/cultureamp/kaizen-design-system/commit/b56864b6982232d4360352bcfc724fa1cc6c37e8))
 
+Migration notes:
+Menu has been refactored to render unordered lists, as a result it now has a change of API.
+MenuContent is no longer required and MenuHeading and MenuDivider have been removed. Wrap your MenuItems inside the new MenuList component instead. You can use multiple MenuLists inside 1 Menu if you want a heading and a separator. If you have content that isn't MenuItems - put them directly into Menu (do not wrap it in MenuList).
 
 
 

--- a/draft-packages/split-button/CHANGELOG.md
+++ b/draft-packages/split-button/CHANGELOG.md
@@ -10,6 +10,9 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 * Adjust Menu structure again to allow content separate from the list of items ([#2126](https://github.com/cultureamp/kaizen-design-system/issues/2126)) ([b56864b](https://github.com/cultureamp/kaizen-design-system/commit/b56864b6982232d4360352bcfc724fa1cc6c37e8))
 
+Migration notes:
+Menu has been refactored to render unordered lists, as a result it now has a change of API.
+For SplitButtons - remove any usages of MenuContent inside the dropdownContent prop. MenuItems should be placed directly inside dropdownContent.
 
 
 

--- a/draft-packages/title-block-zen/CHANGELOG.md
+++ b/draft-packages/title-block-zen/CHANGELOG.md
@@ -48,7 +48,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### BREAKING CHANGES
 
-Ignore this and go to v4.1 for migration notes
+No impact on consumption of TitleBlockZen, internals have been updated after Menu refactor but should be a safe upgrade
 
 
 


### PR DESCRIPTION
We released a breaking change to these components, but then followed up with another refactor and now I'm just manually updating CHANGELOGs to tell our consumers how to upgrade these components.

Original breaking change: https://github.com/cultureamp/kaizen-design-system/pull/2093
Follow up refactor: https://github.com/cultureamp/kaizen-design-system/pull/2126