### PR TITLE
feat: [BREAKING CHANGE] Removed Zen styling option from EmptyState component

### DIFF
--- a/draft-packages/empty-state/KaizenDraft/EmptyState/EmptyState.spec.tsx
+++ b/draft-packages/empty-state/KaizenDraft/EmptyState/EmptyState.spec.tsx
@@ -1,0 +1,106 @@
+import { cleanup, render } from "@testing-library/react"
+import * as React from "react"
+
+import { EmptyStateProps } from "./EmptyState"
+import { EmptyState } from "."
+
+jest.mock("@kaizen/draft-illustration", () => ({
+  EmptyStatesPositive: () => <div>EmptyStatesPositive_Component</div>,
+  EmptyStatesNeutral: () => <div>EmptyStatesNeutral_Component</div>,
+  EmptyStatesNegative: () => <div>EmptyStatesNegative_Component</div>,
+  EmptyStatesInformative: () => <div>EmptyStatesInformative_Component</div>,
+  EmptyStatesAction: () => <div>EmptyStatesAction_Component</div>,
+}))
+
+describe("<EmptyState />", () => {
+  afterEach(cleanup)
+
+  const defaultProps: EmptyStateProps = {
+    id: "someId",
+    automationId: "someAutomationId",
+    headingText: "Some heading",
+    bodyText: "Lorem ipsum dolor...",
+  }
+
+  it("renders an `id` attribute", () => {
+    const { container } = render(<EmptyState {...defaultProps} />)
+
+    expect(container.querySelector("#someId")).toBeTruthy()
+  })
+
+  it("renders a `data-automation-id` attribute", () => {
+    const { container } = render(<EmptyState {...defaultProps} />)
+
+    expect(
+      container.querySelector("[data-automation-id='someAutomationId']")
+    ).toBeTruthy()
+  })
+
+  it("renders given children", () => {
+    const { getByText } = render(
+      <EmptyState {...defaultProps}>
+        <h1>Child Heading</h1>
+      </EmptyState>
+    )
+
+    expect(getByText("Child Heading")).toBeTruthy()
+  })
+
+  describe("Illustrations", () => {
+    it("renders the `informative` illustration by default", () => {
+      const { getByText } = render(<EmptyState {...defaultProps} />)
+
+      expect(getByText("EmptyStatesInformative_Component")).toBeTruthy()
+    })
+
+    it("renders the `informative` illustration when given `informative` as the type", () => {
+      const props: EmptyStateProps = {
+        ...defaultProps,
+        illustrationType: "informative",
+      }
+      const { getByText } = render(<EmptyState {...props} />)
+
+      expect(getByText("EmptyStatesInformative_Component")).toBeTruthy()
+    })
+
+    it("renders the `positive` illustration when given `positive` as the type", () => {
+      const props: EmptyStateProps = {
+        ...defaultProps,
+        illustrationType: "positive",
+      }
+      const { getByText } = render(<EmptyState {...props} />)
+
+      expect(getByText("EmptyStatesPositive_Component")).toBeTruthy()
+    })
+
+    it("renders the `neutral` illustration when given `neutral` as the type", () => {
+      const props: EmptyStateProps = {
+        ...defaultProps,
+        illustrationType: "neutral",
+      }
+      const { getByText } = render(<EmptyState {...props} />)
+
+      expect(getByText("EmptyStatesNeutral_Component")).toBeTruthy()
+    })
+
+    it("renders the `negative` illustration when given `negative` as the type", () => {
+      const props: EmptyStateProps = {
+        ...defaultProps,
+        illustrationType: "negative",
+      }
+      const { getByText } = render(<EmptyState {...props} />)
+
+      expect(getByText("EmptyStatesNegative_Component")).toBeTruthy()
+    })
+
+    it("renders the `action` illustration when given `action` as the type", () => {
+      const props: EmptyStateProps = {
+        ...defaultProps,
+        illustrationType: "action",
+      }
+      const { getByText } = render(<EmptyState {...props} />)
+
+      expect(getByText("EmptyStatesAction_Component")).toBeTruthy()
+    })
+  })
+})

--- a/draft-packages/empty-state/KaizenDraft/EmptyState/EmptyState.tsx
+++ b/draft-packages/empty-state/KaizenDraft/EmptyState/EmptyState.tsx
@@ -35,8 +35,6 @@ export type EmptyStateProps = {
   straightCorners?: boolean
   illustrationType?: IllustrationType
   layoutContext?: LayoutContextType
-  // TODO: Heart Rebrand Cleanup > Deprecate or completely remove this prop once Heart is released.
-  useZenStyles?: boolean
   children?: React.ReactNode
 } & Pick<AnimatedProps, "isAnimated" | "loop">
 
@@ -51,7 +49,6 @@ const EmptyState: EmptyState = ({
   bodyText,
   children,
   straightCorners,
-  useZenStyles,
   isAnimated = true,
   loop = false,
 }) => {
@@ -75,12 +72,7 @@ const EmptyState: EmptyState = ({
           ...animationProps,
         })}
       </div>
-      <div
-        className={classnames([
-          styles.textSide,
-          { [styles.zen]: useZenStyles },
-        ])}
-      >
+      <div className={styles.textSide}>
         <div className={styles.textSideInner}>
           <div className={styles.heading}>{headingText}</div>
           <div className={styles.description}>{bodyText}</div>

--- a/draft-packages/empty-state/KaizenDraft/EmptyState/styles.scss
+++ b/draft-packages/empty-state/KaizenDraft/EmptyState/styles.scss
@@ -163,20 +163,6 @@
   }
 }
 
-// ===================================================
-// This works with the temporary useZenStyles prop and
-// will enable Zen headings. This block can be removed
-// once these typography styles are the default.
-// TODO: Heart Rebrand Cleanup > We can remove the `useZenStyles` and this class variant once Heart is released. This means moving the following heading styles to the class above.
-.zen .heading {
-  font-family: $typography-heading-3-font-family;
-  font-size: $typography-heading-3-font-size;
-  font-weight: $typography-heading-3-font-weight;
-  line-height: $typography-heading-3-line-height;
-  letter-spacing: $typography-heading-3-letter-spacing;
-}
-// ===================================================
-
 .description {
   @include kz-typography-paragraph-body;
   margin-bottom: $spacing-md;

--- a/draft-packages/empty-state/docs/EmptyState.stories.tsx
+++ b/draft-packages/empty-state/docs/EmptyState.stories.tsx
@@ -1,5 +1,4 @@
 import chevronLeft from "@kaizen/component-library/icons/chevron-left.icon.svg"
-
 import chevronRight from "@kaizen/component-library/icons/chevron-right.icon.svg"
 
 import * as React from "react"
@@ -50,7 +49,6 @@ export const DefaultKaizenSiteDemo = () => (
     headingText="Empty state title"
     bodyText="If providing further actions, include a link to an action or use a
           Default or Primary action."
-    useZenStyles
   />
 )
 
@@ -62,7 +60,6 @@ export const Positive = () => (
     bodyText="If providing further actions, include a link to an action or use a
           Default or Primary action."
     illustrationType="positive"
-    useZenStyles
   >
     <div className={styles.buttonContainer}>
       <Button label="Label" icon={chevronRight} iconPosition="end" />
@@ -76,7 +73,6 @@ export const Informative = () => (
     bodyText="If providing further actions, include a link to an action or use a
           Default or Primary action."
     illustrationType="informative"
-    useZenStyles
   />
 )
 
@@ -99,7 +95,6 @@ export const Neutral = () => (
     bodyText="If providing further actions, include a link to an action or use a
           Default or Primary action."
     illustrationType="neutral"
-    useZenStyles
   />
 )
 
@@ -109,7 +104,6 @@ export const Negative = () => (
     bodyText="If providing further actions, include a link to an action or use a
           Default or Primary action."
     illustrationType="negative"
-    useZenStyles
   >
     <div className={styles.buttonContainer}>
       <Button label="Label" icon={chevronRight} iconPosition="end" />
@@ -124,7 +118,6 @@ export const RtlAction = () => (
       bodyText="If providing further actions, include a link to an action or use a
           Default or Primary action."
       illustrationType="action"
-      useZenStyles
     >
       <div className={styles.buttonContainer}>
         <Button label="Label" icon={chevronLeft} iconPosition="end" />
@@ -142,7 +135,6 @@ export const StraightCorners = () => (
           Default or Primary action."
     illustrationType="action"
     straightCorners
-    useZenStyles
   >
     <div className={styles.buttonContainer}>
       <Button label="Label" icon={chevronRight} iconPosition="end" />


### PR DESCRIPTION
# Objective
Removing the Zen style option from the `EmptyState` component.

# Motivation and Context
The Zen theme is not in use anymore.

# Checklist
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] ~~If this contains visual changes, has it been reviewed by a designer?~~ n/a
- [x] If this introduces either a new component or a breaking change to an existing component, has it been reviewed by an advocate? (Ask in #prod_design_systems)
- [ ] I have considered likely risks of these changes and got someone else to QA as appropriate
- [ ] I have or will communicate these changes to the front end practice

# Additional Considerations
- Has the test suite been updated?
  * _Yes, added a new test file with rudimentary tests as there was none_
