### PR TITLE
fix: Adjust Brand variant based on forced-colors user preference

### DIFF
--- a/packages/brand/src/Brand/Brand.tsx
+++ b/packages/brand/src/Brand/Brand.tsx
@@ -16,10 +16,20 @@ export const Brand = (props: BrandProps) => {
   const brandTheme = props.reversed ? "-reversed" : "-default"
 
   return (
-    <img
-      src={assetUrl(`brand/${props.variant}${brandTheme}.svg`)}
-      alt={props.alt}
-      className={styles.img}
-    />
+    <picture>
+      <source
+        srcSet={assetUrl(`brand/${props.variant}-reversed.svg`)}
+        media="(forced-colors: active) and (prefers-color-scheme: dark)"
+      />
+      <source
+        srcSet={assetUrl(`brand/${props.variant}-default.svg`)}
+        media="(forced-colors: active) and (prefers-color-scheme: light)"
+      />
+      <img
+        src={assetUrl(`brand/${props.variant}${brandTheme}.svg`)}
+        alt={props.alt}
+        className={styles.img}
+      />
+    </picture>
   )
 }


### PR DESCRIPTION
# Objective
Forced reversed/not-reversed variant of logo when the user has forced colors (high contast mode).

# Motivation and Context
Images are not adjusted at all in high contrast/forced colors mode. So if we have a logo that is for use on a light background, and the user forces a dark background - they no longer see the logo.