### PR TITLE
fix: export visiuallyHidden props to fix build

### DIFF
--- a/packages/a11y/src/VisuallyHidden/VisuallyHidden.tsx
+++ b/packages/a11y/src/VisuallyHidden/VisuallyHidden.tsx
@@ -4,7 +4,7 @@ import styles from "./VisuallyHidden.module.scss"
 
 export type AllowedTags = "div" | "span"
 
-interface VisuallyHiddenProps
+export interface VisuallyHiddenProps
   extends Omit<HTMLAttributes<HTMLElement>, "className"> {
   children: ReactNode
   /**


### PR DESCRIPTION
Work:
- Build was broken: https://buildkite.com/culture-amp/kaizen-design-system/builds/23939#25367a04-b11f-4f63-8d58-9515652a015b
- We just needed to export the props of the component and should be good to go
<img width="1104" alt="Screen Shot 2021-11-08 at 2 02 38 pm" src="https://user-images.githubusercontent.com/18339250/140677734-07b0bcd9-3de9-45d1-af7b-be559d4500ae.png">
