### PR TITLE
fix: override global figure styles coming from material ui

### DIFF
--- a/draft-packages/illustration/KaizenDraft/Illustration/style.module.scss
+++ b/draft-packages/illustration/KaizenDraft/Illustration/style.module.scss
@@ -1,5 +1,6 @@
 .wrapper {
   width: 100%;
+  margin: 0; // Override global Material UI styles
 }
 
 // If the .visually-hidden class is applied to natively focusable elements


### PR DESCRIPTION
# Objective
- Remove the margin styles that crept into `figure` with Material UI

# Motivation and Context
- Closes this: https://github.com/cultureamp/kaizen-design-system/issues/2210

# Screenshots (if appropriate)

## Before
<img width="1472" alt="Screen Shot 2021-11-09 at 4 36 32 pm" src="https://user-images.githubusercontent.com/18339250/140868658-98e544ba-dc82-4add-a3af-00572cc5a01d.png">

## After
<img width="1470" alt="Screen Shot 2021-11-09 at 4 36 15 pm" src="https://user-images.githubusercontent.com/18339250/140868663-ccb1aee8-1998-48f1-b3a9-68154f8fc6be.png">

