### PR TITLE
fix: Center Brand img vertically

### DIFF
--- a/packages/brand/src/Brand/Brand.scss
+++ b/packages/brand/src/Brand/Brand.scss
@@ -1,3 +1,4 @@
 .img {
   max-inline-size: 100%;
+  display: flex;
 }


### PR DESCRIPTION
Centers the Brand component vertically within `picture` element. This is necessary as the `picture` element expands to fill whatever it's rendered inside of.