### PR TITLE
fix: Remove inbuilt padding on Tabs

### DIFF
--- a/packages/tabs/docs/Tabs.stories.tsx
+++ b/packages/tabs/docs/Tabs.stories.tsx
@@ -25,12 +25,14 @@ export const Uncontrolled = () => (
     // eslint-disable-next-line no-console
     onChange={index => console.log("Tab changed to ", index)}
   >
-    <TabList aria-label="Tabs">
-      <Tab>Tab 1</Tab>
-      <Tab>Tab 2</Tab>
-      <Tab badge="3">Tab 3</Tab>
-      <Tab disabled>Disabled Tab</Tab>
-    </TabList>
+    <Box pt={0.25} pl={1} pr={1}>
+      <TabList aria-label="Tabs">
+        <Tab>Tab 1</Tab>
+        <Tab>Tab 2</Tab>
+        <Tab badge="3">Tab 3</Tab>
+        <Tab disabled>Disabled Tab</Tab>
+      </TabList>
+    </Box>
     <TabPanels>
       <TabPanel>
         <Box p={1}>
@@ -63,11 +65,13 @@ export const Controlled = () => {
         selectedIndex={selectedIndex}
         onChange={index => setSelectedIndex(index)}
       >
-        <TabList aria-label="Tabs">
-          <Tab>Tab 1</Tab>
-          <Tab>Tab 2</Tab>
-          <Tab>Tab 3</Tab>
-        </TabList>
+        <Box pt={0.25} pl={1} pr={1}>
+          <TabList aria-label="Tabs">
+            <Tab>Tab 1</Tab>
+            <Tab>Tab 2</Tab>
+            <Tab>Tab 3</Tab>
+          </TabList>
+        </Box>
         <TabPanels>
           <TabPanel>
             <Box p={1}>
@@ -98,11 +102,13 @@ export const Controlled = () => {
 
 export const ManualKeyboardActivation = () => (
   <Tabs keyboardActivation="manual">
-    <TabList aria-label="Tabs">
-      <Tab>Tab 1</Tab>
-      <Tab>Tab 2</Tab>
-      <Tab>Tab 3</Tab>
-    </TabList>
+    <Box pt={0.25} pl={1} pr={1}>
+      <TabList aria-label="Tabs">
+        <Tab>Tab 1</Tab>
+        <Tab>Tab 2</Tab>
+        <Tab>Tab 3</Tab>
+      </TabList>
+    </Box>
     <TabPanels>
       <TabPanel>
         <Box p={1}>
@@ -139,7 +145,7 @@ export const UsageInCard = () => (
       // eslint-disable-next-line no-console
       onChange={index => console.log("Tab changed to ", index)}
     >
-      <Box pt={0.25}>
+      <Box pt={0.25} pl={1} pr={1}>
         <TabList aria-label="Tabs">
           <Tab>Tab 1</Tab>
           <Tab>Tab 2</Tab>
@@ -147,7 +153,6 @@ export const UsageInCard = () => (
           <Tab disabled>Disabled Tab</Tab>
         </TabList>
       </Box>
-
       <TabPanels>
         <TabPanel>
           <Box p={1}>

--- a/packages/tabs/src/TabList.tsx
+++ b/packages/tabs/src/TabList.tsx
@@ -1,6 +1,5 @@
 import { TabList as ReachTabList } from "@reach/tabs"
 import React, { ReactNode } from "react"
-import styles from "./styles.scss"
 
 export interface TabListProps {
   /**
@@ -15,9 +14,5 @@ export interface TabListProps {
  */
 export const TabList = (props: TabListProps) => {
   const { "aria-label": ariaLabel, children } = props
-  return (
-    <ReachTabList className={styles.tabList} aria-label={ariaLabel}>
-      {children}
-    </ReachTabList>
-  )
+  return <ReachTabList aria-label={ariaLabel}>{children}</ReachTabList>
 }

--- a/packages/tabs/src/TabPanels.tsx
+++ b/packages/tabs/src/TabPanels.tsx
@@ -1,6 +1,6 @@
 import { TabPanels as ReachTabPanels } from "@reach/tabs"
 import React, { ReactNode } from "react"
-
+import styles from "./styles.scss"
 export interface TabPanelsProps {
   children: ReactNode
 }
@@ -10,5 +10,7 @@ export interface TabPanelsProps {
  */
 export const TabPanels = (props: TabPanelsProps) => {
   const { children } = props
-  return <ReachTabPanels>{children}</ReachTabPanels>
+  return (
+    <ReachTabPanels className={styles.tabPanels}>{children}</ReachTabPanels>
+  )
 }

--- a/packages/tabs/src/styles.scss
+++ b/packages/tabs/src/styles.scss
@@ -3,11 +3,6 @@
 @import "~@kaizen/design-tokens/sass/color";
 @import "~@kaizen/design-tokens/sass/typography";
 
-.tabList {
-  border-bottom: 1px solid rgba($color-gray-600-rgb, 0.1);
-  padding: 0 $spacing-md;
-}
-
 .tab {
   display: inline-flex;
   align-items: center;
@@ -76,6 +71,10 @@
   margin-inline-start: $spacing-sm;
   display: inline-flex;
   align-items: center;
+}
+
+.tabPanels {
+  border-top: 1px solid rgba($color-gray-600-rgb, 0.1);
 }
 
 .tabPanel {


### PR DESCRIPTION
@ActuallyACat [was right, I was wrong](https://github.com/cultureamp/kaizen-design-system/pull/2203/files#r743419878) 😅 Started implementing these on survey summary and we don't want this padding 😐

You might be wondering why I moved the border-bottom on tabList to a border-top of tabPanels:
Unfortunately I couldn't do the following, because it loses the `isSelected` prop that is magically passed from `TabList`. 
```
<Tabs>
  <TabList>
    <Box pl={1} pr={1}>
      <Tab>
    </Box>
  </TabList>
</Tabs>
```

So I had to move the border and then put the padding on the outside of TabList.
