### PR TITLE
fix: Replace div with span inside TitleBlock mobile button

### DIFF
--- a/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/MobileActions.tsx
+++ b/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/MobileActions.tsx
@@ -326,12 +326,12 @@ const DrawerHandle = ({
             onClick={toggleDisplay}
           >
             {primaryAction.label}
-            <div className={styles.mobileActionsChevronSquare}>
+            <span className={styles.mobileActionsChevronSquare}>
               <Icon
                 icon={isOpen ? chevronDownIcon : chevronUpIcon}
                 role="presentation"
               />
-            </div>
+            </span>
           </button>
         </div>
       )
@@ -388,12 +388,12 @@ const DrawerHandle = ({
           onClick={toggleDisplay}
         >
           {renderDrawerHandleLabel("Other actions")}
-          <div className={styles.mobileActionsChevronSquare}>
+          <span className={styles.mobileActionsChevronSquare}>
             <Icon
               icon={isOpen ? chevronDownIcon : chevronUpIcon}
               role="presentation"
             />
-          </div>
+          </span>
         </button>
       </div>
     )


### PR DESCRIPTION
Fixes a parsing error due to `div` not being allowed inside `<button>`. Already has a `display` property in CSS so no styling changes required.