### PR TITLE
chore: Fixing icons overlapping sticky header on health page

### DIFF
--- a/site/src/pages/component-health.scss
+++ b/site/src/pages/component-health.scss
@@ -15,6 +15,7 @@
   thead,
   tfoot {
     position: sticky;
+    z-index: 1;
   }
 
   tfoot {


### PR DESCRIPTION
# Issue

Unfortunately noticed too late that the icons are sitting above the sticky header when scrolling

![image](https://user-images.githubusercontent.com/763385/141934197-ec624ba6-d96d-401c-ba75-944f23b19e30.png)



# Fix

Adding a `z-index` helped:

![image](https://user-images.githubusercontent.com/763385/141934285-44e96a37-9a2e-460e-a6b7-76754367a742.png)

