### PR TITLE
fix: bump stale issues tagging and close

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -15,8 +15,8 @@ jobs:
           close-issue-message: "This issue was closed due to 2 months of inactivity. Feel free to reopen it if still relevant."
           days-before-pr-stale: 60
           days-before-pr-close: 14
-          days-before-issue-stale: 60
-          days-before-issue-close: 14
+          days-before-issue-stale: 120
+          days-before-issue-close: 30
           stale-pr-label: stale
           stale-issue-label: stale
           operations-per-run: 100


### PR DESCRIPTION
## Work
- As brought up in standup today, our issues are closing too fast. It was set to:
1. After 2 months of no activity -> tag as stale
2. Then 14 days with no activity -> close

Now it'll be
1. After 4 months of no activity -> tag as stale
2. Then 1 month of no activity -> close