### PR TITLE
fix: Update Input Edit Modal to use new styles and created new StoryBook

### DIFF
--- a/draft-packages/modal/KaizenDraft/Modal/Presets/ConfirmationModal.scss
+++ b/draft-packages/modal/KaizenDraft/Modal/Presets/ConfirmationModal.scss
@@ -3,7 +3,6 @@
 @import "~@kaizen/design-tokens/sass/color";
 @import "~@kaizen/deprecated-component-library-helpers/styles/color";
 @import "~@kaizen/deprecated-component-library-helpers/styles/layout";
-@import "~@kaizen/component-library/styles/responsive";
 
 $dt-positive-header-background: $color-green-100;
 $dt-informative-header-background: $color-blue-100;

--- a/draft-packages/modal/KaizenDraft/Modal/Presets/ConfirmationModal.spec.tsx
+++ b/draft-packages/modal/KaizenDraft/Modal/Presets/ConfirmationModal.spec.tsx
@@ -1,6 +1,7 @@
 import { cleanup, render, fireEvent } from "@testing-library/react"
 import * as React from "react"
 import ConfirmationModal, { ConfirmationModalProps } from "./ConfirmationModal"
+import "./matchMedia.mock"
 
 afterEach(cleanup)
 

--- a/draft-packages/modal/KaizenDraft/Modal/Presets/InformationModal.scss
+++ b/draft-packages/modal/KaizenDraft/Modal/Presets/InformationModal.scss
@@ -2,6 +2,7 @@
 @import "~@kaizen/component-library/styles/border";
 @import "~@kaizen/deprecated-component-library-helpers/styles/color";
 @import "~@kaizen/component-library/styles/responsive";
+@import "~@kaizen/design-tokens/sass/layout";
 @import "~@kaizen/deprecated-component-library-helpers/styles/type";
 
 .modal {
@@ -23,7 +24,7 @@
 .footer {
   white-space: nowrap;
   padding: $ca-grid 0 0 0;
-  @include ca-media-mobile {
+  @media (max-width: $layout-breakpoints-medium) {
     white-space: initial;
   }
 }
@@ -62,7 +63,7 @@
 .image {
   flex: 1;
   padding-left: $ca-grid * 2;
-  @include ca-media-mobile {
+  @media (max-width: $layout-breakpoints-medium) {
     display: none;
   }
 }

--- a/draft-packages/modal/KaizenDraft/Modal/Presets/InformationModal.spec.tsx
+++ b/draft-packages/modal/KaizenDraft/Modal/Presets/InformationModal.spec.tsx
@@ -1,6 +1,7 @@
 import { cleanup, render, fireEvent } from "@testing-library/react"
 import * as React from "react"
 import InformationModal, { InformationModalProps } from "./InformationModal"
+import "./matchMedia.mock"
 
 afterEach(cleanup)
 

--- a/draft-packages/modal/KaizenDraft/Modal/Presets/InputEditModal.scss
+++ b/draft-packages/modal/KaizenDraft/Modal/Presets/InputEditModal.scss
@@ -2,6 +2,7 @@
 @import "~@kaizen/component-library/styles/border";
 @import "~@kaizen/deprecated-component-library-helpers/styles/color";
 @import "~@kaizen/deprecated-component-library-helpers/styles/type";
+@import "~@kaizen/component-library/styles/responsive";
 
 .modal {
   composes: genericModal from "../Primitives/GenericModal.scss";
@@ -11,13 +12,24 @@
 
 .header {
   color: $color-purple-800;
-  padding: $ca-grid $ca-grid $ca-grid * 1.5;
-  text-align: center;
-  border-bottom: 1px solid $ca-border-color;
+  text-align: left;
+  &.textAlignRTL {
+    text-align: right;
+  }
+  &.padded {
+    padding: $ca-grid $ca-grid * 1.5;
+    @include ca-media-mobile {
+      padding: $ca-grid;
+    }
+  }
 }
 
 .body {
-  background: $color-gray-100;
-  padding: $ca-grid $ca-grid $ca-grid * 1.5;
-  border-bottom: 1px solid $ca-border-color;
+  background: $color-gray-200;
+  &.padded {
+    padding: $ca-grid $ca-grid * 1.5 $ca-grid $ca-grid * 1.5;
+    @include ca-media-mobile {
+      padding: $ca-grid;
+    }
+  }
 }

--- a/draft-packages/modal/KaizenDraft/Modal/Presets/InputEditModal.scss
+++ b/draft-packages/modal/KaizenDraft/Modal/Presets/InputEditModal.scss
@@ -13,9 +13,11 @@
 .header {
   color: $color-purple-800;
   text-align: left;
+
   &.textAlignRTL {
     text-align: right;
   }
+
   &.padded {
     padding: $ca-grid $ca-grid * 1.5;
     @include ca-media-mobile {
@@ -26,6 +28,7 @@
 
 .body {
   background: $color-gray-200;
+
   &.padded {
     padding: $ca-grid $ca-grid * 1.5 $ca-grid $ca-grid * 1.5;
     @include ca-media-mobile {

--- a/draft-packages/modal/KaizenDraft/Modal/Presets/InputEditModal.scss
+++ b/draft-packages/modal/KaizenDraft/Modal/Presets/InputEditModal.scss
@@ -2,7 +2,7 @@
 @import "~@kaizen/component-library/styles/border";
 @import "~@kaizen/deprecated-component-library-helpers/styles/color";
 @import "~@kaizen/deprecated-component-library-helpers/styles/type";
-@import "~@kaizen/component-library/styles/responsive";
+@import "~@kaizen/design-tokens/sass/layout";
 
 .modal {
   composes: genericModal from "../Primitives/GenericModal.scss";
@@ -20,7 +20,7 @@
 
   &.padded {
     padding: $ca-grid $ca-grid * 1.5;
-    @include ca-media-mobile {
+    @media (max-width: $layout-breakpoints-medium) {
       padding: $ca-grid;
     }
   }
@@ -31,7 +31,7 @@
 
   &.padded {
     padding: $ca-grid $ca-grid * 1.5 $ca-grid $ca-grid * 1.5;
-    @include ca-media-mobile {
+    @media (max-width: $layout-breakpoints-medium) {
       padding: $ca-grid;
     }
   }

--- a/draft-packages/modal/KaizenDraft/Modal/Presets/InputEditModal.spec.tsx
+++ b/draft-packages/modal/KaizenDraft/Modal/Presets/InputEditModal.spec.tsx
@@ -1,6 +1,7 @@
 import { cleanup, render, fireEvent } from "@testing-library/react"
 import * as React from "react"
 import InputEditModal, { InputEditModalProps } from "./InputEditModal"
+import "./matchMedia.mock"
 
 afterEach(cleanup)
 

--- a/draft-packages/modal/KaizenDraft/Modal/Presets/InputEditModal.tsx
+++ b/draft-packages/modal/KaizenDraft/Modal/Presets/InputEditModal.tsx
@@ -1,7 +1,6 @@
+import classnames from "classnames"
 import * as React from "react"
-
-import { Text } from "@kaizen/component-library"
-
+import { Heading } from "@kaizen/component-library"
 import { ButtonProps } from "@kaizen/draft-button"
 import {
   GenericModal,
@@ -10,11 +9,11 @@ import {
   ModalFooter,
   ModalHeader,
 } from "../"
-
 import styles from "./InputEditModal.scss"
 
 export interface InputEditModalProps {
   readonly isOpen: boolean
+  readonly unpadded?: boolean
   readonly type: "positive" | "negative"
   readonly title: string
   readonly onSubmit: () => void
@@ -40,6 +39,7 @@ const InputEditModal = ({
   submitWorking,
   automationId,
   children,
+  unpadded = false,
   ...props
 }: InputEditModalProps) => {
   const onDismiss = submitWorking ? undefined : props.onDismiss
@@ -64,17 +64,25 @@ const InputEditModal = ({
       automationId={automationId}
     >
       <div className={styles.modal} dir={localeDirection}>
-        <ModalHeader unpadded onDismiss={onDismiss}>
-          <div className={styles.header}>
+        <ModalHeader onDismiss={onDismiss}>
+          <div
+            className={classnames(styles.header, {
+              [styles.textAlignRTL]: localeDirection === "rtl",
+              [styles.padded]: !unpadded,
+            })}
+          >
             <ModalAccessibleLabel>
-              <Text tag="h1" style="zen-heading-3" inline>
+              <Heading tag="h2" variant="heading-2">
                 {title}
-              </Text>
+              </Heading>
             </ModalAccessibleLabel>
           </div>
         </ModalHeader>
-        <ModalBody unpadded>
-          <div className={styles.body} dir={localeDirection}>
+        <ModalBody>
+          <div
+            className={classnames(styles.body, { [styles.padded]: !unpadded })}
+            dir={localeDirection}
+          >
             {children}
           </div>
         </ModalBody>
@@ -82,6 +90,8 @@ const InputEditModal = ({
           actions={footerActions}
           appearance={type === "negative" ? "destructive" : "primary"}
           automationId={automationId}
+          variant={"input"}
+          unpadded={unpadded}
         />
       </div>
     </GenericModal>

--- a/draft-packages/modal/KaizenDraft/Modal/Presets/InputEditModal.tsx
+++ b/draft-packages/modal/KaizenDraft/Modal/Presets/InputEditModal.tsx
@@ -90,7 +90,7 @@ const InputEditModal = ({
           actions={footerActions}
           appearance={type === "negative" ? "destructive" : "primary"}
           automationId={automationId}
-          variant={"input"}
+          variant="inputEdit"
           unpadded={unpadded}
         />
       </div>

--- a/draft-packages/modal/KaizenDraft/Modal/Presets/RoadblockModal.spec.tsx
+++ b/draft-packages/modal/KaizenDraft/Modal/Presets/RoadblockModal.spec.tsx
@@ -1,6 +1,7 @@
 import { cleanup, render, fireEvent } from "@testing-library/react"
 import * as React from "react"
 import RoadblockModal, { RoadblockModalProps } from "./RoadblockModal"
+import "./matchMedia.mock"
 
 afterEach(cleanup)
 

--- a/draft-packages/modal/KaizenDraft/Modal/Presets/RoadblockModal.tsx
+++ b/draft-packages/modal/KaizenDraft/Modal/Presets/RoadblockModal.tsx
@@ -2,6 +2,7 @@ import * as React from "react"
 
 import { Heading } from "@kaizen/component-library"
 import { Negative } from "@kaizen/draft-illustration"
+import { withDeprecatedComponent } from "@kaizen/react-deprecate-warning"
 
 import {
   GenericModal,
@@ -25,6 +26,9 @@ export interface RoadblockModalProps {
 
 type RoadblockModal = React.FunctionComponent<RoadblockModalProps>
 
+/**
+ * @deprecated RoadblockModal is deprecated. Please use Confirmation Modal instead.
+ */
 const RoadblockModal = ({
   isOpen,
   title,
@@ -69,4 +73,7 @@ const RoadblockModal = ({
   </GenericModal>
 )
 
-export default RoadblockModal
+export default withDeprecatedComponent(RoadblockModal, {
+  warning:
+    "RoadblockModal is deprecated. Please use Confirmation Modal instead.",
+})

--- a/draft-packages/modal/KaizenDraft/Modal/Presets/matchMedia.mock
+++ b/draft-packages/modal/KaizenDraft/Modal/Presets/matchMedia.mock
@@ -1,0 +1,15 @@
+// Must be imported before the tested file
+
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: jest.fn().mockImplementation(query => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: jest.fn(), // deprecated
+    removeListener: jest.fn(), // deprecated
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+    dispatchEvent: jest.fn(),
+  })),
+});

--- a/draft-packages/modal/KaizenDraft/Modal/Primitives/GenericModalSection.scss
+++ b/draft-packages/modal/KaizenDraft/Modal/Primitives/GenericModalSection.scss
@@ -1,5 +1,7 @@
-@import "~@kaizen/deprecated-component-library-helpers/styles/type";
+@import "~@kaizen/design-tokens/sass/color";
+@import "~@kaizen/design-tokens/sass/border";
 
-.padded {
-  padding: $ca-grid;
+.inputEdit {
+  background-color: $color-gray-200;
+  border-radius: $border-solid-border-radius;
 }

--- a/draft-packages/modal/KaizenDraft/Modal/Primitives/GenericModalSection.tsx
+++ b/draft-packages/modal/KaizenDraft/Modal/Primitives/GenericModalSection.tsx
@@ -1,9 +1,11 @@
 import * as React from "react"
+import classNames from "classnames"
 
 import styles from "./GenericModalSection.scss"
 
 export interface GenericModalSectionProps {
   readonly unpadded?: boolean
+  readonly inputEdit?: boolean
   readonly children: React.ReactNode
 }
 
@@ -11,7 +13,17 @@ type GenericModalSection = React.FunctionComponent<GenericModalSectionProps>
 
 const GenericModalSection: GenericModalSection = ({
   unpadded = false,
+  inputEdit = false,
   children,
-}) => <div className={unpadded ? undefined : styles.padded}>{children}</div>
+}) => (
+  <div
+    className={classNames(
+      unpadded ? undefined : styles.padded,
+      inputEdit && styles.inputEdit
+    )}
+  >
+    {children}
+  </div>
+)
 
 export default GenericModalSection

--- a/draft-packages/modal/KaizenDraft/Modal/Primitives/ModalAccessibleDescription.scss
+++ b/draft-packages/modal/KaizenDraft/Modal/Primitives/ModalAccessibleDescription.scss
@@ -1,4 +1,6 @@
+@import "~@kaizen/design-tokens/sass/spacing";
+
 .modalDescription {
   grid-column-start: 2;
-  padding-bottom: 1.5rem;
+  padding-bottom: $spacing-md;
 }

--- a/draft-packages/modal/KaizenDraft/Modal/Primitives/ModalAccessibleDescription.scss
+++ b/draft-packages/modal/KaizenDraft/Modal/Primitives/ModalAccessibleDescription.scss
@@ -1,0 +1,4 @@
+.modalDescription {
+  grid-column-start: 2;
+  padding-bottom: 1.5rem;
+}

--- a/draft-packages/modal/KaizenDraft/Modal/Primitives/ModalAccessibleDescription.tsx
+++ b/draft-packages/modal/KaizenDraft/Modal/Primitives/ModalAccessibleDescription.tsx
@@ -1,5 +1,6 @@
 import * as React from "react"
 import { ModalAccessibleContext } from "./ModalAccessibleContext"
+import styles from "./ModalAccessibleDescription.scss"
 
 export interface ModalAccessibleDescriptionProps {
   readonly children: React.ReactNode
@@ -11,7 +12,11 @@ const ModalAccessibleDescription: ModalAccessibleDescription = ({
   children,
 }) => (
   <ModalAccessibleContext.Consumer>
-    {({ describedByID }) => <div id={describedByID}>{children}</div>}
+    {({ describedByID }) => (
+      <div id={describedByID} className={styles.modalDescription}>
+        {children}
+      </div>
+    )}
   </ModalAccessibleContext.Consumer>
 )
 

--- a/draft-packages/modal/KaizenDraft/Modal/Primitives/ModalAccessibleLabel.scss
+++ b/draft-packages/modal/KaizenDraft/Modal/Primitives/ModalAccessibleLabel.scss
@@ -20,7 +20,7 @@ $ca-breakpoint-small-mobile: 375px;
       font-size: 1.625rem;
       line-height: 32px;
     }
-    @include ca-media-mobile {
+    @include ca-media-small-mobile {
       font-size: 1.5rem;
       line-height: 30px;
     }

--- a/draft-packages/modal/KaizenDraft/Modal/Primitives/ModalAccessibleLabel.scss
+++ b/draft-packages/modal/KaizenDraft/Modal/Primitives/ModalAccessibleLabel.scss
@@ -1,11 +1,12 @@
 @import "~@kaizen/design-tokens/sass/color";
 @import "~@kaizen/design-tokens/sass/border";
-@import "~@kaizen/component-library/styles/responsive";
+@import "~@kaizen/design-tokens/sass/layout";
 
+//TODO - Remove below styles for Heading once responsive styling has been added to the Heading Component
 $ca-breakpoint-small-mobile: 375px;
 
 @mixin ca-media-small-mobile {
-  @media (max-width: #{$ca-breakpoint-small-mobile - 1px}) {
+  @media (max-width: #{$ca-breakpoint-small-mobile}) {
     @content;
   }
 }
@@ -19,7 +20,7 @@ $ca-breakpoint-small-mobile: 375px;
       font-size: 1.625rem;
       line-height: 32px;
     }
-    @include ca-media-small-mobile {
+    @media (max-width: $layout-breakpoints-medium) {
       font-size: 1.5rem;
       line-height: 30px;
     }

--- a/draft-packages/modal/KaizenDraft/Modal/Primitives/ModalAccessibleLabel.scss
+++ b/draft-packages/modal/KaizenDraft/Modal/Primitives/ModalAccessibleLabel.scss
@@ -16,11 +16,11 @@ $ca-breakpoint-small-mobile: 375px;
 
   //TODO - Remove below styles for Heading once responsive styling has been added to the Heading Component
   h2 {
-    @include ca-media-mobile {
+    @media (max-width: $layout-breakpoints-medium) {
       font-size: 1.625rem;
       line-height: 32px;
     }
-    @media (max-width: $layout-breakpoints-medium) {
+    @include ca-media-mobile {
       font-size: 1.5rem;
       line-height: 30px;
     }

--- a/draft-packages/modal/KaizenDraft/Modal/Primitives/ModalAccessibleLabel.scss
+++ b/draft-packages/modal/KaizenDraft/Modal/Primitives/ModalAccessibleLabel.scss
@@ -1,7 +1,27 @@
 @import "~@kaizen/design-tokens/sass/color";
 @import "~@kaizen/design-tokens/sass/border";
-.label {
+@import "~@kaizen/component-library/styles/responsive";
+
+$ca-breakpoint-small-mobile: 375px;
+
+@mixin ca-media-small-mobile {
+  @media (max-width: #{$ca-breakpoint-small-mobile - 1px}) {
+    @content;
+  }
+}
+
+.modalLabel {
   position: relative;
+  h2 {
+    @include ca-media-mobile {
+      font-size: 1.625rem;
+      line-height: 32px;
+    }
+    @include ca-media-small-mobile {
+      font-size: 1.5rem;
+      line-height: 30px;
+    }
+  }
 
   // Use JS polyfill to simulate :focus-visible, not yet supported by browsers
   // https://github.com/WICG/focus-visible#backwards-compatibility

--- a/draft-packages/modal/KaizenDraft/Modal/Primitives/ModalAccessibleLabel.scss
+++ b/draft-packages/modal/KaizenDraft/Modal/Primitives/ModalAccessibleLabel.scss
@@ -12,6 +12,8 @@ $ca-breakpoint-small-mobile: 375px;
 
 .modalLabel {
   position: relative;
+
+  //TODO - Remove below styles for Heading once responsive styling has been added to the Heading Component
   h2 {
     @include ca-media-mobile {
       font-size: 1.625rem;

--- a/draft-packages/modal/KaizenDraft/Modal/Primitives/ModalAccessibleLabel.tsx
+++ b/draft-packages/modal/KaizenDraft/Modal/Primitives/ModalAccessibleLabel.tsx
@@ -1,3 +1,4 @@
+import classnames from "classnames"
 import * as React from "react"
 import { ModalAccessibleContext } from "./ModalAccessibleContext"
 import styles from "./ModalAccessibleLabel.scss"
@@ -11,7 +12,11 @@ type ModalAccessibleLabel = React.FunctionComponent<ModalAccessibleLabelProps>
 const ModalAccessibleLabel: ModalAccessibleLabel = ({ children }) => (
   <ModalAccessibleContext.Consumer>
     {({ labelledByID }) => (
-      <div id={labelledByID} tabIndex={-1} className={styles.label}>
+      <div
+        id={labelledByID}
+        tabIndex={-1}
+        className={classnames(styles.modalLabel, {})}
+      >
         {children}
       </div>
     )}

--- a/draft-packages/modal/KaizenDraft/Modal/Primitives/ModalAccessibleLabel.tsx
+++ b/draft-packages/modal/KaizenDraft/Modal/Primitives/ModalAccessibleLabel.tsx
@@ -15,7 +15,7 @@ const ModalAccessibleLabel: ModalAccessibleLabel = ({ children }) => (
       <div
         id={labelledByID}
         tabIndex={-1}
-        className={classnames(styles.modalLabel, {})}
+        className={classnames(styles.modalLabel)}
       >
         {children}
       </div>

--- a/draft-packages/modal/KaizenDraft/Modal/Primitives/ModalBody.scss
+++ b/draft-packages/modal/KaizenDraft/Modal/Primitives/ModalBody.scss
@@ -5,10 +5,6 @@
   overflow-x: hidden;
 }
 
-.padded {
-  padding: $ca-grid $ca-grid $ca-grid $ca-grid;
-}
-
 .modalBody.scrollable {
   overflow-y: scroll;
 }

--- a/draft-packages/modal/KaizenDraft/Modal/Primitives/ModalFooter.scss
+++ b/draft-packages/modal/KaizenDraft/Modal/Primitives/ModalFooter.scss
@@ -1,7 +1,7 @@
 @import "~@kaizen/deprecated-component-library-helpers/styles/layout";
 @import "~@kaizen/deprecated-component-library-helpers/styles/type";
 @import "~@kaizen/deprecated-component-library-helpers/styles/color";
-@import "~@kaizen/component-library/styles/responsive";
+@import "~@kaizen/design-tokens/sass/layout";
 
 .actions {
   display: flex;
@@ -16,13 +16,13 @@
 
 .padded {
   padding: 0 $ca-grid * 1.5 $ca-grid * 1.5 $ca-grid * 1.5;
-  @include ca-media-mobile {
+  @media (max-width: $layout-breakpoints-medium) {
     padding: $ca-grid;
     flex-direction: column;
   }
 }
 .actionButton {
-  @include ca-media-mobile {
+  @media (max-width: $layout-breakpoints-medium) {
     width: 100%;
     //   > *,
     //   > * > * {
@@ -33,7 +33,7 @@
 }
 .actionButton + .actionButton {
   @include ca-margin($end: $ca-grid * 0.5);
-  @include ca-media-mobile {
+  @media (max-width: $layout-breakpoints-medium) {
     @include ca-margin($top: $ca-grid * 0.5);
   }
 }

--- a/draft-packages/modal/KaizenDraft/Modal/Primitives/ModalFooter.scss
+++ b/draft-packages/modal/KaizenDraft/Modal/Primitives/ModalFooter.scss
@@ -1,11 +1,12 @@
 @import "~@kaizen/deprecated-component-library-helpers/styles/layout";
 @import "~@kaizen/deprecated-component-library-helpers/styles/type";
 @import "~@kaizen/deprecated-component-library-helpers/styles/color";
+@import "~@kaizen/component-library/styles/responsive";
 
 .actions {
   display: flex;
   flex-direction: row-reverse;
-  justify-content: center;
+  justify-content: flex-start;
 }
 
 .actionsAlignStart {
@@ -13,17 +14,28 @@
   justify-content: flex-end;
 }
 
-.informationAlign {
-  flex-direction: row;
-  justify-content: flex-start;
-
-  .actionButton + .actionButton {
-    @include ca-margin($start: $ca-grid * 0.5);
+.padded {
+  padding: 0 $ca-grid * 1.5 $ca-grid * 1.5 $ca-grid * 1.5;
+  @include ca-media-mobile {
+    padding: $ca-grid;
+    flex-direction: column;
   }
 }
-
+.actionButton {
+  @include ca-media-mobile {
+    width: 100%;
+    > *,
+    > * > * {
+      width: 100%;
+      justify-content: center;
+    }
+  }
+}
 .actionButton + .actionButton {
   @include ca-margin($end: $ca-grid * 0.5);
+  @include ca-media-mobile {
+    @include ca-margin($top: $ca-grid * 0.5);
+  }
 }
 
 // to avoid the row-reverse styles
@@ -63,8 +75,4 @@
 }
 .filler {
   visibility: hidden;
-}
-
-.padded {
-  padding: $ca-grid;
 }

--- a/draft-packages/modal/KaizenDraft/Modal/Primitives/ModalFooter.scss
+++ b/draft-packages/modal/KaizenDraft/Modal/Primitives/ModalFooter.scss
@@ -24,11 +24,11 @@
 .actionButton {
   @include ca-media-mobile {
     width: 100%;
-    > *,
-    > * > * {
-      width: 100%;
-      justify-content: center;
-    }
+    //   > *,
+    //   > * > * {
+    //     width: 100%;
+    //     justify-content: center;
+    //   }
   }
 }
 .actionButton + .actionButton {

--- a/draft-packages/modal/KaizenDraft/Modal/Primitives/ModalFooter.tsx
+++ b/draft-packages/modal/KaizenDraft/Modal/Primitives/ModalFooter.tsx
@@ -1,10 +1,11 @@
 import { Button, ButtonProps } from "@kaizen/draft-button"
+import { useMediaQueries } from "@kaizen/responsive"
 import classNames from "classnames"
 import * as React from "react"
 import GenericModalSection from "./GenericModalSection"
 import styles from "./ModalFooter.scss"
 
-type ActionsVarianProps = "information" | "input"
+type ActionsVariantProps = "information" | "inputEdit"
 
 export type ModalFooterProps = Readonly<{
   /**
@@ -14,7 +15,7 @@ export type ModalFooterProps = Readonly<{
    * action is anchored to the left edge of the modal.
    * For this rare instance added the variant prop as optional to update the order of action buttons.
    */
-  variant?: ActionsVarianProps
+  variant?: ActionsVariantProps
   unpadded?: boolean
   actions: ButtonProps[]
   appearance?: "primary" | "destructive"
@@ -32,9 +33,13 @@ const ModalFooter: ModalFooter = props => {
     automationId,
     variant,
   } = props
+  const { queries } = useMediaQueries()
 
   return (
-    <GenericModalSection unpadded={unpadded} inputEdit={variant === "input"}>
+    <GenericModalSection
+      unpadded={unpadded}
+      inputEdit={variant === "inputEdit"}
+    >
       <div
         className={classNames(
           styles.actions,
@@ -51,6 +56,7 @@ const ModalFooter: ModalFooter = props => {
               destructive={index === 0 && appearance === "destructive"}
               secondary={index > 0}
               data-automation-id={`${automationId}-action-${index}`}
+              fullWidth={queries.isSmall}
               {...action}
             />
           </div>

--- a/draft-packages/modal/KaizenDraft/Modal/Primitives/ModalFooter.tsx
+++ b/draft-packages/modal/KaizenDraft/Modal/Primitives/ModalFooter.tsx
@@ -4,7 +4,7 @@ import * as React from "react"
 import GenericModalSection from "./GenericModalSection"
 import styles from "./ModalFooter.scss"
 
-type ActionsVarianProps = "information"
+type ActionsVarianProps = "information" | "input"
 
 export type ModalFooterProps = Readonly<{
   /**
@@ -34,12 +34,13 @@ const ModalFooter: ModalFooter = props => {
   } = props
 
   return (
-    <GenericModalSection unpadded={unpadded}>
+    <GenericModalSection unpadded={unpadded} inputEdit={variant === "input"}>
       <div
         className={classNames(
           styles.actions,
-          props.alignStart && styles.actionsAlignStart,
-          variant === "information" && styles.informationAlign
+          !unpadded && styles.padded,
+          variant === "information" && styles.informationPadded,
+          props.alignStart && styles.actionsAlignStart
         )}
       >
         {actions.map((action, index) => (

--- a/draft-packages/modal/docs/InputEditModal.stories.tsx
+++ b/draft-packages/modal/docs/InputEditModal.stories.tsx
@@ -1,0 +1,113 @@
+import { Paragraph } from "@kaizen/component-library"
+import { Button } from "@kaizen/draft-button"
+import { Select } from "@kaizen/draft-select"
+import { InputEditModal, ModalAccessibleDescription } from "@kaizen/draft-modal"
+import isChromatic from "chromatic/isChromatic"
+
+import * as React from "react"
+import { withDesign } from "storybook-addon-designs"
+import { figmaEmbed } from "../../../storybook/helpers"
+
+import { CATEGORIES } from "../../../storybook/constants"
+
+// Add additional height to the stories when running in Chromatic only.
+// Modals have fixed position and would be cropped from snapshot tests.
+// Setting height to 100vh ensures we capture as much content of the
+// modal, as it's height responds to the content within it.
+const withMinHeight = Story => {
+  if (!isChromatic()) return <Story />
+  return (
+    <div style={{ minHeight: "100vh" }}>
+      <Story />
+    </div>
+  )
+}
+class ModalStateContainer extends React.Component<
+  {
+    isInitiallyOpen: boolean
+    children: (renderProps: {
+      open: () => void
+      close: () => void
+      isOpen: boolean
+    }) => React.ReactNode
+  },
+  { isOpen: boolean }
+> {
+  state = { isOpen: this.props.isInitiallyOpen }
+  open = () => this.setState({ isOpen: true })
+  close = () => this.setState({ isOpen: false })
+  render() {
+    return this.props.children({
+      open: this.open,
+      close: this.close,
+      isOpen: this.state.isOpen,
+    })
+  }
+}
+
+export default {
+  title: `${CATEGORIES.components}/Modal/Input Edit Modal`,
+  component: InputEditModal,
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "import { InputEditModal, " +
+          "ModalAccessibleDescription" +
+          ' } from "@kaizen/draft-modal"',
+      },
+    },
+    ...figmaEmbed(
+      "https://www.figma.com/file/GMxm8rvDCbj0Xw3TQWBZ8b/UI-Kit-Zen?node-id=1929%3A35440"
+    ),
+    chromatic: {
+      delay: 400, // match MODAL_TRANSITION_TIMEOUT in modals + 50ms
+      pauseAnimationAtEnd: true,
+    },
+  },
+  decorators: [withDesign, withMinHeight],
+}
+
+const options = [
+  { value: "Mindy", label: "Mindy" },
+  { value: "Jaime", label: "Jaime", isDisabled: true },
+  { value: "Rafa", label: "Rafa" },
+  { value: "Elaine", label: "Elaine" },
+  { value: "Julio", label: "Julio" },
+  { value: "Priyanka", label: "Priyanka" },
+  { value: "Prince", label: "Prince" },
+  { value: "Charith", label: "Charith" },
+  { value: "Nick", label: "Nick" },
+]
+
+export const InputEditModals = args => (
+  <ModalStateContainer isInitiallyOpen={isChromatic()}>
+    {({ open, close, isOpen }) => (
+      <div>
+        <Button label="Open modal" onClick={open} />
+        <InputEditModal
+          isOpen={isOpen}
+          type="positive"
+          title="Input-edit modal title"
+          onSubmit={close}
+          onDismiss={close}
+          submitLabel="Label"
+          {...args}
+        >
+          <ModalAccessibleDescription>
+            <Paragraph variant="body">
+              Instructive text to drive user selection goes here.
+            </Paragraph>
+          </ModalAccessibleDescription>
+          <Select
+            options={options}
+            placeholder="Placeholder"
+            isSearchable={false}
+            isDisabled={false}
+            defaultValue={options[0]}
+          />
+        </InputEditModal>
+      </div>
+    )}
+  </ModalStateContainer>
+)

--- a/draft-packages/modal/package.json
+++ b/draft-packages/modal/package.json
@@ -40,6 +40,7 @@
     "@kaizen/draft-form": "^3.13.12",
     "@kaizen/draft-illustration": "^2.9.0",
     "@kaizen/responsive": "^1.2.1",
+    "@kaizen/react-deprecate-warning": "^1.1.5",
     "@types/classnames": "^2.3.0",
     "classnames": "^2.3.1",
     "react-dom": "^16.13.1",

--- a/draft-packages/modal/package.json
+++ b/draft-packages/modal/package.json
@@ -39,6 +39,7 @@
     "@kaizen/draft-divider": "^1.7.1",
     "@kaizen/draft-form": "^3.13.12",
     "@kaizen/draft-illustration": "^2.9.0",
+    "@kaizen/responsive": "^1.2.1",
     "@types/classnames": "^2.3.0",
     "classnames": "^2.3.1",
     "react-dom": "^16.13.1",

--- a/packages/design-tokens/docs/StoryBoard.stories.tsx
+++ b/packages/design-tokens/docs/StoryBoard.stories.tsx
@@ -36,6 +36,7 @@ import * as LoadingPlaceholderStories from "@kaizen/draft-loading-placeholder/do
 import * as LoadingSpinnerStories from "@kaizen/draft-loading-spinner/docs/LoadingSpinner.stories"
 import * as MenuStories from "@kaizen/draft-menu/docs/Menu.stories"
 import * as ModalStories from "@kaizen/draft-modal/docs/Modal.stories"
+import * as InputEditModalStories from "@kaizen/draft-modal/docs/InputEditModal.stories"
 import * as PageLayoutStories from "@kaizen/draft-page-layout/docs/PageLayout.stories"
 import * as RadioGroupStories from "@kaizen/draft-form/docs/RadioGroup.stories"
 import * as PopoverStories from "@kaizen/draft-popover/docs/Popover.stories"
@@ -443,6 +444,7 @@ export const Everything: Story = () => {
         <StoriesContainer storyModule={LoadingSpinnerStories} />
         <StoriesContainer storyModule={MenuStories} />
         <StoriesContainer storyModule={ModalStories} />
+        <StoriesContainer storyModule={InputEditModalStories} />
         <StoriesContainer storyModule={PageLayoutStories} />
         <StoriesContainer storyModule={ParagraphStories} />
         <StoriesContainer storyModule={PopoverStories} />


### PR DESCRIPTION
# Objective
Update generic modal components and update Input-edit modal to match latest design.
Created new Input Edit Modal story which is controllable.


Notes:
- Ignore previous modal stories! Review only the Input Edit modal sub category in modal [here](https://dev.cultureamp.design/nat/generic-and-input-modal-update/storybook/?path=/story/components-modal-input-edit-modal--input-edit-modals) 
- Created custom breakpoint for smaller mobile phones to be used for the Heading styling as Responsive Typography is still under construction. Will need to come back once Responsive Typography is complete to remove custom styles.

# Motivation and Context
closes #1469

# Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/48232362/142784078-1df614bd-fc05-4a54-9563-016eb43dac28.png)
![image](https://user-images.githubusercontent.com/48232362/142784083-fe7eab2b-5820-4225-8871-09de157773a7.png)

