### PR TITLE
fix: Remove Tab.onClick prop

### DIFF
--- a/packages/tabs/src/Tab.tsx
+++ b/packages/tabs/src/Tab.tsx
@@ -16,7 +16,6 @@ export interface TabProps {
   badge?: string
   disabled?: boolean
   children: ReactNode
-  onClick?: (e: SyntheticEvent) => void
   onBlur?: (e: SyntheticEvent) => void
   onFocus?: (e: SyntheticEvent) => void
 }
@@ -46,7 +45,6 @@ export const Tab = (props: TabProps) => {
       className={classnames(styles.tab, { [styles.selected]: isSelected })}
       onFocus={onFocus}
       onBlur={onBlur}
-      onClick={props.onClick}
       onMouseEnter={() => setIsHovered(true)}
       onMouseLeave={() => setIsHovered(false)}
     >


### PR DESCRIPTION
This isn't actually supported by ReachUI tabs (which we are shimming over). Tabs.onChange can be used instead.