### PR TITLE
chore: Remove FastClick support on Checkbox and Radio

### DIFF
--- a/draft-packages/form/KaizenDraft/Form/CheckboxField/styles.scss
+++ b/draft-packages/form/KaizenDraft/Form/CheckboxField/styles.scss
@@ -21,11 +21,6 @@
     // This is to override bootstrap styles. Remove when appropriate
     padding-top: 0;
     -webkit-tap-highlight-color: transparent;
-
-    // Disable pointer-events on the wrapper for the <Checkbox> primitive
-    > div:first-child {
-      pointer-events: none;
-    }
   }
 
   &.noBottomMargin {

--- a/draft-packages/form/KaizenDraft/Form/Primitives/Checkbox/Checkbox.tsx
+++ b/draft-packages/form/KaizenDraft/Form/Primitives/Checkbox/Checkbox.tsx
@@ -74,9 +74,7 @@ const Input: Input = ({
       data-automation-id={automationId}
       // This si only used as a handle for unit testing
       data-indeterminate={checkedStatus === "mixed"}
-      // TODO - needsclick class disables fastclick on this element to prevent double tap on mobile.
-      // Remove when fastclick is removed from consuming repos
-      className={classnames(styles.checkbox, "needsclick", {
+      className={classnames(styles.checkbox, {
         [styles.reversed]: reversed,
       })}
       checked={getCheckedFromStatus(checkedStatus)}

--- a/draft-packages/form/KaizenDraft/Form/Primitives/Radio/Radio.tsx
+++ b/draft-packages/form/KaizenDraft/Form/Primitives/Radio/Radio.tsx
@@ -47,9 +47,7 @@ const Radio: Radio = ({
       value={value}
       checked={selectedStatus}
       data-automation-id={automationId}
-      // TODO - needsclick class disables fastclick on this element to prevent double tap on mobile.
-      // Remove when fastclick is removed from consuming repos
-      className={classnames(styles.radioInput, "needsclick", {
+      className={classnames(styles.radioInput, {
         [styles.reversed]: reversed,
       })}
       onChange={onChange}

--- a/draft-packages/form/KaizenDraft/Form/RadioField/styles.scss
+++ b/draft-packages/form/KaizenDraft/Form/RadioField/styles.scss
@@ -13,11 +13,6 @@
   label {
     -webkit-tap-highlight-color: transparent;
 
-    // Disable pointer-events on the wrapper for the <RadioInput> primitive
-    > div:first-child {
-      pointer-events: none;
-    }
-
     :global(.ideal-sans) & {
       // This is to override bootstrap styles. Remove when appropriate
       font-size: $ca-inter-font-base-size;

--- a/draft-packages/form/KaizenDraft/Form/RadioGroup/__snapshots__/RadioGroup.spec.tsx.snap
+++ b/draft-packages/form/KaizenDraft/Form/RadioGroup/__snapshots__/RadioGroup.spec.tsx.snap
@@ -96,7 +96,7 @@ exports[`<RadioGroup />  snapshots renders RadioGroup with radios 1`] = `
     >
       <span>
         <input
-          class="radioInput needsclick"
+          class="radioInput"
           data-automation-id="radio-1-radio-input"
           id="radio-1"
           name="radio"
@@ -125,7 +125,7 @@ exports[`<RadioGroup />  snapshots renders RadioGroup with radios 1`] = `
     >
       <span>
         <input
-          class="radioInput needsclick"
+          class="radioInput"
           data-automation-id="radio-2-radio-input"
           id="radio-2"
           name="radio"

--- a/draft-packages/select/KaizenDraft/Select/Select.tsx
+++ b/draft-packages/select/KaizenDraft/Select/Select.tsx
@@ -152,12 +152,11 @@ const Menu: typeof components.Menu = props => (
   <components.Menu {...props} className={styles.menu} />
 )
 
-// TODO - needsclick class disables fastclick on this element. Remove when fastclick is removed from consuming repos
 const Option: typeof components.Option = props => (
   <div data-automation-id="Select__Option">
     <components.Option
       {...props}
-      className={classNames("needsclick", styles.option, {
+      className={classNames(styles.option, {
         [styles.focusedOption]: props.isFocused,
         [styles.selectedOption]: props.isSelected,
         [styles.disabledOption]: props.isDisabled,


### PR DESCRIPTION
There were a couple of things around on Radios and Checkboxes to work around some issues we ran into on Capture where they weren't working properly for touch devices. This recently broke again because the divs were changed to spans and these rules no longer applied.

After a bit of investigation - the checkboxes and radios weren't working properly because of FastClick (which is about to be removed from all our repos), so these can just be removed now.