### PR TITLE
chore: Clean up compiled Storybook assets

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "compile": "tsc",
     "lint": "elm-format --validate packages && yarn eslint --max-warnings=0 && yarn prettier && stylelint '**/*.scss'",
     "lint:fix": "elm-format --yes packages && yarn eslint --max-warnings=0 --fix && yarn prettier --write",
-    "clean:storybook": "rimraf 'storybook/public'",
+    "clean:storybook": "rimraf 'storybook/public' && rimraf 'storybook/**/*.d.ts' && rimraf 'storybook/**/(?!(elm-webpack-loader-fix))*.js*' && rimraf 'storybook/**/*.js.map'",
     "clean": "lerna run clean && yarn gatsby clean && yarn clean:storybook && rimraf 'elm-stuff'",
     "reset": "yarn clean && yarn install --force",
     "chromatic": "chromatic",


### PR DESCRIPTION
# Objective
A couple of compiled storybook scripts are persisting, even though the `clean` script is being run. 

# Motivation and Context
It's confusing to have compiled Storybook files not being cleaned up after running the clean script. 

# Screenshots (if appropriate)

# Checklist
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] If this contains visual changes, has it been reviewed by a designer?
- [ ] If this introduces either a new component or a breaking change to an existing component, has it been reviewed by an advocate? (Ask in #prod_design_systems)
- [ ] I have considered likely risks of these changes and got someone else to QA as appropriate
- [ ] I have or will communicate these changes to the front end practice

# Additional Considerations
- Does there need to be right-to-left (RTL) options for localization and internationalization?
- Has the test suite been updated?
- Have you done cross-browser testing for our [supported browsers](https://academy.cultureamp.com/hc/en-us/articles/204539569-Supported-browsers-for-Participants)?
- Have you updated any relevant documentation or left useful comments in the code?
- Have you reviewed Culture Amp's Web Accessibility guide [Current Compliance, Going Forward, Statement and Answers for Customers](https://cultureamp.atlassian.net/wiki/spaces/Prod/pages/428572998/Web+Accessibility)?
- If this contains substantial visual changes, especially far reaching ones, have you unlocked the Chromatic step in the pipeline?
- Have Storybook stories been updated?

**If you're new to Kaizen, please ask #prod_design_systems to set up an onboarding session to get you up to speed.** If you have an urgent PR to merge before that happens, it is safest to ask in #prod_design_systems to have a design system advocate review the PR to catch any issues.
