### PR TITLE
fix: Update ConfirmationModal to new styles and variants

### DIFF
--- a/draft-packages/modal/KaizenDraft/Modal/Presets/ConfirmationModal.scss
+++ b/draft-packages/modal/KaizenDraft/Modal/Presets/ConfirmationModal.scss
@@ -1,8 +1,7 @@
 @import "~@kaizen/design-tokens/sass/border";
-@import "~@kaizen/design-tokens/sass/spacing";
 @import "~@kaizen/design-tokens/sass/color";
-@import "~@kaizen/deprecated-component-library-helpers/styles/color";
-@import "~@kaizen/deprecated-component-library-helpers/styles/layout";
+@import "~@kaizen/design-tokens/sass/spacing";
+@import "~@kaizen/design-tokens/sass/layout";
 
 $dt-positive-header-background: $color-green-100;
 $dt-informative-header-background: $color-blue-100;
@@ -10,6 +9,7 @@ $dt-negative-header-background: $color-red-100;
 $dt-cautionary-header-background: $color-yellow-100;
 $dt-heading-text-color: $color-purple-800;
 $dt-cautionary-heading-text-color: $color-purple-800;
+$dt-assertive-header-background: $color-orange-100;
 
 .modal {
   composes: genericModal from "../Primitives/GenericModal.scss";
@@ -19,9 +19,15 @@ $dt-cautionary-heading-text-color: $color-purple-800;
 
 .header {
   color: $color-white;
-  padding: $spacing-lg $spacing-md $spacing-lg;
-  text-align: center;
+  text-align: left;
   border-radius: $border-solid-border-radius $border-solid-border-radius 0 0;
+
+  &.padded {
+    padding: $spacing-md $spacing-lg;
+    @media (max-width: $layout-breakpoints-medium) {
+      padding: $spacing-md;
+    }
+  }
 
   // override Murmur global styles :(
   h1 {
@@ -29,39 +35,127 @@ $dt-cautionary-heading-text-color: $color-purple-800;
   }
 }
 
+.positiveHeader,
+.informativeHeader,
+.negativeHeader,
+.cautionaryHeader,
+.assertiveHeader {
+  display: grid;
+  grid-template-columns: 0.2fr 2fr;
+  align-items: center;
+  &.prominent {
+    grid-template-columns: 1.1fr 2fr;
+    @media (max-width: $layout-breakpoints-medium) {
+      display: flex;
+      flex-direction: column;
+      align-content: flex-start;
+      justify-content: center;
+      align-items: flex-start;
+    }
+    .iconContainer {
+      position: absolute;
+      top: 8%;
+      @media (max-width: $layout-breakpoints-medium) {
+        position: relative;
+        top: 0;
+        margin-bottom: $spacing-sm;
+      }
+    }
+    .spotIcon,
+    .svgIcon > svg {
+      width: 155px;
+      height: 155px;
+      margin: 0 auto;
+      color: $color-purple-800;
+      @media (max-width: $layout-breakpoints-medium) {
+        width: 86px;
+        height: 86px;
+      }
+    }
+  }
+  .iconContainer {
+    align-self: start;
+  }
+  .spotIcon,
+  .svgIcon > svg {
+    width: 30px;
+    height: 30px;
+    @media (max-width: $layout-breakpoints-medium) {
+      margin-right: 15px;
+    }
+  }
+}
+
 .positiveHeader {
   background-color: $dt-positive-header-background;
+
+  .spotIcon,
+  .svgIcon > svg {
+    color: $color-green-500;
+  }
+}
+
+.assertiveHeader {
+  background-color: $dt-assertive-header-background;
+
+  .spotIcon,
+  .svgIcon > svg {
+    color: $color-orange-500;
+  }
 }
 
 .informativeHeader {
   background-color: $dt-informative-header-background;
+
+  .spotIcon,
+  .svgIcon > svg {
+    color: $color-blue-500;
+  }
 }
 
 .negativeHeader {
   background-color: $dt-negative-header-background;
+
+  .spotIcon,
+  .svgIcon > svg {
+    color: $color-red-500;
+  }
 }
 
 .cautionaryHeader {
   background-color: $dt-cautionary-header-background;
 
-  &.header h1 {
-    color: $color-purple-800;
+  .spotIcon,
+  .svgIcon > svg {
+    color: $color-yellow-500;
   }
 }
 
 .body {
-  padding: $spacing-md $spacing-xxxxl $spacing-sm;
+  display: grid;
+  grid-template-columns: 0.2fr 2fr;
+  align-items: center;
+  @media (max-width: $layout-breakpoints-medium) {
+    grid-template-columns: 1fr;
+  }
+
+  &.prominent {
+    display: grid;
+    grid-template-columns: 1.1fr 2fr;
+    align-items: center;
+    @media (max-width: $layout-breakpoints-medium) {
+      grid-template-columns: 1fr;
+    }
+  }
+
+  &.padded {
+    padding: $spacing-md $spacing-lg $spacing-md $spacing-lg;
+    @media (max-width: $layout-breakpoints-medium) {
+      padding: $spacing-md;
+    }
+  }
 }
 
 .iconContainer {
   position: relative;
-  margin-bottom: $spacing-sm;
-}
-
-.spotIcon,
-.svgIcon > svg {
-  width: 155px;
-  height: 155px;
-  margin: 0 auto;
-  color: $color-purple-800;
 }

--- a/draft-packages/modal/KaizenDraft/Modal/Presets/ConfirmationModal.tsx
+++ b/draft-packages/modal/KaizenDraft/Modal/Presets/ConfirmationModal.tsx
@@ -10,9 +10,9 @@ import {
   Positive,
 } from "@kaizen/draft-illustration"
 
-import exclamationIcon from "@kaizen/component-library/icons/exclamation.icon.svg"
-import informationIcon from "@kaizen/component-library/icons/information.icon.svg"
-import successIcon from "@kaizen/component-library/icons/success.icon.svg"
+import exclamationIcon from "@kaizen/component-library/icons/exclamation-white.icon.svg"
+import informationIcon from "@kaizen/component-library/icons/information-white.icon.svg"
+import successIcon from "@kaizen/component-library/icons/success-white.icon.svg"
 
 import { ButtonProps } from "@kaizen/draft-button"
 import {

--- a/draft-packages/modal/KaizenDraft/Modal/Presets/ConfirmationModal.tsx
+++ b/draft-packages/modal/KaizenDraft/Modal/Presets/ConfirmationModal.tsx
@@ -1,13 +1,18 @@
 import classnames from "classnames"
 import * as React from "react"
 
-import { Heading } from "@kaizen/component-library"
+import { Heading, Icon } from "@kaizen/component-library"
 import {
+  Assertive,
   Cautionary,
   Informative,
   Negative,
-  PositiveFemale,
+  Positive,
 } from "@kaizen/draft-illustration"
+
+import exclamationIcon from "@kaizen/component-library/icons/exclamation.icon.svg"
+import informationIcon from "@kaizen/component-library/icons/information.icon.svg"
+import successIcon from "@kaizen/component-library/icons/success.icon.svg"
 
 import { ButtonProps } from "@kaizen/draft-button"
 import {
@@ -23,6 +28,8 @@ import styles from "./ConfirmationModal.scss"
 
 export interface ConfirmationModalProps {
   readonly isOpen: boolean
+  readonly unpadded?: boolean
+  readonly isProminent?: boolean
   readonly type: ModalType
   readonly title: string
   readonly onConfirm?: () => void
@@ -35,23 +42,53 @@ export interface ConfirmationModalProps {
 }
 
 type ConfirmationModal = React.FunctionComponent<ConfirmationModalProps>
-type ModalType = "positive" | "informative" | "negative" | "cautionary"
 
-const getIcon = (type: ModalType) => {
+type ModalType =
+  | "positive"
+  | "informative"
+  | "negative"
+  | "cautionary"
+  | "assertive"
+
+const getIcon = (type: ModalType, isProminent: boolean) => {
   switch (type) {
     case "cautionary":
-      return <Cautionary alt="" />
+      return isProminent ? (
+        <Cautionary alt="" isAnimated />
+      ) : (
+        <Icon icon={exclamationIcon} inheritSize role="presentation" />
+      )
     case "informative":
-      return <Informative alt="" />
+      return isProminent ? (
+        <Informative alt="" isAnimated />
+      ) : (
+        <Icon icon={informationIcon} inheritSize role="presentation" />
+      )
     case "negative":
-      return <Negative alt="" />
+      return isProminent ? (
+        <Negative alt="" isAnimated />
+      ) : (
+        <Icon icon={exclamationIcon} inheritSize role="presentation" />
+      )
     case "positive":
-      return <PositiveFemale alt="" />
+      return isProminent ? (
+        <Positive alt="" isAnimated />
+      ) : (
+        <Icon icon={successIcon} inheritSize role="presentation" />
+      )
+    case "assertive":
+      return isProminent ? (
+        <Assertive alt="" isAnimated />
+      ) : (
+        <Icon icon={exclamationIcon} inheritSize role="presentation" />
+      )
   }
 }
 
 const ConfirmationModal = ({
   isOpen,
+  isProminent = false,
+  unpadded = false,
   type,
   title,
   onConfirm,
@@ -92,27 +129,41 @@ const ConfirmationModal = ({
       automationId={automationId}
     >
       <div className={styles.modal}>
-        <ModalHeader unpadded onDismiss={onDismiss}>
+        <ModalHeader onDismiss={onDismiss}>
           <div
             className={classnames(styles.header, {
               [styles.cautionaryHeader]: type === "cautionary",
               [styles.informativeHeader]: type === "informative",
               [styles.negativeHeader]: type === "negative",
               [styles.positiveHeader]: type === "positive",
+              [styles.assertiveHeader]: type === "assertive",
+              [styles.prominent]: isProminent,
+              [styles.padded]: !unpadded,
             })}
           >
-            <div className={styles.iconContainer}>
-              <div className={styles.spotIcon}>{getIcon(type)}</div>
+            <div
+              className={classnames(styles.iconContainer, {
+                [styles.prominent]: isProminent,
+              })}
+            >
+              <div className={styles.spotIcon}>
+                {getIcon(type, isProminent)}
+              </div>
             </div>
-            <ModalAccessibleLabel>
-              <Heading tag="h1" variant="heading-1">
+            <ModalAccessibleLabel isProminent={isProminent}>
+              <Heading tag="h2" variant="heading-2">
                 {title}
               </Heading>
             </ModalAccessibleLabel>
           </div>
         </ModalHeader>
-        <ModalBody unpadded>
-          <div className={styles.body}>
+        <ModalBody>
+          <div
+            className={classnames(styles.body, {
+              [styles.prominent]: isProminent,
+              [styles.padded]: !unpadded,
+            })}
+          >
             <ModalAccessibleDescription>{children}</ModalAccessibleDescription>
           </div>
         </ModalBody>
@@ -120,6 +171,7 @@ const ConfirmationModal = ({
           actions={footerActions}
           appearance={type === "negative" ? "destructive" : "primary"}
           automationId={automationId}
+          unpadded={unpadded}
         />
       </div>
     </GenericModal>

--- a/draft-packages/modal/KaizenDraft/Modal/Primitives/ModalAccessibleLabel.scss
+++ b/draft-packages/modal/KaizenDraft/Modal/Primitives/ModalAccessibleLabel.scss
@@ -26,6 +26,11 @@ $ca-breakpoint-small-mobile: 375px;
     }
   }
 
+  &.prominent {
+    grid-column-start: 2;
+    text-align: left;
+  }
+
   // Use JS polyfill to simulate :focus-visible, not yet supported by browsers
   // https://github.com/WICG/focus-visible#backwards-compatibility
   :global(.js-focus-visible) & {

--- a/draft-packages/modal/KaizenDraft/Modal/Primitives/ModalAccessibleLabel.tsx
+++ b/draft-packages/modal/KaizenDraft/Modal/Primitives/ModalAccessibleLabel.tsx
@@ -5,17 +5,23 @@ import styles from "./ModalAccessibleLabel.scss"
 
 export interface ModalAccessibleLabelProps {
   readonly children: React.ReactNode
+  readonly isProminent?: boolean
 }
 
 type ModalAccessibleLabel = React.FunctionComponent<ModalAccessibleLabelProps>
 
-const ModalAccessibleLabel: ModalAccessibleLabel = ({ children }) => (
+const ModalAccessibleLabel: ModalAccessibleLabel = ({
+  children,
+  isProminent = false,
+}) => (
   <ModalAccessibleContext.Consumer>
     {({ labelledByID }) => (
       <div
         id={labelledByID}
         tabIndex={-1}
-        className={classnames(styles.modalLabel)}
+        className={classnames(styles.modalLabel, {
+          [styles.prominent]: isProminent,
+        })}
       >
         {children}
       </div>

--- a/draft-packages/modal/KaizenDraft/Modal/Primitives/ModalFooter.scss
+++ b/draft-packages/modal/KaizenDraft/Modal/Primitives/ModalFooter.scss
@@ -1,7 +1,10 @@
 @import "~@kaizen/deprecated-component-library-helpers/styles/layout";
 @import "~@kaizen/deprecated-component-library-helpers/styles/type";
 @import "~@kaizen/deprecated-component-library-helpers/styles/color";
+@import "~@kaizen/component-library/styles/responsive";
+@import "~@kaizen/design-tokens/sass/spacing";
 @import "~@kaizen/design-tokens/sass/layout";
+@import "~@kaizen/design-tokens/sass/color";
 
 .actions {
   display: flex;
@@ -15,20 +18,15 @@
 }
 
 .padded {
-  padding: 0 $ca-grid * 1.5 $ca-grid * 1.5 $ca-grid * 1.5;
+  padding: 0 $spacing-lg $spacing-lg $spacing-lg;
   @media (max-width: $layout-breakpoints-medium) {
-    padding: $ca-grid;
+    padding: $spacing-md;
     flex-direction: column;
   }
 }
 .actionButton {
   @media (max-width: $layout-breakpoints-medium) {
     width: 100%;
-    //   > *,
-    //   > * > * {
-    //     width: 100%;
-    //     justify-content: center;
-    //   }
   }
 }
 .actionButton + .actionButton {

--- a/draft-packages/modal/docs/ConfirmationModal.stories.tsx
+++ b/draft-packages/modal/docs/ConfirmationModal.stories.tsx
@@ -74,7 +74,7 @@ export const ConfirmationModals = args => (
         <ConfirmationModal
           isOpen={isOpen}
           type="cautionary"
-          title="Cautionary modal title"
+          title="Confirmation modal title"
           onConfirm={close}
           onDismiss={close}
           confirmLabel="Label"

--- a/draft-packages/modal/docs/ConfirmationModal.stories.tsx
+++ b/draft-packages/modal/docs/ConfirmationModal.stories.tsx
@@ -1,0 +1,91 @@
+import { Paragraph } from "@kaizen/component-library"
+import { Button } from "@kaizen/draft-button"
+import { ConfirmationModal } from "@kaizen/draft-modal"
+import isChromatic from "chromatic/isChromatic"
+
+import * as React from "react"
+import { withDesign } from "storybook-addon-designs"
+import { figmaEmbed } from "../../../storybook/helpers"
+import { CATEGORIES } from "../../../storybook/constants"
+
+// Add additional height to the stories when running in Chromatic only.
+// Modals have fixed position and would be cropped from snapshot tests.
+// Setting height to 100vh ensures we capture as much content of the
+// modal, as it's height responds to the content within it.
+const withMinHeight = Story => {
+  if (!isChromatic()) return <Story />
+  return (
+    <div style={{ minHeight: "100vh" }}>
+      <Story />
+    </div>
+  )
+}
+class ModalStateContainer extends React.Component<
+  {
+    isInitiallyOpen: boolean
+    children: (renderProps: {
+      open: () => void
+      close: () => void
+      isOpen: boolean
+    }) => React.ReactNode
+  },
+  { isOpen: boolean }
+> {
+  state = { isOpen: this.props.isInitiallyOpen }
+  open = () => this.setState({ isOpen: true })
+  close = () => this.setState({ isOpen: false })
+  render() {
+    return this.props.children({
+      open: this.open,
+      close: this.close,
+      isOpen: this.state.isOpen,
+    })
+  }
+}
+
+export default {
+  title: `${CATEGORIES.components}/Modal/Confirmation Modal`,
+  component: ConfirmationModal,
+  args: {
+    type: "cautionary",
+  },
+  parameters: {
+    docs: {
+      description: {
+        component: "import { ConfirmationModal } from @kaizen/draft-modal",
+      },
+    },
+    ...figmaEmbed(
+      "https://www.figma.com/file/GMxm8rvDCbj0Xw3TQWBZ8b/UI-Kit-Zen?node-id=1929%3A35440"
+    ),
+    chromatic: {
+      delay: 400, // match MODAL_TRANSITION_TIMEOUT in modals + 50ms
+      pauseAnimationAtEnd: true,
+    },
+  },
+  decorators: [withDesign, withMinHeight],
+}
+
+export const ConfirmationModals = args => (
+  <ModalStateContainer isInitiallyOpen={isChromatic()}>
+    {({ open, close, isOpen }) => (
+      <div>
+        <Button label="Open modal" onClick={open} />
+        <ConfirmationModal
+          isOpen={isOpen}
+          type="cautionary"
+          title="Cautionary modal title"
+          onConfirm={close}
+          onDismiss={close}
+          confirmLabel="Label"
+          {...args}
+        >
+          <Paragraph variant="body">
+            Confirmation modals contain smaller pieces of content and can
+            provide additional information to aide the user.
+          </Paragraph>
+        </ConfirmationModal>
+      </div>
+    )}
+  </ModalStateContainer>
+)

--- a/packages/design-tokens/docs/StoryBoard.stories.tsx
+++ b/packages/design-tokens/docs/StoryBoard.stories.tsx
@@ -37,6 +37,7 @@ import * as LoadingSpinnerStories from "@kaizen/draft-loading-spinner/docs/Loadi
 import * as MenuStories from "@kaizen/draft-menu/docs/Menu.stories"
 import * as ModalStories from "@kaizen/draft-modal/docs/Modal.stories"
 import * as InputEditModalStories from "@kaizen/draft-modal/docs/InputEditModal.stories"
+import * as ConfirmationModalStories from "@kaizen/draft-modal/docs/ConfirmationModal.stories"
 import * as PageLayoutStories from "@kaizen/draft-page-layout/docs/PageLayout.stories"
 import * as RadioGroupStories from "@kaizen/draft-form/docs/RadioGroup.stories"
 import * as PopoverStories from "@kaizen/draft-popover/docs/Popover.stories"
@@ -445,6 +446,7 @@ export const Everything: Story = () => {
         <StoriesContainer storyModule={MenuStories} />
         <StoriesContainer storyModule={ModalStories} />
         <StoriesContainer storyModule={InputEditModalStories} />
+        <StoriesContainer storyModule={ConfirmationModalStories} />
         <StoriesContainer storyModule={PageLayoutStories} />
         <StoriesContainer storyModule={ParagraphStories} />
         <StoriesContainer storyModule={PopoverStories} />


### PR DESCRIPTION
# Objective

- Update Confirmation Modal to match latest design
- Create Confirmation Modal Story **with** controls
- Update scss files to use design tokens (previously using deprecated component library helpers)

Notes when reviewing:

- Please ignore previous modal stories and only review the Confirmation Modal sub category modal here
- To view the variants use the StoryBook controls (e.g isProminent and type)


# Motivation and Context
closes #1469 

# Screenshots (if appropriate)

