### PR TITLE
feat: Add feature detection for safari version < 13 to avoid addEvent…

### DIFF
--- a/packages/responsive/src/useMediaQueries.tsx
+++ b/packages/responsive/src/useMediaQueries.tsx
@@ -31,16 +31,7 @@ export const useMediaQueries = (
   // The `addEventListener` calls blow up legacy Edge (<= v18/pre chromium),
   // so we disable the functionality of updating after page load.
   const isLegacyEdge = navigator.userAgent.match(/Edge/)
-
-  // To double check:
-  // Does Safari <13 consistently use addListener?
-  type windowAndDeprecatedEventListeners = {
-    addListener: any
-    removeListener: any
-  } & Window
-  const isUnsupportedSafari =
-    ((window as unknown) as windowAndDeprecatedEventListeners).addListener !==
-    undefined
+  const isUnsupportedSafari = (window.matchMedia('')).addEventListener !== undefined; 
 
   // ---------------------------------------
   // Create Kaizen breakpoint matches for initial state

--- a/packages/responsive/src/useMediaQueries.tsx
+++ b/packages/responsive/src/useMediaQueries.tsx
@@ -32,6 +32,16 @@ export const useMediaQueries = (
   // so we disable the functionality of updating after page load.
   const isLegacyEdge = navigator.userAgent.match(/Edge/)
 
+  // To double check:
+  // Does Safari <13 consistently use addListener?
+  type windowAndDeprecatedEventListeners = {
+    addListener: any
+    removeListener: any
+  } & Window
+  const isUnsupportedSafari =
+    ((window as unknown) as windowAndDeprecatedEventListeners).addListener !==
+    undefined
+
   // ---------------------------------------
   // Create Kaizen breakpoint matches for initial state
   // ---------------------------------------
@@ -80,7 +90,7 @@ export const useMediaQueries = (
   // Create an event listener based on the medium breakpoint and update state whenever it changes
   // ---------------------------------------
   useEffect(() => {
-    if (isLegacyEdge) {
+    if (isLegacyEdge || isUnsupportedSafari) {
       return
     }
 
@@ -126,7 +136,7 @@ export const useMediaQueries = (
   // Create an event listener for each custom query
   // ---------------------------------------
   useEffect(() => {
-    if (isLegacyEdge) {
+    if (isLegacyEdge || isUnsupportedSafari) {
       return
     }
 

--- a/packages/responsive/src/useMediaQueries.tsx
+++ b/packages/responsive/src/useMediaQueries.tsx
@@ -31,7 +31,7 @@ export const useMediaQueries = (
   // The `addEventListener` calls blow up legacy Edge (<= v18/pre chromium),
   // so we disable the functionality of updating after page load.
   const isLegacyEdge = navigator.userAgent.match(/Edge/)
-  const isUnsupportedSafari = (window.matchMedia('')).addEventListener !== undefined; 
+  const isUnsupportedSafari = (window.matchMedia("")).addEventListener !== undefined;
 
   // ---------------------------------------
   // Create Kaizen breakpoint matches for initial state

--- a/packages/responsive/src/useMediaQueries.tsx
+++ b/packages/responsive/src/useMediaQueries.tsx
@@ -31,7 +31,8 @@ export const useMediaQueries = (
   // The `addEventListener` calls blow up legacy Edge (<= v18/pre chromium),
   // so we disable the functionality of updating after page load.
   const isLegacyEdge = navigator.userAgent.match(/Edge/)
-  const isUnsupportedSafari = (window.matchMedia("")).addEventListener !== undefined;
+  const isUnsupportedSafari =
+    window.matchMedia("").addEventListener === undefined
 
   // ---------------------------------------
   // Create Kaizen breakpoint matches for initial state


### PR DESCRIPTION
# Objective
<!-- Describe what this change achieves, and the details of how it works. -->

Update useMediaQueries to check fro safari version <= 13 by checking matchMedia.addEventListener method returns undefined when in an unsupported version of safari. 

# Motivation and Context
closes #2299 
