### PR TITLE
feat: Add objective spot illustration to Spot.tsx and stories

### DIFF
--- a/draft-packages/illustration/KaizenDraft/Illustration/Spot.tsx
+++ b/draft-packages/illustration/KaizenDraft/Illustration/Spot.tsx
@@ -976,3 +976,11 @@ export const Recommendation = ({ enableAspectRatio, ...props }: SpotProps) => (
     name="illustrations/heart/spot/miscellaneous-shield.svg"
   />
 )
+
+export const Objective = ({ enableAspectRatio, ...props }: SpotProps) => (
+  <Base
+    aspectRatio={enableAspectRatio ? "square" : undefined}
+    {...props}
+    name="illustrations/heart/spot/miscellaneous-objective.svg"
+  />
+)

--- a/draft-packages/illustration/KaizenDraft/Illustration/__snapshots__/illustration.spec.tsx.snap
+++ b/draft-packages/illustration/KaizenDraft/Illustration/__snapshots__/illustration.spec.tsx.snap
@@ -1130,6 +1130,16 @@ exports[`<Illustration /> Spot Negative should exist and render an alt tag 1`] =
 </div>
 `;
 
+exports[`<Illustration /> Spot Objective should exist and render an alt tag 1`] = `
+<div>
+  <img
+    alt="My accessible title"
+    class=" wrapper"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/heart/spot/miscellaneous-objective.svg"
+  />
+</div>
+`;
+
 exports[`<Illustration /> Spot OneOnOne should exist and render an alt tag 1`] = `
 <div>
   <img

--- a/draft-packages/illustration/docs/IllustrationSpot.stories.tsx
+++ b/draft-packages/illustration/docs/IllustrationSpot.stories.tsx
@@ -513,7 +513,7 @@ export const AllSpotIllustrations = () => {
     {
       Component: Objective,
       name: "Objective",
-    }
+    },
   ]
 
   return (

--- a/draft-packages/illustration/docs/IllustrationSpot.stories.tsx
+++ b/draft-packages/illustration/docs/IllustrationSpot.stories.tsx
@@ -92,6 +92,7 @@ import {
   UnderConstruction,
   ValueAdd,
   Recommendation,
+  Objective,
 } from ".."
 import { CATEGORIES, SUB_CATEGORIES } from "../../../storybook/constants"
 
@@ -509,6 +510,10 @@ export const AllSpotIllustrations = () => {
       Component: Fireworks,
       name: "Fireworks",
     },
+    {
+      Component: Objective,
+      name: "Objective",
+    }
   ]
 
   return (


### PR DESCRIPTION
# Objective
- Add objective spot illustration

# Motivation and Context
- Objective spot illustration needs to be added as part of this ticket (https://trello.com/c/JWjtRIYn/104-improve-ux-for-onboarding-flow)

# Checklist
- [ ] If this contains visual changes, has it been reviewed by a designer?
- [ ] If this introduces either a new component or a breaking change to an existing component, has it been reviewed by an advocate? (Ask in #prod_design_systems)
- [ ] I have considered likely risks of these changes and got someone else to QA as appropriate
- [ ] I have or will communicate these changes to the front end practice

# Additional Considerations
- Does there need to be right-to-left (RTL) options for localization and internationalization?
- Has the test suite been updated?
- Have you done cross-browser testing for our [supported browsers](https://academy.cultureamp.com/hc/en-us/articles/204539569-Supported-browsers-for-Participants)?
- Have you updated any relevant documentation or left useful comments in the code?
- Have you reviewed Culture Amp's Web Accessibility guide [Current Compliance, Going Forward, Statement and Answers for Customers](https://cultureamp.atlassian.net/wiki/spaces/Prod/pages/428572998/Web+Accessibility)?
- If this contains substantial visual changes, especially far reaching ones, have you unlocked the Chromatic step in the pipeline?
- Have Storybook stories been updated?

**If you're new to Kaizen, please ask #prod_design_systems to set up an onboarding session to get you up to speed.** If you have an urgent PR to merge before that happens, it is safest to ask in #prod_design_systems to have a design system advocate review the PR to catch any issues.
