### PR TITLE
chore: update all figma embed to use heart theme

### DIFF
--- a/draft-packages/avatar/docs/Avatar.stories.tsx
+++ b/draft-packages/avatar/docs/Avatar.stories.tsx
@@ -15,7 +15,7 @@ export default {
       },
     },
     ...figmaEmbed(
-      "https://www.figma.com/file/GMxm8rvDCbj0Xw3TQWBZ8b/UI-Kit-Zen?node-id=1929%3A14306"
+      "https://www.figma.com/file/eZKEE5kXbEMY3lx84oz8iN/%E2%9D%A4%EF%B8%8F-UI-Kit%3A-Heart?node-id=1929%3A14306"
     ),
   },
   decorators: [withDesign],

--- a/draft-packages/badge/docs/Badge.stories.tsx
+++ b/draft-packages/badge/docs/Badge.stories.tsx
@@ -17,7 +17,7 @@ export default {
       },
     },
     ...figmaEmbed(
-      "https://www.figma.com/file/GMxm8rvDCbj0Xw3TQWBZ8b/UI-Kit-Zen?node-id=1929%3A14398"
+      "https://www.figma.com/file/eZKEE5kXbEMY3lx84oz8iN/%E2%9D%A4%EF%B8%8F-UI-Kit%3A-Heart?node-id=1929%3A14398"
     ),
   },
   decorators: [withDesign],

--- a/draft-packages/button/docs/Button.stories.tsx
+++ b/draft-packages/button/docs/Button.stories.tsx
@@ -29,7 +29,7 @@ export default {
       },
     },
     ...figmaEmbed(
-      "https://www.figma.com/file/GMxm8rvDCbj0Xw3TQWBZ8b/UI-Kit-Zen?node-id=13555%3A0"
+      "https://www.figma.com/file/eZKEE5kXbEMY3lx84oz8iN/%E2%9D%A4%EF%B8%8F-UI-Kit%3A-Heart?node-id=13555%3A0"
     ),
   },
   decorators: [withDesign],
@@ -809,11 +809,6 @@ export const ReversedButtons = () => (
 export const DefaultKaizenSiteDemo = args => <Button {...args} />
 DefaultKaizenSiteDemo.story = {
   name: "Default Button (Kaizen Site Demo)",
-  parameters: {
-    ...figmaEmbed(
-      "https://www.figma.com/file/GMxm8rvDCbj0Xw3TQWBZ8b/UI-Kit-Zen?node-id=13861%3A65143"
-    ),
-  },
 }
 
 ReversedButtons.parameters = {

--- a/draft-packages/button/docs/IconButton.stories.tsx
+++ b/draft-packages/button/docs/IconButton.stories.tsx
@@ -21,7 +21,7 @@ export default {
       },
     },
     ...figmaEmbed(
-      "https://www.figma.com/file/GMxm8rvDCbj0Xw3TQWBZ8b/UI-Kit-Zen?node-id=13555%3A0"
+      "https://www.figma.com/file/eZKEE5kXbEMY3lx84oz8iN/%E2%9D%A4%EF%B8%8F-UI-Kit%3A-Heart?node-id=13555%3A0"
     ),
   },
   decorators: [withDesign],

--- a/draft-packages/card/docs/Card.stories.tsx
+++ b/draft-packages/card/docs/Card.stories.tsx
@@ -15,7 +15,7 @@ export default {
       },
     },
     ...figmaEmbed(
-      "https://www.figma.com/file/GMxm8rvDCbj0Xw3TQWBZ8b/UI-Kit-Zen?node-id=1929%3A14085"
+      "https://www.figma.com/file/eZKEE5kXbEMY3lx84oz8iN/%E2%9D%A4%EF%B8%8F-UI-Kit%3A-Heart?node-id=1929%3A14085"
     ),
   },
   decorators: [withDesign],

--- a/draft-packages/divider/docs/Divider.stories.tsx
+++ b/draft-packages/divider/docs/Divider.stories.tsx
@@ -22,7 +22,7 @@ export default {
       },
     },
     ...figmaEmbed(
-      "https://www.figma.com/file/GMxm8rvDCbj0Xw3TQWBZ8b/UI-Kit-Zen?node-id=1929%3A14040"
+      "https://www.figma.com/file/eZKEE5kXbEMY3lx84oz8iN/%E2%9D%A4%EF%B8%8F-UI-Kit%3A-Heart?node-id=1929%3A14040"
     ),
   },
   decorators: [withDesign],

--- a/draft-packages/empty-state/docs/EmptyState.stories.tsx
+++ b/draft-packages/empty-state/docs/EmptyState.stories.tsx
@@ -38,7 +38,7 @@ export default {
       },
     },
     ...figmaEmbed(
-      "https://www.figma.com/file/GMxm8rvDCbj0Xw3TQWBZ8b/UI-Kit-Zen?node-id=1929%3A33123"
+      "https://www.figma.com/file/eZKEE5kXbEMY3lx84oz8iN/%E2%9D%A4%EF%B8%8F-UI-Kit%3A-Heart?node-id=1929%3A33123"
     ),
   },
   decorators: [withDesign],

--- a/draft-packages/form/docs/CheckboxField.stories.tsx
+++ b/draft-packages/form/docs/CheckboxField.stories.tsx
@@ -54,7 +54,7 @@ export default {
       },
     },
     ...figmaEmbed(
-      "https://www.figma.com/file/GMxm8rvDCbj0Xw3TQWBZ8b/UI-Kit-Zen?node-id=14462%3A196"
+      "https://www.figma.com/file/eZKEE5kXbEMY3lx84oz8iN/%E2%9D%A4%EF%B8%8F-UI-Kit%3A-Heart?node-id=14462%3A196"
     ),
   },
   decorators: [withDesign],

--- a/draft-packages/form/docs/RadioField.stories.tsx
+++ b/draft-packages/form/docs/RadioField.stories.tsx
@@ -57,7 +57,7 @@ export default {
       },
     },
     ...figmaEmbed(
-      "https://www.figma.com/file/GMxm8rvDCbj0Xw3TQWBZ8b/UI-Kit-Zen?node-id=14354%3A68219"
+      "https://www.figma.com/file/eZKEE5kXbEMY3lx84oz8iN/%E2%9D%A4%EF%B8%8F-UI-Kit%3A-Heart?node-id=14354%3A68219"
     ),
   },
   decorators: [withDesign],

--- a/draft-packages/form/docs/RadioGroup.stories.tsx
+++ b/draft-packages/form/docs/RadioGroup.stories.tsx
@@ -47,7 +47,7 @@ export default {
       },
     },
     ...figmaEmbed(
-      "https://www.figma.com/file/GMxm8rvDCbj0Xw3TQWBZ8b/UI-Kit-Zen?node-id=4496%3A481"
+      "https://www.figma.com/file/eZKEE5kXbEMY3lx84oz8iN/%E2%9D%A4%EF%B8%8F-UI-Kit%3A-Heart?node-id=4496%3A481"
     ),
   },
   decorators: [withDesign],

--- a/draft-packages/form/docs/TextAreaField.stories.tsx
+++ b/draft-packages/form/docs/TextAreaField.stories.tsx
@@ -63,7 +63,7 @@ export default {
       },
     },
     ...figmaEmbed(
-      "https://www.figma.com/file/GMxm8rvDCbj0Xw3TQWBZ8b/UI-Kit-Zen?node-id=14539%3A69482"
+      "https://www.figma.com/file/eZKEE5kXbEMY3lx84oz8iN/%E2%9D%A4%EF%B8%8F-UI-Kit%3A-Heart?node-id=14539%3A69482"
     ),
   },
   decorators: [withDesign],

--- a/draft-packages/form/docs/TextField.stories.tsx
+++ b/draft-packages/form/docs/TextField.stories.tsx
@@ -30,7 +30,7 @@ export default {
       },
     },
     ...figmaEmbed(
-      "https://www.figma.com/file/GMxm8rvDCbj0Xw3TQWBZ8b/UI-Kit-Zen?node-id=14363%3A67837"
+      "https://www.figma.com/file/eZKEE5kXbEMY3lx84oz8iN/%E2%9D%A4%EF%B8%8F-UI-Kit%3A-Heart?node-id=14363%3A67837"
     ),
   },
   decorators: [withDesign],

--- a/draft-packages/form/docs/ToggleSwitchField.stories.tsx
+++ b/draft-packages/form/docs/ToggleSwitchField.stories.tsx
@@ -54,7 +54,7 @@ export default {
       },
     },
     ...figmaEmbed(
-      "https://www.figma.com/file/GMxm8rvDCbj0Xw3TQWBZ8b/UI-Kit-Zen?node-id=14361%3A67850"
+      "https://www.figma.com/file/eZKEE5kXbEMY3lx84oz8iN/%E2%9D%A4%EF%B8%8F-UI-Kit%3A-Heart?node-id=14361%3A67850"
     ),
   },
   decorators: [withDesign],

--- a/draft-packages/guidance-block/docs/GuidanceBlock.stories.tsx
+++ b/draft-packages/guidance-block/docs/GuidanceBlock.stories.tsx
@@ -20,7 +20,7 @@ export default {
     },
     backgrounds: { default: "Gray 100" },
     ...figmaEmbed(
-      "https://www.figma.com/file/GMxm8rvDCbj0Xw3TQWBZ8b/UI-Kit-Zen?node-id=1929%3A39077"
+      "https://www.figma.com/file/eZKEE5kXbEMY3lx84oz8iN/%E2%9D%A4%EF%B8%8F-UI-Kit%3A-Heart?node-id=1929%3A39077"
     ),
   },
   decorators: [withDesign],

--- a/draft-packages/hero-card/docs/HeroCard.stories.tsx
+++ b/draft-packages/hero-card/docs/HeroCard.stories.tsx
@@ -33,7 +33,7 @@ export default {
       },
     },
     ...figmaEmbed(
-      "https://www.figma.com/file/GMxm8rvDCbj0Xw3TQWBZ8b/UI-Kit-Zen?node-id=3568%3A150"
+      "https://www.figma.com/file/eZKEE5kXbEMY3lx84oz8iN/%E2%9D%A4%EF%B8%8F-UI-Kit%3A-Heart?node-id=3568%3A150"
     ),
   },
   decorators: [withDesign],

--- a/draft-packages/illustration/KaizenDraft/Illustration/Base.tsx
+++ b/draft-packages/illustration/KaizenDraft/Illustration/Base.tsx
@@ -4,7 +4,7 @@ import styles from "./style.module.scss"
 
 export type BaseProps = {
   /**
-   *  Refer to the Base Illustration Sticker Sheet in Zen UI Kit
+   *  Refer to the Base Illustration Sticker Sheet in Heart UI Kit
    */
   name: string
 

--- a/draft-packages/likert-scale-legacy/docs/LikertScaleLegacy.stories.tsx
+++ b/draft-packages/likert-scale-legacy/docs/LikertScaleLegacy.stories.tsx
@@ -20,7 +20,7 @@ export default {
       },
     },
     ...figmaEmbed(
-      "https://www.figma.com/file/GMxm8rvDCbj0Xw3TQWBZ8b/UI-Kit-Zen?node-id=14473%3A61902"
+      "https://www.figma.com/file/eZKEE5kXbEMY3lx84oz8iN/%E2%9D%A4%EF%B8%8F-UI-Kit%3A-Heart?node-id=14473%3A61902"
     ),
   },
 }

--- a/draft-packages/loading-placeholder/docs/LoadingPlaceholder.stories.tsx
+++ b/draft-packages/loading-placeholder/docs/LoadingPlaceholder.stories.tsx
@@ -22,7 +22,7 @@ export default {
       },
     },
     ...figmaEmbed(
-      "https://www.figma.com/file/GMxm8rvDCbj0Xw3TQWBZ8b/UI-Kit-Zen?node-id=4496%3A2"
+      "https://www.figma.com/file/eZKEE5kXbEMY3lx84oz8iN/%E2%9D%A4%EF%B8%8F-UI-Kit%3A-Heart?node-id=4496%3A2"
     ),
   },
   decorators: [withDesign],

--- a/draft-packages/loading-spinner/docs/LoadingSpinner.stories.tsx
+++ b/draft-packages/loading-spinner/docs/LoadingSpinner.stories.tsx
@@ -18,7 +18,7 @@ export default {
       },
     },
     ...figmaEmbed(
-      "https://www.figma.com/file/GMxm8rvDCbj0Xw3TQWBZ8b/UI-Kit-Zen?node-id=1929%3A20943"
+      "https://www.figma.com/file/eZKEE5kXbEMY3lx84oz8iN/%E2%9D%A4%EF%B8%8F-UI-Kit%3A-Heart?node-id=1929%3A20943"
     ),
   },
   decorators: [withDesign],

--- a/draft-packages/menu/docs/Menu.stories.tsx
+++ b/draft-packages/menu/docs/Menu.stories.tsx
@@ -90,7 +90,7 @@ export default {
       },
     },
     ...figmaEmbed(
-      "https://www.figma.com/file/GMxm8rvDCbj0Xw3TQWBZ8b/UI-Kit-Zen?node-id=6262%3A1233"
+      "https://www.figma.com/file/eZKEE5kXbEMY3lx84oz8iN/%E2%9D%A4%EF%B8%8F-UI-Kit%3A-Heart?node-id=6262%3A1233"
     ),
   },
   decorators: [withDesign],

--- a/draft-packages/modal/docs/Modal.stories.tsx
+++ b/draft-packages/modal/docs/Modal.stories.tsx
@@ -84,7 +84,7 @@ export default {
       },
     },
     ...figmaEmbed(
-      "https://www.figma.com/file/GMxm8rvDCbj0Xw3TQWBZ8b/UI-Kit-Zen?node-id=1929%3A35440"
+      "https://www.figma.com/file/eZKEE5kXbEMY3lx84oz8iN/%E2%9D%A4%EF%B8%8F-UI-Kit%3A-Heart?node-id=1929%3A35440"
     ),
     chromatic: {
       delay: 400, // match MODAL_TRANSITION_TIMEOUT in modals + 50ms
@@ -118,14 +118,8 @@ export const ConfirmationPositiveKaizenSiteDemo = () => (
   </ModalStateContainer>
 )
 
-ConfirmationPositiveKaizenSiteDemo.story = {
-  name: "Confirmation (positive) (Kaizen Site Demo)",
-  parameters: {
-    ...figmaEmbed(
-      "https://www.figma.com/file/GMxm8rvDCbj0Xw3TQWBZ8b/UI-Kit-Zen?node-id=2272%3A18307"
-    ),
-  },
-}
+ConfirmationPositiveKaizenSiteDemo.story =
+  "Confirmation (positive) (Kaizen Site Demo)"
 
 export const ConfirmationInformative = () => (
   <ModalStateContainer isInitiallyOpen={isChromatic()}>
@@ -151,14 +145,7 @@ export const ConfirmationInformative = () => (
   </ModalStateContainer>
 )
 
-ConfirmationInformative.story = {
-  name: "Confirmation (informative)",
-  parameters: {
-    ...figmaEmbed(
-      "https://www.figma.com/file/GMxm8rvDCbj0Xw3TQWBZ8b/UI-Kit-Zen?node-id=1700%3A65"
-    ),
-  },
-}
+ConfirmationInformative.story = "Confirmation (informative)"
 
 export const ConfirmationCautionary = () => (
   <ModalStateContainer isInitiallyOpen={isChromatic()}>
@@ -184,14 +171,7 @@ export const ConfirmationCautionary = () => (
   </ModalStateContainer>
 )
 
-ConfirmationCautionary.story = {
-  name: "Confirmation (cautionary)",
-  parameters: {
-    ...figmaEmbed(
-      "https://www.figma.com/file/GMxm8rvDCbj0Xw3TQWBZ8b/UI-Kit-Zen?node-id=2272%3A18381"
-    ),
-  },
-}
+ConfirmationCautionary.story = "Confirmation (cautionary)"
 
 export const ConfirmationNegative = () => (
   <ModalStateContainer isInitiallyOpen={isChromatic()}>
@@ -217,14 +197,7 @@ export const ConfirmationNegative = () => (
   </ModalStateContainer>
 )
 
-ConfirmationNegative.story = {
-  name: "Confirmation (negative)",
-  parameters: {
-    ...figmaEmbed(
-      "https://www.figma.com/file/GMxm8rvDCbj0Xw3TQWBZ8b/UI-Kit-Zen?node-id=2272%3A18460"
-    ),
-  },
-}
+ConfirmationNegative.story = "Confirmation (negative)"
 
 export const ConfirmationWorkingButton = () => (
   <ModalStateContainer isInitiallyOpen={isChromatic()}>
@@ -304,14 +277,7 @@ export const InputEditPositive = () => (
   </ModalStateContainer>
 )
 
-InputEditPositive.story = {
-  name: "Input-edit (positive)",
-  parameters: {
-    ...figmaEmbed(
-      "https://www.figma.com/file/GMxm8rvDCbj0Xw3TQWBZ8b/UI-Kit-Zen?node-id=1620%3A121"
-    ),
-  },
-}
+InputEditPositive.story = "Input-edit (positive)"
 
 export const InputEditPositiveRtlLocale = () => (
   <ModalStateContainer isInitiallyOpen={isChromatic()}>
@@ -718,14 +684,8 @@ export const InformationModalWithImage = () => (
   </ModalStateContainer>
 )
 
-InformationModalWithImage.story = {
-  name: "Information (with image) - Outdated browser demo",
-  parameters: {
-    ...figmaEmbed(
-      "https://www.figma.com/file/GMxm8rvDCbj0Xw3TQWBZ8b/UI-Kit-Zen?node-id=1620%3A114"
-    ),
-  },
-}
+InformationModalWithImage.story =
+  "Information (with image) - Outdated browser demo"
 
 const InformationModalContent = () => (
   <>
@@ -796,14 +756,8 @@ export const InformationModalWithNotification = () => (
   </ModalStateContainer>
 )
 
-InformationModalWithNotification.story = {
-  name: "Information (with Inline Notification)",
-  parameters: {
-    ...figmaEmbed(
-      "https://www.figma.com/file/GMxm8rvDCbj0Xw3TQWBZ8b/UI-Kit-Zen?node-id=1620%3A114"
-    ),
-  },
-}
+InformationModalWithNotification.story =
+  "Information (with Inline Notification)"
 
 export const InformationModalWithWorkingButton = () => {
   const [isLoading, setIsLoading] = React.useState(false)
@@ -862,14 +816,7 @@ export const InformationModalWithWorkingButton = () => {
   )
 }
 
-InformationModalWithWorkingButton.story = {
-  name: "Information (with working button)",
-  parameters: {
-    ...figmaEmbed(
-      "https://www.figma.com/file/GMxm8rvDCbj0Xw3TQWBZ8b/UI-Kit-Zen?node-id=1620%3A114"
-    ),
-  },
-}
+InformationModalWithWorkingButton.story = "Information (with working button)"
 
 export const GenericModalPadded = () => (
   <>

--- a/draft-packages/page-layout/docs/PageLayout.stories.tsx
+++ b/draft-packages/page-layout/docs/PageLayout.stories.tsx
@@ -17,6 +17,9 @@ export default {
           'import { Container, Content } from "@kaizen/draft-page-layout"',
       },
     },
+    ...figmaEmbed(
+      "https://www.figma.com/file/eZKEE5kXbEMY3lx84oz8iN/%E2%9D%A4%EF%B8%8F-UI-Kit%3A-Heart?node-id=6243%3A4094"
+    ),
   },
   decorators: [withDesign],
 }
@@ -142,14 +145,7 @@ export const SkirtStory = () => (
   </>
 )
 
-SkirtStory.story = {
-  name: "Skirt (default)",
-  parameters: {
-    ...figmaEmbed(
-      "https://www.figma.com/file/GMxm8rvDCbj0Xw3TQWBZ8b/UI-Kit-Zen?node-id=6243%3A4094"
-    ),
-  },
-}
+SkirtStory.story = "Skirt (default)"
 
 export const SkirtEducationVariant = () => (
   <>
@@ -180,14 +176,7 @@ export const SkirtEducationVariant = () => (
   </>
 )
 
-SkirtEducationVariant.story = {
-  name: "Skirt (Education variant)",
-  parameters: {
-    ...figmaEmbed(
-      "https://www.figma.com/file/GMxm8rvDCbj0Xw3TQWBZ8b/UI-Kit-Zen?node-id=6243%3A4094"
-    ),
-  },
-}
+SkirtEducationVariant.story = "Skirt (Education variant)"
 
 export const SkirtWithoutTitleBlockNavigation = () => (
   <>
@@ -256,14 +245,8 @@ export const SkirtWithoutTitleBlockNavigation = () => (
   </>
 )
 
-SkirtWithoutTitleBlockNavigation.story = {
-  name: "Skirt (Title Block without navigation)",
-  parameters: {
-    ...figmaEmbed(
-      "https://www.figma.com/file/GMxm8rvDCbj0Xw3TQWBZ8b/UI-Kit-Zen?node-id=6243%3A4094"
-    ),
-  },
-}
+SkirtWithoutTitleBlockNavigation.story =
+  "Skirt (Title Block without navigation)"
 
 export const WithoutSkirtCard = () => (
   <>
@@ -304,11 +287,4 @@ export const WithoutSkirtCard = () => (
   </>
 )
 
-WithoutSkirtCard.story = {
-  name: "Skirt (without SkirtCard)",
-  parameters: {
-    ...figmaEmbed(
-      "https://www.figma.com/file/GMxm8rvDCbj0Xw3TQWBZ8b/UI-Kit-Zen?node-id=6243%3A4094"
-    ),
-  },
-}
+WithoutSkirtCard.story = "Skirt (without SkirtCard)"

--- a/draft-packages/popover/docs/Popover.stories.tsx
+++ b/draft-packages/popover/docs/Popover.stories.tsx
@@ -19,7 +19,7 @@ export default {
       },
     },
     ...figmaEmbed(
-      "https://www.figma.com/file/GMxm8rvDCbj0Xw3TQWBZ8b/UI-Kit-Zen?node-id=14473%3A63845"
+      "https://www.figma.com/file/eZKEE5kXbEMY3lx84oz8iN/%E2%9D%A4%EF%B8%8F-UI-Kit%3A-Heart?node-id=14473%3A63845"
     ),
   },
   decorators: [withDesign],

--- a/draft-packages/select/docs/Select.stories.tsx
+++ b/draft-packages/select/docs/Select.stories.tsx
@@ -72,7 +72,7 @@ export default {
       },
     },
     ...figmaEmbed(
-      "https://www.figma.com/file/GMxm8rvDCbj0Xw3TQWBZ8b/UI-Kit-Zen?node-id=14321%3A65630"
+      "https://www.figma.com/file/eZKEE5kXbEMY3lx84oz8iN/%E2%9D%A4%EF%B8%8F-UI-Kit%3A-Heart?node-id=14321%3A65630"
     ),
   },
   decorators: [withDesign],

--- a/draft-packages/split-button/docs/SplitButton.stories.tsx
+++ b/draft-packages/split-button/docs/SplitButton.stories.tsx
@@ -26,7 +26,7 @@ export default {
       },
     },
     ...figmaEmbed(
-      "https://www.figma.com/file/GMxm8rvDCbj0Xw3TQWBZ8b/UI-Kit-Zen?node-id=14512%3A404"
+      "https://www.figma.com/file/eZKEE5kXbEMY3lx84oz8iN/%E2%9D%A4%EF%B8%8F-UI-Kit%3A-Heart?node-id=14512%3A404"
     ),
   },
   decorators: [withDesign, withBottomMargin],

--- a/draft-packages/table/docs/Table.stories.tsx
+++ b/draft-packages/table/docs/Table.stories.tsx
@@ -132,7 +132,7 @@ export default {
       },
     },
     ...figmaEmbed(
-      "https://www.figma.com/file/GMxm8rvDCbj0Xw3TQWBZ8b/UI-Kit-Zen?node-id=1929%3A28358"
+      "https://www.figma.com/file/eZKEE5kXbEMY3lx84oz8iN/%E2%9D%A4%EF%B8%8F-UI-Kit%3A-Heart?node-id=1929%3A28358"
     ),
   },
   decorators: [withDesign],

--- a/draft-packages/tag/docs/Tag.stories.tsx
+++ b/draft-packages/tag/docs/Tag.stories.tsx
@@ -20,7 +20,7 @@ export default {
       },
     },
     ...figmaEmbed(
-      "https://www.figma.com/file/GMxm8rvDCbj0Xw3TQWBZ8b/UI-Kit-Zen?node-id=14473%3A90332"
+      "https://www.figma.com/file/eZKEE5kXbEMY3lx84oz8iN/%E2%9D%A4%EF%B8%8F-UI-Kit%3A-Heart?node-id=14473%3A90332"
     ),
   },
   decorators: [withDesign],

--- a/draft-packages/tile/docs/Tile.stories.tsx
+++ b/draft-packages/tile/docs/Tile.stories.tsx
@@ -32,7 +32,7 @@ export default {
       },
     },
     ...figmaEmbed(
-      "https://www.figma.com/file/GMxm8rvDCbj0Xw3TQWBZ8b/UI-Kit-Zen?node-id=14489%3A69120"
+      "https://www.figma.com/file/eZKEE5kXbEMY3lx84oz8iN/%E2%9D%A4%EF%B8%8F-UI-Kit%3A-Heart?node-id=21815%3A82744"
     ),
   },
   decorators: [withDesign],

--- a/draft-packages/tooltip/docs/Tooltip.stories.tsx
+++ b/draft-packages/tooltip/docs/Tooltip.stories.tsx
@@ -31,7 +31,7 @@ export default {
       },
     },
     ...figmaEmbed(
-      "https://www.figma.com/file/GMxm8rvDCbj0Xw3TQWBZ8b/UI-Kit-Zen?node-id=14473%3A90872"
+      "https://www.figma.com/file/eZKEE5kXbEMY3lx84oz8iN/%E2%9D%A4%EF%B8%8F-UI-Kit%3A-Heart?node-id=14473%3A90872"
     ),
   },
   decorators: [withDesign, openTooltipInChromatic],

--- a/draft-packages/well/docs/Well.stories.tsx
+++ b/draft-packages/well/docs/Well.stories.tsx
@@ -36,7 +36,7 @@ export default {
       },
     },
     ...figmaEmbed(
-      "https://www.figma.com/file/GMxm8rvDCbj0Xw3TQWBZ8b/UI-Kit-Zen?node-id=1929%3A14168"
+      "https://www.figma.com/file/eZKEE5kXbEMY3lx84oz8iN/%E2%9D%A4%EF%B8%8F-UI-Kit%3A-Heart?node-id=1929%3A14168"
     ),
   },
   decorators: [withDesign],

--- a/packages/notification/docs/GlobalNotification.stories.tsx
+++ b/packages/notification/docs/GlobalNotification.stories.tsx
@@ -15,7 +15,7 @@ export default {
       },
     },
     ...figmaEmbed(
-      "https://www.figma.com/file/GMxm8rvDCbj0Xw3TQWBZ8b/UI-Kit-Zen?node-id=1929%3A21284"
+      "https://www.figma.com/file/eZKEE5kXbEMY3lx84oz8iN/%E2%9D%A4%EF%B8%8F-UI-Kit%3A-Heart?node-id=1929%3A39077"
     ),
   },
   decorators: [withDesign],

--- a/packages/notification/docs/InlineNotification.stories.tsx
+++ b/packages/notification/docs/InlineNotification.stories.tsx
@@ -46,7 +46,7 @@ export default {
       },
     },
     ...figmaEmbed(
-      "https://www.figma.com/file/GMxm8rvDCbj0Xw3TQWBZ8b/UI-Kit-Zen?node-id=13877%3A66008"
+      "https://www.figma.com/file/eZKEE5kXbEMY3lx84oz8iN/%E2%9D%A4%EF%B8%8F-UI-Kit%3A-Heart?node-id=13877%3A66008"
     ),
   },
   decorators: [withDesign, withContentBelow],

--- a/packages/notification/docs/ToastNotification.stories.tsx
+++ b/packages/notification/docs/ToastNotification.stories.tsx
@@ -75,7 +75,7 @@ export default {
       },
     },
     ...figmaEmbed(
-      "https://www.figma.com/file/GMxm8rvDCbj0Xw3TQWBZ8b/UI-Kit-Zen?node-id=1929%3A21830"
+      "https://www.figma.com/file/eZKEE5kXbEMY3lx84oz8iN/%E2%9D%A4%EF%B8%8F-UI-Kit%3A-Heart?node-id=1929%3A21830"
     ),
   },
   decorators: [withDesign, withNavigation],


### PR DESCRIPTION
# Objective
- Update all Storybook Figma embeds to the new Heart theme

# Motivation and Context
- They were previously on the Zen theme and out of date
- I've also removed any multiple instances of embeds in a component

# Screenshots (if appropriate)

# Checklist
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] If this contains visual changes, has it been reviewed by a designer?
- [ ] If this introduces either a new component or a breaking change to an existing component, has it been reviewed by an advocate? (Ask in #prod_design_systems)
- [ ] I have considered likely risks of these changes and got someone else to QA as appropriate
- [ ] I have or will communicate these changes to the front end practice

# Additional Considerations
- Does there need to be right-to-left (RTL) options for localization and internationalization?
- Has the test suite been updated?
- Have you done cross-browser testing for our [supported browsers](https://academy.cultureamp.com/hc/en-us/articles/204539569-Supported-browsers-for-Participants)?
- Have you updated any relevant documentation or left useful comments in the code?
- Have you reviewed Culture Amp's Web Accessibility guide [Current Compliance, Going Forward, Statement and Answers for Customers](https://cultureamp.atlassian.net/wiki/spaces/Prod/pages/428572998/Web+Accessibility)?
- If this contains substantial visual changes, especially far reaching ones, have you unlocked the Chromatic step in the pipeline?
- Have Storybook stories been updated?

**If you're new to Kaizen, please ask #prod_design_systems to set up an onboarding session to get you up to speed.** If you have an urgent PR to merge before that happens, it is safest to ask in #prod_design_systems to have a design system advocate review the PR to catch any issues.
