### PR TITLE
fix: Move uuid generation out of component to avoid new id on each render

### DIFF
--- a/draft-packages/menu/KaizenDraft/Menu/components/MenuList.tsx
+++ b/draft-packages/menu/KaizenDraft/Menu/components/MenuList.tsx
@@ -7,9 +7,9 @@ type MenuListProps = {
   children: React.ReactNode
 }
 
+const listHeadingID = v4()
 const MenuList = (props: MenuListProps) => {
   const { heading, children } = props
-  const listHeadingID = v4()
   return (
     <>
       {heading && (


### PR DESCRIPTION
Moves the uuid generation for this component out of the component itself to avoid it being regenerated on every rerender.