### PR TITLE
feat: revert previous modal styles to be used for Elm modals

### DIFF
--- a/draft-packages/modal/KaizenDraft/Modal/Presets/ConfirmationModal.elm
+++ b/draft-packages/modal/KaizenDraft/Modal/Presets/ConfirmationModal.elm
@@ -427,7 +427,7 @@ confirmId id_ (Config config) =
 
 
 styles =
-    css "@kaizen/draft-modal/KaizenDraft/Modal/Presets/ConfirmationModal.scss"
+    css "@kaizen/draft-modal/KaizenDraft/Modal/Presets/ElmConfirmationModal.scss"
         { header = "header"
         , cautionaryHeader = "cautionaryHeader"
         , informativeHeader = "informativeHeader"

--- a/draft-packages/modal/KaizenDraft/Modal/Presets/ConfirmationModal.spec.tsx
+++ b/draft-packages/modal/KaizenDraft/Modal/Presets/ConfirmationModal.spec.tsx
@@ -7,7 +7,7 @@ afterEach(cleanup)
 
 const ConfirmationModalWrapper = (props: Partial<ConfirmationModalProps>) => (
   <ConfirmationModal
-    type="informative"
+    variant="informative"
     isOpen={true}
     title="Example Modal Title"
     onDismiss={() => undefined}

--- a/draft-packages/modal/KaizenDraft/Modal/Presets/ElmConfirmationModal.scss
+++ b/draft-packages/modal/KaizenDraft/Modal/Presets/ElmConfirmationModal.scss
@@ -1,0 +1,68 @@
+@import "~@kaizen/design-tokens/sass/border";
+@import "~@kaizen/design-tokens/sass/spacing";
+@import "~@kaizen/design-tokens/sass/color";
+@import "~@kaizen/deprecated-component-library-helpers/styles/color";
+@import "~@kaizen/deprecated-component-library-helpers/styles/layout";
+@import "~@kaizen/component-library/styles/responsive";
+
+$dt-positive-header-background: $color-green-100;
+$dt-informative-header-background: $color-blue-100;
+$dt-negative-header-background: $color-red-100;
+$dt-cautionary-header-background: $color-yellow-100;
+$dt-heading-text-color: $color-purple-800;
+$dt-cautionary-heading-text-color: $color-purple-800;
+
+.modal {
+  composes: genericModal from "../Primitives/GenericModal.scss";
+  min-width: 300px;
+  max-width: 600px;
+}
+
+.header {
+  color: $color-white;
+  padding: $spacing-lg $spacing-md $spacing-lg;
+  text-align: center;
+  border-radius: $border-solid-border-radius $border-solid-border-radius 0 0;
+
+  // override Murmur global styles :(
+  h1 {
+    color: $dt-heading-text-color;
+  }
+}
+
+.positiveHeader {
+  background-color: $dt-positive-header-background;
+}
+
+.informativeHeader {
+  background-color: $dt-informative-header-background;
+}
+
+.negativeHeader {
+  background-color: $dt-negative-header-background;
+}
+
+.cautionaryHeader {
+  background-color: $dt-cautionary-header-background;
+
+  &.header h1 {
+    color: $color-purple-800;
+  }
+}
+
+.body {
+  padding: $spacing-md $spacing-xxxxl $spacing-sm;
+}
+
+.iconContainer {
+  position: relative;
+  margin-bottom: $spacing-sm;
+}
+
+.spotIcon,
+.svgIcon > svg {
+  width: 155px;
+  height: 155px;
+  margin: 0 auto;
+  color: $color-purple-800;
+}

--- a/draft-packages/modal/KaizenDraft/Modal/Presets/ElmInputEditModal.scss
+++ b/draft-packages/modal/KaizenDraft/Modal/Presets/ElmInputEditModal.scss
@@ -1,0 +1,23 @@
+@import "~@kaizen/design-tokens/sass/color";
+@import "~@kaizen/component-library/styles/border";
+@import "~@kaizen/deprecated-component-library-helpers/styles/color";
+@import "~@kaizen/deprecated-component-library-helpers/styles/type";
+
+.modal {
+  composes: genericModal from "../Primitives/GenericModal.scss";
+  min-width: 300px;
+  max-width: 600px;
+}
+
+.header {
+  color: $color-purple-800;
+  padding: $ca-grid $ca-grid $ca-grid * 1.5;
+  text-align: center;
+  border-bottom: 1px solid $ca-border-color;
+}
+
+.body {
+  background: $color-gray-100;
+  padding: $ca-grid $ca-grid $ca-grid * 1.5;
+  border-bottom: 1px solid $ca-border-color;
+}

--- a/draft-packages/modal/KaizenDraft/Modal/Presets/InputEditModal.elm
+++ b/draft-packages/modal/KaizenDraft/Modal/Presets/InputEditModal.elm
@@ -308,12 +308,12 @@ children value (Config config) =
 
 
 styles =
-    css "@kaizen/draft-modal/KaizenDraft/Modal/Presets/InputEditModal.scss"
+    css "@kaizen/draft-modal/KaizenDraft/Modal/Presets/ElmInputEditModal.scss"
         { header = "header"
         }
 
 
 genericStyles =
-    css "@kaizen/draft-modal/KaizenDraft/Modal/Primitives/GenericModal.scss"
+    css "@kaizen/draft-modal/KaizenDraft/Modal/Primitives/ElmGenericModal.scss"
         { defaultModalWidth = "defaultModalWidth"
         }

--- a/draft-packages/modal/KaizenDraft/Modal/Primitives/ElmGenericModal.scss
+++ b/draft-packages/modal/KaizenDraft/Modal/Primitives/ElmGenericModal.scss
@@ -1,0 +1,130 @@
+@import "~@kaizen/design-tokens/sass/shadow";
+@import "~@kaizen/design-tokens/sass/border";
+@import "~@kaizen/design-tokens/sass/color";
+@import "~@kaizen/component-library/styles/animation";
+@import "~@kaizen/component-library/styles/border";
+@import "~@kaizen/component-library/styles/layers";
+@import "~@kaizen/deprecated-component-library-helpers/styles/layout";
+@import "~@kaizen/component-library/styles/responsive";
+@import "~@kaizen/deprecated-component-library-helpers/styles/color";
+
+.defaultModalWidth {
+  min-width: 300px;
+  max-width: 600px;
+}
+
+.backdropLayer {
+  @include ca-position($start: 0, $end: 0, $top: 0, $bottom: 0);
+  position: fixed;
+  background-color: $black;
+  opacity: 0.5;
+  z-index: $ca-z-index-modal-backdrop;
+}
+
+.scrollLayer {
+  @include ca-position($start: 0, $end: 0, $top: 0, $bottom: 0);
+  position: fixed;
+  display: flex;
+  align-items: center;
+  z-index: $ca-z-index-modal;
+  overflow-y: auto;
+}
+
+.modalLayer {
+  // use flexbox auto margins to horizontally and vertically centre the modal
+  // because in IE11, `align-items: center` and `justify-content: center` cause
+  // long modal content to become unreachable if they go off-screen
+  margin: auto;
+
+  padding: $ca-grid 0;
+  width: 100%;
+}
+
+.genericModal {
+  margin: auto;
+  background-color: $color-white;
+  border-radius: $border-solid-border-radius;
+  box-shadow: $shadow-large-box-shadow;
+  position: relative;
+  width: 90%;
+  -webkit-font-smoothing: antialiased;
+  color: $color-purple-800;
+
+  @include ca-media-tablet-and-up {
+    width: 100%;
+  }
+}
+
+// TODO: unify margin top styling
+.elmGenericModal {
+  @extend .genericModal;
+  display: flex;
+  flex-direction: column;
+  margin-top: 150px;
+  margin-left: auto;
+  margin-right: auto;
+  z-index: $ca-z-index-modal + 1;
+}
+
+.animatingEnter,
+.animatingElmEnter {
+  transition-duration: $ca-duration-fast;
+
+  .backdropLayer {
+    @include ca-animation-fade(
+      $duration: $ca-duration-rapid,
+      $from: 0,
+      $to: 0.5
+    );
+  }
+
+  .genericModal,
+  .elmGenericModal {
+    @include ca-animation(fade($from: 0, $to: 1), zoom($from: 0.5, $to: 1));
+    animation-duration: $ca-duration-fast;
+    animation-fill-mode: forwards;
+    animation-timing-function: $ca-bounce-in;
+  }
+}
+
+.animatingLeave,
+.animatingElmLeave {
+  transition-duration: $ca-duration-rapid;
+
+  .backdropLayer {
+    @include ca-animation-fade(
+      $duration: $ca-duration-rapid,
+      $from: 0.5,
+      $to: 0
+    );
+  }
+
+  .genericModal,
+  .elmGenericModal {
+    @include ca-animation(fade($from: 1, $to: 0), zoom($from: 1, $to: 0.5));
+    animation-duration: $ca-duration-rapid;
+    animation-fill-mode: forwards;
+    animation-timing-function: $ca-bounce-out;
+  }
+}
+
+.elmUnscrollable {
+  .scrollLayer {
+    overflow-y: hidden;
+  }
+}
+
+.unscrollable {
+  /* Tech debt - this !important existed before Stylelint rules */
+  overflow: hidden !important; /* stylelint-disable-line declaration-no-important */
+}
+
+.pseudoScrollbar {
+  /* Tech debt - this !important existed before Stylelint rules */
+  padding-right: 15px !important; /* stylelint-disable-line declaration-no-important */
+}
+
+.hide {
+  opacity: 0;
+  pointer-events: none;
+}

--- a/draft-packages/modal/KaizenDraft/Modal/Primitives/ElmModalBody.scss
+++ b/draft-packages/modal/KaizenDraft/Modal/Primitives/ElmModalBody.scss
@@ -1,0 +1,28 @@
+@import "~@kaizen/design-tokens/sass/color";
+@import "~@kaizen/deprecated-component-library-helpers/styles/type";
+
+.modalBody {
+  overflow-x: hidden;
+}
+
+.padded {
+  padding: $ca-grid $ca-grid $ca-grid $ca-grid;
+}
+
+.modalBody.scrollable {
+  overflow-y: scroll;
+}
+
+.modalBody.fillSpace {
+  flex-grow: 1;
+  min-height: 0;
+  overflow-y: auto;
+}
+
+.white {
+  background-color: $color-white;
+}
+
+.stone {
+  background-color: $color-gray-100;
+}

--- a/draft-packages/modal/KaizenDraft/Modal/Primitives/ElmModalFooter.scss
+++ b/draft-packages/modal/KaizenDraft/Modal/Primitives/ElmModalFooter.scss
@@ -1,0 +1,70 @@
+@import "~@kaizen/deprecated-component-library-helpers/styles/layout";
+@import "~@kaizen/deprecated-component-library-helpers/styles/type";
+@import "~@kaizen/deprecated-component-library-helpers/styles/color";
+
+.actions {
+  display: flex;
+  flex-direction: row-reverse;
+  justify-content: center;
+}
+
+.actionsAlignStart {
+  flex-direction: row-reverse;
+  justify-content: flex-end;
+}
+
+.informationAlign {
+  flex-direction: row;
+  justify-content: flex-start;
+
+  .actionButton + .actionButton {
+    @include ca-margin($start: $ca-grid * 0.5);
+  }
+}
+
+.actionButton + .actionButton {
+  @include ca-margin($end: $ca-grid * 0.5);
+}
+
+// to avoid the row-reverse styles
+.elmActionButton + .elmActionButton {
+  @include ca-margin($start: $ca-grid * 0.5);
+}
+
+.footerWrap {
+  align-items: baseline;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.center {
+  display: flex;
+  justify-content: center;
+}
+
+.border {
+  border-top: 1px solid $ca-border-color;
+}
+
+.start {
+  display: flex;
+  justify-content: flex-start;
+}
+
+.end {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.fixed {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+}
+.filler {
+  visibility: hidden;
+}
+
+.padded {
+  padding: $ca-grid;
+}

--- a/draft-packages/modal/KaizenDraft/Modal/Primitives/ElmModalHeader.scss
+++ b/draft-packages/modal/KaizenDraft/Modal/Primitives/ElmModalHeader.scss
@@ -1,0 +1,23 @@
+@import "~@kaizen/deprecated-component-library-helpers/styles/layout";
+@import "~@kaizen/component-library/styles/layers";
+@import "~@kaizen/deprecated-component-library-helpers/styles/type";
+
+.dismissButton {
+  @include ca-position($end: 0, $top: 0);
+  position: absolute;
+  z-index: $ca-z-index-popover;
+}
+
+.layout {
+  width: 100%;
+}
+
+.fixed {
+  position: absolute;
+  top: 0;
+  left: 0;
+}
+
+.filler {
+  visibility: hidden;
+}

--- a/draft-packages/modal/KaizenDraft/Modal/Primitives/GenericModal.elm
+++ b/draft-packages/modal/KaizenDraft/Modal/Primitives/GenericModal.elm
@@ -83,7 +83,7 @@ events msg (Config config) =
 
 
 styles =
-    css "@kaizen/draft-modal/KaizenDraft/Modal/Primitives/GenericModal.scss"
+    css "@kaizen/draft-modal/KaizenDraft/Modal/Primitives/ElmGenericModal.scss"
         { scrollLayer = "scrollLayer"
         , elmGenericModal = "elmGenericModal"
         }

--- a/draft-packages/modal/KaizenDraft/Modal/Primitives/ModalBody.elm
+++ b/draft-packages/modal/KaizenDraft/Modal/Primitives/ModalBody.elm
@@ -111,7 +111,7 @@ fillVerticalSpace predicate (Config config) =
 
 
 styles =
-    css "@kaizen/draft-modal/KaizenDraft/Modal/Primitives/ModalBody.scss"
+    css "@kaizen/draft-modal/KaizenDraft/Modal/Primitives/ElmModalBody.scss"
         { modalBody = "modalBody"
         , scrollable = "scrollable"
         , fillSpace = "fillSpace"

--- a/draft-packages/modal/KaizenDraft/Modal/Primitives/ModalFooter.elm
+++ b/draft-packages/modal/KaizenDraft/Modal/Primitives/ModalFooter.elm
@@ -142,7 +142,7 @@ padded predicate (Config config) =
 
 
 styles =
-    css "@kaizen/draft-modal/KaizenDraft/Modal/Primitives/ModalFooter.scss"
+    css "@kaizen/draft-modal/KaizenDraft/Modal/Primitives/ElmModalFooter.scss"
         { footerWrap = "footerWrap"
         , center = "center"
         , border = "border"

--- a/draft-packages/modal/KaizenDraft/Modal/Primitives/ModalHeader.elm
+++ b/draft-packages/modal/KaizenDraft/Modal/Primitives/ModalHeader.elm
@@ -193,7 +193,7 @@ preventDismissKeydown keydownDecoders (Config config) =
 
 
 styles =
-    css "@kaizen/draft-modal/KaizenDraft/Modal/Primitives/ModalHeader.scss"
+    css "@kaizen/draft-modal/KaizenDraft/Modal/Primitives/ElmModalHeader.scss"
         { layout = "layout"
         , filler = "filler"
         , fixed = "fixed"


### PR DESCRIPTION
# Objective
Reset Modal styles to be used for Elm Modals only.

# Motivation and Context
To fix visual breaking issues on Elm modals.
We do not intend to uplift the Elm modals at this stage.
