### PR TITLE
fix: remove previous padded styling on GenericModal

### DIFF
--- a/draft-packages/modal/KaizenDraft/Modal/Presets/ContextModal.tsx
+++ b/draft-packages/modal/KaizenDraft/Modal/Presets/ContextModal.tsx
@@ -103,7 +103,7 @@ const ContextModal = ({
         {contentHeader && (
           <div className={styles.contentHeader}>{contentHeader}</div>
         )}
-        <ModalBody unpadded={unpadded}>
+        <ModalBody>
           <div
             className={classnames(styles.contentLayout, {
               [styles.portraitContentlayout]: layout === "portrait",

--- a/draft-packages/modal/KaizenDraft/Modal/Presets/RoadblockModal.tsx
+++ b/draft-packages/modal/KaizenDraft/Modal/Presets/RoadblockModal.tsx
@@ -59,7 +59,7 @@ const RoadblockModal = ({
           </ModalAccessibleLabel>
         </div>
       </ModalHeader>
-      <ModalBody unpadded>
+      <ModalBody>
         <div className={styles.body}>
           <ModalAccessibleDescription>{children}</ModalAccessibleDescription>
         </div>

--- a/draft-packages/modal/KaizenDraft/Modal/Primitives/GenericModalSection.tsx
+++ b/draft-packages/modal/KaizenDraft/Modal/Primitives/GenericModalSection.tsx
@@ -4,7 +4,6 @@ import classNames from "classnames"
 import styles from "./GenericModalSection.scss"
 
 export interface GenericModalSectionProps {
-  readonly unpadded?: boolean
   readonly inputEdit?: boolean
   readonly children: React.ReactNode
 }
@@ -12,13 +11,11 @@ export interface GenericModalSectionProps {
 type GenericModalSection = React.FunctionComponent<GenericModalSectionProps>
 
 const GenericModalSection: GenericModalSection = ({
-  unpadded = false,
   inputEdit = false,
   children,
 }) => (
   <div
     className={classNames({
-      [styles.padded]: !unpadded,
       [styles.inputEdit]: inputEdit,
     })}
   >

--- a/draft-packages/modal/KaizenDraft/Modal/Primitives/ModalFooter.tsx
+++ b/draft-packages/modal/KaizenDraft/Modal/Primitives/ModalFooter.tsx
@@ -36,10 +36,7 @@ const ModalFooter: ModalFooter = props => {
   const { queries } = useMediaQueries()
 
   return (
-    <GenericModalSection
-      unpadded={unpadded}
-      inputEdit={variant === "inputEdit"}
-    >
+    <GenericModalSection inputEdit={variant === "inputEdit"}>
       <div
         className={classNames(
           styles.actions,

--- a/draft-packages/modal/KaizenDraft/Modal/Primitives/ModalHeader.tsx
+++ b/draft-packages/modal/KaizenDraft/Modal/Primitives/ModalHeader.tsx
@@ -15,10 +15,10 @@ export interface ModalHeaderProps {
 
 class ModalHeader extends React.Component<ModalHeaderProps> {
   render() {
-    const { unpadded, reversed, onDismiss, children } = this.props
+    const { reversed, onDismiss, children } = this.props
 
     return (
-      <GenericModalSection unpadded={unpadded}>
+      <GenericModalSection>
         <div className={styles.dismissButton}>
           <IconButton
             label="Dismiss"


### PR DESCRIPTION
# Objective
Fix undefined being rendered as a class on the GenericModal. Removed the .padded styles from classname() as it was no longer required as a style for the generic modal.

# Motivation and Context
Undefined was being added as a class on the GenericModal which wraps ModalHeader, ModalBody and ModalFooter.
