### PR TITLE
fix: add fallback for aspect ratio styles in safari 14

### DIFF
--- a/draft-packages/illustration/KaizenDraft/Illustration/style.module.scss
+++ b/draft-packages/illustration/KaizenDraft/Illustration/style.module.scss
@@ -11,14 +11,56 @@
 
 .landscape {
   aspect-ratio: 4/3;
+
+  @supports not (aspect-ratio: auto) {
+    &::before {
+      float: left;
+      padding-top: 75%;
+      content: "";
+    }
+
+    &::after {
+      display: block;
+      content: "";
+      clear: both;
+    }
+  }
 }
 
 .portrait {
   aspect-ratio: 3/4;
+
+  @supports not (aspect-ratio: auto) {
+    &::before {
+      float: left;
+      padding-top: 133.33%;
+      content: "";
+    }
+
+    &::after {
+      display: block;
+      content: "";
+      clear: both;
+    }
+  }
 }
 
 .square {
   aspect-ratio: auto 1/1;
+
+  @supports not (aspect-ratio: auto) {
+    &::before {
+      float: left;
+      padding-top: 100%;
+      content: "";
+    }
+
+    &::after {
+      display: block;
+      content: "";
+      clear: both;
+    }
+  }
 }
 
 // If the .visually-hidden class is applied to natively focusable elements


### PR DESCRIPTION
# Objective
- Add support for aspect-ratio CSS in Safari 14 and IE11 

# Motivation and Context
- initial PR with feature here: https://github.com/cultureamp/kaizen-design-system/pull/2322

# Screenshots (if appropriate)
Here's the fallback working (just removed the support so it was forced on)
<img width="1858" alt="Screen Shot 2021-12-10 at 4 31 08 pm" src="https://user-images.githubusercontent.com/18339250/145522433-180e9a4e-89a2-4dc0-ad24-41a4243214ca.png">

# Checklist
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] If this contains visual changes, has it been reviewed by a designer?
- [ ] If this introduces either a new component or a breaking change to an existing component, has it been reviewed by an advocate? (Ask in #prod_design_systems)
- [ ] I have considered likely risks of these changes and got someone else to QA as appropriate
- [ ] I have or will communicate these changes to the front end practice

# Additional Considerations
- Does there need to be right-to-left (RTL) options for localization and internationalization?
- Has the test suite been updated?
- Have you done cross-browser testing for our [supported browsers](https://academy.cultureamp.com/hc/en-us/articles/204539569-Supported-browsers-for-Participants)?
- Have you updated any relevant documentation or left useful comments in the code?
- Have you reviewed Culture Amp's Web Accessibility guide [Current Compliance, Going Forward, Statement and Answers for Customers](https://cultureamp.atlassian.net/wiki/spaces/Prod/pages/428572998/Web+Accessibility)?
- If this contains substantial visual changes, especially far reaching ones, have you unlocked the Chromatic step in the pipeline?
- Have Storybook stories been updated?

**If you're new to Kaizen, please ask #prod_design_systems to set up an onboarding session to get you up to speed.** If you have an urgent PR to merge before that happens, it is safest to ask in #prod_design_systems to have a design system advocate review the PR to catch any issues.
