### PR TITLE
fix: 🐛 Update ID prop on SearchField to be required and update name.

### DIFF
--- a/draft-packages/form/KaizenDraft/Form/SearchField/SearchField.tsx
+++ b/draft-packages/form/KaizenDraft/Form/SearchField/SearchField.tsx
@@ -7,10 +7,11 @@ export interface SearchFieldProps
     React.InputHTMLAttributes<HTMLInputElement>,
     "className" | "defaultValue"
   > {
+  id: string
+  labelText: string
   reversed?: boolean
   loading?: boolean
   secondary?: boolean
-  labelText: string
   onClear?: () => void
 }
 
@@ -26,14 +27,13 @@ const SearchField: React.FunctionComponent<SearchFieldProps> = ({
   onClear,
   ...genericInputProps
 }) => {
-  const searchFieldId = `${id}-search-field-input`
   const showVisibleLabel = !secondary
 
   return (
     <FieldGroup inline={false}>
       {showVisibleLabel && (
         <Label
-          htmlFor={searchFieldId}
+          htmlFor={id}
           labelText={labelText}
           reversed={reversed}
           disabled={disabled}
@@ -41,7 +41,7 @@ const SearchField: React.FunctionComponent<SearchFieldProps> = ({
       )}
       <InputSearch
         aria-label={!showVisibleLabel ? labelText : undefined}
-        id={searchFieldId}
+        id={id}
         placeholder={placeholder}
         disabled={disabled}
         value={value}


### PR DESCRIPTION
BREAKING CHANGE: 🧨  Fixed SearchField to have a required ID prop to avoid any undefined errors. Also removes the weird suffix that we stuck onto the ID.

✅  Closes: #2329

# Objective
Adjusts the ID prop of `SearchField` to be required.

# Motivation and Context
We're assuming that people are passing down IDs into this component, but it's not required. This gives us some weird mark-up with undefined IDs if they aren't passed through.