### PR TITLE
docs: Fix Storybook Design Tokens pages not loading [KDS-73]

### DIFF
--- a/packages/design-tokens/docs/DocsComponents.tsx
+++ b/packages/design-tokens/docs/DocsComponents.tsx
@@ -3,7 +3,7 @@
 import { Box, Paragraph } from "@kaizen/component-library"
 import { Card } from "@kaizen/draft-card"
 import { Tabs } from "@kaizen/draft-tabs"
-import { LinkTo } from "@storybook/addon-links/react"
+import { LinkTo } from "@storybook/addon-links"
 import { Meta } from "@storybook/react"
 import classNames from "classnames"
 import "highlight.js/styles/monokai.css"

--- a/packages/design-tokens/docs/DocsComponents.tsx
+++ b/packages/design-tokens/docs/DocsComponents.tsx
@@ -3,7 +3,7 @@
 import { Box, Paragraph } from "@kaizen/component-library"
 import { Card } from "@kaizen/draft-card"
 import { Tabs } from "@kaizen/draft-tabs"
-import { LinkTo } from "@storybook/addon-links"
+import LinkTo from "@storybook/addon-links/react"
 import { Meta } from "@storybook/react"
 import classNames from "classnames"
 import "highlight.js/styles/monokai.css"
@@ -188,7 +188,10 @@ export const LinkToStory = ({
   /* Children can be used to override the Link text */
   children?: React.ReactNode
 }) => (
+  // @ts-ignore
   <LinkTo kind={storyModule.title}>
     {children || getStoryLinkName(storyModule.title)}
   </LinkTo>
 )
+
+export default {}

--- a/packages/design-tokens/docs/pages/getting-started.stories.mdx
+++ b/packages/design-tokens/docs/pages/getting-started.stories.mdx
@@ -3,7 +3,6 @@ import { zenTheme, heartTheme } from '../../src/themes'
 import { Card } from '@kaizen/draft-card'
 import { Box } from "@kaizen/component-library";
 import { ThemesCodeBlocks, SassVariablesCodeBlocks, CodeBlock, LinkToStory } from "../DocsComponents"
-import LinkTo from '@storybook/addon-links/react'
 import howToUseInSass from './how-to-use-with-sass.stories.mdx'
 import howToUseInReact from './how-to-use-in-react.stories.mdx'
 import howToSwitchThemes from './how-to-switch-themes.stories.mdx'

--- a/storybook/main.ts
+++ b/storybook/main.ts
@@ -22,6 +22,7 @@ const getStoryPathsFromEnv = (): string[] | false => {
 
 const defaultStoryPaths = [
   "../packages/**/*.stories.tsx",
+  "../packages/**/*.stories.mdx",
   "../draft-packages/**/*.stories.tsx",
   "../legacy-packages/**/*.stories.tsx",
 ]


### PR DESCRIPTION
🍐 with @mcwinter07 

## Objective

While trying to fix #2100 we noticed that the Design Tokens pages in Storybook had gone completely missing which was due to a recent change in the Storybook config.

![image](https://user-images.githubusercontent.com/763385/145756339-7c4984b9-1758-40bb-94e8-9feb34387860.png)

Once this was solved we managed to fix the problem that these pages weren't loading properly by changing the `LinkTo` import... 🤷 

Here it is all working again:

![image](https://user-images.githubusercontent.com/763385/145756394-5585c0f6-265c-4eca-a1cf-58a97faf071f.png)

Fixes #2100 




