### PR TITLE
Update props 'title' types in `InlineNotification`

### DIFF
--- a/packages/notification/src/InlineNotification.tsx
+++ b/packages/notification/src/InlineNotification.tsx
@@ -5,7 +5,7 @@ import GenericNotification, {
 
 type Props = {
   type: NotificationType
-  title: string
+  title?: string
   children?: React.ReactNode
   autohide?: boolean
   autohideDelay?: "short" | "long"


### PR DESCRIPTION
# Objective
- When using `InlineNotification` component in murmur, we noticed the type of props `title` is mandatory. However, when we check the code in kaizen, the `title` props will be passed into `GenericNotification`, and the type here is optional, which means the props type are not consistent.

# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
-- Updating the prop type of `title` in InlineNotification to optional.

 <!--- If it fixes an open issue, please link to the issue here. -->

# Screenshots (if appropriate)

# Checklist
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] If this contains visual changes, has it been reviewed by a designer?
- [ ] If this introduces either a new component or a breaking change to an existing component, has it been reviewed by an advocate? (Ask in #prod_design_systems)
- [ ] I have considered likely risks of these changes and got someone else to QA as appropriate
- [ ] I have or will communicate these changes to the front end practice

# Additional Considerations
- Does there need to be right-to-left (RTL) options for localization and internationalization?
- Has the test suite been updated?
- Have you done cross-browser testing for our [supported browsers](https://academy.cultureamp.com/hc/en-us/articles/204539569-Supported-browsers-for-Participants)?
- Have you updated any relevant documentation or left useful comments in the code?
- Have you reviewed Culture Amp's Web Accessibility guide [Current Compliance, Going Forward, Statement and Answers for Customers](https://cultureamp.atlassian.net/wiki/spaces/Prod/pages/428572998/Web+Accessibility)?
- If this contains substantial visual changes, especially far reaching ones, have you unlocked the Chromatic step in the pipeline?
- Have Storybook stories been updated?

**If you're new to Kaizen, please ask #prod_design_systems to set up an onboarding session to get you up to speed.** If you have an urgent PR to merge before that happens, it is safest to ask in #prod_design_systems to have a design system advocate review the PR to catch any issues.
