### PR TITLE
fix: Update Team component image url to use team-1

### DIFF
--- a/draft-packages/illustration/KaizenDraft/Illustration/Spot.tsx
+++ b/draft-packages/illustration/KaizenDraft/Illustration/Spot.tsx
@@ -868,7 +868,7 @@ export const Team = ({ enableAspectRatio, ...props }: SpotProps) => (
   <Base
     aspectRatio={enableAspectRatio ? "square" : undefined}
     {...props}
-    name="illustrations/heart/spot/miscellaneous-team.svg"
+    name="illustrations/heart/spot/miscellaneous-team-1.svg"
   />
 )
 

--- a/draft-packages/illustration/KaizenDraft/Illustration/__snapshots__/illustration.spec.tsx.snap
+++ b/draft-packages/illustration/KaizenDraft/Illustration/__snapshots__/illustration.spec.tsx.snap
@@ -1455,7 +1455,7 @@ exports[`<Illustration /> Spot Team should exist and render an alt tag 1`] = `
   <img
     alt="My accessible title"
     class=" wrapper"
-    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/heart/spot/miscellaneous-team.svg"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/heart/spot/miscellaneous-team-1.svg"
   />
 </div>
 `;


### PR DESCRIPTION
# Objective
Update Team Spot component to use team-1.svg after updating in previous ([PR](https://github.com/cultureamp/kaizen-design-system-assets/commit/d07859ecae132a6a37a0bd75ebf7bbb0b13aef3b))

# Motivation and Context
Broke the Team component in production as it was no longer linking to the correct asset Url.