### PR TITLE
feat: new Tooltip mood variants

### DIFF
--- a/draft-packages/tooltip/KaizenDraft/Tooltip/Tooltip.scss
+++ b/draft-packages/tooltip/KaizenDraft/Tooltip/Tooltip.scss
@@ -28,7 +28,7 @@ $arrow-width: 20px;
   font-family: $typography-paragraph-body-font-family;
   font-size: $typography-heading-6-font-size;
   font-weight: $typography-paragraph-body-font-weight;
-  $letter-spacing: $typography-paragraph-body-letter-spacing;
+  letter-spacing: $typography-paragraph-body-letter-spacing;
   line-height: $typography-paragraph-body-line-height;
 
   &.default {

--- a/draft-packages/tooltip/KaizenDraft/Tooltip/Tooltip.scss
+++ b/draft-packages/tooltip/KaizenDraft/Tooltip/Tooltip.scss
@@ -21,19 +21,41 @@ $dt-tooltip-content-border: $color-gray-300;
   border-radius: $border-solid-border-radius;
   transition: opacity $ca-duration-fast, transform $ca-duration-fast;
   padding: $ca-grid / 2 $ca-grid / 2;
-  border: $border-solid-border-width $border-solid-border-style
-    $dt-tooltip-content-border;
   box-shadow: $shadow-small-box-shadow;
   text-align: center;
   max-width: 400px;
+  color: $color-purple-800;
   // I'm having a problem getting the tooltip width to match the size of the text content.
   // As a workaround, I'm just going to set a min width of 200px. It should be enough
   // in most cases.
-  min-width: 200px;
+  // min-width: fit-content;
   @include kz-typography-paragraph-body($size: 14);
   top: initial; // Overrides the `top` value of kz-typography-paragraph-body
-  color: $color-purple-800;
-  background-color: white;
+
+  &.default {
+    background-color: $color-white;
+    border: $border-solid-border-width $border-solid-border-style
+      $dt-tooltip-content-border;
+  }
+  &.informative {
+    background-color: $color-blue-100;
+    border: $border-solid-border-width $border-solid-border-style
+      $color-blue-300;
+  }
+  &.positive {
+    background-color: $color-green-100;
+    border: $border-solid-border-width $border-solid-border-style
+      $color-green-300;
+  }
+  &.negative {
+    background-color: $color-red-100;
+    border: $border-solid-border-width $border-solid-border-style $color-red-300;
+  }
+  &.cautionary {
+    background-color: $color-yellow-100;
+    border: $border-solid-border-width $border-solid-border-style
+      $color-yellow-300;
+  }
 }
 
 .arrow {
@@ -60,8 +82,8 @@ $dt-tooltip-content-border: $color-gray-300;
   }
 }
 
-.arrowWhite::before,
-.arrowWhite::after {
+.arrowMain::before,
+.arrowMain::after {
   content: "";
   position: absolute;
   left: 50%;
@@ -70,13 +92,44 @@ $dt-tooltip-content-border: $color-gray-300;
   margin-left: -($arrow-width / 2);
 }
 
-.arrowWhite::before {
-  border-top: $arrow-height solid $dt-tooltip-content-border;
+.arrowMain {
+  &.default::before {
+    border-top: $arrow-height solid $dt-tooltip-content-border;
+  }
+  &.informative::before {
+    border-top: $arrow-height solid $color-blue-300;
+  }
+  &.positive::before {
+    border-top: $arrow-height solid $color-green-300;
+  }
+  &.negative::before {
+    border-top: $arrow-height solid $color-red-300;
+  }
+  &.cautionary::before {
+    border-top: $arrow-height solid $color-yellow-300;
+  }
 }
 
-.arrowWhite::after {
-  border-top: $arrow-height solid white;
+.arrowMain::after {
   margin-top: -2px;
+}
+
+.arrowMain {
+  &.default::after {
+    border-top: $arrow-height solid white;
+  }
+  &.informative::after {
+    border-top: $arrow-height solid $color-blue-100;
+  }
+  &.positive::after {
+    border-top: $arrow-height solid $color-green-100;
+  }
+  &.negative::after {
+    border-top: $arrow-height solid $color-red-100;
+  }
+  &.cautionary::after {
+    border-top: $arrow-height solid $color-yellow-100;
+  }
 }
 
 .arrowShadow::before {

--- a/draft-packages/tooltip/KaizenDraft/Tooltip/Tooltip.scss
+++ b/draft-packages/tooltip/KaizenDraft/Tooltip/Tooltip.scss
@@ -36,20 +36,24 @@ $arrow-width: 20px;
     border: $border-solid-border-width $border-solid-border-style
       $color-gray-300;
   }
+
   &.informative {
     background-color: $color-blue-100;
     border: $border-solid-border-width $border-solid-border-style
       $color-blue-300;
   }
+
   &.positive {
     background-color: $color-green-100;
     border: $border-solid-border-width $border-solid-border-style
       $color-green-300;
   }
+
   &.negative {
     background-color: $color-red-100;
     border: $border-solid-border-width $border-solid-border-style $color-red-300;
   }
+
   &.cautionary {
     background-color: $color-yellow-100;
     border: $border-solid-border-width $border-solid-border-style
@@ -95,37 +99,45 @@ $arrow-width: 20px;
   &.default::before {
     border-top: $arrow-height solid $color-gray-300;
   }
+
   &.informative::before {
     border-top: $arrow-height solid $color-blue-300;
   }
+
   &.positive::before {
     border-top: $arrow-height solid $color-green-300;
   }
+
   &.negative::before {
     border-top: $arrow-height solid $color-red-300;
   }
+
   &.cautionary::before {
     border-top: $arrow-height solid $color-yellow-300;
   }
 }
 
-.arrowMain::after {
-  margin-top: -2px;
-}
-
 .arrowMain {
+  &:after {
+    margin-top: -2px;
+  }
+
   &.default::after {
     border-top: $arrow-height solid white;
   }
+
   &.informative::after {
     border-top: $arrow-height solid $color-blue-100;
   }
+
   &.positive::after {
     border-top: $arrow-height solid $color-green-100;
   }
+
   &.negative::after {
     border-top: $arrow-height solid $color-red-100;
   }
+
   &.cautionary::after {
     border-top: $arrow-height solid $color-yellow-100;
   }

--- a/draft-packages/tooltip/KaizenDraft/Tooltip/Tooltip.scss
+++ b/draft-packages/tooltip/KaizenDraft/Tooltip/Tooltip.scss
@@ -1,15 +1,14 @@
 @import "~@kaizen/design-tokens/sass/shadow";
 @import "~@kaizen/design-tokens/sass/border";
 @import "~@kaizen/design-tokens/sass/color";
-@import "~@kaizen/deprecated-component-library-helpers/styles/type";
-@import "~@kaizen/component-library/styles/animation";
+@import "~@kaizen/design-tokens/sass/animation";
+@import "~@kaizen/design-tokens/sass/typography";
+@import "~@kaizen/design-tokens/sass/spacing";
 @import "~@kaizen/component-library/styles/layers";
 
 // Sync with Tooltip.tsx
 $arrow-height: 10px;
 $arrow-width: 20px;
-
-$dt-tooltip-content-border: $color-gray-300;
 
 .tooltip {
   position: relative; // Make this a positioned element so z-index works. (Note: Popper overrides this to absolute.)
@@ -19,23 +18,23 @@ $dt-tooltip-content-border: $color-gray-300;
 
 .tooltipContent {
   border-radius: $border-solid-border-radius;
-  transition: opacity $ca-duration-fast, transform $ca-duration-fast;
-  padding: $ca-grid / 2 $ca-grid / 2;
+  transition: opacity $animation-duration-fast,
+    transform $animation-duration-fast;
+  padding: $spacing-sm $spacing-sm;
   box-shadow: $shadow-small-box-shadow;
   text-align: center;
   max-width: 400px;
   color: $color-purple-800;
-  // I'm having a problem getting the tooltip width to match the size of the text content.
-  // As a workaround, I'm just going to set a min width of 200px. It should be enough
-  // in most cases.
-  // min-width: fit-content;
-  @include kz-typography-paragraph-body($size: 14);
-  top: initial; // Overrides the `top` value of kz-typography-paragraph-body
+  font-family: $typography-paragraph-body-font-family;
+  font-size: $typography-heading-6-font-size;
+  font-weight: $typography-paragraph-body-font-weight;
+  $letter-spacing: $typography-paragraph-body-letter-spacing;
+  line-height: $typography-paragraph-body-line-height;
 
   &.default {
     background-color: $color-white;
     border: $border-solid-border-width $border-solid-border-style
-      $dt-tooltip-content-border;
+      $color-gray-300;
   }
   &.informative {
     background-color: $color-blue-100;
@@ -94,7 +93,7 @@ $dt-tooltip-content-border: $color-gray-300;
 
 .arrowMain {
   &.default::before {
-    border-top: $arrow-height solid $dt-tooltip-content-border;
+    border-top: $arrow-height solid $color-gray-300;
   }
   &.informative::before {
     border-top: $arrow-height solid $color-blue-300;
@@ -133,7 +132,7 @@ $dt-tooltip-content-border: $color-gray-300;
 }
 
 .arrowShadow::before {
-  border-top: 0px solid $dt-tooltip-content-border;
+  border-top: 0px solid $color-gray-300;
 }
 
 // Triangle portion is a little darker to bring out shadow

--- a/draft-packages/tooltip/KaizenDraft/Tooltip/Tooltip.tsx
+++ b/draft-packages/tooltip/KaizenDraft/Tooltip/Tooltip.tsx
@@ -9,6 +9,8 @@ import { useUuid } from "./useUuid"
 
 type Position = "above" | "below"
 
+type Mood = "default" | "informative" | "positive" | "negative" | "cautionary"
+
 export type TooltipProps = {
   /**
    * Use `display="inline"` instead
@@ -30,6 +32,7 @@ export type TooltipProps = {
   text: React.ReactNode
   children?: React.ReactNode
   classNameAndIHaveSpokenToDST?: string
+  mood?: Mood
   /**
    * Render the tooltip inside a react portal, given the ccs selector.
    * This is typically used for instances where the menu is a descendant of an
@@ -47,7 +50,13 @@ export type TooltipProps = {
 const arrowHeight = 10
 const arrowWidth = 20
 
-const TooltipContent = ({ position, text, referenceElement, tooltipId }) => {
+const TooltipContent = ({
+  position,
+  text,
+  referenceElement,
+  tooltipId,
+  mood = "default",
+}) => {
   const [popperElement, setPopperElement] = useState<HTMLDivElement | null>(
     null
   )
@@ -99,7 +108,17 @@ const TooltipContent = ({ position, text, referenceElement, tooltipId }) => {
       role="tooltip"
       id={tooltipId}
     >
-      <div className={classnames(tooltipStyles.tooltipContent)}>{text}</div>
+      <div
+        className={classnames(tooltipStyles.tooltipContent, {
+          [tooltipStyles.default]: mood === "default",
+          [tooltipStyles.informative]: mood === "informative",
+          [tooltipStyles.positive]: mood === "positive",
+          [tooltipStyles.negative]: mood === "negative",
+          [tooltipStyles.cautionary]: mood === "cautionary",
+        })}
+      >
+        {text}
+      </div>
       <div
         ref={setArrowElement}
         className={classnames({
@@ -108,7 +127,15 @@ const TooltipContent = ({ position, text, referenceElement, tooltipId }) => {
         style={popperStyles.arrow}
       >
         <div className={tooltipStyles.arrowInner}>
-          <div className={tooltipStyles.arrowWhite} />
+          <div
+            className={classnames(tooltipStyles.arrowMain, {
+              [tooltipStyles.default]: mood === "default",
+              [tooltipStyles.informative]: mood === "informative",
+              [tooltipStyles.positive]: mood === "positive",
+              [tooltipStyles.negative]: mood === "negative",
+              [tooltipStyles.cautionary]: mood === "cautionary",
+            })}
+          />
           <div className={tooltipStyles.arrowShadow} />
         </div>
       </div>
@@ -125,6 +152,7 @@ const Tooltip = ({
   classNameAndIHaveSpokenToDST,
   portalSelector,
   isInitiallyVisible = false,
+  mood = "default",
 }: TooltipProps) => {
   const [isHover, setIsHover] = useState(isInitiallyVisible)
   const [isFocus, setIsFocus] = useState(false)
@@ -143,6 +171,7 @@ const Tooltip = ({
       position={position}
       referenceElement={referenceElement}
       tooltipId={tooltipId}
+      mood={mood}
     />
   )
 

--- a/draft-packages/tooltip/docs/Tooltip.stories.tsx
+++ b/draft-packages/tooltip/docs/Tooltip.stories.tsx
@@ -37,18 +37,20 @@ export default {
   decorators: [withDesign, openTooltipInChromatic],
 }
 
-export const DefaultBelowKaizenSiteDemo = props => (
-  <div style={{ display: "flex", justifyContent: "center" }}>
-    <Tooltip {...props} position="below" text="This is below the tooltip">
+export const DefaultKaizenSiteDemo = props => (
+  <div
+    style={{ marginTop: "100px", display: "flex", justifyContent: "center" }}
+  >
+    <Tooltip {...props} text="This is below the tooltip">
       {/* Using buttons, as so we can test the focus state.
          ie. the tooltip should show when any child is focused. */}
-      <Button label="Below" />
+      <Button label="Default" />
     </Tooltip>
   </div>
 )
 
-DefaultBelowKaizenSiteDemo.storyName = "Default - Below (Kaizen Site Demo)"
-DefaultBelowKaizenSiteDemo.parameters = {
+DefaultKaizenSiteDemo.storyName = "Default (Kaizen Site Demo)"
+DefaultKaizenSiteDemo.parameters = {
   info: {
     text: `
     import { Tooltip } from "@kaizen/draft-tooltip"
@@ -56,20 +58,101 @@ DefaultBelowKaizenSiteDemo.parameters = {
   },
 }
 
-export const DefaultAbove = props => (
+export const DesignSheet = props => (
   <div
-    style={{ marginTop: "100px", display: "flex", justifyContent: "center" }}
+    style={{
+      marginTop: "100px",
+      display: "grid",
+      justifyContent: "center",
+      rowGap: "5rem",
+    }}
   >
-    <div style={{ display: "inline-block", position: "relative" }}>
-      <Tooltip {...props} position="above" text="This is above the tooltip">
-        {/* Using buttons, as so we can test the focus state.
-         ie. the tooltip should show when any child is focused. */}
-        <Button label="Above" />
-      </Tooltip>
+    <div>
+      <div
+        style={{
+          display: "inline-block",
+          marginRight: "2rem",
+          position: "relative",
+        }}
+      >
+        <Tooltip
+          position="above"
+          text="Tooltip"
+          mood="default"
+          isInitiallyVisible
+        >
+          <Button label="Default" />
+        </Tooltip>
+      </div>
+      <div
+        style={{
+          display: "inline-block",
+          marginRight: "2rem",
+          position: "relative",
+        }}
+      >
+        <Tooltip
+          position="above"
+          text="Tooltip"
+          mood="informative"
+          isInitiallyVisible
+        >
+          <Button label="Default" />
+        </Tooltip>
+      </div>
+      <div
+        style={{
+          display: "inline-block",
+          marginRight: "2rem",
+          position: "relative",
+        }}
+      >
+        <Tooltip
+          {...props}
+          position="above"
+          text="Tooltip"
+          mood="positive"
+          isInitiallyVisible
+        >
+          <Button label="Default" />
+        </Tooltip>
+      </div>
+      <div
+        style={{
+          display: "inline-block",
+          marginRight: "2rem",
+          position: "relative",
+        }}
+      >
+        <Tooltip
+          position="above"
+          text="Tooltip"
+          mood="negative"
+          isInitiallyVisible
+        >
+          <Button label="Default" />
+        </Tooltip>
+      </div>
+      <div
+        style={{
+          display: "inline-block",
+          marginRight: "2rem",
+          position: "relative",
+        }}
+      >
+        <Tooltip
+          position="above"
+          text="Tooltip"
+          mood="cautionary"
+          isInitiallyVisible
+        >
+          <Button label="Default" />
+        </Tooltip>
+      </div>
     </div>
   </div>
 )
-DefaultAbove.storyName = "Default - Above"
+DesignSheet.storyName = "Design Sheet"
 
 export const Inline = props => (
   <div
@@ -105,7 +188,7 @@ export const Inline = props => (
           {...props}
           display="inline-block"
           text="This is below the tooltip"
-          position="below"
+          position="bottom"
         >
           <Tag>veniam sapiente ad</Tag>
         </Tooltip>{" "}
@@ -121,7 +204,7 @@ export const ArrowPositioning = props => (
     <div style={{ position: "absolute", top: "0", left: "0" }}>
       <Tooltip
         {...props}
-        position="above"
+        position="top"
         text="This is below the tooltip, despite it being set to position=above. This is because there is not enough room. Also note that the arrow is correctly positioned."
       >
         <Button label="Above" />
@@ -130,7 +213,7 @@ export const ArrowPositioning = props => (
     <div style={{ position: "absolute", bottom: "0", right: "0" }}>
       <Tooltip
         {...props}
-        position="below"
+        position="bottom"
         text="This is above the tooltip, despite it being set to position=below. This is because there is not enough room. Also note that the arrow is correctly positioned."
       >
         <Button label="Bottom" />


### PR DESCRIPTION
# Objective
Adds new `mood` prop which allows different variants of the tooltip.

# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
UI kit parity for different mood variants

[KDS-70](https://cultureamp.atlassian.net/jira/software/projects/KDS/boards/289?selectedIssue=KDS-70)

# Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/48232362/148463976-428abcee-8cee-44df-bfbb-10315f4a8353.png)

