### PR TITLE
feat: tooltip placement for scroll and left/right

### DIFF
--- a/draft-packages/tooltip/KaizenDraft/Tooltip/Tooltip.scss
+++ b/draft-packages/tooltip/KaizenDraft/Tooltip/Tooltip.scss
@@ -19,7 +19,7 @@ $arrow-width: 14px;
   border-radius: $border-solid-border-radius;
   transition: opacity $animation-duration-fast,
     transform $animation-duration-fast;
-  padding: 10px 10px;
+  padding: 9px 9px;
   box-shadow: $shadow-small-box-shadow;
   text-align: center;
   max-width: 400px;
@@ -28,7 +28,7 @@ $arrow-width: 14px;
   font-size: $typography-heading-6-font-size;
   font-weight: $typography-paragraph-body-font-weight;
   letter-spacing: $typography-paragraph-body-letter-spacing;
-  line-height: $typography-paragraph-body-line-height;
+  line-height: 0.875rem;
 
   &.default {
     background-color: $color-white;

--- a/draft-packages/tooltip/KaizenDraft/Tooltip/Tooltip.scss
+++ b/draft-packages/tooltip/KaizenDraft/Tooltip/Tooltip.scss
@@ -83,6 +83,18 @@ $arrow-width: 20px;
       transform: rotate(180deg);
     }
   }
+  [data-popper-placement^="left"] & {
+    right: 0;
+    .arrowInner {
+      transform: rotate(270deg);
+    }
+  }
+  [data-popper-placement^="right"] & {
+    left: 0;
+    .arrowInner {
+      transform: rotate(90deg);
+    }
+  }
 }
 
 .arrowMain::before,
@@ -172,4 +184,13 @@ $arrow-width: 20px;
 
 .displayInlineFlex {
   display: inline-flex;
+}
+
+//Story Styles
+#portalSelectorStory::before,
+#portalSelectorStory::after {
+  content: "";
+  display: block;
+  width: 1px;
+  height: 600px;
 }

--- a/draft-packages/tooltip/KaizenDraft/Tooltip/Tooltip.scss
+++ b/draft-packages/tooltip/KaizenDraft/Tooltip/Tooltip.scss
@@ -3,7 +3,6 @@
 @import "~@kaizen/design-tokens/sass/color";
 @import "~@kaizen/design-tokens/sass/animation";
 @import "~@kaizen/design-tokens/sass/typography";
-@import "~@kaizen/design-tokens/sass/spacing";
 @import "~@kaizen/component-library/styles/layers";
 
 // Sync with Tooltip.tsx
@@ -109,6 +108,7 @@ $arrow-width: 14px;
 }
 
 .arrowMain {
+  // before styles
   &.default::before {
     border-top: $arrow-height solid $color-gray-300;
   }
@@ -128,9 +128,7 @@ $arrow-width: 14px;
   &.cautionary::before {
     border-top: $arrow-height solid $color-yellow-300;
   }
-}
-
-.arrowMain {
+  // after styles
   &:after {
     margin-top: -3px;
   }

--- a/draft-packages/tooltip/KaizenDraft/Tooltip/Tooltip.scss
+++ b/draft-packages/tooltip/KaizenDraft/Tooltip/Tooltip.scss
@@ -185,12 +185,3 @@ $arrow-width: 20px;
 .displayInlineFlex {
   display: inline-flex;
 }
-
-//Story Styles
-#portalSelectorStory::before,
-#portalSelectorStory::after {
-  content: "";
-  display: block;
-  width: 1px;
-  height: 600px;
-}

--- a/draft-packages/tooltip/KaizenDraft/Tooltip/Tooltip.scss
+++ b/draft-packages/tooltip/KaizenDraft/Tooltip/Tooltip.scss
@@ -83,6 +83,7 @@ $arrow-width: 20px;
       transform: rotate(180deg);
     }
   }
+
   [data-popper-placement^="left"] & {
     right: 0;
     .arrowInner {

--- a/draft-packages/tooltip/KaizenDraft/Tooltip/Tooltip.scss
+++ b/draft-packages/tooltip/KaizenDraft/Tooltip/Tooltip.scss
@@ -7,8 +7,8 @@
 @import "~@kaizen/component-library/styles/layers";
 
 // Sync with Tooltip.tsx
-$arrow-height: 10px;
-$arrow-width: 20px;
+$arrow-height: 7px;
+$arrow-width: 14px;
 
 .tooltip {
   position: relative; // Make this a positioned element so z-index works. (Note: Popper overrides this to absolute.)
@@ -20,7 +20,7 @@ $arrow-width: 20px;
   border-radius: $border-solid-border-radius;
   transition: opacity $animation-duration-fast,
     transform $animation-duration-fast;
-  padding: $spacing-sm $spacing-sm;
+  padding: 10px 10px;
   box-shadow: $shadow-small-box-shadow;
   text-align: center;
   max-width: 400px;
@@ -132,7 +132,7 @@ $arrow-width: 20px;
 
 .arrowMain {
   &:after {
-    margin-top: -2px;
+    margin-top: -3px;
   }
 
   &.default::after {

--- a/draft-packages/tooltip/KaizenDraft/Tooltip/Tooltip.tsx
+++ b/draft-packages/tooltip/KaizenDraft/Tooltip/Tooltip.tsx
@@ -47,15 +47,12 @@ export type TooltipProps = {
   isInitiallyVisible?: boolean
 }
 
-const getPlacement = (position: Position): Placement => {
-  if (position === "above") {
-    return "top"
-  } else if (position === "below") {
-    return "bottom"
-  } else {
-    return position
-  }
-}
+const positionToPlacement = new Map<Position, Placement>([
+  ["above", "top"],
+  ["below", "bottom"],
+  ["left", "left"],
+  ["right", "right"],
+])
 
 // Sync with Tooltip.scss
 const arrowHeight = 10
@@ -112,7 +109,7 @@ const TooltipContent = ({
           },
         },
       ],
-      placement: getPlacement(position),
+      placement: positionToPlacement.get(position),
     }
   )
   const { isVisible, isAnimIn, isAnimOut } = useAnimation()

--- a/draft-packages/tooltip/KaizenDraft/Tooltip/Tooltip.tsx
+++ b/draft-packages/tooltip/KaizenDraft/Tooltip/Tooltip.tsx
@@ -47,21 +47,13 @@ export type TooltipProps = {
   isInitiallyVisible?: boolean
 }
 
-const getPlacement = (position: Position) => {
+const getPlacement = (position: Position): Placement => {
   if (position === "above") {
     return "top"
   } else if (position === "below") {
     return "bottom"
   } else {
     return position
-  }
-}
-const getFallbackPlacements = (position: Position) => {
-  const placement = getPlacement(position)
-  if (placement === "left" || placement === "right") {
-    return ["left", "top", "bottom", "right"]
-  } else {
-    return ["top", "bottom"]
   }
 }
 
@@ -91,13 +83,13 @@ const TooltipContent = ({
             element: arrowElement,
             // Ensures that the arrow doesn't go too far to the left or right
             // of the tooltip.
-            padding: arrowWidth / 2 + 20,
+            padding: arrowWidth / 2 + 10,
           },
         },
         {
           name: "offset",
           options: {
-            offset: [0, arrowHeight],
+            offset: [0, arrowHeight + 12],
           },
         },
         {
@@ -116,11 +108,11 @@ const TooltipContent = ({
           options: {
             padding: 8,
             altBoundary: true,
-            fallbackPlacements: getFallbackPlacements(position) as Placement[],
+            fallbackPlacements: ["left", "top", "bottom", "right"],
           },
         },
       ],
-      placement: getPlacement(position) as Placement,
+      placement: getPlacement(position),
     }
   )
   const { isVisible, isAnimIn, isAnimOut } = useAnimation()

--- a/draft-packages/tooltip/KaizenDraft/Tooltip/Tooltip.tsx
+++ b/draft-packages/tooltip/KaizenDraft/Tooltip/Tooltip.tsx
@@ -55,8 +55,8 @@ const positionToPlacement = new Map<Position, Placement>([
 ])
 
 // Sync with Tooltip.scss
-const arrowHeight = 10
-const arrowWidth = 20
+const arrowHeight = 7
+const arrowWidth = 14
 
 const TooltipContent = ({
   position,

--- a/draft-packages/tooltip/KaizenDraft/Tooltip/Tooltip.tsx
+++ b/draft-packages/tooltip/KaizenDraft/Tooltip/Tooltip.tsx
@@ -7,7 +7,7 @@ import animationStyles from "./AppearanceAnim.scss"
 import { AnimationProvider, useAnimation } from "./AppearanceAnim"
 import { useUuid } from "./useUuid"
 
-type Position = "above" | "below"
+type Position = "above" | "below" | "left" | "right"
 
 type Mood = "default" | "informative" | "positive" | "negative" | "cautionary"
 
@@ -46,6 +46,16 @@ export type TooltipProps = {
   isInitiallyVisible?: boolean
 }
 
+const getPlacement = position => {
+  if (position === "above") {
+    return "top"
+  } else if (position === "below") {
+    return "bottom"
+  } else {
+    return position
+  }
+}
+
 // Sync with Tooltip.scss
 const arrowHeight = 10
 const arrowWidth = 20
@@ -72,7 +82,7 @@ const TooltipContent = ({
             element: arrowElement,
             // Ensures that the arrow doesn't go too far to the left or right
             // of the tooltip.
-            padding: arrowWidth / 2 + 10,
+            padding: arrowWidth / 2 + 20,
           },
         },
         {
@@ -86,11 +96,20 @@ const TooltipContent = ({
           options: {
             // Makes sure that the tooltip isn't flush up against the end of the
             // viewport
-            padding: 4,
+            padding: 8,
+            altAxis: true,
+            altBoundary: true,
+            tetherOffset: 50,
+          },
+        },
+        {
+          name: "flip",
+          options: {
+            padding: 8,
           },
         },
       ],
-      placement: position === "below" ? "bottom" : "top",
+      placement: getPlacement(position),
     }
   )
   const { isVisible, isAnimIn, isAnimOut } = useAnimation()

--- a/draft-packages/tooltip/KaizenDraft/Tooltip/Tooltip.tsx
+++ b/draft-packages/tooltip/KaizenDraft/Tooltip/Tooltip.tsx
@@ -86,7 +86,7 @@ const TooltipContent = ({
         {
           name: "offset",
           options: {
-            offset: [0, arrowHeight + 12],
+            offset: [0, arrowHeight + 6],
           },
         },
         {

--- a/draft-packages/tooltip/KaizenDraft/Tooltip/Tooltip.tsx
+++ b/draft-packages/tooltip/KaizenDraft/Tooltip/Tooltip.tsx
@@ -2,6 +2,7 @@ import { usePopper } from "react-popper"
 import React, { useEffect, useState } from "react"
 import ReactDOM from "react-dom"
 import classnames from "classnames"
+import { Placement } from "@popperjs/core"
 import tooltipStyles from "./Tooltip.scss"
 import animationStyles from "./AppearanceAnim.scss"
 import { AnimationProvider, useAnimation } from "./AppearanceAnim"
@@ -46,13 +47,21 @@ export type TooltipProps = {
   isInitiallyVisible?: boolean
 }
 
-const getPlacement = position => {
+const getPlacement = (position: Position) => {
   if (position === "above") {
     return "top"
   } else if (position === "below") {
     return "bottom"
   } else {
     return position
+  }
+}
+const getFallbackPlacements = (position: Position) => {
+  const placement = getPlacement(position)
+  if (placement === "left" || placement === "right") {
+    return ["left", "top", "bottom", "right"]
+  } else {
+    return ["top", "bottom"]
   }
 }
 
@@ -106,10 +115,12 @@ const TooltipContent = ({
           name: "flip",
           options: {
             padding: 8,
+            altBoundary: true,
+            fallbackPlacements: getFallbackPlacements(position) as Placement[],
           },
         },
       ],
-      placement: getPlacement(position),
+      placement: getPlacement(position) as Placement,
     }
   )
   const { isVisible, isAnimIn, isAnimOut } = useAnimation()

--- a/draft-packages/tooltip/docs/Tooltip.stories.tsx
+++ b/draft-packages/tooltip/docs/Tooltip.stories.tsx
@@ -56,7 +56,7 @@ DefaultKaizenSiteDemo.parameters = {
   },
 }
 
-export const StickerSheet = props => (
+export const StickerSheet = () => (
   <div
     style={{
       marginTop: "100px",
@@ -90,7 +90,6 @@ export const StickerSheet = props => (
         <Button label="Default" />
       </Tooltip>
       <Tooltip
-        {...props}
         position="above"
         text="Tooltip"
         mood="positive"
@@ -140,7 +139,6 @@ export const StickerSheet = props => (
         <Button label="Default" />
       </Tooltip>
       <Tooltip
-        {...props}
         position="below"
         text="Tooltip"
         mood="positive"
@@ -185,7 +183,6 @@ export const StickerSheet = props => (
         <Button label="Default" />
       </Tooltip>
       <Tooltip
-        {...props}
         position="left"
         text="Tooltip"
         mood="positive"
@@ -235,7 +232,6 @@ export const StickerSheet = props => (
         <Button label="Default" />
       </Tooltip>
       <Tooltip
-        {...props}
         position="right"
         text="Tooltip"
         mood="positive"
@@ -302,7 +298,7 @@ export const OverflowScroll = props => (
             display="inline-block"
             text="This should not get cropped"
           >
-            <Button label="Bottom" />
+            <Button label="Default" />
           </Tooltip>
         </div>
       </div>
@@ -349,7 +345,7 @@ export const OverflowScroll = props => (
             nulla quas corporis? Perspiciatis, ratione voluptas{" "}
             <Tooltip
               display="inline-block"
-              text="This is above the tooltip"
+              text="This should not get cropped"
               {...props}
             >
               <Tag>ad veniam sapiente</Tag>

--- a/draft-packages/tooltip/docs/Tooltip.stories.tsx
+++ b/draft-packages/tooltip/docs/Tooltip.stories.tsx
@@ -1,9 +1,7 @@
 import * as React from "react"
-
-import { Paragraph } from "@kaizen/component-library"
-import { MenuItem } from "@kaizen/draft-menu"
+import informationIcon from "@kaizen/component-library/icons/information-white.icon.svg"
 import { Tag } from "@kaizen/draft-tag"
-import { SplitButton } from "@kaizen/draft-split-button"
+import { Icon, Paragraph } from "@kaizen/component-library"
 import { withDesign } from "storybook-addon-designs"
 import { Button } from "@kaizen/draft-button"
 import { Tooltip } from "@kaizen/draft-tooltip"
@@ -65,399 +63,320 @@ export const DesignSheet = props => (
       display: "grid",
       justifyContent: "center",
       rowGap: "5rem",
+      gridTemplateColumns: "1fr 1fr 1fr 1fr",
     }}
   >
-    <div>
-      <div
-        style={{
-          display: "inline-block",
-          marginRight: "2rem",
-          position: "relative",
-        }}
+    <div
+      style={{
+        display: "grid",
+        justifyContent: "center",
+        flexDirection: "column",
+        rowGap: "5rem",
+      }}
+    >
+      <Tooltip
+        position="above"
+        text="Tooltip"
+        mood="default"
+        isInitiallyVisible
       >
-        <Tooltip
-          position="above"
-          text="Tooltip"
-          mood="default"
-          isInitiallyVisible
-        >
-          <Button label="Default" />
-        </Tooltip>
-      </div>
-      <div
-        style={{
-          display: "inline-block",
-          marginRight: "2rem",
-          position: "relative",
-        }}
+        <Button label="Default" />
+      </Tooltip>
+      <Tooltip
+        position="above"
+        text="Tooltip"
+        mood="informative"
+        isInitiallyVisible
       >
-        <Tooltip
-          position="above"
-          text="Tooltip"
-          mood="informative"
-          isInitiallyVisible
-        >
-          <Button label="Default" />
-        </Tooltip>
-      </div>
-      <div
-        style={{
-          display: "inline-block",
-          marginRight: "2rem",
-          position: "relative",
-        }}
+        <Button label="Default" />
+      </Tooltip>
+      <Tooltip
+        {...props}
+        position="above"
+        text="Tooltip"
+        mood="positive"
+        isInitiallyVisible
       >
-        <Tooltip
-          {...props}
-          position="above"
-          text="Tooltip"
-          mood="positive"
-          isInitiallyVisible
-        >
-          <Button label="Default" />
-        </Tooltip>
-      </div>
-      <div
-        style={{
-          display: "inline-block",
-          marginRight: "2rem",
-          position: "relative",
-        }}
+        <Button label="Default" />
+      </Tooltip>
+      <Tooltip
+        position="above"
+        text="Tooltip"
+        mood="negative"
+        isInitiallyVisible
       >
-        <Tooltip
-          position="above"
-          text="Tooltip"
-          mood="negative"
-          isInitiallyVisible
-        >
-          <Button label="Default" />
-        </Tooltip>
-      </div>
-      <div
-        style={{
-          display: "inline-block",
-          marginRight: "2rem",
-          position: "relative",
-        }}
+        <Button label="Default" />
+      </Tooltip>
+      <Tooltip
+        position="above"
+        text="Tooltip"
+        mood="cautionary"
+        isInitiallyVisible
       >
-        <Tooltip
-          position="above"
-          text="Tooltip"
-          mood="cautionary"
-          isInitiallyVisible
-        >
-          <Button label="Default" />
-        </Tooltip>
-      </div>
-    </div>
-    <div>
-      <div
-        style={{
-          display: "inline-block",
-          marginRight: "2rem",
-          position: "relative",
-        }}
-      >
-        <Tooltip
-          position="below"
-          text="Tooltip"
-          mood="default"
-          isInitiallyVisible
-        >
-          <Button label="Default" />
-        </Tooltip>
-      </div>
-      <div
-        style={{
-          display: "inline-block",
-          marginRight: "2rem",
-          position: "relative",
-        }}
-      >
-        <Tooltip
-          position="below"
-          text="Tooltip"
-          mood="informative"
-          isInitiallyVisible
-        >
-          <Button label="Default" />
-        </Tooltip>
-      </div>
-      <div
-        style={{
-          display: "inline-block",
-          marginRight: "2rem",
-          position: "relative",
-        }}
-      >
-        <Tooltip
-          {...props}
-          position="below"
-          text="Tooltip"
-          mood="positive"
-          isInitiallyVisible
-        >
-          <Button label="Default" />
-        </Tooltip>
-      </div>
-      <div
-        style={{
-          display: "inline-block",
-          marginRight: "2rem",
-          position: "relative",
-        }}
-      >
-        <Tooltip
-          position="below"
-          text="Tooltip"
-          mood="negative"
-          isInitiallyVisible
-        >
-          <Button label="Default" />
-        </Tooltip>
-      </div>
-      <div
-        style={{
-          display: "inline-block",
-          marginRight: "2rem",
-          position: "relative",
-        }}
-      >
-        <Tooltip
-          position="below"
-          text="Tooltip"
-          mood="cautionary"
-          isInitiallyVisible
-        >
-          <Button label="Default" />
-        </Tooltip>
-      </div>
+        <Button label="Default" />
+      </Tooltip>
     </div>
     <div
       style={{
-        marginTop: "4rem",
+        display: "grid",
+        justifyContent: "center",
+        flexDirection: "column",
+        rowGap: "5rem",
       }}
     >
-      <div
-        style={{
-          display: "inline-block",
-          marginRight: "7rem",
-          position: "relative",
-        }}
+      <Tooltip
+        position="below"
+        text="Tooltip"
+        mood="default"
+        isInitiallyVisible
       >
-        <Tooltip
-          position="left"
-          text="Tooltip"
-          mood="default"
-          isInitiallyVisible
-        >
-          <Button label="Default" />
-        </Tooltip>
-      </div>
-      <div
-        style={{
-          display: "inline-block",
-          marginRight: "7rem",
-          position: "relative",
-        }}
+        <Button label="Default" />
+      </Tooltip>
+      <Tooltip
+        position="below"
+        text="Tooltip"
+        mood="informative"
+        isInitiallyVisible
       >
-        <Tooltip
-          position="left"
-          text="Tooltip"
-          mood="informative"
-          isInitiallyVisible
-        >
-          <Button label="Default" />
-        </Tooltip>
-      </div>
-      <div
-        style={{
-          display: "inline-block",
-          marginRight: "7rem",
-          position: "relative",
-        }}
+        <Button label="Default" />
+      </Tooltip>
+      <Tooltip
+        {...props}
+        position="below"
+        text="Tooltip"
+        mood="positive"
+        isInitiallyVisible
       >
-        <Tooltip
-          {...props}
-          position="left"
-          text="Tooltip"
-          mood="positive"
-          isInitiallyVisible
-        >
-          <Button label="Default" />
-        </Tooltip>
-      </div>
-      <div
-        style={{
-          display: "inline-block",
-          marginRight: "7rem",
-          position: "relative",
-        }}
+        <Button label="Default" />
+      </Tooltip>
+      <Tooltip
+        position="below"
+        text="Tooltip"
+        mood="negative"
+        isInitiallyVisible
       >
-        <Tooltip
-          position="left"
-          text="Tooltip"
-          mood="negative"
-          isInitiallyVisible
-        >
-          <Button label="Default" />
-        </Tooltip>
-      </div>
-      <div
-        style={{
-          display: "inline-block",
-          marginRight: "7rem",
-          position: "relative",
-        }}
+        <Button label="Default" />
+      </Tooltip>
+      <Tooltip
+        position="below"
+        text="Tooltip"
+        mood="cautionary"
+        isInitiallyVisible
       >
-        <Tooltip
-          position="left"
-          text="Tooltip"
-          mood="cautionary"
-          isInitiallyVisible
-        >
-          <Button label="Default" />
-        </Tooltip>
-      </div>
+        <Button label="Default" />
+      </Tooltip>
     </div>
-    <div>
-      <div
-        style={{
-          display: "inline-block",
-          marginRight: "7rem",
-          position: "relative",
-        }}
+    <div
+      style={{
+        display: "grid",
+        justifyContent: "center",
+        flexDirection: "column",
+        rowGap: "5rem",
+      }}
+    >
+      <Tooltip position="left" text="Tooltip" mood="default" isInitiallyVisible>
+        <Button label="Default" />
+      </Tooltip>
+      <Tooltip
+        position="left"
+        text="Tooltip"
+        mood="informative"
+        isInitiallyVisible
       >
-        <Tooltip
-          position="right"
-          text="Tooltip"
-          mood="default"
-          isInitiallyVisible
-        >
-          <Button label="Default" />
-        </Tooltip>
-      </div>
-      <div
-        style={{
-          display: "inline-block",
-          marginRight: "7rem",
-          position: "relative",
-        }}
+        <Button label="Default" />
+      </Tooltip>
+      <Tooltip
+        {...props}
+        position="left"
+        text="Tooltip"
+        mood="positive"
+        isInitiallyVisible
       >
-        <Tooltip
-          position="right"
-          text="Tooltip"
-          mood="informative"
-          isInitiallyVisible
-        >
-          <Button label="Default" />
-        </Tooltip>
-      </div>
-      <div
-        style={{
-          display: "inline-block",
-          marginRight: "7rem",
-          position: "relative",
-        }}
+        <Button label="Default" />
+      </Tooltip>
+      <Tooltip
+        position="left"
+        text="Tooltip"
+        mood="negative"
+        isInitiallyVisible
       >
-        <Tooltip
-          {...props}
-          position="right"
-          text="Tooltip"
-          mood="positive"
-          isInitiallyVisible
-        >
-          <Button label="Default" />
-        </Tooltip>
-      </div>
-      <div
-        style={{
-          display: "inline-block",
-          marginRight: "7rem",
-          position: "relative",
-        }}
+        <Button label="Default" />
+      </Tooltip>
+      <Tooltip
+        position="left"
+        text="Tooltip"
+        mood="cautionary"
+        isInitiallyVisible
       >
-        <Tooltip
-          position="right"
-          text="Tooltip"
-          mood="negative"
-          isInitiallyVisible
-        >
-          <Button label="Default" />
-        </Tooltip>
-      </div>
-      <div
-        style={{
-          display: "inline-block",
-          marginRight: "7rem",
-          position: "relative",
-        }}
+        <Button label="Default" />
+      </Tooltip>
+    </div>
+    <div
+      style={{
+        display: "grid",
+        justifyContent: "center",
+        flexDirection: "column",
+        rowGap: "5rem",
+      }}
+    >
+      <Tooltip
+        position="right"
+        text="Tooltip"
+        mood="default"
+        isInitiallyVisible
       >
-        <Tooltip
-          position="right"
-          text="Tooltip"
-          mood="cautionary"
-          isInitiallyVisible
-        >
-          <Button label="Default" />
-        </Tooltip>
-      </div>
+        <Button label="Default" />
+      </Tooltip>
+      <Tooltip
+        position="right"
+        text="Tooltip"
+        mood="informative"
+        isInitiallyVisible
+      >
+        <Button label="Default" />
+      </Tooltip>
+      <Tooltip
+        {...props}
+        position="right"
+        text="Tooltip"
+        mood="positive"
+        isInitiallyVisible
+      >
+        <Button label="Default" />
+      </Tooltip>
+      <Tooltip
+        position="right"
+        text="Tooltip"
+        mood="negative"
+        isInitiallyVisible
+      >
+        <Button label="Default" />
+      </Tooltip>
+      <Tooltip
+        position="right"
+        text="Tooltip"
+        mood="cautionary"
+        isInitiallyVisible
+      >
+        <Button label="Default" />
+      </Tooltip>
     </div>
   </div>
 )
 DesignSheet.storyName = "Design Sheet"
 
 export const OverflowScroll = props => (
-  <div
-    id="portalSelectorStory"
-    style={{
-      width: "300px",
-      height: "800px",
-      overflow: "scroll",
-      textAlign: "center",
-      position: "relative",
-      overscrollBehavior: "contain",
-      display: "flex",
-      justifyContent: "center",
-      flexDirection: "column",
-    }}
-  >
+  <>
+    <p>
+      Default Placement is' above' and initially set to 'isInitiallyVisible' for
+      Storybook purposes. Scroll horizontally or vertically to view the popper
+      "flip" and move according to the space of the viewport. Ensuring the
+      popper does not get cut off.
+    </p>
+
     <div
       style={{
+        display: "flex",
         width: "300px",
-        height: "300px",
-        textAlign: "center",
-        position: "relative",
-        paddingTop: "100px",
-        paddingLeft: "200px",
+        maxHeight: "700px",
+        overflow: "scroll",
+        border: "solid black 2px",
+        flexDirection: "column",
       }}
     >
-      <Tooltip
-        {...props}
-        display="inline-block"
-        text="This should not get cropped"
-        isInitiallyVisible
+      <div
+        style={{
+          width: "500px",
+          marginLeft: "200px",
+          marginTop: "400px",
+        }}
       >
-        <Button label="Bottom" />
-      </Tooltip>
+        <div
+          style={{
+            width: "300px",
+            height: "200px",
+            textAlign: "center",
+            position: "relative",
+          }}
+        >
+          <Tooltip
+            {...props}
+            display="inline-block"
+            text="This should not get cropped"
+            isInitiallyVisible
+          >
+            <Button label="Bottom" />
+          </Tooltip>
+        </div>
+      </div>
+      <div
+        style={{
+          width: "500px",
+          marginLeft: "200px",
+        }}
+      >
+        <div
+          style={{
+            width: "300px",
+            height: "100px",
+            textAlign: "center",
+            position: "relative",
+          }}
+        >
+          <Tooltip
+            {...props}
+            display="inline"
+            text="This should not get cropped"
+            isInitiallyVisible
+          >
+            <Icon icon={informationIcon} />
+          </Tooltip>
+        </div>
+      </div>
+      <div
+        style={{
+          width: "500px",
+          marginLeft: "200px",
+          marginBottom: "500px",
+        }}
+      >
+        <div
+          style={{
+            width: "300px",
+            height: "200px",
+            textAlign: "center",
+            position: "relative",
+          }}
+        >
+          <Paragraph variant="body">
+            Lorem ipsum dolor sit amet consectetur adipisicing elit. Ratione
+            nulla quas corporis? Perspiciatis, ratione voluptas{" "}
+            <Tooltip
+              display="inline-block"
+              isInitiallyVisible
+              text="This is above the tooltip"
+              {...props}
+            >
+              <Tag>ad veniam sapiente</Tag>
+            </Tooltip>{" "}
+            Maxime harum, ducimus maiores itaque pariatur quod vel porro
+            mollitia. Lorem ipsum dolor sit{" "}
+            <Tooltip
+              display="inline"
+              isInitiallyVisible
+              text="Open in new tab"
+              {...props}
+            >
+              <a href="#">
+                amet consectetur adipisicing elit Itaque obcaecati maxime
+                molestiae blanditiis pariatur
+              </a>
+            </Tooltip>
+            . Magni perspiciatis assumenda in adipisci, eaque commodi quidem
+            dolore, tempore provident animi{" "}
+          </Paragraph>
+        </div>
+      </div>
     </div>
-    <div
-      style={{
-        width: "1000px",
-        height: "1000px",
-      }}
-    >
-      <p>
-        Scroll the panel above, and hover over the button. Notice that the
-        tooltip does not get cropped. Also notice that the tooltip arrow follows
-        the button appropriately.
-      </p>
-    </div>
-  </div>
+  </>
 )
-
-const portalSelectorElement = document.querySelector("#portalSelectorStory")
-
-if (portalSelectorElement) portalSelectorElement.scrollTop = 820
-
-OverflowScroll.storyName = "overflow: scroll"

--- a/draft-packages/tooltip/docs/Tooltip.stories.tsx
+++ b/draft-packages/tooltip/docs/Tooltip.stories.tsx
@@ -262,10 +262,9 @@ export const StickerSheet = () => (
 export const OverflowScroll = props => (
   <>
     <p>
-      Default Placement is' above' and initially set to 'isInitiallyVisible' for
-      Storybook purposes. Scroll horizontally or vertically to view the popper
-      "flip" and move according to the space of the viewport. Ensuring the
-      popper does not get cut off.
+      Default Placement is' above'. Scroll horizontally or vertically to view
+      the popper "flip" and move according to the space of the viewport.
+      Ensuring the popper does not get cut off.
     </p>
 
     <div

--- a/draft-packages/tooltip/docs/Tooltip.stories.tsx
+++ b/draft-packages/tooltip/docs/Tooltip.stories.tsx
@@ -150,130 +150,314 @@ export const DesignSheet = props => (
         </Tooltip>
       </div>
     </div>
+    <div>
+      <div
+        style={{
+          display: "inline-block",
+          marginRight: "2rem",
+          position: "relative",
+        }}
+      >
+        <Tooltip
+          position="below"
+          text="Tooltip"
+          mood="default"
+          isInitiallyVisible
+        >
+          <Button label="Default" />
+        </Tooltip>
+      </div>
+      <div
+        style={{
+          display: "inline-block",
+          marginRight: "2rem",
+          position: "relative",
+        }}
+      >
+        <Tooltip
+          position="below"
+          text="Tooltip"
+          mood="informative"
+          isInitiallyVisible
+        >
+          <Button label="Default" />
+        </Tooltip>
+      </div>
+      <div
+        style={{
+          display: "inline-block",
+          marginRight: "2rem",
+          position: "relative",
+        }}
+      >
+        <Tooltip
+          {...props}
+          position="below"
+          text="Tooltip"
+          mood="positive"
+          isInitiallyVisible
+        >
+          <Button label="Default" />
+        </Tooltip>
+      </div>
+      <div
+        style={{
+          display: "inline-block",
+          marginRight: "2rem",
+          position: "relative",
+        }}
+      >
+        <Tooltip
+          position="below"
+          text="Tooltip"
+          mood="negative"
+          isInitiallyVisible
+        >
+          <Button label="Default" />
+        </Tooltip>
+      </div>
+      <div
+        style={{
+          display: "inline-block",
+          marginRight: "2rem",
+          position: "relative",
+        }}
+      >
+        <Tooltip
+          position="below"
+          text="Tooltip"
+          mood="cautionary"
+          isInitiallyVisible
+        >
+          <Button label="Default" />
+        </Tooltip>
+      </div>
+    </div>
+    <div
+      style={{
+        marginTop: "4rem",
+      }}
+    >
+      <div
+        style={{
+          display: "inline-block",
+          marginRight: "7rem",
+          position: "relative",
+        }}
+      >
+        <Tooltip
+          position="left"
+          text="Tooltip"
+          mood="default"
+          isInitiallyVisible
+        >
+          <Button label="Default" />
+        </Tooltip>
+      </div>
+      <div
+        style={{
+          display: "inline-block",
+          marginRight: "7rem",
+          position: "relative",
+        }}
+      >
+        <Tooltip
+          position="left"
+          text="Tooltip"
+          mood="informative"
+          isInitiallyVisible
+        >
+          <Button label="Default" />
+        </Tooltip>
+      </div>
+      <div
+        style={{
+          display: "inline-block",
+          marginRight: "7rem",
+          position: "relative",
+        }}
+      >
+        <Tooltip
+          {...props}
+          position="left"
+          text="Tooltip"
+          mood="positive"
+          isInitiallyVisible
+        >
+          <Button label="Default" />
+        </Tooltip>
+      </div>
+      <div
+        style={{
+          display: "inline-block",
+          marginRight: "7rem",
+          position: "relative",
+        }}
+      >
+        <Tooltip
+          position="left"
+          text="Tooltip"
+          mood="negative"
+          isInitiallyVisible
+        >
+          <Button label="Default" />
+        </Tooltip>
+      </div>
+      <div
+        style={{
+          display: "inline-block",
+          marginRight: "7rem",
+          position: "relative",
+        }}
+      >
+        <Tooltip
+          position="left"
+          text="Tooltip"
+          mood="cautionary"
+          isInitiallyVisible
+        >
+          <Button label="Default" />
+        </Tooltip>
+      </div>
+    </div>
+    <div>
+      <div
+        style={{
+          display: "inline-block",
+          marginRight: "7rem",
+          position: "relative",
+        }}
+      >
+        <Tooltip
+          position="right"
+          text="Tooltip"
+          mood="default"
+          isInitiallyVisible
+        >
+          <Button label="Default" />
+        </Tooltip>
+      </div>
+      <div
+        style={{
+          display: "inline-block",
+          marginRight: "7rem",
+          position: "relative",
+        }}
+      >
+        <Tooltip
+          position="right"
+          text="Tooltip"
+          mood="informative"
+          isInitiallyVisible
+        >
+          <Button label="Default" />
+        </Tooltip>
+      </div>
+      <div
+        style={{
+          display: "inline-block",
+          marginRight: "7rem",
+          position: "relative",
+        }}
+      >
+        <Tooltip
+          {...props}
+          position="right"
+          text="Tooltip"
+          mood="positive"
+          isInitiallyVisible
+        >
+          <Button label="Default" />
+        </Tooltip>
+      </div>
+      <div
+        style={{
+          display: "inline-block",
+          marginRight: "7rem",
+          position: "relative",
+        }}
+      >
+        <Tooltip
+          position="right"
+          text="Tooltip"
+          mood="negative"
+          isInitiallyVisible
+        >
+          <Button label="Default" />
+        </Tooltip>
+      </div>
+      <div
+        style={{
+          display: "inline-block",
+          marginRight: "7rem",
+          position: "relative",
+        }}
+      >
+        <Tooltip
+          position="right"
+          text="Tooltip"
+          mood="cautionary"
+          isInitiallyVisible
+        >
+          <Button label="Default" />
+        </Tooltip>
+      </div>
+    </div>
   </div>
 )
 DesignSheet.storyName = "Design Sheet"
 
-export const Inline = props => (
+export const OverflowScroll = props => (
   <div
+    id="portalSelectorStory"
     style={{
-      margin: "100px",
+      width: "300px",
+      height: "800px",
+      overflow: "scroll",
+      textAlign: "center",
+      position: "relative",
+      overscrollBehavior: "contain",
       display: "flex",
       justifyContent: "center",
-      width: "400px",
+      flexDirection: "column",
     }}
   >
-    <div style={{ display: "inline-block", position: "relative" }}>
-      <Paragraph variant="body">
-        Lorem ipsum dolor sit amet consectetur adipisicing elit. Ratione nulla
-        quas corporis? Perspiciatis, ratione voluptas{" "}
-        <Tooltip
-          {...props}
-          display="inline-block"
-          text="This is above the tooltip"
-        >
-          <Tag>ad veniam sapiente</Tag>
-        </Tooltip>{" "}
-        Maxime harum, ducimus maiores itaque pariatur quod vel porro mollitia.
-        Lorem ipsum dolor sit{" "}
-        <Tooltip {...props} display="inline" text="Open in new tab">
-          <a href="#">
-            amet consectetur adipisicing elit Itaque obcaecati maxime molestiae
-            blanditiis pariatur
-          </a>
-        </Tooltip>
-        . Magni perspiciatis assumenda in adipisci, eaque commodi quidem dolore,
-        tempore provident animi{" "}
-        <Tooltip
-          {...props}
-          display="inline-block"
-          text="This is below the tooltip"
-          position="bottom"
-        >
-          <Tag>veniam sapiente ad</Tag>
-        </Tooltip>{" "}
-      </Paragraph>
-    </div>
-  </div>
-)
-
-Inline.storyName = "Inline"
-
-export const ArrowPositioning = props => (
-  <div>
-    <div style={{ position: "absolute", top: "0", left: "0" }}>
+    <div
+      style={{
+        width: "300px",
+        height: "300px",
+        textAlign: "center",
+        position: "relative",
+        paddingTop: "100px",
+        paddingLeft: "200px",
+      }}
+    >
       <Tooltip
         {...props}
-        position="top"
-        text="This is below the tooltip, despite it being set to position=above. This is because there is not enough room. Also note that the arrow is correctly positioned."
-      >
-        <Button label="Above" />
-      </Tooltip>
-    </div>
-    <div style={{ position: "absolute", bottom: "0", right: "0" }}>
-      <Tooltip
-        {...props}
-        position="bottom"
-        text="This is above the tooltip, despite it being set to position=below. This is because there is not enough room. Also note that the arrow is correctly positioned."
+        display="inline-block"
+        text="This should not get cropped"
+        isInitiallyVisible
       >
         <Button label="Bottom" />
       </Tooltip>
     </div>
-  </div>
-)
-
-ArrowPositioning.storyName = "Arrow positioning"
-
-export const OverflowScroll = props => (
-  <div>
-    <div style={{ overflowX: "scroll", width: "200px", height: "100px" }}>
-      <div style={{ width: "500px", textAlign: "center" }}>
-        <Tooltip
-          {...props}
-          position="below"
-          display="inline-block"
-          text="This should not get cropped"
-          // Normally, you'd specify a div by ID, but since this is only in storybook,
-          // using `body` is fine (I think). DO NOT USE "BODY" AS A VALUE IN PRODUCTION.
-          portalSelector="body"
-        >
-          <Button label="Bottom" />
-        </Tooltip>
-      </div>
+    <div
+      style={{
+        width: "1000px",
+        height: "1000px",
+      }}
+    >
+      <p>
+        Scroll the panel above, and hover over the button. Notice that the
+        tooltip does not get cropped. Also notice that the tooltip arrow follows
+        the button appropriately.
+      </p>
     </div>
-    <p>
-      Scroll the panel above, and hover over the button. Notice that the tooltip
-      does not get cropped. Also notice that the tooltip arrow follows the
-      button appropriately.
-    </p>
   </div>
 )
+
+const portalSelectorElement = document.querySelector("#portalSelectorStory")
+
+if (portalSelectorElement) portalSelectorElement.scrollTop = 820
 
 OverflowScroll.storyName = "overflow: scroll"
-
-export const TooltipAboveDropdown = props => (
-  <>
-    <div>
-      <SplitButton
-        label="Test"
-        dropdownAltText="test"
-        dropdownContent={
-          <MenuItem
-            onClick={e => undefined}
-            label="Text to appear behind tooltip overlay"
-          />
-        }
-      />
-    </div>
-    <div style={{ paddingTop: "50px" }}>
-      <Tooltip
-        {...props}
-        position="above"
-        display="inline-block"
-        text="Text to appear above the button dropdown text"
-      >
-        <Button label="Above" />
-      </Tooltip>
-    </div>
-  </>
-)

--- a/draft-packages/tooltip/docs/Tooltip.stories.tsx
+++ b/draft-packages/tooltip/docs/Tooltip.stories.tsx
@@ -1,9 +1,10 @@
 import * as React from "react"
 import informationIcon from "@kaizen/component-library/icons/information-white.icon.svg"
+import meatballsIcon from "@kaizen/component-library/icons/meatballs.icon.svg"
 import { Tag } from "@kaizen/draft-tag"
-import { Icon, Paragraph } from "@kaizen/component-library"
+import { Icon, Paragraph, Heading } from "@kaizen/component-library"
 import { withDesign } from "storybook-addon-designs"
-import { Button } from "@kaizen/draft-button"
+import { Button, IconButton } from "@kaizen/draft-button"
 import { Tooltip } from "@kaizen/draft-tooltip"
 import isChromatic from "chromatic/isChromatic"
 import { figmaEmbed } from "../../../storybook/helpers"
@@ -39,7 +40,7 @@ export const DefaultKaizenSiteDemo = props => (
   <div
     style={{ marginTop: "100px", display: "flex", justifyContent: "center" }}
   >
-    <Tooltip {...props} text="This is below the tooltip">
+    <Tooltip {...props} text="Tooltip label">
       {/* Using buttons, as so we can test the focus state.
          ie. the tooltip should show when any child is focused. */}
       <Button label="Default" />
@@ -62,7 +63,7 @@ export const StickerSheet = () => (
       marginTop: "100px",
       display: "grid",
       justifyContent: "center",
-      gridTemplateColumns: "1fr 1fr 1fr 1fr",
+      gridTemplateColumns: "1fr 1fr 1fr 1fr 1fr",
     }}
   >
     <div
@@ -70,48 +71,55 @@ export const StickerSheet = () => (
         display: "grid",
         justifyContent: "center",
         flexDirection: "column",
+        justifyItems: "center",
         rowGap: "5rem",
       }}
     >
-      <Tooltip
-        position="above"
-        text="Tooltip"
-        mood="default"
-        isInitiallyVisible
-      >
-        <Button label="Default" />
+      <Heading variant="heading-5" tag="h2">
+        {" "}
+      </Heading>
+      <Heading variant="heading-5" tag="h2">
+        Default
+      </Heading>
+      <Heading variant="heading-5" tag="h2">
+        Informative
+      </Heading>
+      <Heading variant="heading-5" tag="h2">
+        Positive
+      </Heading>
+      <Heading variant="heading-5" tag="h2">
+        Negative
+      </Heading>
+      <Heading variant="heading-5" tag="h2">
+        Cautionary
+      </Heading>
+    </div>
+    <div
+      style={{
+        display: "grid",
+        justifyContent: "center",
+        flexDirection: "column",
+        justifyItems: "center",
+        rowGap: "5rem",
+      }}
+    >
+      <Heading variant="heading-3" tag="h1">
+        Top
+      </Heading>
+      <Tooltip position="above" text="Tooltip label" mood="default">
+        <IconButton label="Label" icon={meatballsIcon} />
       </Tooltip>
-      <Tooltip
-        position="above"
-        text="Tooltip"
-        mood="informative"
-        isInitiallyVisible
-      >
-        <Button label="Default" />
+      <Tooltip position="above" text="Tooltip label" mood="informative">
+        <IconButton label="Label" icon={meatballsIcon} />
       </Tooltip>
-      <Tooltip
-        position="above"
-        text="Tooltip"
-        mood="positive"
-        isInitiallyVisible
-      >
-        <Button label="Default" />
+      <Tooltip position="above" text="Tooltip label" mood="positive">
+        <IconButton label="Label" icon={meatballsIcon} />
       </Tooltip>
-      <Tooltip
-        position="above"
-        text="Tooltip"
-        mood="negative"
-        isInitiallyVisible
-      >
-        <Button label="Default" />
+      <Tooltip position="above" text="Tooltip label" mood="negative">
+        <IconButton label="Label" icon={meatballsIcon} />
       </Tooltip>
-      <Tooltip
-        position="above"
-        text="Tooltip"
-        mood="cautionary"
-        isInitiallyVisible
-      >
-        <Button label="Default" />
+      <Tooltip position="above" text="Tooltip label" mood="cautionary">
+        <IconButton label="Label" icon={meatballsIcon} />
       </Tooltip>
     </div>
     <div
@@ -119,48 +127,27 @@ export const StickerSheet = () => (
         display: "grid",
         justifyContent: "center",
         flexDirection: "column",
+        justifyItems: "center",
         rowGap: "5rem",
       }}
     >
-      <Tooltip
-        position="below"
-        text="Tooltip"
-        mood="default"
-        isInitiallyVisible
-      >
-        <Button label="Default" />
+      <Heading variant="heading-3" tag="h1">
+        Bottom
+      </Heading>
+      <Tooltip position="below" text="Tooltip label" mood="default">
+        <IconButton label="Label" icon={meatballsIcon} />
       </Tooltip>
-      <Tooltip
-        position="below"
-        text="Tooltip"
-        mood="informative"
-        isInitiallyVisible
-      >
-        <Button label="Default" />
+      <Tooltip position="below" text="Tooltip label" mood="informative">
+        <IconButton label="Label" icon={meatballsIcon} />
       </Tooltip>
-      <Tooltip
-        position="below"
-        text="Tooltip"
-        mood="positive"
-        isInitiallyVisible
-      >
-        <Button label="Default" />
+      <Tooltip position="below" text="Tooltip label" mood="positive">
+        <IconButton label="Label" icon={meatballsIcon} />
       </Tooltip>
-      <Tooltip
-        position="below"
-        text="Tooltip"
-        mood="negative"
-        isInitiallyVisible
-      >
-        <Button label="Default" />
+      <Tooltip position="below" text="Tooltip label" mood="negative">
+        <IconButton label="Label" icon={meatballsIcon} />
       </Tooltip>
-      <Tooltip
-        position="below"
-        text="Tooltip"
-        mood="cautionary"
-        isInitiallyVisible
-      >
-        <Button label="Default" />
+      <Tooltip position="below" text="Tooltip label" mood="cautionary">
+        <IconButton label="Label" icon={meatballsIcon} />
       </Tooltip>
     </div>
     <div
@@ -168,43 +155,27 @@ export const StickerSheet = () => (
         display: "grid",
         justifyContent: "center",
         flexDirection: "column",
+        justifyItems: "center",
         rowGap: "5rem",
       }}
     >
-      <Tooltip position="left" text="Tooltip" mood="default" isInitiallyVisible>
-        <Button label="Default" />
+      <Heading variant="heading-3" tag="h1">
+        Left
+      </Heading>
+      <Tooltip position="left" text="Tooltip label" mood="default">
+        <IconButton label="Label" icon={meatballsIcon} />
       </Tooltip>
-      <Tooltip
-        position="left"
-        text="Tooltip"
-        mood="informative"
-        isInitiallyVisible
-      >
-        <Button label="Default" />
+      <Tooltip position="left" text="Tooltip label" mood="informative">
+        <IconButton label="Label" icon={meatballsIcon} />
       </Tooltip>
-      <Tooltip
-        position="left"
-        text="Tooltip"
-        mood="positive"
-        isInitiallyVisible
-      >
-        <Button label="Default" />
+      <Tooltip position="left" text="Tooltip label" mood="positive">
+        <IconButton label="Label" icon={meatballsIcon} />
       </Tooltip>
-      <Tooltip
-        position="left"
-        text="Tooltip"
-        mood="negative"
-        isInitiallyVisible
-      >
-        <Button label="Default" />
+      <Tooltip position="left" text="Tooltip label" mood="negative">
+        <IconButton label="Label" icon={meatballsIcon} />
       </Tooltip>
-      <Tooltip
-        position="left"
-        text="Tooltip"
-        mood="cautionary"
-        isInitiallyVisible
-      >
-        <Button label="Default" />
+      <Tooltip position="left" text="Tooltip label" mood="cautionary">
+        <IconButton label="Label" icon={meatballsIcon} />
       </Tooltip>
     </div>
     <div
@@ -212,48 +183,27 @@ export const StickerSheet = () => (
         display: "grid",
         justifyContent: "center",
         flexDirection: "column",
+        justifyItems: "center",
         rowGap: "5rem",
       }}
     >
-      <Tooltip
-        position="right"
-        text="Tooltip"
-        mood="default"
-        isInitiallyVisible
-      >
-        <Button label="Default" />
+      <Heading variant="heading-3" tag="h1">
+        Right
+      </Heading>
+      <Tooltip position="right" text="Tooltip label" mood="default">
+        <IconButton label="Label" icon={meatballsIcon} />
       </Tooltip>
-      <Tooltip
-        position="right"
-        text="Tooltip"
-        mood="informative"
-        isInitiallyVisible
-      >
-        <Button label="Default" />
+      <Tooltip position="right" text="Tooltip label" mood="informative">
+        <IconButton label="Label" icon={meatballsIcon} />
       </Tooltip>
-      <Tooltip
-        position="right"
-        text="Tooltip"
-        mood="positive"
-        isInitiallyVisible
-      >
-        <Button label="Default" />
+      <Tooltip position="right" text="Tooltip label" mood="positive">
+        <IconButton label="Label" icon={meatballsIcon} />
       </Tooltip>
-      <Tooltip
-        position="right"
-        text="Tooltip"
-        mood="negative"
-        isInitiallyVisible
-      >
-        <Button label="Default" />
+      <Tooltip position="right" text="Tooltip label" mood="negative">
+        <IconButton label="Label" icon={meatballsIcon} />
       </Tooltip>
-      <Tooltip
-        position="right"
-        text="Tooltip"
-        mood="cautionary"
-        isInitiallyVisible
-      >
-        <Button label="Default" />
+      <Tooltip position="right" text="Tooltip label" mood="cautionary">
+        <IconButton label="Label" icon={meatballsIcon} />
       </Tooltip>
     </div>
   </div>
@@ -262,9 +212,9 @@ export const StickerSheet = () => (
 export const OverflowScroll = props => (
   <>
     <p>
-      Default Placement is' above'. Scroll horizontally or vertically to view
-      the popper "flip" and move according to the space of the viewport.
-      Ensuring the popper does not get cut off.
+      Default Placement is 'above'. Scroll horizontally or vertically to view
+      the Tooltip "flip" and move according to the space of the viewport.
+      Ensuring the Tooltip does not get cut off.
     </p>
 
     <div
@@ -292,11 +242,7 @@ export const OverflowScroll = props => (
             position: "relative",
           }}
         >
-          <Tooltip
-            {...props}
-            display="inline-block"
-            text="This should not get cropped"
-          >
+          <Tooltip {...props} display="inline-block" text="Tooltip label">
             <Button label="Default" />
           </Tooltip>
         </div>
@@ -315,11 +261,7 @@ export const OverflowScroll = props => (
             position: "relative",
           }}
         >
-          <Tooltip
-            {...props}
-            display="inline"
-            text="This should not get cropped"
-          >
+          <Tooltip {...props} display="inline" text="Tooltip label">
             <Icon icon={informationIcon} />
           </Tooltip>
         </div>
@@ -342,11 +284,7 @@ export const OverflowScroll = props => (
           <Paragraph variant="body">
             Lorem ipsum dolor sit amet consectetur adipisicing elit. Ratione
             nulla quas corporis? Perspiciatis, ratione voluptas{" "}
-            <Tooltip
-              display="inline-block"
-              text="This should not get cropped"
-              {...props}
-            >
+            <Tooltip display="inline-block" text="Tooltip label" {...props}>
               <Tag>ad veniam sapiente</Tag>
             </Tooltip>{" "}
             Maxime harum, ducimus maiores itaque pariatur quod vel porro

--- a/draft-packages/tooltip/docs/Tooltip.stories.tsx
+++ b/draft-packages/tooltip/docs/Tooltip.stories.tsx
@@ -56,13 +56,12 @@ DefaultKaizenSiteDemo.parameters = {
   },
 }
 
-export const DesignSheet = props => (
+export const StickerSheet = props => (
   <div
     style={{
       marginTop: "100px",
       display: "grid",
       justifyContent: "center",
-      rowGap: "5rem",
       gridTemplateColumns: "1fr 1fr 1fr 1fr",
     }}
   >
@@ -263,7 +262,6 @@ export const DesignSheet = props => (
     </div>
   </div>
 )
-DesignSheet.storyName = "Design Sheet"
 
 export const OverflowScroll = props => (
   <>
@@ -303,7 +301,6 @@ export const OverflowScroll = props => (
             {...props}
             display="inline-block"
             text="This should not get cropped"
-            isInitiallyVisible
           >
             <Button label="Bottom" />
           </Tooltip>
@@ -327,7 +324,6 @@ export const OverflowScroll = props => (
             {...props}
             display="inline"
             text="This should not get cropped"
-            isInitiallyVisible
           >
             <Icon icon={informationIcon} />
           </Tooltip>
@@ -353,7 +349,6 @@ export const OverflowScroll = props => (
             nulla quas corporis? Perspiciatis, ratione voluptas{" "}
             <Tooltip
               display="inline-block"
-              isInitiallyVisible
               text="This is above the tooltip"
               {...props}
             >
@@ -361,12 +356,7 @@ export const OverflowScroll = props => (
             </Tooltip>{" "}
             Maxime harum, ducimus maiores itaque pariatur quod vel porro
             mollitia. Lorem ipsum dolor sit{" "}
-            <Tooltip
-              display="inline"
-              isInitiallyVisible
-              text="Open in new tab"
-              {...props}
-            >
+            <Tooltip display="inline" text="Open in new tab" {...props}>
               <a href="#">
                 amet consectetur adipisicing elit Itaque obcaecati maxime
                 molestiae blanditiis pariatur


### PR DESCRIPTION
# Objective
<!-- Describe what this change achieves, and the details of how it works. -->

- Add left and right placement variant. 
- Allow the popper to 'flip' depending on the space within the viewport -> see Scroll story example.

# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- Match the UI kit.

# Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/48232362/149057084-cec0e8fe-855a-44cd-9bd5-ebdb04b6a22e.png)
![image](https://user-images.githubusercontent.com/48232362/148887956-b31fd7c0-5e50-4093-a220-76cfc867d174.png)
