### PR TITLE
feat: Guidance block container query

### DIFF
--- a/draft-packages/guidance-block/KaizenDraft/GuidanceBlock/GuidanceBlock.scss
+++ b/draft-packages/guidance-block/KaizenDraft/GuidanceBlock/GuidanceBlock.scss
@@ -180,17 +180,13 @@ $scene-illustration-size-mobile: 200px;
   align-items: unset;
   gap: $spacing-md;
   min-width: unset;
+  flex-wrap: wrap;
+
+  @include ca-media-tablet-and-under {
+    flex-direction: unset;
+  }
 
   &.stackButton {
-    .descriptionAndActions {
-      flex-direction: column;
-      align-items: unset;
-    }
-
-    .illustrationWrapper {
-      display: flex;
-    }
-
     .descriptionContainer {
       margin: 0 0 0 $spacing-sm;
       padding: 0;
@@ -207,12 +203,6 @@ $scene-illustration-size-mobile: 200px;
   }
 
   &.stackIllustration {
-    flex-direction: column;
-
-    .illustrationWrapper {
-      align-self: unset;
-    }
-
     .illustration {
       margin-right: auto;
 
@@ -242,6 +232,8 @@ $scene-illustration-size-mobile: 200px;
   }
 
   &.centerContent {
+    flex-direction: column;
+
     .illustrationWrapper {
       align-self: center;
     }
@@ -256,6 +248,7 @@ $scene-illustration-size-mobile: 200px;
 
     .descriptionContainer {
       text-align: center;
+      min-width: unset;
 
       [dir="rtl"] & {
         text-align: center;
@@ -301,6 +294,7 @@ $scene-illustration-size-mobile: 200px;
   .descriptionContainer {
     text-align: left;
     max-width: unset;
+    min-width: 320px;
 
     [dir="rtl"] & {
       text-align: right;
@@ -310,6 +304,10 @@ $scene-illustration-size-mobile: 200px;
   .buttonContainer {
     justify-content: end;
     width: unset;
+
+    @include ca-media-mobile {
+      flex-direction: row-reverse;
+    }
 
     > * {
       width: unset;

--- a/draft-packages/guidance-block/KaizenDraft/GuidanceBlock/GuidanceBlock.scss
+++ b/draft-packages/guidance-block/KaizenDraft/GuidanceBlock/GuidanceBlock.scss
@@ -316,6 +316,10 @@ $scene-illustration-size-mobile: 200px;
 }
 
 .stacked {
+  &.stackIllustration .illustrationWrapper {
+    margin: 0 auto;
+  }
+
   .descriptionAndActions {
     flex-direction: column;
     align-items: unset;

--- a/draft-packages/guidance-block/KaizenDraft/GuidanceBlock/GuidanceBlock.scss
+++ b/draft-packages/guidance-block/KaizenDraft/GuidanceBlock/GuidanceBlock.scss
@@ -14,7 +14,6 @@ $ca-banner-collapse-height-delayed: margin-top $animation-duration-fast
   $animation-duration-slow ease;
 $illustration-size: 155px;
 $scene-illustration-size: 300px;
-$scene-illustration-size-mobile: 200px;
 
 .banner.noMaxWidth {
   max-width: inherit;
@@ -68,11 +67,11 @@ $scene-illustration-size-mobile: 200px;
 .illustration {
   width: $illustration-size;
   height: $illustration-size;
-}
 
-.sceneIllustration {
-  width: $scene-illustration-size;
-  height: auto;
+  .hasSceneIllustration & {
+    width: $scene-illustration-size;
+    height: auto;
+  }
 }
 
 .descriptionContainer {
@@ -186,64 +185,79 @@ $scene-illustration-size-mobile: 200px;
     flex-direction: unset;
   }
 
-  &.stackButton {
-    .descriptionContainer {
-      margin: 0 0 0 $spacing-sm;
-      padding: 0;
+  .illustrationWrapper {
+    margin-right: $spacing-sm;
 
-      [dir="rtl"] & {
-        margin: 0 $spacing-sm 0 0;
-        padding: 0;
-      }
+    [dir="rtl"] & {
+      margin-left: $spacing-sm;
+      margin-right: inherit;
     }
 
-    .buttonContainer {
-      flex-direction: row-reverse;
+    @include ca-media-tablet {
+      padding: 0;
+    }
+
+    @include ca-media-mobile {
+      display: flex;
     }
   }
 
-  &.stackIllustration {
-    .illustration {
-      margin-right: auto;
+  .descriptionContainer {
+    text-align: left;
+    max-width: unset;
+    min-width: 320px;
 
-      [dir="rtl"] & {
-        margin-right: 0;
-        margin-left: auto;
-      }
-    }
-
-    .sceneIllustration {
-      margin: 0 auto;
-    }
-
-    .descriptionContainer {
-      margin: 0;
+    @include ca-media-desktop {
       padding: 0;
+    }
 
-      [dir="rtl"] & {
-        margin: 0;
+    @include ca-media-mobile {
+      margin: 0;
+    }
+
+    [dir="rtl"] & {
+      text-align: right;
+
+      @include ca-media-desktop {
+        padding: 0;
       }
     }
+  }
 
-    .buttonContainer {
+  .buttonContainer {
+    padding-left: $spacing-sm;
+    justify-content: end;
+    width: unset;
+    min-width: unset;
+
+    @include ca-media-mobile {
       flex-direction: row-reverse;
-      min-width: unset;
     }
+
+    [dir="rtl"] & {
+      padding-left: 0;
+      padding-right: $spacing-sm;
+    }
+
+    > * {
+      width: unset;
+    }
+  }
+
+  &.hasSceneIllustration {
+    justify-content: center;
   }
 
   &.centerContent {
     flex-direction: column;
 
+    &.hasSceneIllustration .illustration {
+      width: 100%;
+    }
+
     .illustrationWrapper {
-      align-self: center;
-    }
-
-    .illustration {
       margin: 0 auto;
-    }
-
-    .sceneIllustration {
-      width: $scene-illustration-size-mobile;
+      align-self: center;
     }
 
     .descriptionContainer {
@@ -256,6 +270,7 @@ $scene-illustration-size-mobile: 200px;
     }
 
     .buttonContainer {
+      padding: 0;
       flex-direction: column;
       min-width: unset;
       justify-content: center;
@@ -282,44 +297,9 @@ $scene-illustration-size-mobile: 200px;
       }
     }
   }
-
-  .illustrationWrapper {
-    padding: 0;
-
-    @include ca-media-mobile {
-      display: flex;
-    }
-  }
-
-  .descriptionContainer {
-    text-align: left;
-    max-width: unset;
-    min-width: 320px;
-
-    [dir="rtl"] & {
-      text-align: right;
-    }
-  }
-
-  .buttonContainer {
-    justify-content: end;
-    width: unset;
-
-    @include ca-media-mobile {
-      flex-direction: row-reverse;
-    }
-
-    > * {
-      width: unset;
-    }
-  }
 }
 
 .stacked {
-  &.stackIllustration .illustrationWrapper {
-    margin: 0 auto;
-  }
-
   .descriptionAndActions {
     flex-direction: column;
     align-items: unset;
@@ -327,11 +307,5 @@ $scene-illustration-size-mobile: 200px;
 
   .descriptionContainer {
     align-self: flex-start;
-    padding-right: 0;
-
-    [dir="rtl"] & {
-      padding-left: 0;
-      padding-right: $spacing-sm;
-    }
   }
 }

--- a/draft-packages/guidance-block/KaizenDraft/GuidanceBlock/GuidanceBlock.scss
+++ b/draft-packages/guidance-block/KaizenDraft/GuidanceBlock/GuidanceBlock.scss
@@ -288,7 +288,7 @@ $scene-illustration-size: 300px;
     }
   }
 
-  &.centerContent.leftAlignTextMobile {
+  &.centerContent.smallScreenTextAlignment {
     .descriptionContainer {
       text-align: left;
 

--- a/draft-packages/guidance-block/KaizenDraft/GuidanceBlock/GuidanceBlock.scss
+++ b/draft-packages/guidance-block/KaizenDraft/GuidanceBlock/GuidanceBlock.scss
@@ -93,7 +93,7 @@ $scene-illustration-size-mobile: 200px;
 
   [dir="rtl"] & {
     @include ca-media-desktop {
-      padding: 0 $spacing-sm 0 $spacing-lg;
+      padding: 0 $spacing-sm;
       text-align: right;
     }
   }
@@ -184,13 +184,21 @@ $scene-illustration-size-mobile: 200px;
   &.stackButton {
     .descriptionAndActions {
       flex-direction: column;
-      // width: 100%;
       align-items: unset;
     }
 
     .illustrationWrapper {
       display: flex;
-      align-items: center;
+    }
+
+    .descriptionContainer {
+      margin: 0 0 0 $spacing-sm;
+      padding: 0;
+
+      [dir="rtl"] & {
+        margin: 0 $spacing-sm 0 0;
+        padding: 0;
+      }
     }
 
     .buttonContainer {
@@ -221,6 +229,10 @@ $scene-illustration-size-mobile: 200px;
     .descriptionContainer {
       margin: 0;
       padding: 0;
+
+      [dir="rtl"] & {
+        margin: 0;
+      }
     }
 
     .buttonContainer {
@@ -268,6 +280,16 @@ $scene-illustration-size-mobile: 200px;
     }
   }
 
+  &.centerContent.leftAlignTextMobile {
+    .descriptionContainer {
+      text-align: left;
+
+      [dir="rtl"] & {
+        text-align: right;
+      }
+    }
+  }
+
   .illustrationWrapper {
     padding: 0;
 
@@ -278,18 +300,11 @@ $scene-illustration-size-mobile: 200px;
 
   .descriptionContainer {
     text-align: left;
-
-    @include ca-media-tablet {
-      margin: 0 $spacing-sm;
-    }
+    max-width: unset;
 
     [dir="rtl"] & {
       text-align: right;
     }
-  }
-
-  .descriptionContainer {
-    align-self: flex-start;
   }
 
   .buttonContainer {
@@ -309,8 +324,12 @@ $scene-illustration-size-mobile: 200px;
   }
 
   .descriptionContainer {
-    @include ca-media-desktop {
-      padding: 0 $spacing-sm;
+    align-self: flex-start;
+    padding-right: 0;
+
+    [dir="rtl"] & {
+      padding-left: 0;
+      padding-right: $spacing-sm;
     }
   }
 }

--- a/draft-packages/guidance-block/KaizenDraft/GuidanceBlock/GuidanceBlock.scss
+++ b/draft-packages/guidance-block/KaizenDraft/GuidanceBlock/GuidanceBlock.scss
@@ -177,10 +177,95 @@ $scene-illustration-size-mobile: 200px;
 .inline,
 .stacked {
   flex-direction: row;
+  align-items: unset;
   gap: $spacing-md;
+  min-width: unset;
 
-  @include ca-media-mobile {
+  &.stackButton {
+    .descriptionAndActions {
+      flex-direction: column;
+      // width: 100%;
+      align-items: unset;
+    }
+
+    .illustrationWrapper {
+      display: flex;
+      align-items: center;
+    }
+
+    .buttonContainer {
+      flex-direction: row-reverse;
+    }
+  }
+
+  &.stackIllustration {
     flex-direction: column;
+
+    .illustrationWrapper {
+      align-self: unset;
+    }
+
+    .illustration {
+      margin-right: auto;
+
+      [dir="rtl"] & {
+        margin-right: 0;
+        margin-left: auto;
+      }
+    }
+
+    .sceneIllustration {
+      margin: 0 auto;
+    }
+
+    .descriptionContainer {
+      margin: 0;
+      padding: 0;
+    }
+
+    .buttonContainer {
+      flex-direction: row-reverse;
+      min-width: unset;
+    }
+  }
+
+  &.centerContent {
+    .illustrationWrapper {
+      align-self: center;
+    }
+
+    .illustration {
+      margin: 0 auto;
+    }
+
+    .sceneIllustration {
+      width: $scene-illustration-size-mobile;
+    }
+
+    .descriptionContainer {
+      text-align: center;
+
+      [dir="rtl"] & {
+        text-align: center;
+      }
+    }
+
+    .buttonContainer {
+      flex-direction: column;
+      min-width: unset;
+      justify-content: center;
+
+      svg {
+        display: none;
+      }
+
+      button span {
+        &,
+        [dir="rtl"] & {
+          margin: 0;
+        }
+      }
+    }
   }
 
   .illustrationWrapper {
@@ -191,22 +276,6 @@ $scene-illustration-size-mobile: 200px;
     }
   }
 
-  .illustration {
-    @include guidance-block-under-480 {
-      margin: 0 auto;
-    }
-  }
-
-  .sceneIllustration {
-    @include ca-media-mobile {
-      margin: 0 auto;
-    }
-
-    @include guidance-block-under-480 {
-      width: $scene-illustration-size-mobile;
-    }
-  }
-
   .descriptionContainer {
     text-align: left;
 
@@ -214,54 +283,21 @@ $scene-illustration-size-mobile: 200px;
       margin: 0 $spacing-sm;
     }
 
-    @include ca-media-mobile {
-      margin: 0;
-    }
-
-    @include guidance-block-under-480 {
-      text-align: center;
-    }
-
     [dir="rtl"] & {
       text-align: right;
-
-      @include guidance-block-under-480 {
-        text-align: center;
-      }
     }
+  }
+
+  .descriptionContainer {
+    align-self: flex-start;
   }
 
   .buttonContainer {
     justify-content: end;
     width: unset;
 
-    @include ca-media-mobile {
-      flex-direction: row-reverse;
-    }
-
-    @include guidance-block-under-480 {
-      flex-wrap: wrap;
-      min-width: unset;
-      justify-content: center;
-    }
-
     > * {
       width: unset;
-    }
-
-    svg {
-      @include guidance-block-under-480 {
-        display: none;
-      }
-    }
-
-    button span {
-      &,
-      [dir="rtl"] & {
-        @include guidance-block-under-480 {
-          margin: 0;
-        }
-      }
     }
   }
 }
@@ -275,14 +311,6 @@ $scene-illustration-size-mobile: 200px;
   .descriptionContainer {
     @include ca-media-desktop {
       padding: 0 $spacing-sm;
-    }
-  }
-}
-
-.inline {
-  .illustrationWrapper {
-    @include guidance-block-under-480 {
-      justify-content: center;
     }
   }
 }

--- a/draft-packages/guidance-block/KaizenDraft/GuidanceBlock/GuidanceBlock.tsx
+++ b/draft-packages/guidance-block/KaizenDraft/GuidanceBlock/GuidanceBlock.tsx
@@ -8,8 +8,7 @@ import classnames from "classnames"
 import { Tooltip, TooltipProps } from "@kaizen/draft-tooltip"
 import Media from "react-media"
 import { SceneProps, SpotProps } from "@kaizen/draft-illustration"
-
-const styles = require("./GuidanceBlock.scss")
+import styles from "./GuidanceBlock.scss"
 
 export type ActionProps = ButtonProps & {
   tooltip?: TooltipProps
@@ -18,6 +17,8 @@ export type ActionProps = ButtonProps & {
 type LayoutType = "default" | "inline" | "stacked"
 
 type IllustrationType = "spot" | "scene"
+
+type TextAlignment = "center" | "left"
 
 type GuidanceBlockActions = {
   primary: ActionProps
@@ -44,6 +45,7 @@ export type GuidanceBlockProps = {
     title: string
     description: string | React.ReactNode
   }
+  mobileTextAlignment?: TextAlignment
   actions?: GuidanceBlockActions
   persistent?: boolean
   variant?: VariantType
@@ -82,6 +84,7 @@ class GuidanceBlock extends React.Component<
     withActionButtonArrow: true,
     noMaxWidth: false,
     illustrationType: "spot",
+    mobileTextAlignment: "center",
   }
 
   state = {
@@ -141,7 +144,11 @@ class GuidanceBlock extends React.Component<
       this.setState({ mediaQueryLayout: "" })
     }
 
-    if (this.props.illustrationType === "scene" && width <= 668) {
+    if (
+      this.props.illustrationType === "scene" &&
+      width > 320 &&
+      width <= 668
+    ) {
       this.setState({ mediaQueryLayout: "stackButton stackIllustration" })
     }
   }
@@ -157,7 +164,15 @@ class GuidanceBlock extends React.Component<
     return (
       <Media query="(max-width: 767px)">
         {isMobile => (
-          <Box mr={isMobile && this.props.layout === "default" ? 0 : 0.5}>
+          <Box
+            mr={
+              isMobile || componentIsMobile
+                ? 0
+                : this.props.layout === "default"
+                ? 0.5
+                : 0
+            }
+          >
             <div
               className={classnames(styles.buttonContainer, {
                 [styles.secondaryAction]: actions?.secondary,
@@ -253,6 +268,7 @@ class GuidanceBlock extends React.Component<
         this.state.mediaQueryLayout.includes("stackIllustration"),
       [styles.centerContent]:
         this.state.mediaQueryLayout.includes("centerContent"),
+      [styles.leftAlignTextMobile]: this.props.mobileTextAlignment === "left",
     })
   }
 

--- a/draft-packages/guidance-block/KaizenDraft/GuidanceBlock/GuidanceBlock.tsx
+++ b/draft-packages/guidance-block/KaizenDraft/GuidanceBlock/GuidanceBlock.tsx
@@ -45,7 +45,7 @@ export type GuidanceBlockProps = {
     title: string
     description: string | React.ReactNode
   }
-  mobileTextAlignment?: TextAlignment
+  smallScreenTextAlignment?: TextAlignment
   actions?: GuidanceBlockActions
   secondaryDismiss?: boolean
   persistent?: boolean
@@ -85,7 +85,7 @@ class GuidanceBlock extends React.Component<
     withActionButtonArrow: true,
     noMaxWidth: false,
     illustrationType: "spot",
-    mobileTextAlignment: "center",
+    smallScreenTextAlignment: "center",
   }
 
   state = {
@@ -258,7 +258,8 @@ class GuidanceBlock extends React.Component<
       [styles.inline]: this.props.layout === "inline",
       [styles.stacked]: this.props.layout === "stacked",
       [styles.centerContent]: this.state.mediaQueryLayout === "centerContent",
-      [styles.leftAlignTextMobile]: this.props.mobileTextAlignment === "left",
+      [styles.smallScreenTextAlignment]:
+        this.props.smallScreenTextAlignment === "left",
     })
   }
 

--- a/draft-packages/guidance-block/KaizenDraft/GuidanceBlock/GuidanceBlock.tsx
+++ b/draft-packages/guidance-block/KaizenDraft/GuidanceBlock/GuidanceBlock.tsx
@@ -47,6 +47,7 @@ export type GuidanceBlockProps = {
   }
   mobileTextAlignment?: TextAlignment
   actions?: GuidanceBlockActions
+  secondaryDismiss?: boolean
   persistent?: boolean
   variant?: VariantType
   withActionButtonArrow?: boolean
@@ -193,6 +194,11 @@ class GuidanceBlock extends React.Component<
                     <Button
                       secondary
                       {...actions.secondary}
+                      onClick={
+                        this.props?.secondaryDismiss
+                          ? () => this.dismissBanner()
+                          : this.props.actions?.secondary?.onClick
+                      }
                       fullWidth={isMobile || componentIsMobile}
                     />
                   </div>

--- a/draft-packages/guidance-block/KaizenDraft/GuidanceBlock/GuidanceBlock.tsx
+++ b/draft-packages/guidance-block/KaizenDraft/GuidanceBlock/GuidanceBlock.tsx
@@ -132,25 +132,12 @@ class GuidanceBlock extends React.Component<
   }
 
   setMediaQueryLayout(width: number) {
-    // Note: 523 is when text occupies 320px width
-    if (width > 523 && width <= 850) {
-      this.setState({ mediaQueryLayout: "stackButton" })
-    } else if (width > 320 && width <= 523) {
-      this.setState({ mediaQueryLayout: "stackButton stackIllustration" })
-    } else if (width <= 320) {
+    if (width <= 320) {
       this.setState({
-        mediaQueryLayout: "stackButton stackIllustration centerContent",
+        mediaQueryLayout: "centerContent",
       })
     } else {
       this.setState({ mediaQueryLayout: "" })
-    }
-
-    if (
-      this.props.illustrationType === "scene" &&
-      width > 320 &&
-      width <= 668
-    ) {
-      this.setState({ mediaQueryLayout: "stackButton stackIllustration" })
     }
   }
 
@@ -235,7 +222,7 @@ class GuidanceBlock extends React.Component<
         onTransitionEnd={this.onTransitionEnd}
       >
         <div className={styles.illustrationWrapper}>
-          <div className={this.illustrationClassName()}>{illustration}</div>
+          <div className={styles.illustration}>{illustration}</div>
         </div>
 
         <div className={styles.descriptionAndActions}>
@@ -267,20 +254,11 @@ class GuidanceBlock extends React.Component<
       [styles.assertive]: this.props.variant === "assertive",
       [styles.prominent]: this.props.variant === "prominent",
       [styles.noMaxWidth]: noMaxWidth,
+      [styles.hasSceneIllustration]: this.props.illustrationType === "scene",
       [styles.inline]: this.props.layout === "inline",
       [styles.stacked]: this.props.layout === "stacked",
-      [styles.stackButton]: this.state.mediaQueryLayout.includes("stackButton"),
-      [styles.stackIllustration]:
-        this.state.mediaQueryLayout.includes("stackIllustration"),
-      [styles.centerContent]:
-        this.state.mediaQueryLayout.includes("centerContent"),
+      [styles.centerContent]: this.state.mediaQueryLayout === "centerContent",
       [styles.leftAlignTextMobile]: this.props.mobileTextAlignment === "left",
-    })
-  }
-
-  illustrationClassName(): string {
-    return classnames(styles.illustration, {
-      [styles.sceneIllustration]: this.props.illustrationType === "scene",
     })
   }
 

--- a/draft-packages/guidance-block/docs/GuidanceBlock.stories.tsx
+++ b/draft-packages/guidance-block/docs/GuidanceBlock.stories.tsx
@@ -260,7 +260,7 @@ export const StackedLayoutWithScene = () => (
     illustration={<HumanityAtWork alt="" />}
     illustrationType="scene"
     text={guidanceBlockText}
-    mobileTextAlignment="left"
+    smallScreenTextAlignment="left"
     actions={{
       primary: {
         label: "Action",

--- a/draft-packages/guidance-block/docs/GuidanceBlock.stories.tsx
+++ b/draft-packages/guidance-block/docs/GuidanceBlock.stories.tsx
@@ -269,10 +269,10 @@ export const StackedLayoutWithScene = () => (
         },
       },
       secondary: {
-        label: "Secondary action",
-        href: "#",
+        label: "Dismiss action",
       },
     }}
+    secondaryDismiss
     persistent
   />
 )

--- a/draft-packages/guidance-block/docs/GuidanceBlock.stories.tsx
+++ b/draft-packages/guidance-block/docs/GuidanceBlock.stories.tsx
@@ -187,10 +187,34 @@ export const InlineLayout = () => (
 
 InlineLayout.storyName = "Inline Content Layout"
 
-export const TwoInlineLayout = () => (
+export const StackedLayout = () => (
+  <GuidanceBlock
+    layout="stacked"
+    illustration={<Informative alt="" />}
+    text={guidanceBlockText}
+    actions={{
+      primary: {
+        label: "Action",
+        onClick: () => {
+          alert("tada: 🎉")
+        },
+      },
+      secondary: {
+        label: "Secondary action",
+        href: "#",
+      },
+    }}
+    persistent
+    noMaxWidth
+  />
+)
+
+StackedLayout.storyName = "Stacked Content Layout"
+
+export const TwoStackedLayout = () => (
   <div style={{ display: "flex", gap: "36px" }}>
     <GuidanceBlock
-      layout="inline"
+      layout="stacked"
       illustration={<Informative alt="" />}
       text={guidanceBlockText}
       actions={{
@@ -208,7 +232,7 @@ export const TwoInlineLayout = () => (
       persistent
     />
     <GuidanceBlock
-      layout="inline"
+      layout="stacked"
       illustration={<Informative alt="" />}
       text={guidanceBlockText}
       actions={{
@@ -228,30 +252,7 @@ export const TwoInlineLayout = () => (
   </div>
 )
 
-TwoInlineLayout.storyName = "Two Inline Content Layout"
-
-export const StackedLayout = () => (
-  <GuidanceBlock
-    layout="stacked"
-    illustration={<Informative alt="" />}
-    text={guidanceBlockText}
-    actions={{
-      primary: {
-        label: "Action",
-        onClick: () => {
-          alert("tada: 🎉")
-        },
-      },
-      secondary: {
-        label: "Secondary action",
-        href: "#",
-      },
-    }}
-    persistent
-  />
-)
-
-StackedLayout.storyName = "Stacked Content Layout"
+TwoStackedLayout.storyName = "Two Stacked Content Layout"
 
 export const StackedLayoutWithScene = () => (
   <GuidanceBlock
@@ -259,6 +260,7 @@ export const StackedLayoutWithScene = () => (
     illustration={<HumanityAtWork alt="" />}
     illustrationType="scene"
     text={guidanceBlockText}
+    mobileTextAlignment="left"
     actions={{
       primary: {
         label: "Action",

--- a/draft-packages/guidance-block/docs/GuidanceBlock.stories.tsx
+++ b/draft-packages/guidance-block/docs/GuidanceBlock.stories.tsx
@@ -187,6 +187,49 @@ export const InlineLayout = () => (
 
 InlineLayout.storyName = "Inline Content Layout"
 
+export const TwoInlineLayout = () => (
+  <div style={{ display: "flex", gap: "36px" }}>
+    <GuidanceBlock
+      layout="inline"
+      illustration={<Informative alt="" />}
+      text={guidanceBlockText}
+      actions={{
+        primary: {
+          label: "Action",
+          onClick: () => {
+            alert("tada: 🎉")
+          },
+        },
+        secondary: {
+          label: "Secondary action",
+          href: "#",
+        },
+      }}
+      persistent
+    />
+    <GuidanceBlock
+      layout="inline"
+      illustration={<Informative alt="" />}
+      text={guidanceBlockText}
+      actions={{
+        primary: {
+          label: "Action",
+          onClick: () => {
+            alert("tada: 🎉")
+          },
+        },
+        secondary: {
+          label: "Secondary action",
+          href: "#",
+        },
+      }}
+      persistent
+    />
+  </div>
+)
+
+TwoInlineLayout.storyName = "Two Inline Content Layout"
+
 export const StackedLayout = () => (
   <GuidanceBlock
     layout="stacked"


### PR DESCRIPTION
# Objective
- Changes allow the guidance block to follow [Tile](https://www.figma.com/file/eZKEE5kXbEMY3lx84oz8iN/%E2%9D%A4%EF%B8%8F-UI-Kit%3A-Heart?node-id=1929%3A33867) design responsive behaviour based on the size of the guidance block instead of the screen size. 
- Utilizes `ResizeObserver` to add necessary css class names to allow us to modify the layout. 
- Additional RTL support to finesse spacings
- Improve button styling on mobile making them fullwidth per [Tile](https://www.figma.com/file/eZKEE5kXbEMY3lx84oz8iN/%E2%9D%A4%EF%B8%8F-UI-Kit%3A-Heart?node-id=1929%3A33867) designs
- Ensure text does not occupy widths less than `320px`
- Allow the secondary button to dismiss and hide the Guidance block
- Add `smallScreenTextAlignment` prop to left align text on mobile layout (center by default)

# Motivation and Context
- Changes were made as Guidance block side by side would behaves differently to a fullwidth Guidance block responsively. This allows the Guidance block to have consistent responsive behaviour.
- RTL spacing previously were not consistent
- Team Unify requires secondary button to allow the Guidance block to be dismissed and hidden on click.


<!--- If it fixes an open issue, please link to the issue here. -->

# Screenshots (if appropriate)

# Checklist
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] If this contains visual changes, has it been reviewed by a designer?
- [ ] If this introduces either a new component or a breaking change to an existing component, has it been reviewed by an advocate? (Ask in #prod_design_systems)
- [ ] I have considered likely risks of these changes and got someone else to QA as appropriate
- [ ] I have or will communicate these changes to the front end practice

# Additional Considerations
- Does there need to be right-to-left (RTL) options for localization and internationalization?
- Has the test suite been updated?
- Have you done cross-browser testing for our [supported browsers](https://academy.cultureamp.com/hc/en-us/articles/204539569-Supported-browsers-for-Participants)?
- Have you updated any relevant documentation or left useful comments in the code?
- Have you reviewed Culture Amp's Web Accessibility guide [Current Compliance, Going Forward, Statement and Answers for Customers](https://cultureamp.atlassian.net/wiki/spaces/Prod/pages/428572998/Web+Accessibility)?
- If this contains substantial visual changes, especially far reaching ones, have you unlocked the Chromatic step in the pipeline?
- Have Storybook stories been updated?

**If you're new to Kaizen, please ask #prod_design_systems to set up an onboarding session to get you up to speed.** If you have an urgent PR to merge before that happens, it is safest to ask in #prod_design_systems to have a design system advocate review the PR to catch any issues.
