### PR TITLE
fix: explicitly set border-bottom: none on Avatar component

### DIFF
--- a/draft-packages/avatar/KaizenDraft/Avatar/styles.module.scss
+++ b/draft-packages/avatar/KaizenDraft/Avatar/styles.module.scss
@@ -81,6 +81,10 @@ $avatar-xxl: 7.75rem;
   & .initials {
     text-decoration: none;
     speak-as: spell-out;
+
+    // to override materialize.css global styling in performance-ui,
+    // which sets a border-bottom on abbr tags
+    border-bottom: none;
   }
 }
 


### PR DESCRIPTION
# Objective
- explicitly set `border-bottom: none` for initials on the Avatar component, since in `performance-ui` global Materialize styling will set `border-bottom: 1px dotted` for all `abbr` tags.

# Motivation and Context
- `border-bottom: 1px dotted` will cause all Avatar components used in `performance-ui` (which render initials) to have appear like so:

![image](https://user-images.githubusercontent.com/31975948/149688565-e32b45a8-91ef-4740-bf61-31d82d93c5ea.png)

# Checklist
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] If this contains visual changes, has it been reviewed by a designer?
- [ ] If this introduces either a new component or a breaking change to an existing component, has it been reviewed by an advocate? (Ask in #prod_design_systems)
- [ ] I have considered likely risks of these changes and got someone else to QA as appropriate
- [ ] I have or will communicate these changes to the front end practice

# Additional Considerations
- Does there need to be right-to-left (RTL) options for localization and internationalization?
- Has the test suite been updated?
- Have you done cross-browser testing for our [supported browsers](https://academy.cultureamp.com/hc/en-us/articles/204539569-Supported-browsers-for-Participants)?
- Have you updated any relevant documentation or left useful comments in the code?
- Have you reviewed Culture Amp's Web Accessibility guide [Current Compliance, Going Forward, Statement and Answers for Customers](https://cultureamp.atlassian.net/wiki/spaces/Prod/pages/428572998/Web+Accessibility)?
- If this contains substantial visual changes, especially far reaching ones, have you unlocked the Chromatic step in the pipeline?
- Have Storybook stories been updated?

**If you're new to Kaizen, please ask #prod_design_systems to set up an onboarding session to get you up to speed.** If you have an urgent PR to merge before that happens, it is safest to ask in #prod_design_systems to have a design system advocate review the PR to catch any issues.
