### PR TITLE
feat: Bump design-tokens in peer dependencies to include v6

### DIFF
--- a/draft-packages/avatar/package.json
+++ b/draft-packages/avatar/package.json
@@ -38,7 +38,7 @@
     "react-textfit": "^1.1.1"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0 || ^6.1.0",
+    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0 || ^5.0.0 || ^6.0.0",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/avatar/package.json
+++ b/draft-packages/avatar/package.json
@@ -38,7 +38,7 @@
     "react-textfit": "^1.1.1"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0",
+    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0 || ^6.1.0",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/badge/package.json
+++ b/draft-packages/badge/package.json
@@ -35,7 +35,7 @@
     "classnames": "^2.3.1"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0",
+    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0 || ^6.1.0",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/badge/package.json
+++ b/draft-packages/badge/package.json
@@ -35,7 +35,7 @@
     "classnames": "^2.3.1"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0 || ^6.1.0",
+    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0 || ^5.0.0 || ^6.0.0",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/button/package.json
+++ b/draft-packages/button/package.json
@@ -42,7 +42,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0",
+    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0 || ^6.1.0",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/button/package.json
+++ b/draft-packages/button/package.json
@@ -42,7 +42,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0 || ^6.1.0",
+    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0 || ^5.0.0 || ^6.0.0",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/card/package.json
+++ b/draft-packages/card/package.json
@@ -32,7 +32,7 @@
   "private": false,
   "license": "MIT",
   "peerDependencies": {
-    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0 || ^6.1.0",
+    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0 || ^5.0.0 || ^6.0.0",
     "classnames": "^2.3.1",
     "react": "^16.9.0"
   }

--- a/draft-packages/card/package.json
+++ b/draft-packages/card/package.json
@@ -32,7 +32,7 @@
   "private": false,
   "license": "MIT",
   "peerDependencies": {
-    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0",
+    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0 || ^6.1.0",
     "classnames": "^2.3.1",
     "react": "^16.9.0"
   }

--- a/draft-packages/collapsible/package.json
+++ b/draft-packages/collapsible/package.json
@@ -42,7 +42,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0",
+    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0 || ^6.1.0",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/collapsible/package.json
+++ b/draft-packages/collapsible/package.json
@@ -42,7 +42,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0 || ^6.1.0",
+    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0 || ^5.0.0 || ^6.0.0",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/divider/package.json
+++ b/draft-packages/divider/package.json
@@ -35,7 +35,7 @@
     "classnames": "^2.3.1"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0",
+    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0 || ^6.1.0",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/divider/package.json
+++ b/draft-packages/divider/package.json
@@ -35,7 +35,7 @@
     "classnames": "^2.3.1"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0 || ^6.1.0",
+    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0 || ^5.0.0 || ^6.0.0",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/dropdown/package.json
+++ b/draft-packages/dropdown/package.json
@@ -42,7 +42,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0",
+    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0 || ^6.1.0",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/dropdown/package.json
+++ b/draft-packages/dropdown/package.json
@@ -42,7 +42,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0 || ^6.1.0",
+    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0 || ^5.0.0 || ^6.0.0",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/empty-state/package.json
+++ b/draft-packages/empty-state/package.json
@@ -42,7 +42,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0",
+    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0 || ^6.1.0",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/empty-state/package.json
+++ b/draft-packages/empty-state/package.json
@@ -42,7 +42,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0 || ^6.1.0",
+    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0 || ^5.0.0 || ^6.0.0",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/events/package.json
+++ b/draft-packages/events/package.json
@@ -41,7 +41,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0",
+    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0 || ^6.1.0",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/events/package.json
+++ b/draft-packages/events/package.json
@@ -41,7 +41,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0 || ^6.1.0",
+    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0 || ^5.0.0 || ^6.0.0",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/filter-menu-button/package.json
+++ b/draft-packages/filter-menu-button/package.json
@@ -38,7 +38,7 @@
     "classnames": "^2.3.1"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0 || ^6.1.0",
+    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0 || ^5.0.0 || ^6.0.0",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/filter-menu-button/package.json
+++ b/draft-packages/filter-menu-button/package.json
@@ -38,7 +38,7 @@
     "classnames": "^2.3.1"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0",
+    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0 || ^6.1.0",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/form/package.json
+++ b/draft-packages/form/package.json
@@ -43,7 +43,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0 || ^6.1.0",
+    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0 || ^5.0.0 || ^6.0.0",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/form/package.json
+++ b/draft-packages/form/package.json
@@ -43,7 +43,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0",
+    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0 || ^6.1.0",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/guidance-block/package.json
+++ b/draft-packages/guidance-block/package.json
@@ -45,7 +45,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0",
+    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0 || ^6.1.0",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/guidance-block/package.json
+++ b/draft-packages/guidance-block/package.json
@@ -45,7 +45,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0 || ^6.1.0",
+    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0 || ^5.0.0 || ^6.0.0",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/hero-card/package.json
+++ b/draft-packages/hero-card/package.json
@@ -42,7 +42,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0",
+    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0 || ^6.1.0",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/hero-card/package.json
+++ b/draft-packages/hero-card/package.json
@@ -42,7 +42,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0 || ^6.1.0",
+    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0 || ^5.0.0 || ^6.0.0",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/hierarchical-menu/package.json
+++ b/draft-packages/hierarchical-menu/package.json
@@ -40,7 +40,7 @@
     "react-transition-group": "^4.4.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0 || ^6.1.0",
+    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0 || ^5.0.0 || ^6.0.0",
     "react": "^16.13.1"
   }
 }

--- a/draft-packages/hierarchical-menu/package.json
+++ b/draft-packages/hierarchical-menu/package.json
@@ -40,7 +40,7 @@
     "react-transition-group": "^4.4.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0",
+    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0 || ^6.1.0",
     "react": "^16.13.1"
   }
 }

--- a/draft-packages/hierarchical-select/package.json
+++ b/draft-packages/hierarchical-select/package.json
@@ -38,7 +38,7 @@
     "@kaizen/draft-hierarchical-menu": "^2.2.35"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0 || ^6.1.0",
+    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0 || ^5.0.0 || ^6.0.0",
     "react": "^16.13.1"
   }
 }

--- a/draft-packages/hierarchical-select/package.json
+++ b/draft-packages/hierarchical-select/package.json
@@ -38,7 +38,7 @@
     "@kaizen/draft-hierarchical-menu": "^2.2.35"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0",
+    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0 || ^6.1.0",
     "react": "^16.13.1"
   }
 }

--- a/draft-packages/illustration/package.json
+++ b/draft-packages/illustration/package.json
@@ -44,7 +44,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0",
+    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0 || ^6.1.0",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/illustration/package.json
+++ b/draft-packages/illustration/package.json
@@ -44,7 +44,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0 || ^6.1.0",
+    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0 || ^5.0.0 || ^6.0.0",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/likert-scale-legacy/package.json
+++ b/draft-packages/likert-scale-legacy/package.json
@@ -36,7 +36,7 @@
     "classnames": "^2.3.1"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0 || ^6.1.0",
+    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0 || ^5.0.0 || ^6.0.0",
     "react": "^16.9.0"
   },
   "devDependencies": {

--- a/draft-packages/likert-scale-legacy/package.json
+++ b/draft-packages/likert-scale-legacy/package.json
@@ -36,7 +36,7 @@
     "classnames": "^2.3.1"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0",
+    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0 || ^6.1.0",
     "react": "^16.9.0"
   },
   "devDependencies": {

--- a/draft-packages/loading-placeholder/package.json
+++ b/draft-packages/loading-placeholder/package.json
@@ -41,7 +41,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0",
+    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0 || ^6.1.0",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/loading-placeholder/package.json
+++ b/draft-packages/loading-placeholder/package.json
@@ -41,7 +41,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0 || ^6.1.0",
+    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0 || ^5.0.0 || ^6.0.0",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/loading-spinner/package.json
+++ b/draft-packages/loading-spinner/package.json
@@ -32,7 +32,7 @@
   "private": false,
   "license": "MIT",
   "peerDependencies": {
-    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0",
+    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0 || ^6.1.0",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/loading-spinner/package.json
+++ b/draft-packages/loading-spinner/package.json
@@ -32,7 +32,7 @@
   "private": false,
   "license": "MIT",
   "peerDependencies": {
-    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0 || ^6.1.0",
+    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0 || ^5.0.0 || ^6.0.0",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/menu/package.json
+++ b/draft-packages/menu/package.json
@@ -45,7 +45,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0",
+    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0 || ^6.1.0",
     "react": "^16.9.0",
     "react-dom": "^16.9.0"
   }

--- a/draft-packages/menu/package.json
+++ b/draft-packages/menu/package.json
@@ -45,7 +45,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0 || ^6.1.0",
+    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0 || ^5.0.0 || ^6.0.0",
     "react": "^16.9.0",
     "react-dom": "^16.9.0"
   }

--- a/draft-packages/modal/package.json
+++ b/draft-packages/modal/package.json
@@ -52,7 +52,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0",
+    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0 || ^6.1.0",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/modal/package.json
+++ b/draft-packages/modal/package.json
@@ -52,7 +52,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0 || ^6.1.0",
+    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0 || ^5.0.0 || ^6.0.0",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/page-layout/package.json
+++ b/draft-packages/page-layout/package.json
@@ -38,7 +38,7 @@
     "resize-observer-polyfill": "^1.5.1"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0",
+    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0 || ^6.1.0",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/page-layout/package.json
+++ b/draft-packages/page-layout/package.json
@@ -38,7 +38,7 @@
     "resize-observer-polyfill": "^1.5.1"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0 || ^6.1.0",
+    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0 || ^5.0.0 || ^6.0.0",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/popover/package.json
+++ b/draft-packages/popover/package.json
@@ -44,7 +44,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0",
+    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0 || ^6.1.0",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/popover/package.json
+++ b/draft-packages/popover/package.json
@@ -44,7 +44,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0 || ^6.1.0",
+    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0 || ^5.0.0 || ^6.0.0",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/select/package.json
+++ b/draft-packages/select/package.json
@@ -47,7 +47,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0 || ^6.1.0",
+    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0 || ^5.0.0 || ^6.0.0",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/select/package.json
+++ b/draft-packages/select/package.json
@@ -47,7 +47,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0",
+    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0 || ^6.1.0",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/split-button/package.json
+++ b/draft-packages/split-button/package.json
@@ -42,7 +42,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0",
+    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0 || ^6.1.0",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/split-button/package.json
+++ b/draft-packages/split-button/package.json
@@ -42,7 +42,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0 || ^6.1.0",
+    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0 || ^5.0.0 || ^6.0.0",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/table/package.json
+++ b/draft-packages/table/package.json
@@ -43,7 +43,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0 || ^6.1.0",
+    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0 || ^5.0.0 || ^6.0.0",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/table/package.json
+++ b/draft-packages/table/package.json
@@ -43,7 +43,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0",
+    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0 || ^6.1.0",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/tabs/package.json
+++ b/draft-packages/tabs/package.json
@@ -42,7 +42,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0",
+    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0 || ^6.1.0",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/tabs/package.json
+++ b/draft-packages/tabs/package.json
@@ -42,7 +42,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0 || ^6.1.0",
+    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0 || ^5.0.0 || ^6.0.0",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/tag/package.json
+++ b/draft-packages/tag/package.json
@@ -43,7 +43,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0 || ^6.1.0",
+    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0 || ^5.0.0 || ^6.0.0",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/tag/package.json
+++ b/draft-packages/tag/package.json
@@ -43,7 +43,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0",
+    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0 || ^6.1.0",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/tile/package.json
+++ b/draft-packages/tile/package.json
@@ -32,7 +32,7 @@
   "private": false,
   "license": "MIT",
   "peerDependencies": {
-    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0 || ^6.1.0",
+    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0 || ^5.0.0 || ^6.0.0",
     "react": "^16.9.0"
   },
   "dependencies": {

--- a/draft-packages/tile/package.json
+++ b/draft-packages/tile/package.json
@@ -32,7 +32,7 @@
   "private": false,
   "license": "MIT",
   "peerDependencies": {
-    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0",
+    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0 || ^6.1.0",
     "react": "^16.9.0"
   },
   "dependencies": {

--- a/draft-packages/title-block-zen/package.json
+++ b/draft-packages/title-block-zen/package.json
@@ -48,7 +48,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0 || ^6.1.0",
+    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0 || ^5.0.0 || ^6.0.0",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/title-block-zen/package.json
+++ b/draft-packages/title-block-zen/package.json
@@ -48,7 +48,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0",
+    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0 || ^6.1.0",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/tooltip/package.json
+++ b/draft-packages/tooltip/package.json
@@ -46,7 +46,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0",
+    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0 || ^6.1.0",
     "react": "^16.9.0",
     "react-dom": "^16.9.0"
   }

--- a/draft-packages/tooltip/package.json
+++ b/draft-packages/tooltip/package.json
@@ -46,7 +46,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0 || ^6.1.0",
+    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0 || ^5.0.0 || ^6.0.0",
     "react": "^16.9.0",
     "react-dom": "^16.9.0"
   }

--- a/draft-packages/user-interactions/package.json
+++ b/draft-packages/user-interactions/package.json
@@ -41,7 +41,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0",
+    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0 || ^6.1.0",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/user-interactions/package.json
+++ b/draft-packages/user-interactions/package.json
@@ -41,7 +41,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0 || ^6.1.0",
+    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0 || ^5.0.0 || ^6.0.0",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/well/package.json
+++ b/draft-packages/well/package.json
@@ -41,7 +41,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0",
+    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0 || ^6.1.0",
     "react": "^16.9.0"
   }
 }

--- a/draft-packages/well/package.json
+++ b/draft-packages/well/package.json
@@ -41,7 +41,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0 || ^6.1.0",
+    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0 || ^5.0.0 || ^6.0.0",
     "react": "^16.9.0"
   }
 }

--- a/legacy-packages/title-block/package.json
+++ b/legacy-packages/title-block/package.json
@@ -45,7 +45,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0",
+    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0 || ^6.1.0",
     "react": "^16.9.0"
   }
 }

--- a/legacy-packages/title-block/package.json
+++ b/legacy-packages/title-block/package.json
@@ -45,7 +45,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0 || ^6.1.0",
+    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0 || ^5.0.0 || ^6.0.0",
     "react": "^16.9.0"
   }
 }

--- a/packages/brand-moment/package.json
+++ b/packages/brand-moment/package.json
@@ -46,7 +46,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0",
+    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0 || ^6.1.0",
     "react": "^16.9.0"
   }
 }

--- a/packages/brand-moment/package.json
+++ b/packages/brand-moment/package.json
@@ -46,7 +46,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0 || ^6.1.0",
+    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0 || ^5.0.0 || ^6.0.0",
     "react": "^16.9.0"
   }
 }

--- a/packages/component-library/package.json
+++ b/packages/component-library/package.json
@@ -26,7 +26,7 @@
   "private": false,
   "license": "MIT",
   "peerDependencies": {
-    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0 || ^6.1.0",
+    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0 || ^5.0.0 || ^6.0.0",
     "focus-visible": "4.x || 5.x",
     "react": "^16.9.0"
   },

--- a/packages/component-library/package.json
+++ b/packages/component-library/package.json
@@ -26,7 +26,7 @@
   "private": false,
   "license": "MIT",
   "peerDependencies": {
-    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0",
+    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0 || ^6.1.0",
     "focus-visible": "4.x || 5.x",
     "react": "^16.9.0"
   },

--- a/packages/deprecated-component-library-helpers/package.json
+++ b/packages/deprecated-component-library-helpers/package.json
@@ -16,6 +16,6 @@
   "private": false,
   "license": "MIT",
   "peerDependencies": {
-    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0 || ^6.1.0"
+    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0 || ^5.0.0 || ^6.0.0"
   }
 }

--- a/packages/deprecated-component-library-helpers/package.json
+++ b/packages/deprecated-component-library-helpers/package.json
@@ -16,6 +16,6 @@
   "private": false,
   "license": "MIT",
   "peerDependencies": {
-    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0"
+    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0 || ^6.1.0"
   }
 }

--- a/packages/notification/package.json
+++ b/packages/notification/package.json
@@ -42,7 +42,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0",
+    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0 || ^6.1.0",
     "react": "^16.9.0",
     "react-dom": "^16.9.0"
   }

--- a/packages/notification/package.json
+++ b/packages/notification/package.json
@@ -42,7 +42,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0 || ^6.1.0",
+    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0 || ^5.0.0 || ^6.0.0",
     "react": "^16.9.0",
     "react-dom": "^16.9.0"
   }

--- a/packages/pagination/package.json
+++ b/packages/pagination/package.json
@@ -36,7 +36,7 @@
     "classnames": "^2.3.1"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0",
+    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0 || ^6.1.0",
     "react": "^16.9.0"
   }
 }

--- a/packages/pagination/package.json
+++ b/packages/pagination/package.json
@@ -36,7 +36,7 @@
     "classnames": "^2.3.1"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0 || ^6.1.0",
+    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0 || ^5.0.0 || ^6.0.0",
     "react": "^16.9.0"
   }
 }

--- a/packages/progress-bar/package.json
+++ b/packages/progress-bar/package.json
@@ -32,7 +32,7 @@
   "private": false,
   "license": "MIT",
   "peerDependencies": {
-    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0 || ^6.1.0",
+    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0 || ^5.0.0 || ^6.0.0",
     "react": "^16.9.0"
   },
   "dependencies": {

--- a/packages/progress-bar/package.json
+++ b/packages/progress-bar/package.json
@@ -32,7 +32,7 @@
   "private": false,
   "license": "MIT",
   "peerDependencies": {
-    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0",
+    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0 || ^6.1.0",
     "react": "^16.9.0"
   },
   "dependencies": {

--- a/packages/responsive/package.json
+++ b/packages/responsive/package.json
@@ -35,7 +35,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0",
+    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0 || ^6.1.0",
     "react": "^16.9.0"
   }
 }

--- a/packages/responsive/package.json
+++ b/packages/responsive/package.json
@@ -35,7 +35,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0 || ^6.1.0",
+    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0 || ^5.0.0 || ^6.0.0",
     "react": "^16.9.0"
   }
 }

--- a/packages/stylelint-plugin/package.json
+++ b/packages/stylelint-plugin/package.json
@@ -27,7 +27,7 @@
     "tinycolor2": "^1.4.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^3.0.0"
+    "@kaizen/design-tokens": "^3.0.0 || ^6.1.0"
   },
   "devDependencies": {
     "@types/lodash.kebabcase": "^4.1.6",

--- a/packages/stylelint-plugin/package.json
+++ b/packages/stylelint-plugin/package.json
@@ -27,7 +27,7 @@
     "tinycolor2": "^1.4.2"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^3.0.0 || ^6.1.0"
+    "@kaizen/design-tokens": "^3.0.0 || ^5.0.0 || ^6.0.0"
   },
   "devDependencies": {
     "@types/lodash.kebabcase": "^4.1.6",

--- a/packages/tabs/package.json
+++ b/packages/tabs/package.json
@@ -43,7 +43,7 @@
     "@kaizen/draft-card": "^1.5.0"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0 || ^6.1.0",
+    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0 || ^5.0.0 || ^6.0.0",
     "react": "^16.9.0"
   }
 }

--- a/packages/tabs/package.json
+++ b/packages/tabs/package.json
@@ -43,7 +43,7 @@
     "@kaizen/draft-card": "^1.5.0"
   },
   "peerDependencies": {
-    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0",
+    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0 || ^6.1.0",
     "react": "^16.9.0"
   }
 }


### PR DESCRIPTION
# Objective
<!-- Describe what this change achieves, and the details of how it works. -->

 Bump design-tokens in peer dependencies to include v6

# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Warnings for incorrect peer dependencies for design tokens when running yarn install.