### PR TITLE
feat: improve RadioGroup accessibility

### DIFF
--- a/draft-packages/form/KaizenDraft/Form/RadioGroup/RadioGroup.spec.tsx
+++ b/draft-packages/form/KaizenDraft/Form/RadioGroup/RadioGroup.spec.tsx
@@ -1,7 +1,7 @@
 import { RadioField } from "@kaizen/draft-form"
 import { cleanup, render } from "@testing-library/react"
 import * as React from "react"
-import RadioGroup, { RadioGroupProps } from "./RadioGroup"
+import RadioGroup from "./RadioGroup"
 
 afterEach(cleanup)
 
@@ -63,6 +63,24 @@ describe("<RadioGroup /> ", () => {
         <RadioGroup labelText={title} children={null} />
       )
       expect(queryByText(title)).toBeTruthy()
+    })
+  })
+  describe("accessibilty", () => {
+    it("should markup aria label when supplied labelId", () => {
+      const labelId = "labelId"
+      const { getByText, getByRole } = render(
+        <RadioGroup
+          labelText="Label title"
+          labelId={labelId}
+          automationId="test"
+        />
+      )
+      expect(getByRole("radiogroup").getAttribute("aria-labelledby")).toEqual(
+        labelId
+      )
+      expect(
+        getByText("Label title").parentElement?.getAttribute("id")
+      ).toEqual(labelId)
     })
   })
 })

--- a/draft-packages/form/KaizenDraft/Form/RadioGroup/RadioGroup.tsx
+++ b/draft-packages/form/KaizenDraft/Form/RadioGroup/RadioGroup.tsx
@@ -8,6 +8,7 @@ import styles from "./styles.scss"
 export type RadioGroupProps = {
   automationId?: string
   labelText: string | React.ReactNode
+  labelId?: string
   noBottomMargin?: boolean
   reversed?: boolean
 }
@@ -18,6 +19,7 @@ const RadioGroup: RadioGroup = ({
   automationId = "",
   children,
   labelText = "",
+  labelId,
   noBottomMargin = false,
   reversed = false,
 }) => (
@@ -27,9 +29,12 @@ const RadioGroup: RadioGroup = ({
       [styles.noBottomMargin]: noBottomMargin,
       [styles.reversed]: reversed,
     })}
+    role="radiogroup"
+    aria-labelledby={labelId}
   >
     <div className={styles.radioGroupLabel}>
       <Label
+        id={labelId}
         automationId={`${automationId}-field-label`}
         labelText={labelText}
         labelType="text"

--- a/draft-packages/form/KaizenDraft/Form/RadioGroup/__snapshots__/RadioGroup.spec.tsx.snap
+++ b/draft-packages/form/KaizenDraft/Form/RadioGroup/__snapshots__/RadioGroup.spec.tsx.snap
@@ -4,6 +4,7 @@ exports[`<RadioGroup />  snapshots renders RadioGroup in a column and with a lab
 <div
   class="radioGroupContainer"
   data-automation-id=""
+  role="radiogroup"
 >
   <div
     class="radioGroupLabel"
@@ -26,6 +27,7 @@ exports[`<RadioGroup />  snapshots renders RadioGroup in a column and with a lab
 <div
   class="radioGroupContainer"
   data-automation-id=""
+  role="radiogroup"
 >
   <div
     class="radioGroupLabel"
@@ -48,6 +50,7 @@ exports[`<RadioGroup />  snapshots renders RadioGroup in a row and with a label 
 <div
   class="radioGroupContainer"
   data-automation-id=""
+  role="radiogroup"
 >
   <div
     class="radioGroupLabel"
@@ -70,6 +73,7 @@ exports[`<RadioGroup />  snapshots renders RadioGroup with radios 1`] = `
 <div
   class="radioGroupContainer"
   data-automation-id=""
+  role="radiogroup"
 >
   <div
     class="radioGroupLabel"

--- a/draft-packages/form/docs/RadioGroup.stories.tsx
+++ b/draft-packages/form/docs/RadioGroup.stories.tsx
@@ -62,9 +62,9 @@ const reversedBg = {
 export const DefaultKaizenSiteDemo = () => (
   <RadioGroupExample
     render={({ selectedOption, onChangeHandler }) => (
-      <RadioGroup labelText="Radio group label">
+      <RadioGroup labelText="Radio group label" labelId="RadioGroupLabel">
         <RadioField
-          labelText="Label"
+          labelText="Option one"
           name="radio"
           id="radio-1"
           selectedStatus={selectedOption === "radio-1"}
@@ -72,7 +72,7 @@ export const DefaultKaizenSiteDemo = () => (
           value="radio-1"
         />
         <RadioField
-          labelText="Label"
+          labelText="Option two"
           name="radio"
           id="radio-2"
           selectedStatus={selectedOption === "radio-2"}
@@ -80,7 +80,7 @@ export const DefaultKaizenSiteDemo = () => (
           value="radio-2"
         />
         <RadioField
-          labelText="Label"
+          labelText="Option three"
           name="radio"
           id="radio-3"
           selectedStatus={selectedOption === "radio-3"}


### PR DESCRIPTION
# Objective
To allow screen readers to connect the radio group to the label so it can be read out (also general accessibility).

# Motivation and Context
https://github.com/cultureamp/kaizen-design-system/issues/2409

This was originally discovered when trying to use RadioGroup to mark up a radio group in performance-ui. This change fixes the accessibility of the component, but it is still not able to be used in perform-ui. This is because the component enforces the use of the Label component that does not match what the perform product uses:

<img width="875" alt="image" src="https://user-images.githubusercontent.com/4666090/150910520-1c2b0a0a-d909-4cd3-83b4-87039bb140ba.png">

I raised a possible solution to allow the consumer to override the Label element by supplying a render function for it where a consumer could render custom UI with the appropriate ID, but that was deemed too flexible.

# Screenshots (if appropriate)

# Checklist
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] If this contains visual changes, has it been reviewed by a designer?
- [x] If this introduces either a new component or a breaking change to an existing component, has it been reviewed by an advocate? (Ask in #prod_design_systems)
- [x] I have considered likely risks of these changes and got someone else to QA as appropriate
- [ ] I have or will communicate these changes to the front end practice

# Additional Considerations
- Does there need to be right-to-left (RTL) options for localization and internationalization?
- Has the test suite been updated?
- Have you done cross-browser testing for our [supported browsers](https://academy.cultureamp.com/hc/en-us/articles/204539569-Supported-browsers-for-Participants)?
- Have you updated any relevant documentation or left useful comments in the code?
- Have you reviewed Culture Amp's Web Accessibility guide [Current Compliance, Going Forward, Statement and Answers for Customers](https://cultureamp.atlassian.net/wiki/spaces/Prod/pages/428572998/Web+Accessibility)?
- If this contains substantial visual changes, especially far reaching ones, have you unlocked the Chromatic step in the pipeline?
- Have Storybook stories been updated?

**If you're new to Kaizen, please ask #prod_design_systems to set up an onboarding session to get you up to speed.** If you have an urgent PR to merge before that happens, it is safest to ask in #prod_design_systems to have a design system advocate review the PR to catch any issues.
