### PR TITLE
fix: calc function syntax error

### DIFF
--- a/draft-packages/tooltip/KaizenDraft/Tooltip/Tooltip.scss
+++ b/draft-packages/tooltip/KaizenDraft/Tooltip/Tooltip.scss
@@ -97,9 +97,9 @@ $arrow-width: 14px;
   content: "";
   position: absolute;
   left: 50%;
-  border-left: calc($arrow-width / 2) solid transparent;
-  border-right: calc($arrow-width / 2) solid transparent;
-  margin-left: calc($arrow-width / -2);
+  border-left: calc(#{$arrow-width} / 2) solid transparent;
+  border-right: calc(#{$arrow-width} / 2) solid transparent;
+  margin-left: calc(#{$arrow-width} / -2);
 }
 
 .arrowMain {


### PR DESCRIPTION
# Objective
<!-- Describe what this change achieves, and the details of how it works. -->
Update calc() to use `calc(#{$kz-some-var})` syntax. 

# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Causing error on other builds.

