### PR TITLE
ci: Run Chromatic action on the master branch to auto accept baselines

### DIFF
--- a/.github/workflows/chromatic.yaml
+++ b/.github/workflows/chromatic.yaml
@@ -28,7 +28,8 @@ jobs:
       - run: |
           echo "runChromatic=${runChromatic}" >> $GITHUB_ENV
         env:
-          runChromatic: ${{ github.event.review.state == 'approved' }}
+          # If action is running on master branch we would like to update baselines via autoAcceptChanges
+          runChromatic: ${{ github.event.review.state == 'approved' || github.ref == 'refs/heads/master' }}
 
       - run: echo "PR has been approved, trigger Chromatic"
         if: ${{ env.runChromatic == 'true' }}


### PR DESCRIPTION
# Objective
The Chromatic baselines were not being updated when a branch was merged to master as there was an early exit in the steps. This change allows all master branches to update snapshots and autoaccepts them as the new baseline. 

