### PR TITLE
chore: address node-fetch vulnerability CVE-2022-0235

### DIFF
--- a/js-audit-allow-list.json
+++ b/js-audit-allow-list.json
@@ -72,6 +72,13 @@
       "reason": "Dev dependency",
       "reviewer": "christianklammer",
       "whenSubDependencyOf": ["eslint-plugin-graphql"]
+    },
+    {
+      "title": "node-fetch is vulnerable to Exposure of Sensitive Information to an Unauthorized Actor",
+      "cve": "CVE-2022-0235",
+      "reason": "As per Ops team: The Gatsby site is incredibly low risk (no customer data, static site only, separate domain, etc)",
+      "reviewer": "cassandra.tam",
+      "whenSubDependencyOf": ["gatsby"]
     }
   ],
   "is-svg": [

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
   "devDependencies": {
     "@storybook/node-logger": "^6.4.9",
     "chromatic": "^6.2.3",
-    "danger": "^10.8.0",
+    "danger": "^10.9.0",
     "eslint-import-resolver-typescript": "^2.5.0",
     "eslint-plugin-ssr-friendly": "https://github.com/cultureamp/eslint-plugin-ssr-friendly",
     "loader-utils": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,6 @@
     "jest-static-stubs": "^0.0.1",
     "lerna": "^3.22.1",
     "lodash.isempty": "^4.4.0",
-    "node-fetch": "^2.6.6",
     "node-sass": "^6.0.1",
     "normalize.css": "^8.0.1",
     "postcss-flexbugs-fixes": "^4.2.1",
@@ -108,7 +107,8 @@
     "eslint-import-resolver-typescript": "^2.5.0",
     "eslint-plugin-ssr-friendly": "https://github.com/cultureamp/eslint-plugin-ssr-friendly",
     "loader-utils": "^1.4.0",
-    "node-elm-compiler": "^5.0.6"
+    "node-elm-compiler": "^5.0.6",
+    "node-fetch": "^2.6.7"
   },
   "resolutions": {
     "axios": "0.21.2"

--- a/packages/stylelint-plugin/package.json
+++ b/packages/stylelint-plugin/package.json
@@ -38,7 +38,7 @@
     "@types/stylelint": "^13.13.3",
     "@types/tinycolor2": "^1.4.3",
     "lodash.merge": "^4.6.2",
-    "node-fetch": "^2.6.6",
+    "node-fetch": "^2.6.7",
     "prettier": "^2.3.2",
     "ts-node": "^9.1.1"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -9946,9 +9946,9 @@ focus-visible@^5.2.0:
   integrity sha512-Rwix9pBtC1Nuy5wysTmKy+UjbDJpIfg8eHjw0rjZ1mX4GNLz1Bmd16uDpI3Gk1i70Fgcs8Csg2lPm8HULFg9DQ==
 
 follow-redirects@^1.0.0, follow-redirects@^1.14.0:
-  version "1.14.5"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.5.tgz#f09a5848981d3c772b5392309778523f8d85c381"
-  integrity sha512-wtphSXy7d4/OR+MvIFbCVBDzZ5520qV8XfPklSN5QtxuMUJZ+b0Wnst1e1lCDocfzuCkHqj8k0FpZqO+UIaKNA==
+  version "1.14.7"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.7.tgz#2004c02eb9436eee9a21446a6477debf17e81685"
+  integrity sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ==
 
 for-each@^0.3.3:
   version "0.3.3"
@@ -15896,9 +15896,9 @@ nano-memoize@^1.2.1:
   integrity sha512-ANfJ0QFhLzv9BZV8tHxwaDClqr+U8yY65hZA+slbgJrx+ePnHtlY92F2ZJInkkQWUUR71NzCEHBshKCHJnNyaQ==
 
 nanoid@^3.1.23, nanoid@^3.1.30:
-  version "3.1.30"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.30.tgz#63f93cc548d2a113dc5dfbc63bfa09e2b9b64362"
-  integrity sha512-zJpuPDwOv8D2zq2WRoMe1HsfZthVewpel9CAvTfc/2mBD1uUT/agc5f7GHGWXlYkFvi1mVxe4IjvP2HNrop7nQ==
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.2.0.tgz#62667522da6673971cca916a6d3eff3f415ff80c"
+  integrity sha512-fmsZYa9lpn69Ad5eDn7FMcnnSR+8R34W9qJEijxYhTbfOWzr22n1QxCMzXLK+ODyW2973V3Fux959iQoUxzUIA==
 
 nanomatch@^1.2.1, nanomatch@^1.2.9:
   version "1.2.13"
@@ -16025,10 +16025,10 @@ node-fetch@2.6.1:
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
   integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
 
-node-fetch@^2.5.0, node-fetch@^2.6.0, node-fetch@^2.6.1, node-fetch@^2.6.6:
-  version "2.6.6"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.6.tgz#1751a7c01834e8e1697758732e9efb6eeadfaf89"
-  integrity sha512-Z8/6vRlTUChSdIgMa51jxQ4lrw/Jy5SOW10ObaA47/RElsAN2c5Pn8bTgFGWn/ibwzXTE8qwr1Yzx28vsecXEA==
+node-fetch@^2.5.0, node-fetch@^2.6.0, node-fetch@^2.6.1, node-fetch@^2.6.7:
+  version "2.6.7"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.7.tgz#24de9fba827e3b4ae44dc8b20256a379160052ad"
+  integrity sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==
   dependencies:
     whatwg-url "^5.0.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7821,10 +7821,10 @@ damerau-levenshtein@^1.0.7:
   resolved "https://registry.yarnpkg.com/damerau-levenshtein/-/damerau-levenshtein-1.0.7.tgz#64368003512a1a6992593741a09a9d31a836f55d"
   integrity sha512-VvdQIPGdWP0SqFXghj79Wf/5LArmreyMsGLa6FG6iC4t3j7j5s71TrwWmT/4akbDQIqjfACkLZmjXhA7g2oUZw==
 
-danger@^10.8.0:
-  version "10.8.0"
-  resolved "https://registry.yarnpkg.com/danger/-/danger-10.8.0.tgz#666718908572b4ee13f287fa7afebb1cda9c7790"
-  integrity sha512-s4Ge4jKQdENdVhGndHpnXnUmfR60IHQeIxkZlHIupHKmYiMYWYCazlTtTS1ieApYhhKPrtEgZYXF7zQ6SBg9lw==
+danger@^10.9.0:
+  version "10.9.0"
+  resolved "https://registry.yarnpkg.com/danger/-/danger-10.9.0.tgz#0a5f6eae76029257f23246e2fb922cf401ac55ee"
+  integrity sha512-eEWQAaIPfWSfzlQiFx+w9fWuP3jwq8VAV9W22EZRxfmCBnkdDa5aN0Akr7lzfCKudzy+4uEmIGUtxnYeFgTthQ==
   dependencies:
     "@babel/polyfill" "^7.2.5"
     "@octokit/rest" "^16.43.1"
@@ -7850,7 +7850,7 @@ danger@^10.8.0:
     memfs-or-file-map-to-github-branch "^1.1.0"
     micromatch "^4.0.4"
     node-cleanup "^2.1.2"
-    node-fetch "2.6.1"
+    node-fetch "^2.6.7"
     override-require "^1.1.1"
     p-limit "^2.1.0"
     parse-diff "^0.7.0"
@@ -16019,11 +16019,6 @@ node-fetch@2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.1.2.tgz#ab884e8e7e57e38a944753cec706f788d1768bb5"
   integrity sha1-q4hOjn5X44qUR1POxwb3iNF2i7U=
-
-node-fetch@2.6.1:
-  version "2.6.1"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
-  integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
 
 node-fetch@^2.5.0, node-fetch@^2.6.0, node-fetch@^2.6.1, node-fetch@^2.6.7:
   version "2.6.7"


### PR DESCRIPTION
# What

Address https://nvd.nist.gov/vuln/detail/CVE-2022-0235

# Why

To fix failing audit step in our builds

# Changes

- Upgrade `node-fetch` to `^2.6.7` where we have it as a direct dependency
	- Move `node-fetch` from `dependencies` to `devDependencies`
- Upgrade `danger` to `^10.9.0` (they upgraded `node-fetch`)
- Add `node-fetch` CVE-2022-0235 to audit allow list