### PR TITLE
chore: fix chromatic false positives

### DIFF
--- a/draft-packages/avatar/docs/avatarData.json
+++ b/draft-packages/avatar/docs/avatarData.json
@@ -203,35 +203,35 @@
       "title": "Initials Personal",
       "stories": [
         {
-          "fullName": "Very Long Name Which Shows Initials But Fits Within A Container",
+          "fullName": "The Quick Brown Fox Jumps Over The Lazy Dog",
           "disableInitials": false,
           "avatarSrc": "",
           "isCurrentUser": true,
           "size": "xxlarge"
         },
         {
-          "fullName": "Very Long Name Which Shows Initials But Fits Within A Container",
+          "fullName": "The Quick Brown Fox Jumps Over The Lazy Dog",
           "disableInitials": false,
           "avatarSrc": "",
           "isCurrentUser": true,
           "size": "xlarge"
         },
         {
-          "fullName": "Very Long Name Which Shows Initials But Fits Within A Container",
+          "fullName": "The Quick Brown Fox Jumps Over The Lazy Dog",
           "disableInitials": false,
           "avatarSrc": "",
           "isCurrentUser": true,
           "size": "large"
         },
         {
-          "fullName": "Very Long Name Which Shows Initials But Fits Within A Container",
+          "fullName": "The Quick Brown Fox Jumps Over The Lazy Dog",
           "disableInitials": false,
           "avatarSrc": "",
           "isCurrentUser": true,
           "size": "medium"
         },
         {
-          "fullName": "Very Long Name Which Shows Initials But Fits Within A Container",
+          "fullName": "The Quick Brown Fox Jumps Over The Lazy Dog",
           "disableInitials": false,
           "avatarSrc": "",
           "isCurrentUser": true,
@@ -243,35 +243,35 @@
       "title": "Initials Generic",
       "stories": [
         {
-          "fullName": "Very Long Name Which Shows Initials But Fits Within A Container",
+          "fullName": "The Quick Brown Fox Jumps Over The Lazy Dog",
           "disableInitials": false,
           "avatarSrc": "",
           "isCurrentUser": false,
           "size": "xxlarge"
         },
         {
-          "fullName": "Very Long Name Which Shows Initials But Fits Within A Container",
+          "fullName": "The Quick Brown Fox Jumps Over The Lazy Dog",
           "disableInitials": false,
           "avatarSrc": "",
           "isCurrentUser": false,
           "size": "xlarge"
         },
         {
-          "fullName": "Very Long Name Which Shows Initials But Fits Within A Container",
+          "fullName": "The Quick Brown Fox Jumps Over The Lazy Dog",
           "disableInitials": false,
           "avatarSrc": "",
           "isCurrentUser": false,
           "size": "large"
         },
         {
-          "fullName": "Very Long Name Which Shows Initials But Fits Within A Container",
+          "fullName": "The Quick Brown Fox Jumps Over The Lazy Dog",
           "disableInitials": false,
           "avatarSrc": "",
           "isCurrentUser": false,
           "size": "medium"
         },
         {
-          "fullName": "Very Long Name Which Shows Initials But Fits Within A Container",
+          "fullName": "The Quick Brown Fox Jumps Over The Lazy Dog",
           "disableInitials": false,
           "avatarSrc": "",
           "isCurrentUser": false,

--- a/draft-packages/illustration/docs/IllustrationSpot.stories.tsx
+++ b/draft-packages/illustration/docs/IllustrationSpot.stories.tsx
@@ -778,3 +778,6 @@ export const AnimatedSpot = args => (
   </div>
 )
 AnimatedSpot.storyName = "Spot, animated"
+AnimatedSpot.parameters = {
+  chromatic: { diffThreshold: 0.9 },
+}

--- a/draft-packages/popover/docs/Popover.stories.tsx
+++ b/draft-packages/popover/docs/Popover.stories.tsx
@@ -1,8 +1,7 @@
+import React, { useState } from "react"
 import { usePopover, Popover as PopoverRaw } from "@kaizen/draft-popover"
-import * as React from "react"
 import { withDesign } from "storybook-addon-designs"
 import { Heading } from "@kaizen/component-library"
-import { useState } from "react"
 import { Button, IconButton } from "@kaizen/draft-button"
 import isChromatic from "chromatic/isChromatic"
 import informationIcon from "@kaizen/component-library/icons/information-white.icon.svg"
@@ -10,10 +9,17 @@ import { figmaEmbed } from "../../../storybook/helpers"
 import { CATEGORIES } from "../../../storybook/constants"
 import AppearanceAnim from "../KaizenDraft/Popover/AppearanceAnim"
 
+const DEFAULT_IS_OPEN: boolean = isChromatic()
+
 export default {
   title: `${CATEGORIES.components}/Popover`,
   component: PopoverRaw,
   parameters: {
+    /**
+     * To cater for false positives when the popover renders
+     * with a different alignment (controlled by react-popper).
+     */
+    chromatic: { diffThreshold: 0.7 },
     docs: {
       description: {
         component: 'import { usePopover } from "@kaizen/draft-popover"',
@@ -89,7 +95,7 @@ const InlineBlockTargetElement = ({
 export const DefaultKaizenSiteDemo = props => {
   const [ElementRef, Popover] = usePopover()
   // set the popover open state to be true when testing on chromatic
-  const [isOpen, setIsOpen] = isChromatic() ? useState(true) : useState(false)
+  const [isOpen, setIsOpen] = useState(DEFAULT_IS_OPEN)
   const openPopover = () => setIsOpen(true)
   return (
     <div
@@ -124,7 +130,7 @@ DefaultKaizenSiteDemo.storyName = "Default (Kaizen Site Demo)"
 
 export const OverflowScroll = props => {
   const [ElementRef, Popover] = usePopover()
-  const [isOpen, setIsOpen] = useState(false)
+  const [isOpen, setIsOpen] = useState(DEFAULT_IS_OPEN)
   const openPopover = () => setIsOpen(true)
 
   return (
@@ -151,7 +157,7 @@ export const OverflowScroll = props => {
 }
 
 export const StickerSheet = () => {
-  const [isOpen, setIsOpen] = useState(false)
+  const [isOpen, setIsOpen] = useState(DEFAULT_IS_OPEN)
 
   const [ElementRefTopDefault, PopoverTopDefault] = usePopover()
   const [ElementRefTopInformative, PopoverTopInformative] = usePopover()

--- a/draft-packages/tooltip/docs/Tooltip.stories.tsx
+++ b/draft-packages/tooltip/docs/Tooltip.stories.tsx
@@ -10,11 +10,6 @@ import isChromatic from "chromatic/isChromatic"
 import { figmaEmbed } from "../../../storybook/helpers"
 import { CATEGORIES } from "../../../storybook/constants"
 
-/**
- * We should not be running visual regressions on these tooltip stories
- * until there is a clean way to trigger open states for the snapshots. See:
- * https://github.com/cultureamp/kaizen-design-system/issues/1375
- */
 const openTooltipInChromatic = (story, config) => {
   if (isChromatic()) config.args.isInitiallyVisible = true
   return story()
@@ -24,6 +19,11 @@ export default {
   title: `${CATEGORIES.components}/Tooltip`,
   component: Tooltip,
   parameters: {
+    /**
+     * To cater for false positives when the tooltip renders
+     * with a different alignment (controlled by react-popper).
+     */
+    chromatic: { diffThreshold: 0.7 },
     docs: {
       description: {
         component: 'import { Tooltip } from "@kaizen/draft-tooltip"',
@@ -51,13 +51,11 @@ export const DefaultKaizenSiteDemo = props => (
 DefaultKaizenSiteDemo.storyName = "Default (Kaizen Site Demo)"
 DefaultKaizenSiteDemo.parameters = {
   info: {
-    text: `
-    import { Tooltip } from "@kaizen/draft-tooltip"
-    `,
+    text: 'import { Tooltip } from "@kaizen/draft-tooltip"',
   },
 }
 
-export const StickerSheet = () => (
+export const StickerSheet = props => (
   <div
     style={{
       marginTop: "100px",
@@ -106,19 +104,34 @@ export const StickerSheet = () => (
       <Heading variant="heading-3" tag="h1">
         Top
       </Heading>
-      <Tooltip position="above" text="Tooltip label" mood="default">
+      <Tooltip {...props} position="above" text="Tooltip label" mood="default">
         <IconButton label="Label" icon={meatballsIcon} />
       </Tooltip>
-      <Tooltip position="above" text="Tooltip label" mood="informative">
+      <Tooltip
+        {...props}
+        position="above"
+        text="Tooltip label"
+        mood="informative"
+      >
         <IconButton label="Label" icon={meatballsIcon} />
       </Tooltip>
-      <Tooltip position="above" text="Tooltip label" mood="positive">
+      <Tooltip {...props} position="above" text="Tooltip label" mood="positive">
         <IconButton label="Label" icon={meatballsIcon} />
       </Tooltip>
-      <Tooltip position="above" text="Tooltip label" mood="highlight">
+      <Tooltip
+        {...props}
+        position="above"
+        text="Tooltip label"
+        mood="highlight"
+      >
         <IconButton label="Label" icon={meatballsIcon} />
       </Tooltip>
-      <Tooltip position="above" text="Tooltip label" mood="cautionary">
+      <Tooltip
+        {...props}
+        position="above"
+        text="Tooltip label"
+        mood="cautionary"
+      >
         <IconButton label="Label" icon={meatballsIcon} />
       </Tooltip>
     </div>
@@ -134,19 +147,34 @@ export const StickerSheet = () => (
       <Heading variant="heading-3" tag="h1">
         Bottom
       </Heading>
-      <Tooltip position="below" text="Tooltip label" mood="default">
+      <Tooltip {...props} position="below" text="Tooltip label" mood="default">
         <IconButton label="Label" icon={meatballsIcon} />
       </Tooltip>
-      <Tooltip position="below" text="Tooltip label" mood="informative">
+      <Tooltip
+        {...props}
+        position="below"
+        text="Tooltip label"
+        mood="informative"
+      >
         <IconButton label="Label" icon={meatballsIcon} />
       </Tooltip>
-      <Tooltip position="below" text="Tooltip label" mood="positive">
+      <Tooltip {...props} position="below" text="Tooltip label" mood="positive">
         <IconButton label="Label" icon={meatballsIcon} />
       </Tooltip>
-      <Tooltip position="below" text="Tooltip label" mood="highlight">
+      <Tooltip
+        {...props}
+        position="below"
+        text="Tooltip label"
+        mood="highlight"
+      >
         <IconButton label="Label" icon={meatballsIcon} />
       </Tooltip>
-      <Tooltip position="below" text="Tooltip label" mood="cautionary">
+      <Tooltip
+        {...props}
+        position="below"
+        text="Tooltip label"
+        mood="cautionary"
+      >
         <IconButton label="Label" icon={meatballsIcon} />
       </Tooltip>
     </div>
@@ -162,19 +190,29 @@ export const StickerSheet = () => (
       <Heading variant="heading-3" tag="h1">
         Left
       </Heading>
-      <Tooltip position="left" text="Tooltip label" mood="default">
+      <Tooltip {...props} position="left" text="Tooltip label" mood="default">
         <IconButton label="Label" icon={meatballsIcon} />
       </Tooltip>
-      <Tooltip position="left" text="Tooltip label" mood="informative">
+      <Tooltip
+        {...props}
+        position="left"
+        text="Tooltip label"
+        mood="informative"
+      >
         <IconButton label="Label" icon={meatballsIcon} />
       </Tooltip>
-      <Tooltip position="left" text="Tooltip label" mood="positive">
+      <Tooltip {...props} position="left" text="Tooltip label" mood="positive">
         <IconButton label="Label" icon={meatballsIcon} />
       </Tooltip>
-      <Tooltip position="left" text="Tooltip label" mood="highlight">
+      <Tooltip {...props} position="left" text="Tooltip label" mood="highlight">
         <IconButton label="Label" icon={meatballsIcon} />
       </Tooltip>
-      <Tooltip position="left" text="Tooltip label" mood="cautionary">
+      <Tooltip
+        {...props}
+        position="left"
+        text="Tooltip label"
+        mood="cautionary"
+      >
         <IconButton label="Label" icon={meatballsIcon} />
       </Tooltip>
     </div>
@@ -190,19 +228,34 @@ export const StickerSheet = () => (
       <Heading variant="heading-3" tag="h1">
         Right
       </Heading>
-      <Tooltip position="right" text="Tooltip label" mood="default">
+      <Tooltip {...props} position="right" text="Tooltip label" mood="default">
         <IconButton label="Label" icon={meatballsIcon} />
       </Tooltip>
-      <Tooltip position="right" text="Tooltip label" mood="informative">
+      <Tooltip
+        {...props}
+        position="right"
+        text="Tooltip label"
+        mood="informative"
+      >
         <IconButton label="Label" icon={meatballsIcon} />
       </Tooltip>
-      <Tooltip position="right" text="Tooltip label" mood="positive">
+      <Tooltip {...props} position="right" text="Tooltip label" mood="positive">
         <IconButton label="Label" icon={meatballsIcon} />
       </Tooltip>
-      <Tooltip position="right" text="Tooltip label" mood="highlight">
+      <Tooltip
+        {...props}
+        position="right"
+        text="Tooltip label"
+        mood="highlight"
+      >
         <IconButton label="Label" icon={meatballsIcon} />
       </Tooltip>
-      <Tooltip position="right" text="Tooltip label" mood="cautionary">
+      <Tooltip
+        {...props}
+        position="right"
+        text="Tooltip label"
+        mood="cautionary"
+      >
         <IconButton label="Label" icon={meatballsIcon} />
       </Tooltip>
     </div>
@@ -284,12 +337,12 @@ export const OverflowScroll = props => (
           <Paragraph variant="body">
             Lorem ipsum dolor sit amet consectetur adipisicing elit. Ratione
             nulla quas corporis? Perspiciatis, ratione voluptas{" "}
-            <Tooltip display="inline-block" text="Tooltip label" {...props}>
+            <Tooltip {...props} display="inline-block" text="Tooltip label">
               <Tag>ad veniam sapiente</Tag>
             </Tooltip>{" "}
             Maxime harum, ducimus maiores itaque pariatur quod vel porro
             mollitia. Lorem ipsum dolor sit{" "}
-            <Tooltip display="inline" text="Open in new tab" {...props}>
+            <Tooltip {...props} display="inline" text="Open in new tab">
               <a href="#">
                 amet consectetur adipisicing elit Itaque obcaecati maxime
                 molestiae blanditiis pariatur


### PR DESCRIPTION
# What

Fix/mitigate Chromatic false positives.

|Avatar - Initials long (large)|Cause|
|---|---|
|<img width="405" alt="image" src="https://user-images.githubusercontent.com/25891850/153308983-7da84f19-802e-4565-a5f6-6f7c89f08306.png">|`react-textfit` deviates between 10px and 11px for the snapshots|

|Spot Illustration - Animated|Cause|
|---|---|
|<img width="142" alt="image" src="https://user-images.githubusercontent.com/25891850/153309114-f35a726d-7c7f-45ef-b965-fc990efe14ba.png">|Snapshot is taken during different times of the animation|

|Tooltip (Also happens to Popover)|Cause|
|---|---|
|<img width="130" alt="image" src="https://user-images.githubusercontent.com/25891850/153309164-a6d71e62-e00a-492a-92ac-00be738b2c9f.png">|`react-popper` position calculation deviates|

# Why

False positives have been slowing down merging as Chromatic picks up "changes" which need accepting even though they weren't touched in the PRs (also preventing auto merge from doing its job).

# Changes

- Change `fullName` value for Avatar long initials (snapshot update)
- Reduce chromatic threshold for Animated Spot Illustration
- Reduce chromatic threshold for Tooltip
	- Update stories to always be visible by default for Chromatic (snapshot update)
- Reduce chromatic threshold for Popover
	- Update stories to always be open by default for Chromatic (snapshot update)