### PR TITLE
chore: Kaizen Site scrolls to top of page when selecting different animation preset on animation guidelines [KDS-190]

### DIFF
--- a/site/src/docs-components/animation/AnimationExample.tsx
+++ b/site/src/docs-components/animation/AnimationExample.tsx
@@ -48,12 +48,13 @@ class AnimationExample extends React.PureComponent<AnimationExampleProps> {
           {this.presets.map(item => (
             <MenuItem
               key={item.preset}
-              action={() =>
+              action={e => {
                 this.setState(
                   { preset: item.preset, duration: item.duration },
                   this.playAnimation
                 )
-              }
+                e.preventDefault()
+              }}
               active={item.preset === preset}
             >
               {item.preset}

--- a/site/src/docs-components/animation/TransitionDrop.tsx
+++ b/site/src/docs-components/animation/TransitionDrop.tsx
@@ -58,12 +58,13 @@ class TransitionDrop extends React.PureComponent<TransitionDropProps> {
           {this.presets.map(item => (
             <MenuItem
               key={item.preset}
-              action={() =>
+              action={e => {
                 this.setState(
                   { preset: item.preset, duration: item.duration },
                   this.playTransition
                 )
-              }
+                e.preventDefault()
+              }}
               active={item.preset === preset}
             >
               {item.preset}


### PR DESCRIPTION
# Issue

<img width="954" alt="image" src="https://user-images.githubusercontent.com/763385/152913771-f8ecdeea-ff10-478e-9be1-ce715e8ea0f6.png">

I noticed that selecting a different animation preset on our [Animation Guidelines](https://cultureamp.design/guidelines/animation/) would make the page jump to the very top and I had to scroll all the way back again :(

# Investigation

Turns out each option in the dropdown is using the deprecated `MenuItem` component, which is essential an `A` tag with `href="#"` by default - hence it jumping to the top.

# Solution

I amended to `onClick` function passed to `MenuItem` with a good ol' `e.preventDefault()` and now it doesn't jump anymore but you can immediately see the change in animation :)

[See in action here on the branch build for the Kaizen site](https://dev.cultureamp.design/kds-190-fix-kaizen-site-scrolling-issue-on-animation-guidelines/guidelines/animation/)