### PR TITLE
chore: add node-sass and engine.io to audit allow list

### DIFF
--- a/js-audit-allow-list.json
+++ b/js-audit-allow-list.json
@@ -157,5 +157,22 @@
       "reviewer": "christianklammer",
       "whenSubDependencyOf": ["axios", "http-proxy"]
     }
+  ],
+  "node-sass": [
+    {
+      "title": "Certificate validation in node-sass 2.0.0 to 4.14.1 is disabled when requesting binaries even if the user is not specifying an alternative download path.",
+      "cve": "CVE-2020-24025",
+      "reason": "Our builds fail",
+      "reviewer": "cassandra.tam"
+    }
+  ],
+  "engine.io": [
+    {
+      "title": "Engine.IO before 4.0.0 allows attackers to cause a denial of service (resource consumption) via a POST request to the long polling transport.",
+      "cve": "CVE-2020-36048",
+      "reason": "Our builds fail",
+      "reviewer": "cassandra.tam",
+      "whenSubDependencyOf": ["gatsby"]
+    }
   ]
 }


### PR DESCRIPTION
# What

Add `node-sass` and `engine.io` to js audit allow list.

# Why

Our builds fail the vulnerability check.

```
VULNERABILITY WARNINGS (not allow-listed)
--
  | The following vulnerability warnings were raised, and must be resolved to satisfy this build step:
  |  
  | !! [moderate]  node-sass: "Upgrade to version 7.0.0 or later" (CVE-2020-24025). Dependency chain: site>node-sass
  | !! [high]  engine.io: "Upgrade to version 4.0.0 or later" (CVE-2020-36048). Dependency chain: site>gatsby>socket.io>engine.io
  | !! [moderate]  node-sass: "Upgrade to version 7.0.0 or later" (CVE-2020-24025). Dependency chain: node-sass
```

# Changes

- Add `node-sass` to allow list
- Add `engine.io` to allow list when sub dependency of `gatsby`

# Notes

This is not the ideal solution, but due to an upgrade requiring a significant refactor, we are adding these exceptions until we can figure out a way forward.