### PR TITLE
feat: add final scene illustrations

### DIFF
--- a/draft-packages/illustration/KaizenDraft/Illustration/Scene.tsx
+++ b/draft-packages/illustration/KaizenDraft/Illustration/Scene.tsx
@@ -609,7 +609,6 @@ export const EngagementSurveySummaryMale = ({
   />
 )
 
-// TODO Update and Remove - survey-configuration HeroCard.tsx
 export const SurveyOverviewClosed = ({
   enableAspectRatio,
   ...props
@@ -617,11 +616,10 @@ export const SurveyOverviewClosed = ({
   <Base
     aspectRatio={enableAspectRatio ? "portrait" : undefined}
     {...props}
-    name="illustrations/scene/survey-overview-closed.svg"
+    name="illustrations/heart/scene/survey-overview-closed.svg"
   />
 )
 
-// TODO Update and Remove - survey-configuration HeroCard.tsx
 export const SurveyGetStarted = ({
   enableAspectRatio,
   ...props
@@ -629,11 +627,10 @@ export const SurveyGetStarted = ({
   <Base
     aspectRatio={enableAspectRatio ? "portrait" : undefined}
     {...props}
-    name="illustrations/scene/getting-started.svg"
+    name="illustrations/heart/scene/getting-started.svg"
   />
 )
 
-// TODO Update and Remove - msteams-integration/teams_bot Cards.ts
 export const PerformanceCompanySettings = ({
   enableAspectRatio,
   ...props
@@ -641,6 +638,6 @@ export const PerformanceCompanySettings = ({
   <Base
     aspectRatio={enableAspectRatio ? "landscape" : undefined}
     {...props}
-    name="illustrations/scene/performance-company-settings.svg"
+    name="illustrations/heart/scene/performance-company-settings.svg"
   />
 )

--- a/draft-packages/illustration/KaizenDraft/Illustration/__snapshots__/illustration.spec.tsx.snap
+++ b/draft-packages/illustration/KaizenDraft/Illustration/__snapshots__/illustration.spec.tsx.snap
@@ -285,7 +285,7 @@ exports[`<Illustration /> Scene PerformanceCompanySettings should exist and rend
   <img
     alt="My accessible title"
     class=" wrapper"
-    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/scene/performance-company-settings.svg"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/heart/scene/performance-company-settings.svg"
   />
 </div>
 `;
@@ -445,7 +445,7 @@ exports[`<Illustration /> Scene SurveyGetStarted should exist and render an alt 
   <img
     alt="My accessible title"
     class=" wrapper"
-    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/scene/getting-started.svg"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/heart/scene/getting-started.svg"
   />
 </div>
 `;
@@ -455,7 +455,7 @@ exports[`<Illustration /> Scene SurveyOverviewClosed should exist and render an 
   <img
     alt="My accessible title"
     class=" wrapper"
-    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/scene/survey-overview-closed.svg"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/heart/scene/survey-overview-closed.svg"
   />
 </div>
 `;

--- a/draft-packages/illustration/docs/IllustrationScene.stories.tsx
+++ b/draft-packages/illustration/docs/IllustrationScene.stories.tsx
@@ -23,6 +23,7 @@ import {
   HumanityAtWork,
   TermsAgreement,
   Programs,
+  PerformanceCompanySettings,
   EngagementSurveySummaryFemale,
   EngagementSurveySummaryMale,
   BrandMomentCaptureIntro,
@@ -46,6 +47,8 @@ import {
   SkillsCoachRemoteManager,
   SkillsCoachResilience,
   SkillsCoachStrategy,
+  SurveyGetStarted,
+  SurveyOverviewClosed,
 } from ".."
 import { CATEGORIES, SUB_CATEGORIES } from "../../../storybook/constants"
 
@@ -374,6 +377,16 @@ export const Miscellaneous = args => (
         <TermsAgreement {...args} />
       </div>
     </Box>
+    <Box mb={3}>
+      <div style={{ width: "450px" }}>
+        <Box mb={1}>
+          <Heading variant="heading-4" tag="div">
+            Performance Company Settings
+          </Heading>
+        </Box>
+        <PerformanceCompanySettings {...args} />
+      </div>
+    </Box>
   </>
 )
 
@@ -517,6 +530,31 @@ export const SkillsCoach = args => (
           </Heading>
         </Box>
         <SkillsCoachLeadingChange alt="" {...args} />
+      </div>
+    </Box>
+  </>
+)
+
+export const Survey = args => (
+  <>
+    <Box mb={3}>
+      <div style={{ width: "450px" }}>
+        <Box mb={1}>
+          <Heading variant="heading-4" tag="div">
+            Survey Get Started
+          </Heading>
+        </Box>
+        <SurveyGetStarted alt="" {...args} />
+      </div>
+    </Box>
+    <Box mb={3}>
+      <div style={{ width: "450px" }}>
+        <Box mb={1}>
+          <Heading variant="heading-4" tag="div">
+            Survey Overview Closed
+          </Heading>
+        </Box>
+        <SurveyOverviewClosed alt="" {...args} />
       </div>
     </Box>
   </>


### PR DESCRIPTION
# Objective
<!-- Describe what this change achieves, and the details of how it works. -->
Add the final illustrations that had to be created for specific use-case.

# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
In order to remove the following...As at the time of my prior updates there was no illustration to be replaced with.

- illustrations/scene/performance-company-settings.svg
- illustrations/scene/getting-started.svg
- illustrations/scene/survey-overview-closed.svg

# Screenshots (if appropriate)
<img width="823" alt="image" src="https://user-images.githubusercontent.com/48232362/153499883-970576a5-2a8e-4775-ad16-5cf4a5072f06.png">
<img width="430" alt="image" src="https://user-images.githubusercontent.com/48232362/153499920-687fdd74-5e77-4166-9c96-a957e82e5eb7.png">
