### PR TITLE
feat: Install eslint-plugin-jsx-a11y

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -17,7 +17,11 @@ module.exports = {
       typescript: {}, // this empty key is required for eslint-import-resolver-typescript
     },
   },
-  extends: ["prettier", "plugin:ssr-friendly/recommended"],
+  extends: [
+    "prettier",
+    "plugin:ssr-friendly/recommended",
+    "plugin:jsx-a11y/recommended",
+  ],
   parser: "@typescript-eslint/parser",
   parserOptions: {
     sourceType: "module",
@@ -27,6 +31,7 @@ module.exports = {
     "import",
     "sort-imports-es6-autofix",
     "ssr-friendly",
+    "jsx-a11y",
   ],
   rules: {
     "@typescript-eslint/adjacent-overload-signatures": "error",

--- a/draft-packages/button/docs/deprecated.Button.stories.tsx
+++ b/draft-packages/button/docs/deprecated.Button.stories.tsx
@@ -987,6 +987,8 @@ const MultipleButtons = args => (
 
 const CustomComponent = args => {
   const CustomLink = (buttonProps: CustomButtonProps) => (
+    // Disabling because it's a false positive
+    // eslint-disable-next-line jsx-a11y/anchor-has-content
     <a href={buttonProps.href} {...buttonProps} {...args} />
   )
   // ^ In actual usage - this would be a react-router <Link> component or similar

--- a/draft-packages/form/KaizenDraft/Form/Primitives/InputSearch/InputSearch.tsx
+++ b/draft-packages/form/KaizenDraft/Form/Primitives/InputSearch/InputSearch.tsx
@@ -82,11 +82,12 @@ const InputSearch: React.FunctionComponent<InputSearchProps> = (
       <div className={styles.focusRing} />
 
       {value && (
-        <div className={styles.endIconAdornment} onClick={onClear}>
+        <div className={styles.endIconAdornment}>
           <button
             type="button"
             className={styles.cancelButton}
             aria-label="clear"
+            onClick={onClear}
           >
             <Icon icon={clear} role="presentation" />
           </button>

--- a/draft-packages/hero-card/docs/HeroCard.stories.tsx
+++ b/draft-packages/hero-card/docs/HeroCard.stories.tsx
@@ -66,7 +66,7 @@ export const Image = () => (
     image={
       <img
         src={surveyIllustration}
-        alt="survey-preview-image"
+        alt=""
         style={{
           position: "absolute",
           bottom: "15px",

--- a/draft-packages/illustration/KaizenDraft/Illustration/Players/LottiePlayer.tsx
+++ b/draft-packages/illustration/KaizenDraft/Illustration/Players/LottiePlayer.tsx
@@ -97,7 +97,7 @@ export const AnimatedBase = ({
     </svg>
   )
 
-  const FailedState = <img src={assetUrl(fallback)} aria-hidden={true} />
+  const FailedState = <img src={assetUrl(fallback)} alt={alt} />
 
   return (
     <figure className={wrapper}>

--- a/draft-packages/menu/KaizenDraft/Menu/MenuDropdown.tsx
+++ b/draft-packages/menu/KaizenDraft/Menu/MenuDropdown.tsx
@@ -106,6 +106,9 @@ const MenuDropdown = ({
   }, [autoHide, handleDocumentClickForAutoHide])
 
   return (
+    // Disabling these because we don't want this to be keyboard focusable.
+    // Esc keypress should be used instead for the same behaviour (hasn't been implemented here yet)
+    // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
     <div
       id={id}
       ref={setPopperElement}

--- a/draft-packages/menu/KaizenDraft/Menu/StatelessMenu.tsx
+++ b/draft-packages/menu/KaizenDraft/Menu/StatelessMenu.tsx
@@ -113,6 +113,7 @@ export const StatelessMenu: React.FunctionComponent<StatelessMenuProps> = ({
   ) : null
 
   return (
+    // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
     <div data-automation-id={automationId} onClick={onClick}>
       <div className={styles.buttonWrapper} ref={setReferenceElement}>
         {menuButton}

--- a/draft-packages/modal/KaizenDraft/Modal/Primitives/GenericModal.tsx
+++ b/draft-packages/modal/KaizenDraft/Modal/Primitives/GenericModal.tsx
@@ -179,9 +179,14 @@ class GenericModal extends React.Component<GenericModalProps> {
         <FocusLock
           disabled={focusLockDisabled}
           returnFocus={true}
+          // Disabling false positive
+          // eslint-disable-next-line jsx-a11y/no-autofocus
           autoFocus={false}
         >
           <div className={styles.backdropLayer} />
+          {/* Disabling these because we don't want this to be keyboard focusable. Users can use Esc to achieve this with a keyboard.
+           */}
+          {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */}
           <div
             className={styles.scrollLayer}
             ref={scrollLayer => (this.scrollLayer = scrollLayer)}

--- a/draft-packages/popover/docs/Popover.stories.tsx
+++ b/draft-packages/popover/docs/Popover.stories.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable jsx-a11y/anchor-is-valid */
 import React, { useState } from "react"
 import { usePopover, Popover as PopoverRaw } from "@kaizen/draft-popover"
 import { withDesign } from "storybook-addon-designs"
@@ -84,11 +85,10 @@ const InlineBlockTargetElement = ({
       display: "inline-block",
       marginTop: "100px",
     }}
-    onClick={openPopover}
     onMouseEnter={openPopover}
     onFocusCapture={openPopover}
   >
-    <IconButton label="Label" icon={informationIcon} />
+    <IconButton label="Label" icon={informationIcon} onClick={openPopover} />
   </div>
 )
 

--- a/draft-packages/split-button/KaizenDraft/SplitButton/DropdownMenu.tsx
+++ b/draft-packages/split-button/KaizenDraft/SplitButton/DropdownMenu.tsx
@@ -88,6 +88,9 @@ class DropdownMenu extends React.Component<Props> {
   render() {
     const props = this.props
     return (
+      // Disabling these because we don't want this to be keyboard focusable.
+      // Esc keypress should be used instead for the same behaviour (hasn't been implemented here yet)
+      // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
       <div
         className={styles.menuContainer}
         ref={this.menuRef}

--- a/draft-packages/table/KaizenDraft/Table/Table.tsx
+++ b/draft-packages/table/KaizenDraft/Table/Table.tsx
@@ -372,6 +372,7 @@ export const TableRowCell: TableRowCell = ({
 }) =>
   href != null ? (
     <a
+      // eslint-disable-next-line jsx-a11y/no-interactive-element-to-noninteractive-role
       role="cell"
       style={{
         width: ratioToPercent(width),

--- a/draft-packages/tabs/KaizenDraft/Tabs/Tabs.tsx
+++ b/draft-packages/tabs/KaizenDraft/Tabs/Tabs.tsx
@@ -60,6 +60,8 @@ const RowTab = ({ tabs, renderTab, textDirection }) => (
           disabledTabClassName: styles.horizontalTabDisabled,
         })
       ) : (
+        // Disabling instead of addressing because this component is deprecated
+        // eslint-disable-next-line jsx-a11y/anchor-is-valid
         <a
           data-automation-id={t.automationId}
           key={t.label}
@@ -89,6 +91,8 @@ const VerticalTab = ({ tabs, renderTab, textDirection }) => (
           disabledTabClassName: styles.verticalTabDisabled,
         })
       ) : (
+        // Disabling instead of addressing because this component is deprecated
+        // eslint-disable-next-line jsx-a11y/anchor-is-valid
         <a
           data-automation-id={t.automationId}
           key={t.label}

--- a/draft-packages/title-block-zen/docs/TitleBlockZen.stories.tsx
+++ b/draft-packages/title-block-zen/docs/TitleBlockZen.stories.tsx
@@ -439,7 +439,7 @@ export const Performance = () => (
     <TitleBlockZen
       title="Blanca Wheeler"
       subtitle="Director of Stuff and Things"
-      avatar={<img alt="avatar image" src={assetUrl("site/empty-state.png")} />}
+      avatar={<img alt="" src={assetUrl("site/empty-state.png")} />}
       primaryAction={{
         href: "#",
         label: "Request feedback",
@@ -656,7 +656,7 @@ export const LongLabels = () => (
           alert("breadcrumb clicked!")
         },
       }}
-      avatar={<img alt="avatar image" src={assetUrl("site/empty-state.png")} />}
+      avatar={<img alt="" src={assetUrl("site/empty-state.png")} />}
       subtitle="Wissenschaftlicher Mitarbeiter (Habilitation)"
       navigationTabs={[
         <NavigationTab text="Feedback" href="#" active />,

--- a/draft-packages/tooltip/docs/Tooltip.stories.tsx
+++ b/draft-packages/tooltip/docs/Tooltip.stories.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable jsx-a11y/anchor-is-valid */
 import * as React from "react"
 import informationIcon from "@kaizen/component-library/icons/information-white.icon.svg"
 import meatballsIcon from "@kaizen/component-library/icons/meatballs.icon.svg"

--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "elm-webpack-loader": "^8.0.0",
     "eslint-import-resolver-typescript": "^2.5.0",
     "eslint-plugin-ssr-friendly": "https://github.com/cultureamp/eslint-plugin-ssr-friendly",
+    "eslint-plugin-jsx-a11y": "^6.5.1",
     "jest": "^26.6.3",
     "jest-canvas-mock": "^2.3.1",
     "jest-circus": "^27.4.2",

--- a/packages/brand-moment/docs/BrandMoment.stories.tsx
+++ b/packages/brand-moment/docs/BrandMoment.stories.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable jsx-a11y/anchor-is-valid */
 import React from "react"
 import {
   BrandMomentCaptureIntro,

--- a/packages/button/docs/Button.stories.tsx
+++ b/packages/button/docs/Button.stories.tsx
@@ -987,6 +987,8 @@ const MultipleButtons = args => (
 
 const CustomComponent = args => {
   const CustomLink = (buttonProps: CustomButtonProps) => (
+    // Disabling because it's a false positive
+    // eslint-disable-next-line jsx-a11y/anchor-has-content
     <a href={buttonProps.href} {...buttonProps} {...args} />
   )
   // ^ In actual usage - this would be a react-router <Link> component or similar

--- a/packages/component-library/components/Dropdown/DropdownMenu.tsx
+++ b/packages/component-library/components/Dropdown/DropdownMenu.tsx
@@ -71,6 +71,8 @@ class DropdownMenu extends React.Component<DropdownMenuProps> {
     const { hideDropdownMenu, children } = this.props
 
     return (
+      // Disabling instead of addressing because this component is deprecated
+      // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
       <div
         className={styles.menuContainer}
         ref={this.menu}

--- a/packages/component-library/components/MenuList/MenuItem.tsx
+++ b/packages/component-library/components/MenuList/MenuItem.tsx
@@ -58,6 +58,8 @@ const MenuItem = (props: {
   }
 
   return (
+    // Disabling instead of addressing because this component is deprecated.
+    // eslint-disable-next-line jsx-a11y/anchor-is-valid
     <a
       href="#"
       onClick={action}

--- a/packages/design-tokens/docs/DocsComponents.tsx
+++ b/packages/design-tokens/docs/DocsComponents.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable jsx-a11y/anchor-is-valid */
 /* eslint-disable import/no-extraneous-dependencies */
 
 import { Box, Paragraph } from "@kaizen/component-library"

--- a/packages/design-tokens/docs/DocsComponents.tsx
+++ b/packages/design-tokens/docs/DocsComponents.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable jsx-a11y/anchor-is-valid */
 /* eslint-disable import/no-extraneous-dependencies */
 
 import { Box, Paragraph } from "@kaizen/component-library"
@@ -66,6 +65,7 @@ const TabbedCodeBlocks = ({
               tabClassName,
               disabledTabClassName,
             }) => (
+              // eslint-disable-next-line jsx-a11y/anchor-is-valid
               <a
                 style={{ flexShrink: 0 }}
                 data-automation-id={tab.automationId}

--- a/site/src/components/Footer.scss
+++ b/site/src/components/Footer.scss
@@ -47,6 +47,20 @@ $reverse-variant-color: $color-blue-100;
   @extend %link;
 }
 
+.cookieButton {
+  // button reset
+  border: none;
+  background: none;
+  box-shadow: none;
+  color: inherit;
+
+  // consistency with the other items in the footer
+  text-decoration: underline;
+  &:hover {
+    text-decoration: none;
+  }
+}
+
 .logoLink {
   display: flex;
   align-items: center;

--- a/site/src/components/Footer.tsx
+++ b/site/src/components/Footer.tsx
@@ -58,13 +58,11 @@ const Footer: React.SFC<FooterProps> = ({
             variant="body"
             classNameAndIHaveSpokenToDST={styles.footerLink}
           >
-            <a
-              className="ca-cookie-consent-open-preferences"
-              href="#"
-              role="button"
+            <button
+              className={`${styles.cookieButton} ca-cookie-consent-open-preferences`}
             >
               Cookie preferences
-            </a>
+            </button>
           </Paragraph>
         </div>
       </div>

--- a/site/src/components/NavigationBar/components/Link.tsx
+++ b/site/src/components/NavigationBar/components/Link.tsx
@@ -34,13 +34,13 @@ class Link extends React.PureComponent<LinkProps> {
     } = this.props
 
     return (
+      // eslint-disable-next-line jsx-a11y/click-events-have-key-events
       <a
         className={classNames(styles.link, {
           [styles.active]: active,
           [styles.containsText]: text !== "",
           [styles.secondary]: section === "secondary",
         })}
-        tabIndex={0}
         {...{ href, id, onClick, target }}
       >
         {icon && (

--- a/site/src/components/StorybookDemo.tsx
+++ b/site/src/components/StorybookDemo.tsx
@@ -30,6 +30,7 @@ export default class StorybookDemo extends React.Component<StorybookDemoProps> {
     return (
       <div className={styles.container}>
         <iframe
+          title="Component demo"
           src={withPrefix(`/storybook/iframe.html?id=${this.props.demoId}`)}
           onLoad={() => {
             setTimeout(() => {

--- a/site/src/components/markdownComponents.tsx
+++ b/site/src/components/markdownComponents.tsx
@@ -1,3 +1,6 @@
+/* eslint-disable jsx-a11y/alt-text */
+/* eslint-disable jsx-a11y/anchor-has-content */
+/* eslint-disable jsx-a11y/heading-has-content */
 import * as React from "react"
 
 export default {

--- a/site/src/docs-components/animation/Drop.scss
+++ b/site/src/docs-components/animation/Drop.scss
@@ -11,9 +11,9 @@ $cardPadding: $spacing-sm;
 }
 
 .container {
+  border: none;
   align-items: center;
   background: white;
-  border-radius: 3px;
   box-shadow: rgba(0, 0, 0, 0.1) 0px 1px 2px 0px;
   padding: $cardPadding;
   display: flex;

--- a/site/src/docs-components/animation/Drop.tsx
+++ b/site/src/docs-components/animation/Drop.tsx
@@ -15,12 +15,12 @@ class Drop extends React.PureComponent<DropProps> {
 
     return (
       <div className={styles.droplet}>
-        <div className={styles.container} onClick={onClick}>
-          <div
+        <button className={styles.container} onClick={onClick}>
+          <span
             className={classnames(classes, styles.example)}
             style={{ background: color }}
           />
-        </div>
+        </button>
         {children}
       </div>
     )

--- a/site/src/docs-components/icons/IconTile.tsx
+++ b/site/src/docs-components/icons/IconTile.tsx
@@ -37,7 +37,7 @@ class IconTile extends React.Component<IconTileProps> {
             <span className={styles.iconLabelText}>{title}</span>
           </span>
           <span className={styles.iconWrapper}>
-            <img src={path} />
+            <img src={path} alt="" />
           </span>
           {this.renderCopyLabel()}
         </div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -10707,7 +10707,7 @@ eslint-plugin-import@^2.25.3:
     resolve "^1.20.0"
     tsconfig-paths "^3.11.0"
 
-eslint-plugin-jsx-a11y@^6.3.1:
+eslint-plugin-jsx-a11y@^6.3.1, eslint-plugin-jsx-a11y@^6.5.1:
   version "6.5.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.5.1.tgz#cdbf2df901040ca140b6ec14715c988889c2a6d8"
   integrity sha512-sVCFKX9fllURnXT2JwLN5Qgo24Ug5NF6dxhkmxsMEUZhXRcGg+X3e1JbJ84YePQKBl5E0ZjAH5Q4rkdcGY99+g==


### PR DESCRIPTION
# Objective
Installs [eslint-plugin-jsx-a11y](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y) and remediates/ignores any issues after implementing the recommended set of rules.

# Motivation and Context
Helps to catch some common a11y anti-patterns. The main ones I came across while remediating the issues that surfaced here were:
* onClick being put onto non-interactive elements (div)
* Images with no/obsolete alt text
* Links being used where it should be a button