### PR TITLE
chore(chromatic): fix chromatic false positives (again)

### DIFF
--- a/draft-packages/avatar/docs/avatarData.json
+++ b/draft-packages/avatar/docs/avatarData.json
@@ -203,35 +203,35 @@
       "title": "Initials Personal",
       "stories": [
         {
-          "fullName": "The Quick Brown Fox Jumps Over The Lazy Dog",
+          "fullName": "Spicy Jalapeno Bacon Ipsum Dolor Amet Aute Elit Chicken Mollit",
           "disableInitials": false,
           "avatarSrc": "",
           "isCurrentUser": true,
           "size": "xxlarge"
         },
         {
-          "fullName": "The Quick Brown Fox Jumps Over The Lazy Dog",
+          "fullName": "Spicy Jalapeno Bacon Ipsum Dolor Amet Aute Elit Chicken Mollit",
           "disableInitials": false,
           "avatarSrc": "",
           "isCurrentUser": true,
           "size": "xlarge"
         },
         {
-          "fullName": "The Quick Brown Fox Jumps Over The Lazy Dog",
+          "fullName": "Spicy Jalapeno Bacon Ipsum Dolor Amet Aute Elit Chicken Mollit",
           "disableInitials": false,
           "avatarSrc": "",
           "isCurrentUser": true,
           "size": "large"
         },
         {
-          "fullName": "The Quick Brown Fox Jumps Over The Lazy Dog",
+          "fullName": "Spicy Jalapeno Bacon Ipsum Dolor Amet Aute Elit Chicken Mollit",
           "disableInitials": false,
           "avatarSrc": "",
           "isCurrentUser": true,
           "size": "medium"
         },
         {
-          "fullName": "The Quick Brown Fox Jumps Over The Lazy Dog",
+          "fullName": "Spicy Jalapeno Bacon Ipsum Dolor Amet Aute Elit Chicken Mollit",
           "disableInitials": false,
           "avatarSrc": "",
           "isCurrentUser": true,
@@ -243,35 +243,35 @@
       "title": "Initials Generic",
       "stories": [
         {
-          "fullName": "The Quick Brown Fox Jumps Over The Lazy Dog",
+          "fullName": "Spicy Jalapeno Bacon Ipsum Dolor Amet Aute Elit Chicken Mollit",
           "disableInitials": false,
           "avatarSrc": "",
           "isCurrentUser": false,
           "size": "xxlarge"
         },
         {
-          "fullName": "The Quick Brown Fox Jumps Over The Lazy Dog",
+          "fullName": "Spicy Jalapeno Bacon Ipsum Dolor Amet Aute Elit Chicken Mollit",
           "disableInitials": false,
           "avatarSrc": "",
           "isCurrentUser": false,
           "size": "xlarge"
         },
         {
-          "fullName": "The Quick Brown Fox Jumps Over The Lazy Dog",
+          "fullName": "Spicy Jalapeno Bacon Ipsum Dolor Amet Aute Elit Chicken Mollit",
           "disableInitials": false,
           "avatarSrc": "",
           "isCurrentUser": false,
           "size": "large"
         },
         {
-          "fullName": "The Quick Brown Fox Jumps Over The Lazy Dog",
+          "fullName": "Spicy Jalapeno Bacon Ipsum Dolor Amet Aute Elit Chicken Mollit",
           "disableInitials": false,
           "avatarSrc": "",
           "isCurrentUser": false,
           "size": "medium"
         },
         {
-          "fullName": "The Quick Brown Fox Jumps Over The Lazy Dog",
+          "fullName": "Spicy Jalapeno Bacon Ipsum Dolor Amet Aute Elit Chicken Mollit",
           "disableInitials": false,
           "avatarSrc": "",
           "isCurrentUser": false,

--- a/draft-packages/popover/docs/Popover.stories.tsx
+++ b/draft-packages/popover/docs/Popover.stories.tsx
@@ -19,7 +19,7 @@ export default {
      * To cater for false positives when the popover renders
      * with a different alignment (controlled by react-popper).
      */
-    chromatic: { diffThreshold: 0.7 },
+    chromatic: { diffThreshold: 1 },
     docs: {
       description: {
         component: 'import { usePopover } from "@kaizen/draft-popover"',

--- a/draft-packages/tooltip/docs/Tooltip.stories.tsx
+++ b/draft-packages/tooltip/docs/Tooltip.stories.tsx
@@ -23,7 +23,7 @@ export default {
      * To cater for false positives when the tooltip renders
      * with a different alignment (controlled by react-popper).
      */
-    chromatic: { diffThreshold: 0.7 },
+    chromatic: { diffThreshold: 1 },
     docs: {
       description: {
         component: 'import { Tooltip } from "@kaizen/draft-tooltip"',


### PR DESCRIPTION
# What

Attempt 2 at fixing Chromatic false positives.

# Why

Apparently it just wasn't good enough last time.
Last attempt: #2507 

# Changes

- Change the accuracy threshold for Tooltip and Popover to the least accurate
	- If this fails again, I reckon we'll just need to ignore the stories
- Change the `fullName` value for Avatar long initials again and hope they don't deviate this time