### PR TITLE
fix: Remove circular dependency from draft-page-layout

### DIFF
--- a/draft-packages/page-layout/KaizenDraft/Skirt/Skirt.tsx
+++ b/draft-packages/page-layout/KaizenDraft/Skirt/Skirt.tsx
@@ -1,6 +1,6 @@
 import * as React from "react"
-import { Container, Content } from "@kaizen/draft-page-layout"
 import classNames from "classnames"
+import { Container, Content } from "../../"
 import { DOMRectReadOnly, useResizeObserver } from "../useResizeObserver"
 import styles from "./styles.scss"
 

--- a/draft-packages/page-layout/package.json
+++ b/draft-packages/page-layout/package.json
@@ -33,7 +33,6 @@
   "license": "MIT",
   "dependencies": {
     "@kaizen/draft-card": "^1.7.0",
-    "@kaizen/draft-page-layout": "^1.7.0",
     "classnames": "^2.3.1",
     "resize-observer-polyfill": "^1.5.1"
   },


### PR DESCRIPTION
# Objective
Remove a dependency on itself from `draft-page-layout`

# Motivation and Context
Closes https://github.com/cultureamp/kaizen-design-system/issues/2370
