### PR TITLE
chore(chromatic): disable chromatic snapshots as a default

### DIFF
--- a/draft-packages/avatar/docs/Avatar.stories.tsx
+++ b/draft-packages/avatar/docs/Avatar.stories.tsx
@@ -1,4 +1,4 @@
-import * as React from "react"
+import React from "react"
 import { withDesign } from "storybook-addon-designs"
 import { Heading } from "@kaizen/component-library"
 import { Avatar, AvatarProps } from "../../avatar/KaizenDraft/Avatar/Avatar"
@@ -26,9 +26,7 @@ export default {
 }
 
 export const DefaultStory = args => <Avatar {...args} />
-
 DefaultStory.storyName = "Default (Kaizen Demo)"
-
 DefaultStory.args = {
   avatarSrc:
     "https://www.cultureampcom-preview-1.usw2.wp-dev-us.cultureamp-cdn.com/assets/slices/main/assets/public/media/chapters-card-1@2x.05e547444387f29f14df0b82634bf2b6.png",
@@ -37,7 +35,6 @@ DefaultStory.args = {
   isCompany: false,
   isCurrentUser: false,
 }
-
 DefaultStory.parameters = { controls: { exclude: ["isCompany"] } }
 
 export const DesignSheetDefault = () => (
@@ -67,8 +64,8 @@ export const DesignSheetDefault = () => (
     ))}
   </div>
 )
-
 DesignSheetDefault.storyName = "Design Sheet (default)"
+DesignSheetDefault.parameters = { chromatic: { disable: false } }
 
 export const DesignSheetReversed = () => (
   <div
@@ -97,10 +94,10 @@ export const DesignSheetReversed = () => (
     ))}
   </div>
 )
-
 DesignSheetReversed.storyName = "Design Sheet (reversed)"
 DesignSheetReversed.parameters = {
   backgrounds: { default: "Purple 700" },
+  chromatic: { disable: false },
 }
 
 export const InitialsLong = () => (
@@ -130,6 +127,7 @@ export const InitialsLong = () => (
     ))}
   </div>
 )
+InitialsLong.parameters = { chromatic: { disable: false } }
 
 export const InitialsUnicode = () => (
   <div
@@ -158,3 +156,4 @@ export const InitialsUnicode = () => (
     ))}
   </div>
 )
+InitialsUnicode.parameters = { chromatic: { disable: false } }

--- a/draft-packages/avatar/docs/AvatarGroup.stories.tsx
+++ b/draft-packages/avatar/docs/AvatarGroup.stories.tsx
@@ -1,4 +1,4 @@
-import * as React from "react"
+import React from "react"
 import { withDesign } from "storybook-addon-designs"
 import { Heading } from "@kaizen/component-library"
 import { AvatarGroup, AvatarList } from "../KaizenDraft/Avatar/AvatarGroup"
@@ -24,9 +24,7 @@ export default {
 }
 
 export const DefaultStory = args => <AvatarGroup {...args} />
-
 DefaultStory.storyName = "Default (Kaizen Demo)"
-
 DefaultStory.args = {
   maxVisible: 2,
   size: "medium",
@@ -69,8 +67,8 @@ export const DesignSheetDefault = () => {
     </div>
   )
 }
-
 DesignSheetDefault.storyName = "Design Sheet (default)"
+DesignSheetDefault.parameters = { chromatic: { disable: false } }
 
 export const DesignSheetReversed = () => {
   const data = avatarGroupData["company"] as AvatarList
@@ -109,8 +107,8 @@ export const DesignSheetReversed = () => {
     </div>
   )
 }
-
 DesignSheetReversed.storyName = "Design Sheet (reversed)"
 DesignSheetReversed.parameters = {
   backgrounds: { default: "Purple 700" },
+  chromatic: { disable: false },
 }

--- a/draft-packages/avatar/docs/CompanyAvatar.stories.tsx
+++ b/draft-packages/avatar/docs/CompanyAvatar.stories.tsx
@@ -1,4 +1,4 @@
-import * as React from "react"
+import React from "react"
 import { withDesign } from "storybook-addon-designs"
 import { Heading } from "@kaizen/component-library"
 import { assetUrl } from "@kaizen/hosted-assets"
@@ -27,15 +27,12 @@ export default {
 }
 
 export const DefaultStory = args => <Avatar {...args} />
-
 DefaultStory.storyName = "Default (Kaizen Demo)"
-
 DefaultStory.args = {
   avatarSrc: assetUrl("third-party-logos/hooli-logo.svg"),
   fullName: "Hooli",
   isCompany: true,
 }
-
 DefaultStory.parameters = {
   controls: { exclude: ["disableInitials", "isCurrentUser"] },
 }
@@ -67,8 +64,8 @@ export const DesignSheetDefault = () => (
     ))}
   </div>
 )
-
 DesignSheetDefault.storyName = "Design Sheet (default)"
+DesignSheetDefault.parameters = { chromatic: { disable: false } }
 
 export const DesignSheetReversed = () => (
   <div
@@ -97,8 +94,8 @@ export const DesignSheetReversed = () => (
     ))}
   </div>
 )
-
 DesignSheetReversed.storyName = "Design Sheet (reversed)"
 DesignSheetReversed.parameters = {
   backgrounds: { default: "Purple 700" },
+  chromatic: { disable: false },
 }

--- a/draft-packages/avatar/docs/avatarData.json
+++ b/draft-packages/avatar/docs/avatarData.json
@@ -203,35 +203,35 @@
       "title": "Initials Personal",
       "stories": [
         {
-          "fullName": "Spicy Jalapeno Bacon Ipsum Dolor Amet Aute Elit Chicken Mollit",
+          "fullName": "Spicy Jalapeno Taco Bacon Ipsum Pretzel Dolor Amet Nacho Elit Chicken",
           "disableInitials": false,
           "avatarSrc": "",
           "isCurrentUser": true,
           "size": "xxlarge"
         },
         {
-          "fullName": "Spicy Jalapeno Bacon Ipsum Dolor Amet Aute Elit Chicken Mollit",
+          "fullName": "Spicy Jalapeno Taco Bacon Ipsum Pretzel Dolor Amet Nacho Elit Chicken",
           "disableInitials": false,
           "avatarSrc": "",
           "isCurrentUser": true,
           "size": "xlarge"
         },
         {
-          "fullName": "Spicy Jalapeno Bacon Ipsum Dolor Amet Aute Elit Chicken Mollit",
+          "fullName": "Spicy Jalapeno Taco Bacon Ipsum Pretzel Dolor Amet Nacho Elit Chicken",
           "disableInitials": false,
           "avatarSrc": "",
           "isCurrentUser": true,
           "size": "large"
         },
         {
-          "fullName": "Spicy Jalapeno Bacon Ipsum Dolor Amet Aute Elit Chicken Mollit",
+          "fullName": "Spicy Jalapeno Taco Bacon Ipsum Pretzel Dolor Amet Nacho Elit Chicken",
           "disableInitials": false,
           "avatarSrc": "",
           "isCurrentUser": true,
           "size": "medium"
         },
         {
-          "fullName": "Spicy Jalapeno Bacon Ipsum Dolor Amet Aute Elit Chicken Mollit",
+          "fullName": "Spicy Jalapeno Taco Bacon Ipsum Pretzel Dolor Amet Nacho Elit Chicken",
           "disableInitials": false,
           "avatarSrc": "",
           "isCurrentUser": true,
@@ -243,35 +243,35 @@
       "title": "Initials Generic",
       "stories": [
         {
-          "fullName": "Spicy Jalapeno Bacon Ipsum Dolor Amet Aute Elit Chicken Mollit",
+          "fullName": "Spicy Jalapeno Taco Bacon Ipsum Pretzel Dolor Amet Nacho Elit Chicken",
           "disableInitials": false,
           "avatarSrc": "",
           "isCurrentUser": false,
           "size": "xxlarge"
         },
         {
-          "fullName": "Spicy Jalapeno Bacon Ipsum Dolor Amet Aute Elit Chicken Mollit",
+          "fullName": "Spicy Jalapeno Taco Bacon Ipsum Pretzel Dolor Amet Nacho Elit Chicken",
           "disableInitials": false,
           "avatarSrc": "",
           "isCurrentUser": false,
           "size": "xlarge"
         },
         {
-          "fullName": "Spicy Jalapeno Bacon Ipsum Dolor Amet Aute Elit Chicken Mollit",
+          "fullName": "Spicy Jalapeno Taco Bacon Ipsum Pretzel Dolor Amet Nacho Elit Chicken",
           "disableInitials": false,
           "avatarSrc": "",
           "isCurrentUser": false,
           "size": "large"
         },
         {
-          "fullName": "Spicy Jalapeno Bacon Ipsum Dolor Amet Aute Elit Chicken Mollit",
+          "fullName": "Spicy Jalapeno Taco Bacon Ipsum Pretzel Dolor Amet Nacho Elit Chicken",
           "disableInitials": false,
           "avatarSrc": "",
           "isCurrentUser": false,
           "size": "medium"
         },
         {
-          "fullName": "Spicy Jalapeno Bacon Ipsum Dolor Amet Aute Elit Chicken Mollit",
+          "fullName": "Spicy Jalapeno Taco Bacon Ipsum Pretzel Dolor Amet Nacho Elit Chicken",
           "disableInitials": false,
           "avatarSrc": "",
           "isCurrentUser": false,

--- a/draft-packages/badge/docs/Badge.stories.tsx
+++ b/draft-packages/badge/docs/Badge.stories.tsx
@@ -1,5 +1,4 @@
-import * as React from "react"
-
+import React from "react"
 import { Button } from "@kaizen/draft-button"
 import { ToggleSwitchField, ToggledStatus } from "@kaizen/draft-form"
 import { Badge, BadgeAnimated } from "@kaizen/draft-badge"
@@ -130,6 +129,9 @@ export const LightBadges = () => (
     </div>
   </>
 )
+
+LightBadges.parameters = { chromatic: { disable: false } }
+
 export const ReversedBadges = () => (
   <>
     <Heading
@@ -189,7 +191,6 @@ export const ReversedBadges = () => (
 )
 
 ReversedBadges.parameters = {
-  backgrounds: {
-    default: "Purple 700",
-  },
+  backgrounds: { default: "Purple 700" },
+  chromatic: { disable: false },
 }

--- a/draft-packages/card/docs/Card.stories.tsx
+++ b/draft-packages/card/docs/Card.stories.tsx
@@ -1,5 +1,5 @@
-import { Box, Paragraph, Heading } from "@kaizen/component-library"
-import * as React from "react"
+import React from "react"
+import { Box, Heading } from "@kaizen/component-library"
 import { withDesign } from "storybook-addon-designs"
 import { Card, CardProps } from ".."
 import { figmaEmbed } from "../../../storybook/helpers"
@@ -26,7 +26,6 @@ export default {
 export const DefaultStory = args => (
   <Card {...args}>This is a default card</Card>
 )
-
 DefaultStory.storyName = "Default (Kaizen Site Demo)"
 DefaultStory.args = {
   tag: "div",
@@ -59,5 +58,5 @@ export const DesignSheetDefault = () => (
     ))}
   </div>
 )
-
 DesignSheetDefault.storyName = "Design Sheet (default)"
+DesignSheetDefault.parameters = { chromatic: { disable: false } }

--- a/draft-packages/collapsible/docs/Collapsible.stories.tsx
+++ b/draft-packages/collapsible/docs/Collapsible.stories.tsx
@@ -1,7 +1,6 @@
+import React from "react"
 import { Icon, Paragraph, Box } from "@kaizen/component-library"
 import { Collapsible, CollapsibleGroup } from "@kaizen/draft-collapsible"
-
-import * as React from "react"
 import translationIcon from "@kaizen/component-library/icons/translation.icon.svg"
 import { CATEGORIES } from "../../../storybook/constants"
 import styles from "./Collapsible.stories.scss"
@@ -67,8 +66,8 @@ export const SingleCollapsibleNoPadding = () => (
     </Collapsible>
   </Box>
 )
-
 SingleCollapsibleNoPadding.storyName = "Single collapsible (no padding)"
+SingleCollapsibleNoPadding.parameters = { chromatic: { disable: false } }
 
 export const SingleCollapsibleCustomHeader = () => (
   <Box m={1}>
@@ -94,8 +93,8 @@ export const SingleCollapsibleCustomHeader = () => (
     </Collapsible>
   </Box>
 )
-
 SingleCollapsibleCustomHeader.storyName = "Single collapsible (custom header)"
+SingleCollapsibleCustomHeader.parameters = { chromatic: { disable: false } }
 
 export const SingleCollapsibleLazyLoad = () => (
   <Box m={1}>
@@ -112,11 +111,9 @@ export const SingleCollapsibleLazyLoad = () => (
     </Collapsible>
   </Box>
 )
-
 SingleCollapsibleLazyLoad.storyName = "Single collapsible (lazy load)"
 
-// eslint-disable-next-line no-underscore-dangle
-export const _CollapsibleGroup = () => (
+export const CollapsibleGroupDefault = () => (
   <Box m={1}>
     <CollapsibleGroup>
       <Collapsible id="collapsible-separate-1" open title="First panel">
@@ -131,12 +128,9 @@ export const _CollapsibleGroup = () => (
     </CollapsibleGroup>
   </Box>
 )
+CollapsibleGroupDefault.storyName = "Collapsible group"
 
-_CollapsibleGroup.storyName = "Collapsible group"
-SingleCollapsibleLazyLoad.storyName = "Single collapsible (lazy load)"
-
-// eslint-disable-next-line no-underscore-dangle
-export const _CollapsibleClearVariantGroup = () => (
+export const CollapsibleGroupVariantClear = () => (
   <Box m={1}>
     <CollapsibleGroup>
       <Collapsible
@@ -164,8 +158,8 @@ export const _CollapsibleClearVariantGroup = () => (
     </CollapsibleGroup>
   </Box>
 )
-
-_CollapsibleClearVariantGroup.storyName = "Collapsible group (clear variant)"
+CollapsibleGroupVariantClear.storyName = "Collapsible group (clear variant)"
+CollapsibleGroupVariantClear.parameters = { chromatic: { disable: false } }
 
 export const CollapsibleGroupSeparated = () => (
   <Box m={1}>
@@ -182,8 +176,8 @@ export const CollapsibleGroupSeparated = () => (
     </CollapsibleGroup>
   </Box>
 )
-
 CollapsibleGroupSeparated.storyName = "Collapsible group (separated)"
+CollapsibleGroupSeparated.parameters = { chromatic: { disable: false } }
 
 export const CollapsibleGroupStickyHeaders = () => (
   <div style={{ margin: "4rem", width: "40rem" }}>
@@ -215,7 +209,6 @@ export const CollapsibleGroupStickyHeaders = () => (
     </CollapsibleGroup>
   </div>
 )
-
 CollapsibleGroupStickyHeaders.storyName = "Collapsible group (sticky headers)"
 
 export const CollapsibleGroupCallbackOnOpenClose = () => (
@@ -233,6 +226,5 @@ export const CollapsibleGroupCallbackOnOpenClose = () => (
     </CollapsibleGroup>
   </Box>
 )
-
 CollapsibleGroupCallbackOnOpenClose.storyName =
   "Collapsible group (callback on open/close)"

--- a/draft-packages/divider/docs/Divider.stories.tsx
+++ b/draft-packages/divider/docs/Divider.stories.tsx
@@ -1,12 +1,12 @@
+import React from "react"
 import { Divider } from "@kaizen/draft-divider"
 import { Card } from "@kaizen/draft-card"
 import { Box, Heading, Paragraph } from "@kaizen/component-library"
-import * as React from "react"
 import { withDesign } from "storybook-addon-designs"
 import { figmaEmbed } from "../../../storybook/helpers"
 import { CATEGORIES } from "../../../storybook/constants"
 
-const reversedBg = {
+const REVERSED_BG = {
   backgrounds: {
     default: "Purple 700",
   },
@@ -35,12 +35,13 @@ export const DefaultStory = () => (
 )
 DefaultStory.storyName = "Default (Kaizen Site Demo)"
 
-export const CanvasStory = () => (
+export const CanvasDivider = () => (
   <Box m={1}>
     <Divider variant="canvas" />
   </Box>
 )
-CanvasStory.storyName = "Canvas Divider"
+CanvasDivider.storyName = "Canvas Divider"
+CanvasDivider.parameters = { chromatic: { disable: false } }
 
 export const ContentDivider = () => (
   <Box m={1}>
@@ -48,14 +49,7 @@ export const ContentDivider = () => (
   </Box>
 )
 ContentDivider.storyName = "Content Divider"
-
-export const ContentDividerReversed = () => (
-  <Box m={1}>
-    <Divider variant="content" isReversed />
-  </Box>
-)
-ContentDividerReversed.storyName = "Content Divider Reversed"
-ContentDividerReversed.parameters = { ...reversedBg }
+ContentDivider.parameters = { chromatic: { disable: false } }
 
 export const CanvasDividerReversed = () => (
   <Box m={1}>
@@ -63,7 +57,21 @@ export const CanvasDividerReversed = () => (
   </Box>
 )
 CanvasDividerReversed.storyName = "Canvas Divider Reversed"
-CanvasDividerReversed.parameters = { ...reversedBg }
+CanvasDividerReversed.parameters = {
+  ...REVERSED_BG,
+  chromatic: { disable: false },
+}
+
+export const ContentDividerReversed = () => (
+  <Box m={1}>
+    <Divider variant="content" isReversed />
+  </Box>
+)
+ContentDividerReversed.storyName = "Content Divider Reversed"
+ContentDividerReversed.parameters = {
+  ...REVERSED_BG,
+  chromatic: { disable: false },
+}
 
 export const TabDivider = () => (
   <Card>

--- a/draft-packages/empty-state/docs/EmptyState.stories.tsx
+++ b/draft-packages/empty-state/docs/EmptyState.stories.tsx
@@ -1,32 +1,12 @@
+import React from "react"
 import chevronLeft from "@kaizen/component-library/icons/chevron-left.icon.svg"
 import chevronRight from "@kaizen/component-library/icons/chevron-right.icon.svg"
-
-import * as React from "react"
-
 import { Button } from "@kaizen/draft-button"
 import { withDesign } from "storybook-addon-designs"
 import { EmptyState } from ".."
 import { figmaEmbed } from "../../../storybook/helpers"
 import { CATEGORIES } from "../../../storybook/constants"
-
 import styles from "./EmptyState.stories.scss"
-
-const SidebarAndContentLayout = ({
-  children,
-}: {
-  children: React.ReactNode
-}) => (
-  <div className={styles.container}>
-    <div className={styles.sidebar} />
-    <div className={styles.content}>{children}</div>
-  </div>
-)
-
-const ContentOnlyLayout = ({ children }: { children: React.ReactNode }) => (
-  <div className={styles.container}>
-    <div className={styles.content}>{children}</div>
-  </div>
-)
 
 export default {
   title: `${CATEGORIES.components}/Empty State`,
@@ -51,7 +31,6 @@ export const DefaultKaizenSiteDemo = () => (
           Default or Primary action."
   />
 )
-
 DefaultKaizenSiteDemo.storyName = "Default (Kaizen Site Demo)"
 
 export const Positive = () => (
@@ -66,6 +45,7 @@ export const Positive = () => (
     </div>
   </EmptyState>
 )
+Positive.parameters = { chromatic: { disable: false } }
 
 export const Informative = () => (
   <EmptyState
@@ -75,6 +55,7 @@ export const Informative = () => (
     illustrationType="informative"
   />
 )
+Informative.parameters = { chromatic: { disable: false } }
 
 export const Action = () => (
   <EmptyState
@@ -88,6 +69,7 @@ export const Action = () => (
     </div>
   </EmptyState>
 )
+Action.parameters = { chromatic: { disable: false } }
 
 export const Neutral = () => (
   <EmptyState
@@ -97,6 +79,7 @@ export const Neutral = () => (
     illustrationType="neutral"
   />
 )
+Neutral.parameters = { chromatic: { disable: false } }
 
 export const Negative = () => (
   <EmptyState
@@ -110,6 +93,7 @@ export const Negative = () => (
     </div>
   </EmptyState>
 )
+Negative.parameters = { chromatic: { disable: false } }
 
 export const RtlAction = () => (
   <div dir="rtl">
@@ -125,8 +109,8 @@ export const RtlAction = () => (
     </EmptyState>
   </div>
 )
-
 RtlAction.storyName = "RTL, Action"
+RtlAction.parameters = { chromatic: { disable: false } }
 
 export const StraightCorners = () => (
   <EmptyState
@@ -141,5 +125,5 @@ export const StraightCorners = () => (
     </div>
   </EmptyState>
 )
-
 StraightCorners.storyName = "Straight corners"
+StraightCorners.parameters = { chromatic: { disable: false } }

--- a/draft-packages/filter-menu-button/docs/FilterMenuButton.stories.tsx
+++ b/draft-packages/filter-menu-button/docs/FilterMenuButton.stories.tsx
@@ -1,9 +1,9 @@
+import React, { useState } from "react"
 import { Box, Paragraph } from "@kaizen/component-library"
 import { Button } from "@kaizen/draft-button"
 import { FilterMenuButton } from "@kaizen/draft-filter-menu-button"
 import { CheckboxField, CheckboxGroup } from "@kaizen/draft-form"
 import isChromatic from "chromatic/isChromatic"
-import React, { useState } from "react"
 import { CATEGORIES } from "../../../storybook/constants"
 import styles from "./FilterMenuButton.stories.scss"
 
@@ -30,11 +30,6 @@ export default {
     },
   },
   decorators: [withMinHeight],
-}
-
-type DropdownOption = {
-  id: number
-  label: string
 }
 
 export const DefaultStory = props => (
@@ -80,8 +75,14 @@ export const DefaultEmpty = () => {
   )
 }
 DefaultEmpty.storyName = "Default (Empty)"
+DefaultEmpty.parameters = { chromatic: { disable: false } }
 
-const dropdownOptions = [
+type DropdownOption = {
+  id: number
+  label: string
+}
+
+const dropdownOptions: DropdownOption[] = [
   { id: 1, label: "Furry" },
   { id: 2, label: "Aquatic" },
   { id: 3, label: "Venomous" },
@@ -163,6 +164,7 @@ export const DefaultWithChildrenSimpleFilter = () => {
 }
 DefaultWithChildrenSimpleFilter.storyName =
   "Default with children (Simple filter)"
+DefaultWithChildrenSimpleFilter.parameters = { chromatic: { disable: false } }
 
 export const DefaultWithChildrenAdvancedFilter = () => {
   const isInitialDropdownVisible = isChromatic()
@@ -241,3 +243,4 @@ export const DefaultWithChildrenAdvancedFilter = () => {
 }
 DefaultWithChildrenAdvancedFilter.storyName =
   "Default with children (Advanced filter)"
+DefaultWithChildrenAdvancedFilter.parameters = { chromatic: { disable: false } }

--- a/draft-packages/form/docs/CheckboxField.stories.tsx
+++ b/draft-packages/form/docs/CheckboxField.stories.tsx
@@ -1,8 +1,14 @@
+import React from "react"
 import { CheckboxField } from "@kaizen/draft-form"
-import * as React from "react"
 import { withDesign } from "storybook-addon-designs"
 import { figmaEmbed } from "../../../storybook/helpers"
 import { CATEGORIES, SUB_CATEGORIES } from "../../../storybook/constants"
+
+const REVERSED_BG = {
+  backgrounds: {
+    default: "Purple 700",
+  },
+}
 
 type RenderProps = {
   checkedStatus: string
@@ -48,6 +54,7 @@ export default {
   title: `${CATEGORIES.components}/${SUB_CATEGORIES.form}/Checkbox Field`,
   component: CheckboxField,
   parameters: {
+    chromatic: { disable: false },
     docs: {
       description: {
         component: 'import { CheckboxField } from "@kaizen/draft-form";',
@@ -58,12 +65,6 @@ export default {
     ),
   },
   decorators: [withDesign],
-}
-
-const reversedBg = {
-  backgrounds: {
-    default: "Purple 700",
-  },
 }
 
 export const InteractiveKaizenSiteDemo = () => (
@@ -85,7 +86,6 @@ export const InteractiveKaizenSiteDemo = () => (
     )}
   />
 )
-
 InteractiveKaizenSiteDemo.storyName = "Interactive (Kaizen Site Demo)"
 
 export const On = () => (
@@ -123,7 +123,6 @@ export const DisabledOn = () => (
     labelText="Label"
   />
 )
-
 DisabledOn.storyName = "Disabled + on"
 
 export const DisabledMixed = () => (
@@ -134,7 +133,6 @@ export const DisabledMixed = () => (
     labelText="Label"
   />
 )
-
 DisabledMixed.storyName = "Disabled + mixed"
 
 export const DisabledOff = () => (
@@ -145,7 +143,6 @@ export const DisabledOff = () => (
     labelText="Label"
   />
 )
-
 DisabledOff.storyName = "Disabled + off"
 
 export const WithBottomMargin = () => (
@@ -164,7 +161,6 @@ export const WithBottomMargin = () => (
     />
   </div>
 )
-
 WithBottomMargin.storyName = "with bottom margin"
 
 export const WithoutBottomMargin = () => (
@@ -185,7 +181,6 @@ export const WithoutBottomMargin = () => (
     />
   </div>
 )
-
 WithoutBottomMargin.storyName = "without bottom margin"
 
 export const ReversedOn = () => (
@@ -198,9 +193,7 @@ export const ReversedOn = () => (
 )
 ReversedOn.story = {
   name: "Reversed + on",
-  parameters: {
-    ...reversedBg,
-  },
+  parameters: { ...REVERSED_BG },
 }
 
 export const ReversedDisabledOn = () => (
@@ -214,9 +207,7 @@ export const ReversedDisabledOn = () => (
 )
 ReversedDisabledOn.story = {
   name: "Reversed Disabled + on",
-  parameters: {
-    ...reversedBg,
-  },
+  parameters: { ...REVERSED_BG },
 }
 
 export const ReversedOff = () => (
@@ -229,9 +220,7 @@ export const ReversedOff = () => (
 )
 ReversedOff.story = {
   name: "Reversed + off",
-  parameters: {
-    ...reversedBg,
-  },
+  parameters: { ...REVERSED_BG },
 }
 
 export const ReversedDisabledOff = () => (
@@ -245,7 +234,5 @@ export const ReversedDisabledOff = () => (
 )
 ReversedDisabledOff.story = {
   name: "Reversed Disabled + off",
-  parameters: {
-    ...reversedBg,
-  },
+  parameters: { ...REVERSED_BG },
 }

--- a/draft-packages/form/docs/CheckboxGroup.stories.tsx
+++ b/draft-packages/form/docs/CheckboxGroup.stories.tsx
@@ -1,8 +1,14 @@
+import React from "react"
 import { CheckboxGroup, CheckboxField, Label } from "@kaizen/draft-form"
-import * as React from "react"
 import { withDesign } from "storybook-addon-designs"
 import { figmaEmbed } from "../../../storybook/helpers"
 import { CATEGORIES, SUB_CATEGORIES } from "../../../storybook/constants"
+
+const REVERSED_BG = {
+  backgrounds: {
+    default: "Purple 700",
+  },
+}
 
 interface RenderProps {
   checkedStatus: string
@@ -61,12 +67,6 @@ export default {
   decorators: [withDesign],
 }
 
-const reversedBg = {
-  backgrounds: {
-    default: "Purple 700",
-  },
-}
-
 export const InteractiveKaizenSiteDemo = args => (
   <div>
     <CheckboxGroup labelText="Checkbox Group Label">
@@ -106,7 +106,6 @@ export const InteractiveKaizenSiteDemo = args => (
     </CheckboxGroup>
   </div>
 )
-
 InteractiveKaizenSiteDemo.storyName = "Interactive (Kaizen Site Demo)"
 
 export const WithDisabledCheckboxes = () => (
@@ -133,7 +132,6 @@ export const WithDisabledCheckboxes = () => (
     </CheckboxGroup>
   </div>
 )
-
 WithDisabledCheckboxes.storyName = "with disabled checkboxes"
 
 export const Rtl = () => (
@@ -160,8 +158,8 @@ export const Rtl = () => (
     </CheckboxGroup>
   </div>
 )
-
 Rtl.storyName = "RTL"
+Rtl.parameters = { chromatic: { disable: false } }
 
 export const WithBottomMargin = () => (
   <div>
@@ -194,8 +192,8 @@ export const WithBottomMargin = () => (
     />
   </div>
 )
-
 WithBottomMargin.storyName = "with bottom margin"
+WithBottomMargin.parameters = { chromatic: { disable: false } }
 
 export const WithoutBottomMargin = () => (
   <div>
@@ -228,8 +226,8 @@ export const WithoutBottomMargin = () => (
     />
   </div>
 )
-
 WithoutBottomMargin.storyName = "without bottom margin"
+WithoutBottomMargin.parameters = { chromatic: { disable: false } }
 
 export const NestedCheckboxGroup = () => {
   const [selectedOptions, setSelectedOptions] = React.useState<number[]>([])
@@ -294,7 +292,6 @@ export const NestedCheckboxGroup = () => {
     </div>
   )
 }
-
 NestedCheckboxGroup.storyName = "Nested Checkbox Group"
 
 export const ReversedCheckboxGroup = args => (
@@ -339,10 +336,10 @@ export const ReversedCheckboxGroup = args => (
     </CheckboxGroup>
   </div>
 )
-
 ReversedCheckboxGroup.story = {
   name: "Reversed Checkbox Group",
   parameters: {
-    ...reversedBg,
+    ...REVERSED_BG,
+    chromatic: { disable: false },
   },
 }

--- a/draft-packages/form/docs/RadioField.stories.tsx
+++ b/draft-packages/form/docs/RadioField.stories.tsx
@@ -1,12 +1,19 @@
+import React from "react"
 import { RadioField } from "@kaizen/draft-form"
-import * as React from "react"
 import { withDesign } from "storybook-addon-designs"
 import { figmaEmbed } from "../../../storybook/helpers"
 import { CATEGORIES, SUB_CATEGORIES } from "../../../storybook/constants"
 
+const REVERSED_BG = {
+  backgrounds: {
+    default: "Purple 700",
+  },
+}
+
 const ExampleContent = () => (
   <div style={{ padding: "1em 2em", maxWidth: "400px" }} />
 )
+
 type RenderProps = {
   selectedStatus: boolean
   onChangeHandler: (event: React.ChangeEvent<HTMLInputElement>) => any
@@ -51,6 +58,7 @@ export default {
   title: `${CATEGORIES.components}/${SUB_CATEGORIES.form}/Radio Field`,
   component: RadioField,
   parameters: {
+    chromatic: { disable: false },
     docs: {
       description: {
         component: 'import { RadioField } from "@kaizen/draft-form"',
@@ -61,11 +69,6 @@ export default {
     ),
   },
   decorators: [withDesign],
-}
-const reversedBg = {
-  backgrounds: {
-    default: "Purple 700",
-  },
 }
 
 export const InteractiveKaizenSiteDemo = () => (
@@ -89,7 +92,6 @@ export const InteractiveKaizenSiteDemo = () => (
     )}
   />
 )
-
 InteractiveKaizenSiteDemo.storyName = "Interactive (Kaizen Site Demo)"
 
 export const UnselectedDisabled = () => (
@@ -104,7 +106,6 @@ export const UnselectedDisabled = () => (
     <ExampleContent />
   </RadioField>
 )
-
 UnselectedDisabled.storyName = "Unselected disabled"
 
 export const UnselectedDefault = () => (
@@ -119,7 +120,6 @@ export const UnselectedDefault = () => (
     <ExampleContent />
   </RadioField>
 )
-
 UnselectedDefault.storyName = "Unselected default"
 
 export const SelectedDefault = () => (
@@ -134,7 +134,6 @@ export const SelectedDefault = () => (
     <ExampleContent />
   </RadioField>
 )
-
 SelectedDefault.storyName = "Selected default"
 
 export const SelectedDisabled = () => (
@@ -149,7 +148,6 @@ export const SelectedDisabled = () => (
     <ExampleContent />
   </RadioField>
 )
-
 SelectedDisabled.storyName = "Selected disabled"
 
 export const Rtl = () => (
@@ -166,7 +164,6 @@ export const Rtl = () => (
     </RadioField>
   </div>
 )
-
 Rtl.storyName = "RTL"
 
 export const ReversedDefaultUnselected = () => (
@@ -182,9 +179,7 @@ export const ReversedDefaultUnselected = () => (
 )
 ReversedDefaultUnselected.story = {
   name: "Reversed Default Unselected",
-  parameters: {
-    ...reversedBg,
-  },
+  parameters: { ...REVERSED_BG },
 }
 
 export const ReversedDefaultUnselectedDisabled = () => (
@@ -201,9 +196,7 @@ export const ReversedDefaultUnselectedDisabled = () => (
 )
 ReversedDefaultUnselectedDisabled.story = {
   name: "Reversed Default Unselected Disabled ",
-  parameters: {
-    ...reversedBg,
-  },
+  parameters: { ...REVERSED_BG },
 }
 
 export const ReversedDefaultSelected = () => (
@@ -220,9 +213,7 @@ export const ReversedDefaultSelected = () => (
 )
 ReversedDefaultSelected.story = {
   name: "Reversed Default Selected",
-  parameters: {
-    ...reversedBg,
-  },
+  parameters: { ...REVERSED_BG },
 }
 
 export const ReversedDefaultSelectedDisabled = () => (
@@ -240,7 +231,5 @@ export const ReversedDefaultSelectedDisabled = () => (
 )
 ReversedDefaultSelectedDisabled.story = {
   name: "Reversed Default Selected Disabled",
-  parameters: {
-    ...reversedBg,
-  },
+  parameters: { ...REVERSED_BG },
 }

--- a/draft-packages/form/docs/RadioGroup.stories.tsx
+++ b/draft-packages/form/docs/RadioGroup.stories.tsx
@@ -1,8 +1,14 @@
+import React from "react"
 import { Label, RadioField, RadioGroup } from "@kaizen/draft-form"
-import * as React from "react"
 import { withDesign } from "storybook-addon-designs"
 import { figmaEmbed } from "../../../storybook/helpers"
 import { CATEGORIES, SUB_CATEGORIES } from "../../../storybook/constants"
+
+const REVERSED_BG = {
+  backgrounds: {
+    default: "Purple 700",
+  },
+}
 
 type RenderProps = {
   selectedOption: string
@@ -53,12 +59,6 @@ export default {
   decorators: [withDesign],
 }
 
-const reversedBg = {
-  backgrounds: {
-    default: "Purple 700",
-  },
-}
-
 export const DefaultKaizenSiteDemo = () => (
   <RadioGroupExample
     render={({ selectedOption, onChangeHandler }) => (
@@ -91,7 +91,6 @@ export const DefaultKaizenSiteDemo = () => (
     )}
   />
 )
-
 DefaultKaizenSiteDemo.storyName = "Default (Kaizen Site Demo)"
 
 export const WithDisabledRadios = () => (
@@ -127,7 +126,6 @@ export const WithDisabledRadios = () => (
     )}
   />
 )
-
 WithDisabledRadios.storyName = "With disabled radios"
 
 export const Rtl = () => (
@@ -164,8 +162,8 @@ export const Rtl = () => (
     />
   </div>
 )
-
 Rtl.storyName = "RTL"
+Rtl.parameters = { chromatic: { disable: false } }
 
 export const RtlWithDisabledRadios = () => (
   <div dir="rtl">
@@ -203,7 +201,6 @@ export const RtlWithDisabledRadios = () => (
     />
   </div>
 )
-
 RtlWithDisabledRadios.storyName = "RTL with disabled radios"
 
 export const WithLinks = () => (
@@ -254,53 +251,8 @@ export const WithLinks = () => (
     )}
   />
 )
-
 WithLinks.storyName = "With links"
-
-export const WithoutBottomMargin = () => (
-  <RadioGroupExample
-    render={({ selectedOption, onChangeHandler }) => (
-      <>
-        <RadioGroup noBottomMargin labelText="Radio group label">
-          <RadioField
-            labelText="Label"
-            name="radio"
-            id="radio-1"
-            selectedStatus={selectedOption === "radio-1"}
-            onChange={onChangeHandler}
-            value="radio-1"
-          />
-          <RadioField
-            labelText="Label"
-            name="radio"
-            id="radio-2"
-            selectedStatus={selectedOption === "radio-2"}
-            onChange={onChangeHandler}
-            value="radio-2"
-          />
-          <RadioField
-            labelText="Label"
-            name="radio"
-            id="radio-3"
-            selectedStatus={selectedOption === "radio-3"}
-            onChange={onChangeHandler}
-            value="radio-3"
-          />
-        </RadioGroup>
-
-        <Label
-          id="test_label"
-          htmlFor="test_label"
-          automationId="test_label"
-          labelText="Next line"
-          labelType="radio"
-        />
-      </>
-    )}
-  />
-)
-
-WithoutBottomMargin.storyName = "Without bottom margin"
+WithLinks.parameters = { chromatic: { disable: false } }
 
 export const WithBottomMargin = () => (
   <RadioGroupExample
@@ -344,8 +296,53 @@ export const WithBottomMargin = () => (
     )}
   />
 )
-
 WithBottomMargin.storyName = "With bottom margin"
+WithBottomMargin.parameters = { chromatic: { disable: false } }
+
+export const WithoutBottomMargin = () => (
+  <RadioGroupExample
+    render={({ selectedOption, onChangeHandler }) => (
+      <>
+        <RadioGroup noBottomMargin labelText="Radio group label">
+          <RadioField
+            labelText="Label"
+            name="radio"
+            id="radio-1"
+            selectedStatus={selectedOption === "radio-1"}
+            onChange={onChangeHandler}
+            value="radio-1"
+          />
+          <RadioField
+            labelText="Label"
+            name="radio"
+            id="radio-2"
+            selectedStatus={selectedOption === "radio-2"}
+            onChange={onChangeHandler}
+            value="radio-2"
+          />
+          <RadioField
+            labelText="Label"
+            name="radio"
+            id="radio-3"
+            selectedStatus={selectedOption === "radio-3"}
+            onChange={onChangeHandler}
+            value="radio-3"
+          />
+        </RadioGroup>
+
+        <Label
+          id="test_label"
+          htmlFor="test_label"
+          automationId="test_label"
+          labelText="Next line"
+          labelType="radio"
+        />
+      </>
+    )}
+  />
+)
+WithoutBottomMargin.storyName = "Without bottom margin"
+WithoutBottomMargin.parameters = { chromatic: { disable: false } }
 
 export const ReversedDefault = () => (
   <RadioGroupExample
@@ -385,6 +382,7 @@ export const ReversedDefault = () => (
 ReversedDefault.story = {
   name: "Reversed Default",
   parameters: {
-    ...reversedBg,
+    ...REVERSED_BG,
+    chromatic: { disable: false },
   },
 }

--- a/draft-packages/form/docs/SearchField.stories.tsx
+++ b/draft-packages/form/docs/SearchField.stories.tsx
@@ -1,8 +1,13 @@
 import React, { useState } from "react"
 import { withDesign } from "storybook-addon-designs"
-
 import { SearchField } from "@kaizen/draft-form"
 import { CATEGORIES, SUB_CATEGORIES } from "../../../storybook/constants"
+
+const REVERSED_BG = {
+  backgrounds: {
+    default: "Purple 700",
+  },
+}
 
 const ExampleContainer: React.FunctionComponent = ({ children }) => (
   <div style={{ width: "98%", margin: "1%" }}>{children}</div>
@@ -12,6 +17,7 @@ export default {
   title: `${CATEGORIES.components}/${SUB_CATEGORIES.form}/Search Field`,
   component: SearchField,
   parameters: {
+    chromatic: { disable: false },
     docs: {
       description: {
         component: 'import { SearchField } from "@kaizen/draft-form"',
@@ -19,12 +25,6 @@ export default {
     },
   },
   decorators: [withDesign],
-}
-
-const reversedBg = {
-  backgrounds: {
-    default: "Purple 700",
-  },
 }
 
 export const DefaultKaizenSiteDemo = () => {
@@ -43,8 +43,26 @@ export const DefaultKaizenSiteDemo = () => {
     </ExampleContainer>
   )
 }
-
 DefaultKaizenSiteDemo.storyName = "Default (Kaizen Site Demo) - with state"
+
+export const SearchFieldLoading = () => {
+  const [value, setValue] = useState("Some value")
+
+  return (
+    <ExampleContainer>
+      <SearchField
+        id="search-field"
+        placeholder="Search…"
+        loading
+        labelText="Label"
+        value={value}
+        onChange={e => setValue(e.target.value)}
+        onClear={() => setValue("")}
+      />
+    </ExampleContainer>
+  )
+}
+SearchFieldLoading.storyName = "Default Loading"
 
 export const SearchFieldDisabled = () => {
   const [value, setValue] = useState("Some value")
@@ -62,7 +80,6 @@ export const SearchFieldDisabled = () => {
     </ExampleContainer>
   )
 }
-
 SearchFieldDisabled.storyName = "Default Disabled"
 
 export const SearchFieldSecondary = () => {
@@ -81,7 +98,6 @@ export const SearchFieldSecondary = () => {
     </ExampleContainer>
   )
 }
-
 SearchFieldSecondary.storyName = "Secondary"
 
 export const SearchFieldSecondaryLoading = () => {
@@ -101,7 +117,6 @@ export const SearchFieldSecondaryLoading = () => {
     </ExampleContainer>
   )
 }
-
 SearchFieldSecondaryLoading.storyName = "Secondary Loading"
 
 export const SearchFieldSecondaryDisabled = () => {
@@ -123,26 +138,6 @@ export const SearchFieldSecondaryDisabled = () => {
 }
 SearchFieldSecondaryDisabled.storyName = "Secondary Disabled"
 
-export const SearchFieldLoading = () => {
-  const [value, setValue] = useState("Some value")
-
-  return (
-    <ExampleContainer>
-      <SearchField
-        id="search-field"
-        placeholder="Search…"
-        loading
-        labelText="Label"
-        value={value}
-        onChange={e => setValue(e.target.value)}
-        onClear={() => setValue("")}
-      />
-    </ExampleContainer>
-  )
-}
-
-SearchFieldLoading.storyName = "Default Loading"
-
 export const SearchFieldReversed = () => {
   const [value, setValue] = useState("Some value")
 
@@ -160,12 +155,9 @@ export const SearchFieldReversed = () => {
     </ExampleContainer>
   )
 }
-
 SearchFieldReversed.story = {
   name: "Default Reversed",
-  parameters: {
-    ...reversedBg,
-  },
+  parameters: { ...REVERSED_BG },
 }
 
 export const SearchFieldReversedLoading = () => {
@@ -186,12 +178,9 @@ export const SearchFieldReversedLoading = () => {
     </ExampleContainer>
   )
 }
-
 SearchFieldReversedLoading.story = {
   name: "Default Reversed Loading",
-  parameters: {
-    ...reversedBg,
-  },
+  parameters: { ...REVERSED_BG },
 }
 
 export const SearchFieldReversedDisabled = () => {
@@ -211,12 +200,9 @@ export const SearchFieldReversedDisabled = () => {
     </ExampleContainer>
   )
 }
-
 SearchFieldReversedDisabled.story = {
   name: "Default Reversed Disabled",
-  parameters: {
-    ...reversedBg,
-  },
+  parameters: { ...REVERSED_BG },
 }
 
 export const SearchFieldSecondaryReversed = () => {
@@ -236,12 +222,9 @@ export const SearchFieldSecondaryReversed = () => {
     </ExampleContainer>
   )
 }
-
 SearchFieldSecondaryReversed.story = {
   name: "Secondary Reversed",
-  parameters: {
-    ...reversedBg,
-  },
+  parameters: { ...REVERSED_BG },
 }
 
 export const SearchFieldSecondaryReversedLoading = () => {
@@ -262,12 +245,9 @@ export const SearchFieldSecondaryReversedLoading = () => {
     </ExampleContainer>
   )
 }
-
 SearchFieldSecondaryReversedLoading.story = {
   name: "Secondary Reversed Loading",
-  parameters: {
-    ...reversedBg,
-  },
+  parameters: { ...REVERSED_BG },
 }
 
 export const SearchFieldSecondaryReversedDisabled = () => {
@@ -288,10 +268,7 @@ export const SearchFieldSecondaryReversedDisabled = () => {
     </ExampleContainer>
   )
 }
-
 SearchFieldSecondaryReversedDisabled.story = {
   name: "Secondary Reversed Disabled",
-  parameters: {
-    ...reversedBg,
-  },
+  parameters: { ...REVERSED_BG },
 }

--- a/draft-packages/form/docs/Slider.stories.tsx
+++ b/draft-packages/form/docs/Slider.stories.tsx
@@ -1,4 +1,4 @@
-import * as React from "react"
+import React from "react"
 import { Slider } from "@kaizen/draft-form"
 import { useState } from "@storybook/addons"
 import { Paragraph, Box } from "@kaizen/component-library"
@@ -38,6 +38,7 @@ export const Uncontrolled = () => (
   />
 )
 Uncontrolled.storyName = "Uncontrolled"
+Uncontrolled.parameters = { chromatic: { disable: false } }
 
 export const Controlled = () => {
   const [value, setValue] = useState(5.5)
@@ -66,6 +67,7 @@ export const LabelAboveSlider = () => (
   />
 )
 LabelAboveSlider.storyName = "Label above input"
+LabelAboveSlider.parameters = { chromatic: { disable: false } }
 
 export const CustomMinMaxLabels = () => (
   <Slider
@@ -92,6 +94,7 @@ export const CustomMinMax = () => (
   />
 )
 CustomMinMax.storyName = "Custom min/max"
+CustomMinMax.parameters = { chromatic: { disable: false } }
 
 export const Prominent = () => (
   <Slider
@@ -104,6 +107,7 @@ export const Prominent = () => (
   />
 )
 Prominent.storyName = "Prominent"
+Prominent.parameters = { chromatic: { disable: false } }
 
 export const Disabled = () => (
   <Slider
@@ -117,6 +121,7 @@ export const Disabled = () => (
   />
 )
 Disabled.storyName = "Disabled"
+Disabled.parameters = { chromatic: { disable: false } }
 
 export const ReadOnly = () => (
   <Slider
@@ -143,6 +148,7 @@ export const ReadOnlyNoValue = () => (
   />
 )
 ReadOnlyNoValue.storyName = "Read only (no value)"
+ReadOnlyNoValue.parameters = { chromatic: { disable: false } }
 
 export const UsingPrimitive = () => (
   <>

--- a/draft-packages/form/docs/TextAreaField.stories.tsx
+++ b/draft-packages/form/docs/TextAreaField.stories.tsx
@@ -22,7 +22,6 @@ export default {
 }
 
 export const DefaultStory = args => <TextAreaField {...args} />
-
 DefaultStory.args = {
   id: "reply",
   labelText: "Your reply",
@@ -32,7 +31,6 @@ DefaultStory.args = {
   validationMessage: "",
   description: "",
 }
-
 DefaultStory.argTypes = {
   textAreaRef: {
     control: {
@@ -49,7 +47,6 @@ DefaultStory.argTypes = {
     defaultValue: "default",
   },
 }
-
 DefaultStory.storyName = "Default (Kaizen Demo)"
 
 export const StickerSheetDefault = () => (
@@ -117,8 +114,8 @@ export const StickerSheetDefault = () => (
     </StoryWrapper.Row>
   </StoryWrapper>
 )
-
 StickerSheetDefault.storyName = "Sticker Sheet (Default)"
+StickerSheetDefault.parameters = { chromatic: { disable: false } }
 
 export const StickerSheetReversed = () => (
   <StoryWrapper isReversed>
@@ -192,11 +189,8 @@ export const StickerSheetReversed = () => (
     </StoryWrapper.Row>
   </StoryWrapper>
 )
-
 StickerSheetReversed.storyName = "Sticker Sheet (Reversed)"
-
 StickerSheetReversed.parameters = {
-  backgrounds: {
-    default: "Purple 700",
-  },
+  backgrounds: { default: "Purple 700" },
+  chromatic: { disable: false },
 }

--- a/draft-packages/form/docs/TextField.stories.tsx
+++ b/draft-packages/form/docs/TextField.stories.tsx
@@ -2,7 +2,6 @@ import React from "react"
 import { withDesign } from "storybook-addon-designs"
 import { Heading } from "@kaizen/component-library"
 import { TextField } from "@kaizen/draft-form"
-
 import dateIcon from "@kaizen/component-library/icons/date-start.icon.svg"
 import { figmaEmbed } from "../../../storybook/helpers"
 import { CATEGORIES, SUB_CATEGORIES } from "../../../storybook/constants"
@@ -60,7 +59,6 @@ export const DefaultStory = args => (
     <TextField {...args} />
   </StoryContainer>
 )
-
 DefaultStory.args = {
   id: "kaizen-demo-text-field",
   labelText: "Label Text",
@@ -74,7 +72,6 @@ DefaultStory.args = {
   inline: false,
   reversed: false,
 }
-
 DefaultStory.argTypes = {
   inputRef: {
     control: {
@@ -95,7 +92,6 @@ DefaultStory.argTypes = {
       "A message that describes `status` for error or caution states. The Storybook example uses a String but the component can also take HTML or React Nodes",
   },
 }
-
 DefaultStory.storyName = "Default (Kaizen Demo)"
 
 export const StickerSheetDefault = () => (
@@ -368,8 +364,9 @@ export const StickerSheetDefault = () => (
     </StoryGrid>
   </>
 )
+StickerSheetDefault.storyName = "Sticker Sheet (Default)"
 
-export const StickerSheetDefaultReversed = () => (
+export const StickerSheetReversed = () => (
   <>
     <Heading color="white" variant="heading-3" tag="h2">
       Default
@@ -657,8 +654,8 @@ export const StickerSheetDefaultReversed = () => (
     </StoryGrid>
   </>
 )
-StickerSheetDefaultReversed.parameters = {
-  backgrounds: {
-    default: "Purple 700",
-  },
+StickerSheetReversed.storyName = "Sticker Sheet (Reversed)"
+StickerSheetReversed.parameters = {
+  backgrounds: { default: "Purple 700" },
+  chromatic: { disable: false },
 }

--- a/draft-packages/form/docs/ToggleSwitchField.stories.tsx
+++ b/draft-packages/form/docs/ToggleSwitchField.stories.tsx
@@ -1,6 +1,6 @@
+import React from "react"
 import { Heading } from "@kaizen/component-library"
 import { ToggledStatus, ToggleSwitchField } from "@kaizen/draft-form"
-import * as React from "react"
 import { withDesign } from "storybook-addon-designs"
 import { CATEGORIES, SUB_CATEGORIES } from "../../../storybook/constants"
 import { figmaEmbed } from "../../../storybook/helpers"
@@ -65,10 +65,9 @@ export const Default = props => (
     )}
   </ToggleStateContainer>
 )
-
 Default.storyName = "Default (Kaizen Demo)"
 
-export const StickerSheet = () => (
+export const StickerSheetDefault = () => (
   <div
     style={{
       display: "grid",
@@ -125,8 +124,8 @@ export const StickerSheet = () => (
     </ToggleStateContainer>
   </div>
 )
-
-StickerSheet.storyName = "Sticker Sheet (Default)"
+StickerSheetDefault.storyName = "Sticker Sheet (Default)"
+StickerSheetDefault.parameters = { chromatic: { disable: false } }
 
 export const StickerSheetReversed = () => (
   <div
@@ -188,11 +187,8 @@ export const StickerSheetReversed = () => (
     </ToggleStateContainer>
   </div>
 )
-
-StickerSheetReversed.parameters = {
-  backgrounds: {
-    default: "Purple 700",
-  },
-}
-
 StickerSheetReversed.storyName = "Sticker Sheet (Reversed)"
+StickerSheetReversed.parameters = {
+  backgrounds: { default: "Purple 700" },
+  chromatic: { disable: false },
+}

--- a/draft-packages/guidance-block/docs/GuidanceBlock.stories.tsx
+++ b/draft-packages/guidance-block/docs/GuidanceBlock.stories.tsx
@@ -1,5 +1,4 @@
-import * as React from "react"
-
+import React from "react"
 import { GuidanceBlock } from "@kaizen/draft-guidance-block"
 import {
   Informative,
@@ -12,7 +11,8 @@ import { Heading } from "@kaizen/component-library"
 import { withDesign } from "storybook-addon-designs"
 import { figmaEmbed } from "../../../storybook/helpers"
 import { CATEGORIES } from "../../../storybook/constants"
-const externalLinkIcon =
+
+const ICON_EXTERNAL_LINK =
   require("@kaizen/component-library/icons/external-link.icon.svg").default
 
 export default {
@@ -33,7 +33,7 @@ export default {
   decorators: [withDesign],
 }
 
-const guidanceBlockText = {
+const GUIDANCE_BLOCK_TEXT = {
   title: "This is the Guidance block title",
   description:
     "Mussum Ipsum, cacilds vidis litro abertis. Suco de cevadiss, é um leite divinis, " +
@@ -43,7 +43,7 @@ const guidanceBlockText = {
 export const DefaultStory = args => (
   <GuidanceBlock
     illustration={args.illustration}
-    text={guidanceBlockText}
+    text={GUIDANCE_BLOCK_TEXT}
     actions={{
       primary: {
         label: "Action",
@@ -58,9 +58,7 @@ export const DefaultStory = args => (
     {...args}
   />
 )
-
 DefaultStory.storyName = "Default (Kaizen Demo)"
-
 DefaultStory.args = {
   layout: "default",
   illustrationType: "spot",
@@ -69,11 +67,10 @@ DefaultStory.args = {
   withActionButtonArrow: true,
   noMaxWidth: false,
   smallScreenTextAlignment: "center",
-  text: guidanceBlockText,
+  text: GUIDANCE_BLOCK_TEXT,
   secondaryDismiss: false,
   persistent: true,
 }
-
 DefaultStory.argTypes = {
   actions: {
     control: false,
@@ -108,7 +105,7 @@ export const Moods = () => (
     <GuidanceBlock
       persistent
       illustration={<Informative alt="" />}
-      text={guidanceBlockText}
+      text={GUIDANCE_BLOCK_TEXT}
       actions={{
         primary: {
           label: "Action",
@@ -125,7 +122,7 @@ export const Moods = () => (
     <GuidanceBlock
       persistent
       illustration={<Informative alt="" />}
-      text={guidanceBlockText}
+      text={GUIDANCE_BLOCK_TEXT}
       actions={{
         primary: {
           label: "Action",
@@ -142,7 +139,7 @@ export const Moods = () => (
     <GuidanceBlock
       persistent
       illustration={<Informative alt="" />}
-      text={guidanceBlockText}
+      text={GUIDANCE_BLOCK_TEXT}
       actions={{
         primary: {
           label: "Action",
@@ -159,7 +156,7 @@ export const Moods = () => (
     <GuidanceBlock
       persistent
       illustration={<Informative alt="" />}
-      text={guidanceBlockText}
+      text={GUIDANCE_BLOCK_TEXT}
       actions={{
         primary: {
           label: "Action",
@@ -176,7 +173,7 @@ export const Moods = () => (
     <GuidanceBlock
       persistent
       illustration={<Informative alt="" />}
-      text={guidanceBlockText}
+      text={GUIDANCE_BLOCK_TEXT}
       actions={{
         primary: {
           label: "Action",
@@ -193,7 +190,7 @@ export const Moods = () => (
     <GuidanceBlock
       persistent
       illustration={<Informative alt="" />}
-      text={guidanceBlockText}
+      text={GUIDANCE_BLOCK_TEXT}
       actions={{
         primary: {
           label: "Action",
@@ -206,6 +203,7 @@ export const Moods = () => (
     />
   </div>
 )
+Moods.parameters = { chromatic: { disable: false } }
 
 export const StickerSheet = () => (
   <div style={{ display: "flex", flexDirection: "column", gap: "36px" }}>
@@ -214,7 +212,7 @@ export const StickerSheet = () => (
     </Heading>
     <GuidanceBlock
       illustration={<Informative alt="" />}
-      text={guidanceBlockText}
+      text={GUIDANCE_BLOCK_TEXT}
       persistent
     />
     <Heading tag="h2" variant="heading-4">
@@ -222,7 +220,7 @@ export const StickerSheet = () => (
     </Heading>
     <GuidanceBlock
       illustration={<Informative alt="" />}
-      text={guidanceBlockText}
+      text={GUIDANCE_BLOCK_TEXT}
       actions={{
         primary: {
           label: "Action",
@@ -242,7 +240,7 @@ export const StickerSheet = () => (
     </Heading>
     <GuidanceBlock
       illustration={<Informative alt="" />}
-      text={guidanceBlockText}
+      text={GUIDANCE_BLOCK_TEXT}
       withActionButtonArrow={false}
       actions={{
         primary: {
@@ -279,7 +277,7 @@ export const StickerSheet = () => (
             text: "Opens in a new tab",
             mood: "cautionary",
           },
-          icon: externalLinkIcon,
+          icon: ICON_EXTERNAL_LINK,
         },
         secondary: {
           label: "Dismiss",
@@ -294,7 +292,7 @@ export const StickerSheet = () => (
     <GuidanceBlock
       illustration={<HumanityAtWork alt="" />}
       illustrationType="scene"
-      text={guidanceBlockText}
+      text={GUIDANCE_BLOCK_TEXT}
       actions={{
         primary: {
           label: "Action",
@@ -310,12 +308,13 @@ export const StickerSheet = () => (
     </Heading>
     <GuidanceBlock
       illustration={<Informative alt="" />}
-      text={guidanceBlockText}
+      text={GUIDANCE_BLOCK_TEXT}
       noMaxWidth
       persistent
     />
   </div>
 )
+StickerSheet.parameters = { chromatic: { disable: false } }
 
 export const Layouts = () => (
   <div style={{ display: "flex", flexDirection: "column", gap: "36px" }}>
@@ -325,7 +324,7 @@ export const Layouts = () => (
     <GuidanceBlock
       layout="default"
       illustration={<Informative alt="" />}
-      text={guidanceBlockText}
+      text={GUIDANCE_BLOCK_TEXT}
       actions={{
         primary: {
           label: "Action",
@@ -346,7 +345,7 @@ export const Layouts = () => (
     <GuidanceBlock
       layout="inline"
       illustration={<Informative alt="" />}
-      text={guidanceBlockText}
+      text={GUIDANCE_BLOCK_TEXT}
       actions={{
         primary: {
           label: "Action",
@@ -368,7 +367,7 @@ export const Layouts = () => (
       layout="inline"
       illustration={<SkillsCoachManagerHub alt="" />}
       illustrationType="scene"
-      text={guidanceBlockText}
+      text={GUIDANCE_BLOCK_TEXT}
       actions={{
         primary: {
           label: "Action",
@@ -389,7 +388,7 @@ export const Layouts = () => (
     <GuidanceBlock
       layout="stacked"
       illustration={<Informative alt="" />}
-      text={guidanceBlockText}
+      text={GUIDANCE_BLOCK_TEXT}
       actions={{
         primary: {
           label: "Action",
@@ -411,7 +410,7 @@ export const Layouts = () => (
       layout="stacked"
       illustration={<SkillsCoachManagerHub alt="" />}
       illustrationType="scene"
-      text={guidanceBlockText}
+      text={GUIDANCE_BLOCK_TEXT}
       smallScreenTextAlignment="left"
       actions={{
         primary: {
@@ -434,7 +433,7 @@ export const Layouts = () => (
       <GuidanceBlock
         layout="stacked"
         illustration={<Informative alt="" />}
-        text={guidanceBlockText}
+        text={GUIDANCE_BLOCK_TEXT}
         actions={{
           primary: {
             label: "Action",
@@ -452,7 +451,7 @@ export const Layouts = () => (
       <GuidanceBlock
         layout="stacked"
         illustration={<Informative alt="" />}
-        text={guidanceBlockText}
+        text={GUIDANCE_BLOCK_TEXT}
         actions={{
           primary: {
             label: "Action",
@@ -470,6 +469,7 @@ export const Layouts = () => (
     </div>
   </div>
 )
+Layouts.parameters = { chromatic: { disable: false } }
 
 export const AspectRatio = () => (
   <div style={{ display: "flex", flexDirection: "column", gap: "36px" }}>
@@ -481,7 +481,7 @@ export const AspectRatio = () => (
         <SkillsCoachEssentialFeedback alt="" enableAspectRatio={true} />
       }
       illustrationType="scene"
-      text={guidanceBlockText}
+      text={GUIDANCE_BLOCK_TEXT}
       layout="inline"
       smallScreenTextAlignment="left"
       actions={{
@@ -503,7 +503,7 @@ export const AspectRatio = () => (
         layout="stacked"
         illustrationType="scene"
         illustration={<HumanityAtWork alt="" />}
-        text={guidanceBlockText}
+        text={GUIDANCE_BLOCK_TEXT}
         actions={{
           primary: {
             label: "Action",
@@ -522,7 +522,7 @@ export const AspectRatio = () => (
         layout="stacked"
         illustrationType="scene"
         illustration={<Communication alt="" />}
-        text={guidanceBlockText}
+        text={GUIDANCE_BLOCK_TEXT}
         actions={{
           primary: {
             label: "Action",
@@ -546,7 +546,7 @@ export const AspectRatio = () => (
         layout="stacked"
         illustrationType="scene"
         illustration={<SkillsCoachEssentialFeedback alt="" />}
-        text={guidanceBlockText}
+        text={GUIDANCE_BLOCK_TEXT}
         actions={{
           primary: {
             label: "Action",
@@ -562,7 +562,7 @@ export const AspectRatio = () => (
         layout="stacked"
         illustrationType="scene"
         illustration={<HumanityAtWork alt="" />}
-        text={guidanceBlockText}
+        text={GUIDANCE_BLOCK_TEXT}
         actions={{
           primary: {
             label: "Action",
@@ -577,3 +577,4 @@ export const AspectRatio = () => (
     </div>
   </div>
 )
+AspectRatio.parameters = { chromatic: { disable: false } }

--- a/draft-packages/hero-card/docs/HeroCard.stories.tsx
+++ b/draft-packages/hero-card/docs/HeroCard.stories.tsx
@@ -1,11 +1,11 @@
+import React from "react"
 import { Button } from "@kaizen/draft-button"
 import { HeroCard } from "@kaizen/draft-hero-card"
-import * as React from "react"
 import { withDesign } from "storybook-addon-designs"
 import { CATEGORIES } from "../../../storybook/constants"
 import { figmaEmbed } from "../../../storybook/helpers"
 
-const surveyIllustration = require("./survey.png")
+const ILLUSTRATION_SURVEY = require("./survey.png")
 
 const renderContent = () => (
   <div
@@ -58,6 +58,7 @@ export const Badge = () => (
     {renderContent()}
   </HeroCard>
 )
+Badge.parameters = { chromatic: { disable: false } }
 
 export const Image = () => (
   <HeroCard
@@ -65,7 +66,7 @@ export const Image = () => (
     badge={<span>1</span>}
     image={
       <img
-        src={surveyIllustration}
+        src={ILLUSTRATION_SURVEY}
         alt=""
         style={{
           position: "absolute",
@@ -79,6 +80,7 @@ export const Image = () => (
     {renderContent()}
   </HeroCard>
 )
+Image.parameters = { chromatic: { disable: false } }
 
 export const CustomLeftContent = () => (
   <HeroCard
@@ -88,6 +90,7 @@ export const CustomLeftContent = () => (
     {renderContent()}
   </HeroCard>
 )
+CustomLeftContent.parameters = { chromatic: { disable: false } }
 
 export const CustomLeftContentAndBadge = () => (
   <HeroCard
@@ -98,6 +101,7 @@ export const CustomLeftContentAndBadge = () => (
     {renderContent()}
   </HeroCard>
 )
+CustomLeftContentAndBadge.parameters = { chromatic: { disable: false } }
 
 export const FullWidth = () => (
   <HeroCard
@@ -108,6 +112,7 @@ export const FullWidth = () => (
     {renderContent()}
   </HeroCard>
 )
+FullWidth.parameters = { chromatic: { disable: false } }
 
 export const BackgroundColors = () => (
   <HeroCard
@@ -117,3 +122,4 @@ export const BackgroundColors = () => (
     {renderContent()}
   </HeroCard>
 )
+BackgroundColors.parameters = { chromatic: { disable: false } }

--- a/draft-packages/illustration/docs/IllustrationScene.stories.tsx
+++ b/draft-packages/illustration/docs/IllustrationScene.stories.tsx
@@ -1,5 +1,5 @@
+import React from "react"
 import { Heading, Box } from "@kaizen/component-library"
-import * as React from "react"
 import {
   EmptyStatesAction,
   EmptyStatesInformative,
@@ -62,6 +62,7 @@ export default {
   title: `${CATEGORIES.components}/${SUB_CATEGORIES.illustration}/Scene`,
   component: EmptyStatesInformative,
   parameters: {
+    chromatic: { disable: false },
     docs: {
       description: {
         component:

--- a/draft-packages/illustration/docs/IllustrationSpot.stories.tsx
+++ b/draft-packages/illustration/docs/IllustrationSpot.stories.tsx
@@ -1,4 +1,4 @@
-import * as React from "react"
+import React from "react"
 import { Heading, Paragraph } from "@kaizen/component-library"
 import {
   AccountBasics,
@@ -742,6 +742,7 @@ export const AllSpotIllustrations = () => {
     </>
   )
 }
+AllSpotIllustrations.parameters = { chromatic: { disable: false } }
 
 export const AnimatedSpot = args => (
   <div style={{ width: "156px" }}>
@@ -779,5 +780,8 @@ export const AnimatedSpot = args => (
 )
 AnimatedSpot.storyName = "Spot, animated"
 AnimatedSpot.parameters = {
-  chromatic: { diffThreshold: 0.9 },
+  chromatic: {
+    disable: false,
+    diffThreshold: 0.9,
+  },
 }

--- a/draft-packages/likert-scale-legacy/docs/LikertScaleLegacy.stories.tsx
+++ b/draft-packages/likert-scale-legacy/docs/LikertScaleLegacy.stories.tsx
@@ -1,5 +1,4 @@
 import React, { useState } from "react"
-
 import {
   LikertScaleLegacy,
   Scale,
@@ -13,6 +12,7 @@ export default {
   title: `${CATEGORIES.components}/Likert Scale`,
   component: LikertScaleLegacy,
   parameters: {
+    chromatic: { disable: false },
     docs: {
       description: {
         component:
@@ -68,7 +68,6 @@ export const DefaultStory = () => {
     </div>
   )
 }
-
 DefaultStory.storyName = "Default"
 
 export const Reversed = () => {
@@ -92,6 +91,5 @@ export const Reversed = () => {
     </div>
   )
 }
-
 Reversed.storyName = "Reversed"
 Reversed.parameters = { backgrounds: { default: "Purple 700" } }

--- a/draft-packages/loading-placeholder/docs/LoadingPlaceholder.stories.tsx
+++ b/draft-packages/loading-placeholder/docs/LoadingPlaceholder.stories.tsx
@@ -1,10 +1,9 @@
+import React from "react"
 import { Heading, Paragraph } from "@kaizen/component-library"
 import { LoadingPlaceholder } from "@kaizen/draft-loading-placeholder"
-import * as React from "react"
 import { withDesign } from "storybook-addon-designs"
 import { CATEGORIES } from "../../../storybook/constants"
 import { figmaEmbed } from "../../../storybook/helpers"
-
 import styles from "./LoadingPlaceholder.stories.scss"
 
 const StoryContainer: React.FunctionComponent = ({ children }) => (
@@ -47,7 +46,6 @@ export const DefaultMultipleKaizenSiteDemo = () => (
     </>
   </StoryContainer>
 )
-
 DefaultMultipleKaizenSiteDemo.storyName = "Default, Multiple (Kaizen Site Demo)"
 
 export const DefaultMultipleInline = () => (
@@ -91,7 +89,6 @@ export const DefaultMultipleInline = () => (
     </>
   </StoryContainer>
 )
-
 DefaultMultipleInline.storyName = "Default, Multiple, Inline"
 
 export const DefaultMultipleVariableWidth = () => (
@@ -113,7 +110,6 @@ export const DefaultMultipleVariableWidth = () => (
     </>
   </StoryContainer>
 )
-
 DefaultMultipleVariableWidth.storyName = "Default, Multiple, Variable width"
 
 export const DefaultMultipleVariableWidthCentered = () => (
@@ -137,9 +133,11 @@ export const DefaultMultipleVariableWidthCentered = () => (
     </>
   </StoryContainer>
 )
-
 DefaultMultipleVariableWidthCentered.storyName =
   "Default, Multiple, Variable width, Centered"
+DefaultMultipleVariableWidthCentered.parameters = {
+  chromatic: { disable: false },
+}
 
 export const DefaultMultipleCombinedBlockAndInline = () => (
   <StoryContainer>
@@ -177,9 +175,11 @@ export const DefaultMultipleCombinedBlockAndInline = () => (
     </>
   </StoryContainer>
 )
-
 DefaultMultipleCombinedBlockAndInline.storyName =
   "Default, Multiple, Combined block and inline"
+DefaultMultipleCombinedBlockAndInline.parameters = {
+  chromatic: { disable: false },
+}
 
 export const DefaultWithoutBottomMargin = () => (
   <StoryContainer>
@@ -191,10 +191,10 @@ export const DefaultWithoutBottomMargin = () => (
     <LoadingPlaceholder noBottomMargin />
   </StoryContainer>
 )
-
 DefaultWithoutBottomMargin.storyName = "Default, Without bottom margin"
+DefaultWithoutBottomMargin.parameters = { chromatic: { disable: false } }
 
-export const Defaul = () => (
+export const DefaultInheritBaseline = () => (
   <StoryContainer>
     <div className={styles.flexbox}>
       <Heading tag="h2" variant="heading-2">
@@ -204,8 +204,8 @@ export const Defaul = () => (
     </div>
   </StoryContainer>
 )
-
-Defaul.storyName = "Default, Inherit baseline"
+DefaultInheritBaseline.storyName = "Default, Inherit baseline"
+DefaultInheritBaseline.parameters = { chromatic: { disable: false } }
 
 export const HeadingLoading = () => (
   <StoryContainer>
@@ -228,6 +228,7 @@ export const HeadingLoading = () => (
     </>
   </StoryContainer>
 )
+HeadingLoading.parameters = { chromatic: { disable: false } }
 
 export const ReversedDefault = () => (
   <StoryContainer>
@@ -248,9 +249,8 @@ export const ReversedDefault = () => (
 )
 ReversedDefault.storyName = "Reversed, Default"
 ReversedDefault.parameters = {
-  backgrounds: {
-    default: "Purple 700",
-  },
+  backgrounds: { default: "Purple 700" },
+  chromatic: { disable: false },
 }
 
 export const InTheWild = () => (
@@ -331,5 +331,4 @@ export const InTheWild = () => (
     </div>
   </StoryContainer>
 )
-
 InTheWild.storyName = "In the wild"

--- a/draft-packages/modal/docs/ConfirmationModal.stories.tsx
+++ b/draft-packages/modal/docs/ConfirmationModal.stories.tsx
@@ -1,9 +1,8 @@
+import React from "react"
 import { Paragraph } from "@kaizen/component-library"
 import { Button } from "@kaizen/draft-button"
 import { ConfirmationModal } from "@kaizen/draft-modal"
 import isChromatic from "chromatic/isChromatic"
-
-import * as React from "react"
 import { withDesign } from "storybook-addon-designs"
 import { figmaEmbed } from "../../../storybook/helpers"
 import { CATEGORIES } from "../../../storybook/constants"
@@ -50,6 +49,11 @@ export default {
     mood: "cautionary",
   },
   parameters: {
+    chromatic: {
+      disable: false,
+      delay: 400, // match MODAL_TRANSITION_TIMEOUT in modals + 50ms
+      pauseAnimationAtEnd: true,
+    },
     docs: {
       description: {
         component: "import { ConfirmationModal } from @kaizen/draft-modal",
@@ -58,10 +62,6 @@ export default {
     ...figmaEmbed(
       "https://www.figma.com/file/GMxm8rvDCbj0Xw3TQWBZ8b/UI-Kit-Zen?node-id=1929%3A35440"
     ),
-    chromatic: {
-      delay: 400, // match MODAL_TRANSITION_TIMEOUT in modals + 50ms
-      pauseAnimationAtEnd: true,
-    },
     actions: {
       argTypesRegex: "^on.*",
     },

--- a/draft-packages/modal/docs/ContextModal.stories.tsx
+++ b/draft-packages/modal/docs/ContextModal.stories.tsx
@@ -1,10 +1,8 @@
+import React from "react"
 import { Paragraph } from "@kaizen/component-library"
 import { Button } from "@kaizen/draft-button"
 import { ContextModal, ModalAccessibleDescription } from "@kaizen/draft-modal"
 import isChromatic from "chromatic/isChromatic"
-import classNames from "classnames"
-
-import * as React from "react"
 import { withDesign } from "storybook-addon-designs"
 import { AddImage } from "@kaizen/draft-illustration"
 import { figmaEmbed } from "../../../storybook/helpers"
@@ -50,6 +48,11 @@ export default {
   title: `${CATEGORIES.components}/Modal/Context Modal`,
   component: ContextModal,
   parameters: {
+    chromatic: {
+      disable: false,
+      delay: 400, // match MODAL_TRANSITION_TIMEOUT in modals + 50ms
+      pauseAnimationAtEnd: true,
+    },
     docs: {
       description: {
         component:
@@ -61,10 +64,6 @@ export default {
     ...figmaEmbed(
       "https://www.figma.com/file/GMxm8rvDCbj0Xw3TQWBZ8b/UI-Kit-Zen?node-id=1929%3A35440"
     ),
-    chromatic: {
-      delay: 400, // match MODAL_TRANSITION_TIMEOUT in modals + 50ms
-      pauseAnimationAtEnd: true,
-    },
     actions: {
       argTypesRegex: "^on.*",
     },

--- a/draft-packages/modal/docs/InputEditModal.stories.tsx
+++ b/draft-packages/modal/docs/InputEditModal.stories.tsx
@@ -1,13 +1,11 @@
+import React from "react"
 import { Paragraph } from "@kaizen/component-library"
 import { Button } from "@kaizen/draft-button"
 import { Select } from "@kaizen/draft-select"
 import { InputEditModal, ModalAccessibleDescription } from "@kaizen/draft-modal"
 import isChromatic from "chromatic/isChromatic"
-
-import * as React from "react"
 import { withDesign } from "storybook-addon-designs"
 import { figmaEmbed } from "../../../storybook/helpers"
-
 import { CATEGORIES } from "../../../storybook/constants"
 
 // Add additional height to the stories when running in Chromatic only.
@@ -22,6 +20,7 @@ const withMinHeight = Story => {
     </div>
   )
 }
+
 class ModalStateContainer extends React.Component<
   {
     isInitiallyOpen: boolean
@@ -49,6 +48,11 @@ export default {
   title: `${CATEGORIES.components}/Modal/Input Edit Modal`,
   component: InputEditModal,
   parameters: {
+    chromatic: {
+      disable: false,
+      delay: 400, // match MODAL_TRANSITION_TIMEOUT in modals + 50ms
+      pauseAnimationAtEnd: true,
+    },
     docs: {
       description: {
         component:
@@ -60,15 +64,11 @@ export default {
     ...figmaEmbed(
       "https://www.figma.com/file/GMxm8rvDCbj0Xw3TQWBZ8b/UI-Kit-Zen?node-id=1929%3A35440"
     ),
-    chromatic: {
-      delay: 400, // match MODAL_TRANSITION_TIMEOUT in modals + 50ms
-      pauseAnimationAtEnd: true,
-    },
   },
   decorators: [withDesign, withMinHeight],
 }
 
-const options = [
+const SELECT_OPTIONS = [
   { value: "Mindy", label: "Mindy" },
   { value: "Jaime", label: "Jaime", isDisabled: true },
   { value: "Rafa", label: "Rafa" },
@@ -100,11 +100,11 @@ export const InputEditModals = args => (
             </Paragraph>
           </ModalAccessibleDescription>
           <Select
-            options={options}
+            options={SELECT_OPTIONS}
             placeholder="Placeholder"
             isSearchable={false}
             isDisabled={false}
-            defaultValue={options[0]}
+            defaultValue={SELECT_OPTIONS[0]}
           />
         </InputEditModal>
       </div>

--- a/draft-packages/page-layout/docs/PageLayout.stories.tsx
+++ b/draft-packages/page-layout/docs/PageLayout.stories.tsx
@@ -1,4 +1,4 @@
-import * as React from "react"
+import React from "react"
 import { Box, Paragraph } from "@kaizen/component-library"
 import { NavigationTab, TitleBlockZen } from "@kaizen/draft-title-block-zen"
 import { withDesign } from "storybook-addon-designs"
@@ -54,7 +54,6 @@ export const DefaultStory = () => (
     </Container>
   </OffsetPadding>
 )
-
 DefaultStory.storyName = "Container/Content (default)"
 
 export const FullBleedBackgroundStory = () => (
@@ -81,8 +80,8 @@ export const FullBleedBackgroundStory = () => (
     </Container>
   </OffsetPadding>
 )
-
 FullBleedBackgroundStory.storyName = "Container/Content (Full-bleed background)"
+FullBleedBackgroundStory.parameters = { chromatic: { disable: false } }
 
 export const SkirtStory = () => (
   <>
@@ -144,7 +143,6 @@ export const SkirtStory = () => (
     </Skirt>
   </>
 )
-
 SkirtStory.storyName = "Skirt (default)"
 
 export const SkirtEducationVariant = () => (
@@ -175,8 +173,8 @@ export const SkirtEducationVariant = () => (
     </Skirt>
   </>
 )
-
 SkirtEducationVariant.storyName = "Skirt (Education variant)"
+SkirtEducationVariant.parameters = { chromatic: { disable: false } }
 
 export const SkirtWithoutTitleBlockNavigation = () => (
   <>
@@ -244,9 +242,9 @@ export const SkirtWithoutTitleBlockNavigation = () => (
     </Skirt>
   </>
 )
-
 SkirtWithoutTitleBlockNavigation.storyName =
   "Skirt (Title Block without navigation)"
+SkirtWithoutTitleBlockNavigation.parameters = { chromatic: { disable: false } }
 
 export const WithoutSkirtCard = () => (
   <>
@@ -286,5 +284,4 @@ export const WithoutSkirtCard = () => (
     </Skirt>
   </>
 )
-
 WithoutSkirtCard.storyName = "Skirt (without SkirtCard)"

--- a/draft-packages/popover/docs/Popover.stories.tsx
+++ b/draft-packages/popover/docs/Popover.stories.tsx
@@ -125,7 +125,6 @@ export const DefaultKaizenSiteDemo = props => {
     </div>
   )
 }
-
 DefaultKaizenSiteDemo.storyName = "Default (Kaizen Site Demo)"
 
 export const OverflowScroll = props => {
@@ -524,3 +523,4 @@ export const StickerSheet = () => {
     </>
   )
 }
+StickerSheet.parameters = { chromatic: { disable: false } }

--- a/draft-packages/select/docs/Select.stories.tsx
+++ b/draft-packages/select/docs/Select.stories.tsx
@@ -1,6 +1,5 @@
-import * as colorTokens from "@kaizen/design-tokens/tokens/color.json"
+import React from "react"
 import { AsyncSelect, Select } from "@kaizen/draft-select"
-import * as React from "react"
 import { withDesign } from "storybook-addon-designs"
 import { CATEGORIES } from "../../../storybook/constants"
 import { figmaEmbed } from "../../../storybook/helpers"
@@ -89,6 +88,7 @@ export const Single = () => (
     />
   </StoryContainer>
 )
+Single.parameters = { chromatic: { disable: false } }
 
 export const SingleDisabled = () => (
   <StoryContainer>
@@ -101,6 +101,7 @@ export const SingleDisabled = () => (
     />
   </StoryContainer>
 )
+SingleDisabled.parameters = { chromatic: { disable: false } }
 
 export const SingleEllipsis = () => {
   const localOptions = [
@@ -122,8 +123,8 @@ export const SingleEllipsis = () => {
     </NarrowStoryContainer>
   )
 }
-
 SingleEllipsis.storyName = "Single with ellipsizing selection"
+SingleEllipsis.parameters = { chromatic: { disable: false } }
 
 export const SingleClearable = () => (
   <StoryContainer>
@@ -147,7 +148,6 @@ export const MultiSelectSearchable = () => (
     <Select options={options} placeholder="Placeholder" isMulti={true} />
   </WideStoryContainer>
 )
-
 MultiSelectSearchable.storyName = "Multi-Select Searchable"
 
 export const AsyncSearchable = () => (
@@ -182,27 +182,8 @@ export const SingleSecondary = () => (
     />
   </StoryContainer>
 )
-
 SingleSecondary.storyName = "Single, Secondary"
-
-export const SingleSecondarySmall = () => (
-  <StoryContainer>
-    <Select
-      options={options}
-      isSearchable={false}
-      defaultValue={options[0]}
-      variant="secondary-small"
-      reversed={true}
-    />
-  </StoryContainer>
-)
-
-SingleSecondarySmall.storyName = "Single, Secondary-Small, Reversed"
-SingleSecondarySmall.parameters = {
-  backgrounds: {
-    default: "Purple 700",
-  },
-}
+SingleSecondary.parameters = { chromatic: { disable: false } }
 
 export const SingleSecondaryDisabled = () => (
   <StoryContainer>
@@ -215,8 +196,8 @@ export const SingleSecondaryDisabled = () => (
     />
   </StoryContainer>
 )
-
 SingleSecondaryDisabled.storyName = "Single, Secondary, Disabled"
+SingleSecondaryDisabled.parameters = { chromatic: { disable: false } }
 
 export const SingleSecondaryReversed = () => (
   <StoryContainer>
@@ -229,12 +210,46 @@ export const SingleSecondaryReversed = () => (
     />
   </StoryContainer>
 )
-
 SingleSecondaryReversed.storyName = "Single, Secondary, Reversed"
 SingleSecondaryReversed.parameters = {
-  backgrounds: {
-    default: "Purple 700",
-  },
+  backgrounds: { default: "Purple 700" },
+  chromatic: { disable: false },
+}
+
+export const SingleSecondarySmallReversed = () => (
+  <StoryContainer>
+    <Select
+      options={options}
+      isSearchable={false}
+      defaultValue={options[0]}
+      variant="secondary-small"
+      reversed={true}
+    />
+  </StoryContainer>
+)
+SingleSecondarySmallReversed.storyName = "Single, Secondary-Small, Reversed"
+SingleSecondarySmallReversed.parameters = {
+  backgrounds: { default: "Purple 700" },
+  chromatic: { disable: false },
+}
+
+export const SingleSecondaryReversedDisabled = () => (
+  <StoryContainer>
+    <Select
+      options={options}
+      isDisabled={true}
+      isSearchable={false}
+      defaultValue={options[0]}
+      variant="secondary"
+      reversed={true}
+    />
+  </StoryContainer>
+)
+SingleSecondaryReversedDisabled.storyName =
+  "Single Secondary Reversed (disabled)"
+SingleSecondaryReversedDisabled.parameters = {
+  backgrounds: { default: "Purple 700" },
+  chromatic: { disable: false },
 }
 
 export const SingleSecondaryWithEllipsis = () => {
@@ -259,31 +274,7 @@ export const SingleSecondaryWithEllipsis = () => {
     </NarrowStoryContainer>
   )
 }
-
 SingleSecondaryWithEllipsis.storyName = "Single Secondary with ellipsis"
 SingleSecondaryWithEllipsis.parameters = {
-  backgrounds: {
-    default: "Purple 700",
-  },
-}
-
-export const SingleSecondaryReversedDisabled = () => (
-  <StoryContainer>
-    <Select
-      options={options}
-      isDisabled={true}
-      isSearchable={false}
-      defaultValue={options[0]}
-      variant="secondary"
-      reversed={true}
-    />
-  </StoryContainer>
-)
-
-SingleSecondaryReversedDisabled.storyName =
-  "Single Secondary Reversed (disabled)"
-SingleSecondaryReversedDisabled.parameters = {
-  backgrounds: {
-    default: "Purple 700",
-  },
+  backgrounds: { default: "Purple 700" },
 }

--- a/draft-packages/split-button/docs/SplitButton.stories.tsx
+++ b/draft-packages/split-button/docs/SplitButton.stories.tsx
@@ -1,8 +1,7 @@
+import React from "react"
 import { MenuItem } from "@kaizen/draft-menu"
 import { SplitButton } from "@kaizen/draft-split-button"
-import * as React from "react"
 import { withDesign } from "storybook-addon-designs"
-
 import duplicateIcon from "@kaizen/component-library/icons/duplicate.icon.svg"
 import editIcon from "@kaizen/component-library/icons/edit.icon.svg"
 import { figmaEmbed } from "../../../storybook/helpers"
@@ -53,8 +52,8 @@ export const DefaultKaizenSiteDemo = () => (
     dropdownAltText="Open menu"
   />
 )
-
 DefaultKaizenSiteDemo.storyName = "Default (Kaizen Site Demo)"
+DefaultKaizenSiteDemo.parameters = { chromatic: { disable: false } }
 
 export const Disabled = () => (
   <SplitButton
@@ -67,8 +66,8 @@ export const Disabled = () => (
     dropdownAltText="Open menu"
   />
 )
-
 Disabled.storyName = "Default button disabled"
+Disabled.parameters = { chromatic: { disable: false } }
 
 export const EnabledWithDisabledItems = () => (
   <SplitButton
@@ -96,7 +95,6 @@ export const EnabledWithDisabledItems = () => (
     dropdownAltText="Open menu"
   />
 )
-
 EnabledWithDisabledItems.storyName = "Default enabled with disabled items"
 
 export const Primary = () => (
@@ -121,8 +119,8 @@ export const Primary = () => (
     dropdownAltText="Open menu"
   />
 )
-
 Primary.storyName = "Primary"
+Primary.parameters = { chromatic: { disable: false } }
 
 export const PrimaryDisabled = () => (
   <SplitButton
@@ -147,8 +145,8 @@ export const PrimaryDisabled = () => (
     dropdownAltText="Open menu"
   />
 )
-
 PrimaryDisabled.storyName = "Primary disabled"
+PrimaryDisabled.parameters = { chromatic: { disable: false } }
 
 export const AnchorLink = () => (
   <SplitButton
@@ -160,7 +158,6 @@ export const AnchorLink = () => (
     dropdownAltText="Open menu"
   />
 )
-
 AnchorLink.storyName = "Anchor link"
 
 export const Rtl = () => (
@@ -185,8 +182,8 @@ export const Rtl = () => (
     dropdownAltText="Open menu"
   />
 )
-
 Rtl.storyName = "RTL"
+Rtl.parameters = { chromatic: { disable: false } }
 
 export const PrimaryRtl = () => (
   <SplitButton
@@ -213,5 +210,5 @@ export const PrimaryRtl = () => (
     dropdownAltText="Open menu"
   />
 )
-
 PrimaryRtl.storyName = "Primary RTL"
+PrimaryRtl.parameters = { chromatic: { disable: false } }

--- a/draft-packages/table/docs/Table.stories.tsx
+++ b/draft-packages/table/docs/Table.stories.tsx
@@ -1,7 +1,7 @@
+import React from "react"
 import { Paragraph } from "@kaizen/component-library"
 import { IconButton, Button } from "@kaizen/draft-button"
 import { CheckboxField } from "@kaizen/draft-form"
-import * as React from "react"
 import chevronDownIcon from "@kaizen/component-library/icons/chevron-down.icon.svg"
 import chevronUpIcon from "@kaizen/component-library/icons/chevron-up.icon.svg"
 import { withDesign } from "storybook-addon-designs"
@@ -156,7 +156,6 @@ export const DefaultKaizenSiteDemo = () => (
     </TableContainer>
   </Container>
 )
-
 DefaultKaizenSiteDemo.storyName = "Default (Kaizen Site Demo)"
 
 export const Multiline = () => (
@@ -177,6 +176,7 @@ export const Multiline = () => (
     </TableContainer>
   </Container>
 )
+Multiline.parameters = { chromatic: { disable: false } }
 
 export const Reversed = () => (
   <Container>
@@ -196,12 +196,10 @@ export const Reversed = () => (
     </TableContainer>
   </Container>
 )
-
 Reversed.storyName = "Reversed"
 Reversed.parameters = {
-  backgrounds: {
-    default: "Purple 700",
-  },
+  backgrounds: { default: "Purple 700" },
+  chromatic: { disable: false },
 }
 
 export const DataVariant = () => (
@@ -222,8 +220,8 @@ export const DataVariant = () => (
     </TableContainer>
   </Container>
 )
-
 DataVariant.storyName = "Data Variant"
+DataVariant.parameters = { chromatic: { disable: false } }
 
 export const Clickable = () => (
   <Container>
@@ -326,8 +324,8 @@ export const ExpandedPopout = () => {
     </Container>
   )
 }
-
 ExpandedPopout.storyName = "Expanded popout"
+ExpandedPopout.parameters = { chromatic: { disable: false } }
 
 export const NoHeader = () => (
   <Container>
@@ -344,8 +342,8 @@ export const NoHeader = () => (
     </TableContainer>
   </Container>
 )
-
 NoHeader.storyName = "No header"
+NoHeader.parameters = { chromatic: { disable: false } }
 
 export const ExtraSpacing = () => (
   <Container>
@@ -362,8 +360,8 @@ export const ExtraSpacing = () => (
     </TableContainer>
   </Container>
 )
-
 ExtraSpacing.storyName = "Default variant (extra spacing)"
+ExtraSpacing.parameters = { chromatic: { disable: false } }
 
 export const HeaderAlignmentAndWrapping = () => (
   <Container>
@@ -421,8 +419,8 @@ export const HeaderAlignmentAndWrapping = () => (
     </TableContainer>
   </Container>
 )
-
 HeaderAlignmentAndWrapping.storyName = "Header alignments and wrapping"
+HeaderAlignmentAndWrapping.parameters = { chromatic: { disable: false } }
 
 export const Tooltip = () => (
   // Extra margin added, so we can see the tooltip above
@@ -480,12 +478,11 @@ export const Tooltip = () => (
     </TableContainer>
   </Container>
 )
-
 Tooltip.storyName = "Tooltip"
+Tooltip.parameters = { chromatic: { disable: false } }
 
 export const AnchorLink = () => (
-  // Extra margin added, so we can see the tooltip above
-  <Container style={{ marginTop: "200px" }}>
+  <Container>
     <TableContainer>
       <TableHeader>
         <TableHeaderRow>
@@ -528,7 +525,6 @@ export const AnchorLink = () => (
     </TableContainer>
   </Container>
 )
-
 AnchorLink.storyName = "Anchor Link"
 
 export const HoverHeaderCell = () => (
@@ -583,5 +579,4 @@ export const HoverHeaderCell = () => (
     </TableContainer>
   </Container>
 )
-
 HoverHeaderCell.storyName = "Header row hover"

--- a/draft-packages/tag/docs/Tag.stories.tsx
+++ b/draft-packages/tag/docs/Tag.stories.tsx
@@ -1,5 +1,5 @@
+import React from "react"
 import { Tag } from "@kaizen/draft-tag"
-import * as React from "react"
 import { withDesign } from "storybook-addon-designs"
 import { Avatar } from "@kaizen/draft-avatar"
 import { CATEGORIES } from "../../../storybook/constants"
@@ -38,7 +38,6 @@ export const DefaultMediumKaizenSiteDemo = args => (
     </Tag>
   </StoryContainer>
 )
-
 DefaultMediumKaizenSiteDemo.storyName = "Default - Medium (Kaizen Site Demo)"
 
 export const Status = () => (
@@ -69,8 +68,8 @@ export const Status = () => (
     </StorySection>
   </StoryContainer>
 )
-
 Status.storyName = "Status"
+Status.parameters = { chromatic: { disable: false } }
 
 export const Sentiment = () => (
   <StoryContainer>
@@ -100,8 +99,8 @@ export const Sentiment = () => (
     </StorySection>
   </StoryContainer>
 )
-
 Sentiment.storyName = "Sentiment"
+Sentiment.parameters = { chromatic: { disable: false } }
 
 export const Validation = () => (
   <StoryContainer>
@@ -111,8 +110,8 @@ export const Validation = () => (
     <Tag variant="validationCautionary">Cautionary</Tag>
   </StoryContainer>
 )
-
 Validation.storyName = "Validation"
+Validation.parameters = { chromatic: { disable: false } }
 
 export const Profile = () => (
   <StoryContainer>
@@ -134,8 +133,8 @@ export const Profile = () => (
     </Tag>
   </StoryContainer>
 )
-
 Profile.storyName = "Profile"
+Profile.parameters = { chromatic: { disable: false } }
 
 export const Dismissible = () => (
   <StoryContainer>
@@ -144,5 +143,5 @@ export const Dismissible = () => (
     </Tag>
   </StoryContainer>
 )
-
 Dismissible.storyName = "Dismissible"
+Dismissible.parameters = { chromatic: { disable: false } }

--- a/draft-packages/tile/docs/Tile.stories.tsx
+++ b/draft-packages/tile/docs/Tile.stories.tsx
@@ -1,5 +1,4 @@
-import * as React from "react"
-
+import React from "react"
 import {
   MultiActionTile,
   TileInformation,
@@ -72,7 +71,6 @@ export const MultiAction = () => (
     primaryAction={primaryAction}
   />
 )
-
 MultiAction.storyName = "Multi action tile"
 
 export const MultiActionMoods = () => (
@@ -120,8 +118,8 @@ export const MultiActionMoods = () => (
     />
   </TileGrid>
 )
-
 MultiActionMoods.storyName = "Multi action tile moods"
+MultiActionMoods.parameters = { chromatic: { disable: false } }
 
 export const MultiActionWithSecondary = () => (
   <MultiActionTile
@@ -131,8 +129,8 @@ export const MultiActionWithSecondary = () => (
     secondaryAction={secondaryAction}
   />
 )
-
 MultiActionWithSecondary.storyName = "Multi action tile with secondary action"
+MultiActionWithSecondary.parameters = { chromatic: { disable: false } }
 
 export const MultiActionWithChildren = () => (
   <MultiActionTile
@@ -143,8 +141,8 @@ export const MultiActionWithChildren = () => (
     {children}
   </MultiActionTile>
 )
-
 MultiActionWithChildren.storyName = "Multi action tile with children"
+MultiActionWithChildren.parameters = { chromatic: { disable: false } }
 
 export const MultiActionWithCustomTitle = () => (
   <MultiActionTile
@@ -155,7 +153,6 @@ export const MultiActionWithCustomTitle = () => (
     {children}
   </MultiActionTile>
 )
-
 MultiActionWithCustomTitle.storyName = "Multi action tile with custom title tag"
 
 export const MultiActionWithInformation = () => (
@@ -166,7 +163,6 @@ export const MultiActionWithInformation = () => (
     information={information}
   />
 )
-
 MultiActionWithInformation.storyName = "Multi action tile with information"
 
 export const MultiActionActionInNewTabs = () => (
@@ -185,7 +181,6 @@ export const MultiActionActionInNewTabs = () => (
     }}
   />
 )
-
 MultiActionActionInNewTabs.storyName =
   "Multi action tile with actions opening in new tabs"
 
@@ -197,8 +192,8 @@ export const Information = () => (
     footer={<Tag variant="statusLive">Live</Tag>}
   />
 )
-
 Information.storyName = "Information tile"
+Information.parameters = { chromatic: { disable: false } }
 
 export const InformationMood = () => (
   <TileGrid>
@@ -252,7 +247,6 @@ export const InformationMood = () => (
     />
   </TileGrid>
 )
-
 InformationMood.storyName = "Information tile moods"
 
 export const InformationWithChildren = () => (
@@ -265,7 +259,6 @@ export const InformationWithChildren = () => (
     {children}
   </InformationTile>
 )
-
 InformationWithChildren.storyName = "Information tile with children"
 
 export const InformationWithCustomTitle = () => (
@@ -278,7 +271,6 @@ export const InformationWithCustomTitle = () => (
     {children}
   </InformationTile>
 )
-
 InformationMood.storyName = "Information tile moods"
 
 export const InformationCustomInfoElement = () => (
@@ -289,7 +281,6 @@ export const InformationCustomInfoElement = () => (
     footer={<Tag variant="statusLive">Live</Tag>}
   />
 )
-
 InformationCustomInfoElement.storyName =
   "Information tile (custom information element)"
 
@@ -302,7 +293,6 @@ export const InformationCustomTitleTag = () => (
     footer={<Tag variant="statusLive">Live</Tag>}
   />
 )
-
 InformationCustomTitleTag.storyName = "Information tile (custom title tag)"
 
 export const TileGridWithTiles = () => (
@@ -345,8 +335,8 @@ export const TileGridWithTiles = () => (
     />
   </TileGrid>
 )
-
 TileGridWithTiles.storyName = "Tile Grid"
+TileGridWithTiles.parameters = { chromatic: { disable: false } }
 
 export const TileGridWithFewTiles = () => (
   <TileGrid>
@@ -363,5 +353,5 @@ export const TileGridWithFewTiles = () => (
     />
   </TileGrid>
 )
-
 TileGridWithFewTiles.storyName = "Tile Grid (less than one row)"
+TileGridWithFewTiles.parameters = { chromatic: { disable: false } }

--- a/draft-packages/title-block-zen/docs/TitleBlockZen.stories.tsx
+++ b/draft-packages/title-block-zen/docs/TitleBlockZen.stories.tsx
@@ -1,4 +1,4 @@
-import * as React from "react"
+import React from "react"
 import addIcon from "@kaizen/component-library/icons/add.icon.svg"
 import { Box, Heading, Paragraph } from "@kaizen/component-library"
 import commentIcon from "@kaizen/component-library/icons/comment.icon.svg"
@@ -120,7 +120,6 @@ Default.args = {
     <NavigationTab text="Label" href="#" />,
   ],
 }
-
 Default.storyName = "Default"
 
 export const WithBadge = () => {
@@ -157,8 +156,8 @@ export const WithBadge = () => {
     </OffsetPadding>
   )
 }
-
 WithBadge.storyName = "With Primary Action Badge"
+WithBadge.parameters = { chromatic: { disable: false } }
 
 export const WithDefaultTag = () => (
   <OffsetPadding>
@@ -181,8 +180,8 @@ export const WithDefaultTag = () => (
     />
   </OffsetPadding>
 )
-
 WithDefaultTag.storyName = "With Default Survey Status (Tag)"
+WithDefaultTag.parameters = { chromatic: { disable: false } }
 
 export const AdminWithDefaultTag = () => (
   <OffsetPadding>
@@ -206,8 +205,8 @@ export const AdminWithDefaultTag = () => (
     />
   </OffsetPadding>
 )
-
 AdminWithDefaultTag.storyName = "Admin With Default Survey Status (Tag)"
+AdminWithDefaultTag.parameters = { chromatic: { disable: false } }
 
 export const DefaultWithMenuButton = () => (
   <OffsetPadding>
@@ -259,8 +258,8 @@ export const DefaultWithMenuButton = () => (
     />
   </OffsetPadding>
 )
-
 DefaultWithMenuButton.storyName = "Default (Menu Button)"
+DefaultWithMenuButton.parameters = { chromatic: { disable: false } }
 
 export const AdminVariant = () => (
   <OffsetPadding>
@@ -292,8 +291,9 @@ export const AdminVariant = () => (
     />
   </OffsetPadding>
 )
-
 AdminVariant.storyName = "Admin variant"
+AdminVariant.parameters = { chromatic: { disable: false } }
+
 export const AdminVariantWithNavTabs = () => (
   <OffsetPadding>
     <TitleBlockZen
@@ -323,8 +323,8 @@ export const AdminVariantWithNavTabs = () => (
     />
   </OffsetPadding>
 )
-
 AdminVariantWithNavTabs.storyName = "Admin variant with Navigation Tabs"
+AdminVariantWithNavTabs.parameters = { chromatic: { disable: false } }
 
 export const EducationVariant = () => (
   <OffsetPadding>
@@ -385,8 +385,8 @@ export const EducationVariant = () => (
     </Skirt>
   </OffsetPadding>
 )
-
 EducationVariant.storyName = "Education variant"
+EducationVariant.parameters = { chromatic: { disable: false } }
 
 export const Engagement = () => (
   <OffsetPadding>
@@ -431,8 +431,8 @@ export const Engagement = () => (
     />
   </OffsetPadding>
 )
-
 Engagement.storyName = "Engagement"
+Engagement.parameters = { chromatic: { disable: false } }
 
 export const Performance = () => (
   <OffsetPadding>
@@ -490,8 +490,8 @@ export const Performance = () => (
     />
   </OffsetPadding>
 )
-
 Performance.storyName = "Performance"
+Performance.parameters = { chromatic: { disable: false } }
 
 export const PerformanceWithAvatarProps = () => (
   <OffsetPadding>
@@ -552,7 +552,6 @@ export const PerformanceWithAvatarProps = () => (
     />
   </OffsetPadding>
 )
-
 PerformanceWithAvatarProps.storyName = "Performance with AvatarProps"
 
 export const PerformanceWithEmptyAvatarProps = () => (
@@ -611,7 +610,6 @@ export const PerformanceWithEmptyAvatarProps = () => (
     />
   </OffsetPadding>
 )
-
 PerformanceWithEmptyAvatarProps.storyName = "Performance with Empty AvatarProps"
 
 export const LongLabels = () => (
@@ -674,6 +672,7 @@ export const LongLabels = () => (
     />
   </OffsetPadding>
 )
+LongLabels.parameters = { chromatic: { disable: false } }
 
 const MENU_LINKS = [
   {
@@ -815,8 +814,8 @@ export const DefaultWithContent = () => (
     </Container>
   </OffsetPadding>
 )
-
 DefaultWithContent.storyName = "Default with content"
+DefaultWithContent.parameters = { chromatic: { disable: false } }
 
 export const DefaultNoSecondary = () => (
   <OffsetPadding>
@@ -933,7 +932,6 @@ export const DefaultNoSecondary = () => (
     </Skirt> */}
   </OffsetPadding>
 )
-
 DefaultNoSecondary.storyName = "Default (no secondary actions)"
 
 export const DefaultOnlyPrimary = () => (
@@ -967,7 +965,6 @@ export const DefaultOnlyPrimary = () => (
     />
   </OffsetPadding>
 )
-
 DefaultOnlyPrimary.storyName = "Default (only primary action)"
 
 export const DefaultWithReportSwitcher = () => (
@@ -1024,8 +1021,8 @@ export const DefaultWithReportSwitcher = () => (
     />
   </OffsetPadding>
 )
-
 DefaultWithReportSwitcher.storyName = "Default with report switcher"
+DefaultWithReportSwitcher.parameters = { chromatic: { disable: false } }
 
 export const DefaultNoLink = () => (
   <OffsetPadding>
@@ -1086,7 +1083,6 @@ export const DefaultNoLink = () => (
     </Skirt>
   </OffsetPadding>
 )
-
 DefaultNoLink.storyName = "Default (no link in breadcrumb)"
 
 export const DefaultOnlyLongTitle = () => (
@@ -1107,7 +1103,6 @@ export const DefaultOnlyLongTitle = () => (
     />
   </OffsetPadding>
 )
-
 DefaultOnlyLongTitle.storyName = "Default (only long title)"
 
 export const DefaultCollapsedNavigation = () => (
@@ -1136,8 +1131,8 @@ export const DefaultCollapsedNavigation = () => (
     </Container>
   </OffsetPadding>
 )
-
 DefaultCollapsedNavigation.storyName = "Default (collapsed navigation)"
+DefaultCollapsedNavigation.parameters = { chromatic: { disable: false } }
 
 export const DefaultCollapsedNavigationCard = () => (
   <OffsetPadding>
@@ -1167,7 +1162,6 @@ export const DefaultCollapsedNavigationCard = () => (
     </Skirt>
   </OffsetPadding>
 )
-
 DefaultCollapsedNavigationCard.story = {
   name: "Default (collapsed navigation with card)",
 }
@@ -1201,5 +1195,4 @@ export const AdminVariantNavigation = () => (
     </Container>
   </OffsetPadding>
 )
-
 AdminVariantNavigation.storyName = "Admin (collapsed navigation)"

--- a/draft-packages/tooltip/docs/Tooltip.stories.tsx
+++ b/draft-packages/tooltip/docs/Tooltip.stories.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable jsx-a11y/anchor-is-valid */
-import * as React from "react"
+import React from "react"
 import informationIcon from "@kaizen/component-library/icons/information-white.icon.svg"
 import meatballsIcon from "@kaizen/component-library/icons/meatballs.icon.svg"
 import { Tag } from "@kaizen/draft-tag"
@@ -48,7 +48,6 @@ export const DefaultKaizenSiteDemo = props => (
     </Tooltip>
   </div>
 )
-
 DefaultKaizenSiteDemo.storyName = "Default (Kaizen Site Demo)"
 DefaultKaizenSiteDemo.parameters = {
   info: {
@@ -262,6 +261,7 @@ export const StickerSheet = props => (
     </div>
   </div>
 )
+StickerSheet.parameters = { chromatic: { disable: false } }
 
 export const OverflowScroll = props => (
   <>

--- a/draft-packages/well/docs/Well.stories.tsx
+++ b/draft-packages/well/docs/Well.stories.tsx
@@ -1,7 +1,7 @@
+import React from "react"
 import { Box, Heading, Paragraph } from "@kaizen/component-library"
 import { TextField } from "@kaizen/draft-form"
 import { Well } from "@kaizen/draft-well"
-import * as React from "react"
 import { withDesign } from "storybook-addon-designs"
 import { CATEGORIES } from "../../../storybook/constants"
 import { figmaEmbed } from "../../../storybook/helpers"
@@ -47,46 +47,48 @@ export const DefaultWithSolidBorderKaizenSiteDemo = () => (
     <ExampleContent />
   </Well>
 )
-
 DefaultWithSolidBorderKaizenSiteDemo.storyName =
   "Default with solid border (Kaizen Site Demo)"
+DefaultWithSolidBorderKaizenSiteDemo.parameters = {
+  chromatic: { disable: false },
+}
 
 export const DefaultWithDashedBorder = () => (
   <Well borderStyle="dashed">
     <ExampleContent />
   </Well>
 )
-
 DefaultWithDashedBorder.storyName = "Default with dashed border"
+DefaultWithDashedBorder.parameters = { chromatic: { disable: false } }
 
 export const DefaultWithoutBorder = () => (
   <Well borderStyle="none">
     <ExampleContent />
   </Well>
 )
-
 DefaultWithoutBorder.storyName = "Default without border"
+DefaultWithoutBorder.parameters = { chromatic: { disable: false } }
 
 export const DefaultWithNoMargin = () => (
   <Well noMargin>
     <ExampleContent />
   </Well>
 )
-
 DefaultWithNoMargin.storyName = "Default with no margin"
+DefaultWithNoMargin.parameters = { chromatic: { disable: false } }
 
 export const Positive = () => (
   <Well variant="positive">
     <ExampleContent />
   </Well>
 )
+Positive.parameters = { chromatic: { disable: false } }
 
 export const PositiveWithDashedBorder = () => (
   <Well variant="positive" borderStyle="dashed">
     <ExampleContent />
   </Well>
 )
-
 PositiveWithDashedBorder.storyName = "Positive with dashed border"
 
 export const PositiveWithNoBorder = () => (
@@ -94,7 +96,6 @@ export const PositiveWithNoBorder = () => (
     <ExampleContent />
   </Well>
 )
-
 PositiveWithNoBorder.storyName = "Positive with no border"
 
 export const Negative = () => (
@@ -102,13 +103,13 @@ export const Negative = () => (
     <ExampleContent />
   </Well>
 )
+Negative.parameters = { chromatic: { disable: false } }
 
 export const NegativeWithDashedBorder = () => (
   <Well variant="negative" borderStyle="dashed">
     <ExampleContent />
   </Well>
 )
-
 NegativeWithDashedBorder.storyName = "Negative with dashed border"
 
 export const NegativeWithNoBorder = () => (
@@ -116,7 +117,6 @@ export const NegativeWithNoBorder = () => (
     <ExampleContent />
   </Well>
 )
-
 NegativeWithNoBorder.storyName = "Negative with no border"
 
 export const Informative = () => (
@@ -124,13 +124,13 @@ export const Informative = () => (
     <ExampleContent />
   </Well>
 )
+Informative.parameters = { chromatic: { disable: false } }
 
 export const InformativeWithDashedBorder = () => (
   <Well variant="informative" borderStyle="dashed">
     <ExampleContent />
   </Well>
 )
-
 InformativeWithDashedBorder.storyName = "Informative with dashed border"
 
 export const InformativeWithNoBorder = () => (
@@ -138,7 +138,6 @@ export const InformativeWithNoBorder = () => (
     <ExampleContent />
   </Well>
 )
-
 InformativeWithNoBorder.storyName = "Informative with no border"
 
 export const Cautionary = () => (
@@ -146,13 +145,13 @@ export const Cautionary = () => (
     <ExampleContent />
   </Well>
 )
+Cautionary.parameters = { chromatic: { disable: false } }
 
 export const CautionaryWithDashedBorder = () => (
   <Well variant="cautionary" borderStyle="dashed">
     <ExampleContent />
   </Well>
 )
-
 CautionaryWithDashedBorder.storyName = "Cautionary with dashed border"
 
 export const CautionaryWithNoBorder = () => (
@@ -160,7 +159,6 @@ export const CautionaryWithNoBorder = () => (
     <ExampleContent />
   </Well>
 )
-
 CautionaryWithNoBorder.storyName = "Cautionary with no border"
 
 export const Assertive = () => (
@@ -168,13 +166,13 @@ export const Assertive = () => (
     <ExampleContent />
   </Well>
 )
+Assertive.parameters = { chromatic: { disable: false } }
 
 export const AssertiveWithDashedBorder = () => (
   <Well variant="assertive" borderStyle="dashed">
     <ExampleContent />
   </Well>
 )
-
 AssertiveWithDashedBorder.storyName = "Assertive with dashed border"
 
 export const AssertiveWithNoBorder = () => (
@@ -182,7 +180,6 @@ export const AssertiveWithNoBorder = () => (
     <ExampleContent />
   </Well>
 )
-
 AssertiveWithNoBorder.storyName = "Assertive with no border"
 
 export const Prominent = () => (
@@ -190,13 +187,13 @@ export const Prominent = () => (
     <ExampleContent />
   </Well>
 )
+Prominent.parameters = { chromatic: { disable: false } }
 
 export const ProminentWithDashedBorder = () => (
   <Well variant="prominent" borderStyle="dashed">
     <ExampleContent />
   </Well>
 )
-
 ProminentWithDashedBorder.storyName = "Prominent with dashed border"
 
 export const ProminentWithNoBorder = () => (
@@ -204,5 +201,4 @@ export const ProminentWithNoBorder = () => (
     <ExampleContent />
   </Well>
 )
-
 ProminentWithNoBorder.storyName = "Prominent with no border"

--- a/packages/a11y/docs/VisuallyHidden.stories.tsx
+++ b/packages/a11y/docs/VisuallyHidden.stories.tsx
@@ -1,5 +1,4 @@
 import React from "react"
-
 import { CATEGORIES, SUB_CATEGORIES } from "../../../storybook/constants"
 import { VisuallyHidden } from ".."
 
@@ -23,3 +22,4 @@ export const TextWithVisuallyHidden = () => (
 )
 
 TextWithVisuallyHidden.storyName = "Hidden text embedded in visible text"
+TextWithVisuallyHidden.parameters = { chromatic: { disable: false } }

--- a/packages/brand-moment/docs/BrandMoment.stories.tsx
+++ b/packages/brand-moment/docs/BrandMoment.stories.tsx
@@ -56,6 +56,7 @@ export const InformativeIntro = (_, { isRTL }) => (
   />
 )
 InformativeIntro.storyName = "Informative intro"
+InformativeIntro.parameters = { chromatic: { disable: false } }
 
 export const PositiveOutro = (_, { isRTL }) => (
   <BrandMoment
@@ -153,6 +154,7 @@ export const PositiveOutroCustomerFocused = (_, { isRTL }) => (
   />
 )
 PositiveOutroCustomerFocused.storyName = "Positive outro (customer focused)"
+PositiveOutroCustomerFocused.parameters = { chromatic: { disable: false } }
 
 export const Error = (_, { isRTL }) => (
   <BrandMoment
@@ -187,3 +189,4 @@ export const Error = (_, { isRTL }) => (
     }}
   />
 )
+Error.parameters = { chromatic: { disable: false } }

--- a/packages/brand/docs/Brand.stories.tsx
+++ b/packages/brand/docs/Brand.stories.tsx
@@ -3,21 +3,22 @@ import { CATEGORIES } from "../../../storybook/constants"
 import { figmaEmbed } from "../../../storybook/helpers/figmaEmbed"
 import { Brand } from "../src/Brand/Brand"
 
+const REVERSED_BG = {
+  backgrounds: {
+    default: "Purple 700",
+  },
+}
+
 export default {
   title: `${CATEGORIES.components}/Brand`,
   component: Brand,
   parameters: {
+    chromatic: { disable: false },
     docs: {
       description: {
         component: 'Import { Brand } from "@kaizen/brand"',
       },
     },
-  },
-}
-
-const reversedBg = {
-  backgrounds: {
-    default: "Purple 700",
   },
 }
 
@@ -39,7 +40,7 @@ export const LogoHorizontalReversed = () => (
 LogoHorizontalReversed.story = {
   name: "Logo horizontal (Reversed)",
   parameters: {
-    ...reversedBg,
+    ...REVERSED_BG,
     ...figmaEmbed(
       "https://www.figma.com/file/eZKEE5kXbEMY3lx84oz8iN/%E2%9D%A4%EF%B8%8F-UI-Kit-Heart?node-id=1929%3A13091"
     ),
@@ -64,7 +65,7 @@ export const LogoVerticalReversed = () => (
 LogoVerticalReversed.story = {
   name: "Logo Vertical (Reversed)",
   parameters: {
-    ...reversedBg,
+    ...REVERSED_BG,
     ...figmaEmbed(
       "https://www.figma.com/file/eZKEE5kXbEMY3lx84oz8iN/%E2%9D%A4%EF%B8%8F-UI-Kit-Heart?node-id=1929%3A13091"
     ),
@@ -89,7 +90,7 @@ export const EnsoReversed = () => (
 EnsoReversed.story = {
   name: "Enso (Reversed)",
   parameters: {
-    ...reversedBg,
+    ...REVERSED_BG,
     ...figmaEmbed(
       "https://www.figma.com/file/eZKEE5kXbEMY3lx84oz8iN/%E2%9D%A4%EF%B8%8F-UI-Kit-Heart?node-id=1929%3A13091"
     ),
@@ -122,7 +123,7 @@ export const CollectiveIntelligenceReversed = () => (
 CollectiveIntelligenceReversed.story = {
   name: "Collective Intelligence (Reversed)",
   parameters: {
-    ...reversedBg,
+    ...REVERSED_BG,
     ...figmaEmbed(
       "https://www.figma.com/file/eZKEE5kXbEMY3lx84oz8iN/%E2%9D%A4%EF%B8%8F-UI-Kit-Heart?node-id=1929%3A13091"
     ),

--- a/packages/button/docs/Button.stories.tsx
+++ b/packages/button/docs/Button.stories.tsx
@@ -1,3 +1,4 @@
+import React, { useState } from "react"
 import { Heading } from "@kaizen/component-library"
 import configureIcon from "@kaizen/component-library/icons/configure.icon.svg"
 import filterIcon from "@kaizen/component-library/icons/filter.icon.svg"
@@ -6,7 +7,6 @@ import arrowRight from "@kaizen/component-library/icons/arrow-right.icon.svg"
 import addIcon from "@kaizen/component-library/icons/add.icon.svg"
 import chevronDown from "@kaizen/component-library/icons/chevron-down.icon.svg"
 import meatballsIcon from "@kaizen/component-library/icons/meatballs.icon.svg"
-import React, { useState } from "react"
 import { withDesign } from "storybook-addon-designs"
 import { Button, CustomButtonProps, IconButton } from ".."
 import { CATEGORIES, SUB_CATEGORIES } from "../../../storybook/constants"
@@ -37,6 +37,11 @@ export default {
 }
 
 const clickAction = () => alert("This shouldn't fire when button is working")
+
+export const DefaultKaizenSiteDemo = args => <Button {...args} />
+DefaultKaizenSiteDemo.story = {
+  name: "Default Button (Kaizen Site Demo)",
+}
 
 export const LightButtons = () => (
   <>
@@ -431,6 +436,7 @@ export const LightButtons = () => (
     <IconFormDiscouraged />
   </>
 )
+LightButtons.parameters = { chromatic: { disable: false } }
 
 export const ReversedButtons = () => (
   <>
@@ -807,15 +813,9 @@ export const ReversedButtons = () => (
     <IconFormDiscouraged reversed={true} />
   </>
 )
-export const DefaultKaizenSiteDemo = args => <Button {...args} />
-DefaultKaizenSiteDemo.story = {
-  name: "Default Button (Kaizen Site Demo)",
-}
-
 ReversedButtons.parameters = {
-  backgrounds: {
-    default: "Purple 700",
-  },
+  backgrounds: { default: "Purple 700" },
+  chromatic: { disable: false },
 }
 
 // Default Button

--- a/packages/button/docs/IconButton.stories.tsx
+++ b/packages/button/docs/IconButton.stories.tsx
@@ -1,5 +1,5 @@
+import React from "react"
 import configureIcon from "@kaizen/component-library/icons/configure.icon.svg"
-import * as React from "react"
 import { withDesign } from "storybook-addon-designs"
 import { IconButton } from ".."
 import { CATEGORIES, SUB_CATEGORIES } from "../../../storybook/constants"
@@ -31,5 +31,5 @@ export default {
 export const DefaultKaizenSiteDemoIcon = args => (
   <IconButton {...args} icon={configureIcon} />
 )
-
 DefaultKaizenSiteDemoIcon.storyName = "Default Icon (Kaizen Site Demo)"
+DefaultKaizenSiteDemoIcon.parameters = { chromatic: { disable: false } }

--- a/packages/component-library/stories/Box.stories.tsx
+++ b/packages/component-library/stories/Box.stories.tsx
@@ -1,4 +1,4 @@
-import * as React from "react"
+import React from "react"
 import { Paragraph } from "@kaizen/component-library"
 import {
   Title,
@@ -10,7 +10,6 @@ import {
   PRIMARY_STORY,
 } from "@storybook/addon-docs"
 import { Box } from "../components/Box"
-
 import { CATEGORIES } from "../../../storybook/constants"
 import styles from "./Box.stories.scss"
 
@@ -64,61 +63,55 @@ const Documentation = ({ reversed }: { reversed?: boolean }) => (
 )
 
 export const BoxDefault = () => (
-  <>
-    <div className={styles.boxStoriesWrapper}>
-      <Box>
-        A box with no props has a default margin and padding of 0. The children
-        of box are also unstyled.
-      </Box>
-    </div>
-  </>
+  <div className={styles.boxStoriesWrapper}>
+    <Box>
+      A box with no props has a default margin and padding of 0. The children of
+      box are also unstyled.
+    </Box>
+  </div>
 )
 BoxDefault.storyName = "Default"
 
 export const BoxWithMargin = () => (
-  <>
-    <div className={styles.boxStoriesWrapper}>
-      <Box ml={1} mr={0.25} mt={0.5} mb={0.5}>
-        This is an example Box with margin left, right, and top explicitly
-        defined.
-      </Box>
-    </div>
-  </>
+  <div className={styles.boxStoriesWrapper}>
+    <Box ml={1} mr={0.25} mt={0.5} mb={0.5}>
+      This is an example Box with margin left, right, and top explicitly
+      defined.
+    </Box>
+  </div>
 )
 BoxWithMargin.storyName = "Box With Margin"
+BoxWithMargin.parameters = { chromatic: { disable: false } }
 
 export const BoxWithPadding = () => (
-  <>
-    <div className={styles.boxStoriesWrapper}>
-      <Box p={4}>
-        <span>Box with 4 units of padding</span>
-      </Box>
-    </div>
-  </>
+  <div className={styles.boxStoriesWrapper}>
+    <Box p={4}>
+      <span>Box with 4 units of padding</span>
+    </Box>
+  </div>
 )
 BoxWithPadding.storyName = "Box With Padding"
+BoxWithPadding.parameters = { chromatic: { disable: false } }
 
 export const BoxWithXAndYPadding = () => (
-  <>
-    <div className={styles.boxStoriesWrapper}>
-      <Box px={4} py={1}>
-        <span>Box with 4 units of padding</span>
-      </Box>
-    </div>
-  </>
+  <div className={styles.boxStoriesWrapper}>
+    <Box px={4} py={1}>
+      <span>Box with 4 units of padding</span>
+    </Box>
+  </div>
 )
 BoxWithXAndYPadding.storyName = "Box With X And Y Padding"
+BoxWithXAndYPadding.parameters = { chromatic: { disable: false } }
 
 export const BoxWithRtlSupport = () => (
-  <>
-    <div className={styles.boxStoriesWrapper}>
-      <Box rtl pr={4}>
-        <span>
-          Box with 4 units of padding on the <strong>left</strong> for RTL
-          languages
-        </span>
-      </Box>
-    </div>
-  </>
+  <div className={styles.boxStoriesWrapper}>
+    <Box rtl pr={4}>
+      <span>
+        Box with 4 units of padding on the <strong>left</strong> for RTL
+        languages
+      </span>
+    </Box>
+  </div>
 )
 BoxWithRtlSupport.storyName = "Box With Rtl Support"
+BoxWithRtlSupport.parameters = { chromatic: { disable: false } }

--- a/packages/component-library/stories/Heading.stories.tsx
+++ b/packages/component-library/stories/Heading.stories.tsx
@@ -1,4 +1,4 @@
-import * as React from "react"
+import React from "react"
 import { Paragraph, Box } from "@kaizen/component-library"
 import {
   Title,
@@ -16,6 +16,7 @@ export default {
   title: `${CATEGORIES.components}/${SUB_CATEGORIES.typography}/Heading`,
   component: Heading,
   parameters: {
+    chromatic: { disable: false },
     docs: {
       page: () => (
         <>
@@ -80,11 +81,7 @@ const Documentation = ({ reversed }: { reversed?: boolean }) => (
   </Box>
 )
 
-export const Display0 = () => (
-  <>
-    <Heading variant="display-0">Display 0</Heading>
-  </>
-)
+export const Display0 = () => <Heading variant="display-0">Display 0</Heading>
 
 export const Heading1 = () => (
   <Heading data-automation-id="test" variant="heading-1" id="make-me-unique">
@@ -92,46 +89,41 @@ export const Heading1 = () => (
   </Heading>
 )
 
-export const Heading2 = () => (
-  <>
-    <Heading variant="heading-2">Heading 2</Heading>
-  </>
+export const Heading2 = () => <Heading variant="heading-2">Heading 2</Heading>
+
+export const Heading3 = () => <Heading variant="heading-3">Heading 3</Heading>
+
+export const Heading4 = () => <Heading variant="heading-4">Heading 4</Heading>
+
+export const Heading5 = () => <Heading variant="heading-5">Heading 5</Heading>
+
+export const Heading6 = () => <Heading variant="heading-6">Heading 6</Heading>
+
+export const Heading1Positive = () => (
+  <Heading variant="heading-1" color="positive">
+    Heading 1 (positive)
+  </Heading>
 )
 
-export const Heading3 = () => (
-  <>
-    <Heading variant="heading-3">Heading 3</Heading>
-  </>
+export const Heading1Negative = () => (
+  <Heading variant="heading-1" color="negative">
+    Heading 1 (negative)
+  </Heading>
 )
 
-export const Heading4 = () => (
-  <>
-    {" "}
-    <Heading variant="heading-4">Heading 4</Heading>
-  </>
+export const Heading3Positive = () => (
+  <Heading variant="heading-3" color="positive">
+    Heading 3 (positive)
+  </Heading>
 )
 
-export const Heading5 = () => (
-  <>
-    <Heading variant="heading-5">Heading 5</Heading>
-  </>
+export const Heading3Negative = () => (
+  <Heading variant="heading-3" color="negative">
+    Heading 3 (negative)
+  </Heading>
 )
 
-export const Heading6 = () => (
-  <>
-    <Heading variant="heading-6">Heading 6</Heading>
-  </>
-)
-
-const Heading1DarkReducedOpacity = () => (
-  <>
-    <Heading variant="heading-1" color="dark-reduced-opacity">
-      Heading 1 (dark, reduced opacity)
-    </Heading>
-  </>
-)
-
-const Heading1White = () => (
+export const Heading1White = () => (
   <>
     <Heading variant="heading-1" color="white">
       Heading 1 (white)
@@ -139,8 +131,12 @@ const Heading1White = () => (
     <Documentation reversed />
   </>
 )
+Heading1White.storyName = "Heading 1 White"
+Heading1White.parameters = {
+  backgrounds: { default: "Purple 700" },
+}
 
-const Heading1WhiteReducedOpacity = () => (
+export const Heading1WhiteReducedOpacity = () => (
   <>
     <Heading variant="heading-1" color="white-reduced-opacity">
       Heading 1 (white, reduced opacity)
@@ -148,53 +144,13 @@ const Heading1WhiteReducedOpacity = () => (
     <Documentation reversed />
   </>
 )
-
-export const Heading1Positive = () => (
-  <>
-    <Heading variant="heading-1" color="positive">
-      Heading 1 (positive)
-    </Heading>
-  </>
-)
-
-export const Heading1Negative = () => (
-  <>
-    <Heading variant="heading-1" color="negative">
-      Heading 1 (negative)
-    </Heading>
-  </>
-)
-
-export const Heading3Positive = () => (
-  <>
-    <Heading variant="heading-3" color="positive">
-      Heading 3 (positive)
-    </Heading>
-  </>
-)
-
-export const Heading3Negative = () => (
-  <>
-    <Heading variant="heading-3" color="negative">
-      Heading 3 (negative)
-    </Heading>
-  </>
-)
-
-Heading1White.storyName = "Heading 1 White"
-
-Heading1White.parameters = {
-  backgrounds: { default: "Purple 700" },
-}
-
 Heading1WhiteReducedOpacity.storyName = "Heading 1 White Reduced Opacity"
-
 Heading1WhiteReducedOpacity.parameters = {
   backgrounds: { default: "Purple 700" },
 }
 
-export {
-  Heading1White,
-  Heading1WhiteReducedOpacity,
-  Heading1DarkReducedOpacity,
-}
+export const Heading1DarkReducedOpacity = () => (
+  <Heading variant="heading-1" color="dark-reduced-opacity">
+    Heading 1 (dark, reduced opacity)
+  </Heading>
+)

--- a/packages/component-library/stories/Icon.stories.tsx
+++ b/packages/component-library/stories/Icon.stories.tsx
@@ -1,5 +1,4 @@
-import * as React from "react"
-
+import React from "react"
 import { Icon } from "@kaizen/component-library"
 import configureIcon from "@kaizen/component-library/icons/configure.icon.svg"
 import { CATEGORIES } from "../../../storybook/constants"
@@ -29,15 +28,16 @@ export const MeaningfulKaizenSiteDemo = () => (
     />
   </div>
 )
-
 MeaningfulKaizenSiteDemo.storyName = "Meaningful (Kaizen Site Demo)"
 
 export const Presentational = () => (
   <Icon icon={configureIcon} role="presentation" />
 )
+Presentational.parameters = { chromatic: { disable: false } }
 
 export const InheritSize = () => (
   <div style={{ width: "100%" }}>
     <Icon icon={configureIcon} role="presentation" inheritSize={true} />
   </div>
 )
+InheritSize.parameters = { chromatic: { disable: false } }

--- a/packages/component-library/stories/Paragraph.stories.tsx
+++ b/packages/component-library/stories/Paragraph.stories.tsx
@@ -1,5 +1,4 @@
-import * as colorTokens from "@kaizen/design-tokens/tokens/color.json"
-import * as React from "react"
+import React from "react"
 import { Box } from "@kaizen/component-library"
 import {
   Title,
@@ -17,6 +16,7 @@ export default {
   title: `${CATEGORIES.components}/${SUB_CATEGORIES.typography}/Paragraph`,
   component: Box,
   parameters: {
+    chromatic: { disable: false },
     docs: {
       page: () => (
         <>
@@ -82,31 +82,25 @@ export const IntroLede = () => (
 )
 
 export const Body = () => (
-  <>
-    <Paragraph data-automation-id="test" variant="body">
-      Paragraph Body
-    </Paragraph>
-  </>
+  <Paragraph data-automation-id="test" variant="body">
+    Paragraph Body
+  </Paragraph>
 )
 
 export const BodyBold = () => (
-  <>
-    <Paragraph data-automation-id="test" variant="body">
-      <strong>Paragraph Body (bold)</strong>
-    </Paragraph>
-  </>
+  <Paragraph data-automation-id="test" variant="body">
+    <strong>Paragraph Body (bold)</strong>
+  </Paragraph>
 )
 
 export const BodyDarkReducedOpacity = () => (
-  <>
-    <Paragraph
-      data-automation-id="test"
-      variant="body"
-      color="dark-reduced-opacity"
-    >
-      Paragraph Body
-    </Paragraph>
-  </>
+  <Paragraph
+    data-automation-id="test"
+    variant="body"
+    color="dark-reduced-opacity"
+  >
+    Paragraph Body
+  </Paragraph>
 )
 
 export const BodyWhite = () => (
@@ -117,37 +111,27 @@ export const BodyWhite = () => (
     <Documentation reversed />
   </>
 )
-
 BodyWhite.storyName = "Body White"
-
 BodyWhite.parameters = {
   backgrounds: { default: "Purple 700" },
 }
 
 export const BodyPositive = () => (
-  <>
-    <Paragraph variant="body" color="positive">
-      Paragraph Body
-    </Paragraph>
-  </>
+  <Paragraph variant="body" color="positive">
+    Paragraph Body
+  </Paragraph>
 )
 
 export const BodyNegative = () => (
-  <>
-    <Paragraph variant="body" color="negative">
-      Paragraph Body
-    </Paragraph>
-  </>
+  <Paragraph variant="body" color="negative">
+    Paragraph Body
+  </Paragraph>
 )
 
 export const Small = () => (
-  <>
-    <Paragraph variant="small">Paragraph Small</Paragraph>
-  </>
+  <Paragraph variant="small">Paragraph Small</Paragraph>
 )
 
 export const ExtraSmall = () => (
-  <>
-    <Paragraph variant="extra-small">Paragraph Extra Small</Paragraph>
-  </>
+  <Paragraph variant="extra-small">Paragraph Extra Small</Paragraph>
 )

--- a/packages/date-picker/docs/DatePicker.stories.tsx
+++ b/packages/date-picker/docs/DatePicker.stories.tsx
@@ -49,6 +49,7 @@ export const DefaultWithDisabledDates = () => {
     />
   )
 }
+DefaultWithDisabledDates.parameters = { chromatic: { disable: false } }
 
 export const DefaultInputWithValue = () => {
   const [selectedDate, setSelectedDate] = useState<Date | undefined>()
@@ -66,6 +67,7 @@ export const DefaultInputWithValue = () => {
     />
   )
 }
+DefaultInputWithValue.parameters = { chromatic: { disable: false } }
 
 export const DisabledInput = () => {
   const [selectedDate, setSelectedDate] = useState<Date | undefined>()
@@ -84,6 +86,7 @@ export const DisabledInput = () => {
     />
   )
 }
+DisabledInput.parameters = { chromatic: { disable: false } }
 
 export const DisabledInputWithValue = () => {
   const [selectedDate, setSelectedDate] = useState<Date | undefined>()
@@ -102,3 +105,4 @@ export const DisabledInputWithValue = () => {
     />
   )
 }
+DisabledInputWithValue.parameters = { chromatic: { disable: false } }

--- a/packages/design-tokens/docs/ColorTokens.stories.tsx
+++ b/packages/design-tokens/docs/ColorTokens.stories.tsx
@@ -8,6 +8,7 @@ import { useTheme } from "../react"
 export default {
   title: "Design Tokens/Color Tokens",
   parameters: {
+    chromatic: { disable: false },
     layout: "fullscreen",
     docs: {
       description: {

--- a/packages/loading-spinner/docs/LoadingSpinner.stories.tsx
+++ b/packages/loading-spinner/docs/LoadingSpinner.stories.tsx
@@ -1,4 +1,4 @@
-import * as React from "react"
+import React from "react"
 import { LoadingSpinner } from "@kaizen/loading-spinner"
 import { Box, Paragraph } from "@kaizen/component-library"
 import { withDesign } from "storybook-addon-designs"
@@ -10,6 +10,7 @@ export default {
   title: `${CATEGORIES.components}/Loading Spinner`,
   component: LoadingSpinner,
   parameters: {
+    chromatic: { disable: false },
     docs: {
       description: {
         component: 'import { LoadingSpinner } from "@kaizen/loading-spinner"',
@@ -43,9 +44,7 @@ export const DefaultStory = args => (
     </Paragraph>
   </div>
 )
-
 DefaultStory.storyName = "Default (Kaizen Site Demo)"
-
 DefaultStory.argTypes = {
   accessibilityLabel: {
     defaultValue: "Loading comments",

--- a/packages/notification/docs/GlobalNotification.stories.tsx
+++ b/packages/notification/docs/GlobalNotification.stories.tsx
@@ -1,5 +1,4 @@
-import * as React from "react"
-
+import React from "react"
 import { GlobalNotification } from "@kaizen/notification"
 import { Heading, Box } from "@kaizen/component-library"
 import { withDesign } from "storybook-addon-designs"
@@ -113,5 +112,5 @@ export const GlobalNotificationVariants = () => (
     </div>
   </div>
 )
-
 GlobalNotificationVariants.storyName = "Global notification variants"
+GlobalNotificationVariants.parameters = { chromatic: { disable: false } }

--- a/packages/notification/docs/InlineNotification.stories.tsx
+++ b/packages/notification/docs/InlineNotification.stories.tsx
@@ -1,5 +1,4 @@
-import * as React from "react"
-
+import React from "react"
 import { InlineNotification } from "@kaizen/notification"
 import { withDesign } from "storybook-addon-designs"
 import { figmaEmbed } from "../../../storybook/helpers"
@@ -29,6 +28,7 @@ const forceMultilineText = (
     </ol>
   </>
 )
+
 const withContentBelow = (Story: React.FunctionComponent) => (
   <>
     <Story />
@@ -62,7 +62,6 @@ export const DismissiblePositiveKaizenSiteDemo = () => (
     <a href="/">Manage users is now available</a>
   </InlineNotification>
 )
-
 DismissiblePositiveKaizenSiteDemo.storyName =
   "Dismissible, Positive (Kaizen Site Demo)"
 
@@ -77,7 +76,6 @@ export const DismissiblePositiveAutohide = () => (
     <a href="/">Manage users is now available</a>
   </InlineNotification>
 )
-
 DismissiblePositiveAutohide.storyName = "Dismissible, Positive, Autohide"
 
 export const DismissiblePositiveAutohideHideCloseIcon = () => (
@@ -92,7 +90,6 @@ export const DismissiblePositiveAutohideHideCloseIcon = () => (
     <a href="/">Manage users is now available</a>
   </InlineNotification>
 )
-
 DismissiblePositiveAutohideHideCloseIcon.storyName =
   "Dismissible, Positive, Autohide, Hide Close Icon"
 
@@ -106,7 +103,6 @@ export const DismissibleInformative = () => (
     process is completed. <a href="/">Manage users</a>
   </InlineNotification>
 )
-
 DismissibleInformative.storyName = "Dismissible, Informative"
 
 export const DismissibleCautionary = () => (
@@ -119,7 +115,6 @@ export const DismissibleCautionary = () => (
     issues. <a href="/">View issues</a>
   </InlineNotification>
 )
-
 DismissibleCautionary.storyName = "Dismissible, Cautionary"
 
 export const DismissibleNegative = () => (
@@ -131,7 +126,6 @@ export const DismissibleNegative = () => (
     Check your connection and try again. <a href="/">Refresh</a>.
   </InlineNotification>
 )
-
 DismissibleNegative.storyName = "Dismissible, Negative"
 
 export const DismissibleMultiline = () => (
@@ -143,8 +137,8 @@ export const DismissibleMultiline = () => (
     {multilineText}
   </InlineNotification>
 )
-
 DismissibleMultiline.storyName = "Dismissible, Multiline"
+DismissibleMultiline.parameters = { chromatic: { disable: false } }
 
 export const DismissibleForcedMultiline = () => (
   <InlineNotification
@@ -156,7 +150,6 @@ export const DismissibleForcedMultiline = () => (
     {forceMultilineText}
   </InlineNotification>
 )
-
 DismissibleForcedMultiline.storyName = "Dismissible, Forced Multiline"
 
 export const DismissibleSlim = () => (
@@ -168,7 +161,6 @@ export const DismissibleSlim = () => (
     <a href="/">Manage users is now available</a>
   </InlineNotification>
 )
-
 DismissibleSlim.storyName = "Dismissible, Slim"
 
 export const PersistentPositive = () => (
@@ -182,7 +174,6 @@ export const PersistentPositive = () => (
     <a href="/">Manage users is now available</a>
   </InlineNotification>
 )
-
 PersistentPositive.storyName = "Persistent, Positive"
 
 export const PersistentInformative = () => (
@@ -196,7 +187,6 @@ export const PersistentInformative = () => (
     process is completed. <a href="/">Manage users</a>
   </InlineNotification>
 )
-
 PersistentInformative.storyName = "Persistent, Informative"
 
 export const PersistentCautionary = () => (
@@ -210,7 +200,6 @@ export const PersistentCautionary = () => (
     issues. <a href="/">View issues</a>
   </InlineNotification>
 )
-
 PersistentCautionary.storyName = "Persistent, Cautionary"
 
 export const PersistentNegative = () => (
@@ -222,7 +211,6 @@ export const PersistentNegative = () => (
     Check your connection and try again. <a href="/">Refresh</a>.
   </InlineNotification>
 )
-
 PersistentNegative.storyName = "Persistent, Negative"
 
 export const PersistentMultiline = () => (
@@ -235,7 +223,6 @@ export const PersistentMultiline = () => (
     {multilineText}
   </InlineNotification>
 )
-
 PersistentMultiline.storyName = "Persistent, Multiline"
 
 export const PersistentForcedMultiline = () => (
@@ -249,8 +236,8 @@ export const PersistentForcedMultiline = () => (
     {forceMultilineText}
   </InlineNotification>
 )
-
 PersistentForcedMultiline.storyName = "Persistent, Forced Multiline"
+PersistentForcedMultiline.parameters = { chromatic: { disable: false } }
 
 export const PersistentSlim = () => (
   <InlineNotification
@@ -262,11 +249,10 @@ export const PersistentSlim = () => (
     <a href="/">Manage users is now available</a>
   </InlineNotification>
 )
-
 PersistentSlim.storyName = "Persistent, Slim"
 
 export const MultipleNotification = () => (
-  <React.Fragment>
+  <>
     <InlineNotification
       type="positive"
       title="Success"
@@ -298,8 +284,9 @@ export const MultipleNotification = () => (
     >
       Check your connection and try again. <a href="/">Refresh</a>.
     </InlineNotification>
-  </React.Fragment>
+  </>
 )
+MultipleNotification.parameters = { chromatic: { disable: false } }
 
 export const NoChildren = () => (
   <InlineNotification title="No children" type="positive" persistent />

--- a/packages/pagination/docs/Pagination.stories.tsx
+++ b/packages/pagination/docs/Pagination.stories.tsx
@@ -41,3 +41,4 @@ export const Default = args => {
     />
   )
 }
+Default.parameters = { chromatic: { disable: false } }

--- a/packages/progress-bar/docs/ProgressBar.stories.tsx
+++ b/packages/progress-bar/docs/ProgressBar.stories.tsx
@@ -15,7 +15,7 @@ export default {
   },
 }
 
-export const DefaultStory = _ => (
+export const DefaultStory = () => (
   <ProgressBar
     value={25}
     max={100}
@@ -33,7 +33,7 @@ DefaultStory.story = {
   },
 }
 
-export const PositiveSubtext = _ => (
+export const PositiveSubtext = () => (
   <ProgressBar
     isAnimating={false}
     value={25}
@@ -43,11 +43,10 @@ export const PositiveSubtext = _ => (
     subtext="Subtext"
   />
 )
-PositiveSubtext.story = {
-  name: "Positive (with subtext)",
-}
+PositiveSubtext.storyName = "Positive (with subtext)"
+PositiveSubtext.parameters = { chromatic: { disable: false } }
 
-export const PositiveAnimating = _ => (
+export const PositiveAnimating = () => (
   <ProgressBar
     isAnimating={true}
     value={25}
@@ -56,11 +55,9 @@ export const PositiveAnimating = _ => (
     mood="positive"
   />
 )
-PositiveAnimating.story = {
-  name: "Positive (isAnimating)",
-}
+PositiveAnimating.storyName = "Positive (isAnimating)"
 
-export const Informative = _ => (
+export const Informative = () => (
   <ProgressBar
     isAnimating={false}
     value={25}
@@ -69,8 +66,9 @@ export const Informative = _ => (
     label="Label"
   />
 )
+Informative.parameters = { chromatic: { disable: false } }
 
-export const Negative = _ => (
+export const Negative = () => (
   <ProgressBar
     isAnimating={false}
     value={25}
@@ -79,8 +77,9 @@ export const Negative = _ => (
     label="Label"
   />
 )
+Negative.parameters = { chromatic: { disable: false } }
 
-export const Cautionary = _ => (
+export const Cautionary = () => (
   <ProgressBar
     isAnimating={false}
     value={25}
@@ -89,7 +88,9 @@ export const Cautionary = _ => (
     label="Label"
   />
 )
+Cautionary.parameters = { chromatic: { disable: false } }
 
-export const NoLabel = _ => (
+export const NoLabel = () => (
   <ProgressBar isAnimating={true} value={25} max={100} mood="positive" />
 )
+NoLabel.parameters = { chromatic: { disable: false } }

--- a/packages/tabs/docs/Tabs.stories.tsx
+++ b/packages/tabs/docs/Tabs.stories.tsx
@@ -54,6 +54,7 @@ export const Uncontrolled = () => (
     </TabPanels>
   </Tabs>
 )
+Uncontrolled.parameters = { chromatic: { disable: false } }
 
 export const Controlled = () => {
   const [selectedIndex, setSelectedIndex] = useState<number>(0)
@@ -165,7 +166,6 @@ export const UsageInCard = () => (
     </Tabs>
   </Card>
 )
-
 UsageInCard.parameters = {
   backgrounds: { default: "Gray 100" },
 }

--- a/storybook/preview.tsx
+++ b/storybook/preview.tsx
@@ -45,6 +45,7 @@ addParameters({
       return null
     },
   },
+  chromatic: { disable: true },
 })
 
 export const globalTypes = {


### PR DESCRIPTION
# What

Disable sending stories to Chromatic as a default and only add them in when we want them to be.

I selected unique stories (or at least the ones that made sense to stay) and excluded ones which didn't seem worth visually testing.

# Why

We've been unnecessarily sending stories to Chromatic and it's costing us without providing us benefit.

# Changes

- Disable uploading stories to Chromatic as a default
- Enable stories individually with `chromatic: { disable: false }`
- When testing a single component (eg. wip), you can add `disableSnapshot: true` to `storybook/preview.tsx` and then add `chromatic: { disableSnapshot: false }` to your individual story

## Components

See Chromatic build here: https://www.chromatic.com/build?appId=60a1e4a102f0cb003b5d19d6&number=259

### Visually Hidden
- Included ✅ :
	- `Hidden text embedded in visible text`

### Avatar

#### Avatar
- Included ✅ :
	- `Design Sheet (default)`
	- `Design Sheet (reversed)`
	- `Initials Long`
	- `Initials Unicode`
- Excluded ❌ :
	- `Default (Kaizen Demo)`

#### Avatar Group
- Included ✅ :
	- `Design Sheet (default)`
	- `Design Sheet (reversed)`
- Excluded ❌ :
	- `Default (Kaizen Demo)`

#### Company Avatar
- Included ✅ :
	- `Design Sheet (default)`
	- `Design Sheet (reversed)`
- Excluded ❌ :
	- `Default (Kaizen Demo)`

### Badge
- Included ✅ :
	- `Light Badges`
	- `Reversed Badges`
- Excluded ❌ :
	- `Default (with args)`
	- `Animated Badge`

### Box
- Included ✅ :
	- `Box With Margin`
	- `Box With Padding`
	- `Box With X And Y Padding`
	- `Box With Rtl Support`
- Excluded ❌ :
	- `Default`

### Brand
- All included ✅ 

### Brand Moment
- Included ✅ :
	- `Informative intro`
	- `Positive outro (customer focused)`
	- `Error`
- Excluded ❌ :
	- `Positive outro`
	- `Informative intro (customer focused)`

### Button

#### Button
- Included ✅ :
	- `Light Buttons`
	- `Reversed Buttons`
- Excluded ❌ :
	- `Default Button (Kaizen Site Demo)`

#### IconButton
- Included ✅ :
	- `Default Icon (Kaizen Site Demo)`

### Card
- Included ✅ :
	- `Design Sheet (default)`
- Excluded ❌ :
	- `Default (Kaizen Site Demo)`

### Collapsible
- Included ✅ :
	- `Single collapsible (no padding)`
	- `Single collapsible (custom header)`
	- `Collapsible group (clear variant)`
	- `Collapsible group (separated)`
- Excluded ❌ :
	- `Default`
	- `Single collapsible (lazy load)`
	- `Collapsible group`
	- `Collapsible group (sticky headers)`
	- `Collapsible group (callback on open/close)`

### DatePicker
- Included ✅ :
	- Default With Disabled Dates
	- Default Input With Value
	- Disabled Input
	- Disabled Input With Value
- Excluded ❌ :
	- Kaizen Default

### Divider
- Included ✅ :
	- `Canvas Divider`
	- `Content Divider`
	- `Canvas Divider Reversed`
	- `Content Divider Reversed`
- Excluded ❌ :
	- `Default (Kaizen Site Demo)`
	- `Composing divider, card, box, and typography`
- 📘 **Note:** The reversed snapshots don't appear to be working?

### Empty State
- Included ✅ :
	- Positive
	- Informative
	- Action
	- Neutral
	- Negative
	- RTL, Action
	- Straight corners
- Excluded ❌ :
	- `Default (Kaizen Site Demo)`

### Filter Menu
- Included ✅ :
 	- `Default (Empty)`
 	- `Default with children (Simple filter)`
 	- `Default with children (Advanced filter)`
- Excluded ❌ :
	- `Simple Filter (Kaizen Site Demo)`
- 📘 **Note:** The snapshots are blank and need to be fixed

### Form

#### Checkbox Field
- Included ✅ :
	- All

#### Checkbox Group
- Included ✅ :
	- `RTL`
	- `with bottom margin`
	- `without bottom margin`
	- `Reversed Checkbox Group`
- Excluded ❌ :
	- `Interactive (Kaizen Site Demo)`
	- `with disabled checkboxes`
	- `Nested Checkbox Group`

#### Radio Field
- Included ✅ :
	- All

#### Radio Group
- Included ✅ :
	- `RTL`
	- `With links`
	- `With bottom margin`
	- `Without bottom margin`
	- `Reversed Default`
- Excluded ❌ :
	- `Default (Kaizen Site Demo)`
	- `With disabled radios`
	- `RTL with disabled radios`

#### Search Field
- Included ✅ :
	- All

#### Slider
- Included ✅ :
 	- `Uncontrolled`
 	- `Label above input`
 	- `Custom min/max`
 	- `Prominent`
 	- `Disabled`
 	- `Read only (no value)`
- Excluded ❌ :
	- `Default (Kaizen Site Demo)`
	- `Controlled`
	- `Custom mix/max labels` (this usage is the same as `Uncontrolled`)
	- `Read only`
	- `Using InputRange primitive`
- 📘 **Note:** `Using InputRange primitive` probably shouldn't exist?

#### Text Area Field
- Included ✅ :
	- `Sticker Sheet (Default)`
	- `Sticker Sheet (Reversed)`
- Excluded ❌ :
	- `Default (Kaizen Demo)`

#### Text Field
- Included ✅ :
	- `Sticker Sheet (Default)`
	- `Sticker Sheet (Reversed)`
- Excluded ❌ :
	- `Default (Kaizen Demo)`

#### Toggle Switch Field
- Included ✅ :
	- `Sticker Sheet (Default)`
	- `Sticker Sheet (Reversed)`
- Excluded ❌ :
	- `Default (Kaizen Demo)`

### Guidance Block
- Included ✅ :
	- `Moods`
	- `Sticker Sheet`
	- `Layouts`
	- `Aspect Ratio`
- Excluded ❌ :
	- `Default (Kaizen Demo)`

### Hero Card
- Included ✅ :
	- `Badge`
	- `Image`
	- `Custom Left Content`
	- `Custom Left Content And Badge`
	- `Full Width`
	- `Background Colors`
- Excluded ❌ :
	- `Default (Kaizen Site Demo)`
	- `Title` 

### Icon
- Included ✅ :
	- `Presentational`
	- `Inherit Size`
- Excluded ❌ :
	- `Meaningful (Kaizen Site Demo)`

### Illustration / Scene
- Included ✅ :
	- All
- 📘 **Note:** Animated scenes do not appear in Chromatic snapshots

### Illustration / Spot
- Included ✅ :
	- `All Spot Illustrations`
	- `Spot, animated`
- Excluded ❌ :
	- `Spot (Kaizen Site Demo)`

### Likert Scale
- Included ✅ :
	- All

###  Loading Placeholder
- Included ✅ :
	- `Default, Multiple, Variable width, Centered`
	- `Default, Multiple, Combined block and inline`
	- `Default, Without bottom margin`
	- `Default, Inherit baseline`
	- `Heading Loading`
	- `Reversed, Default`
- Excluded ❌ :
	- `Default, Multiple (Kaizen Site Demo)`
		- `Default, Multiple, Inline`
		- `Default, Multiple, Variable width`
		- `In the wild`

### Loading Spinner
- Included ✅ :
	- `Default (Kaizen Site Demo)`
	- `Sticker Sheet`

### Menu
- Excluded ❌ :
	- All
- 📘 **Note:** These stories need revisiting as Chromatic does not see them open and all you see is a button (which is controlled by the consumer using `<Button />`)

### Modal

#### Confirmation Modal
- Included ✅ :
	- `Confirmation Modals`

#### Context Modal
- Included ✅ :
	- `Context Modals`

#### Input Edit Modal
- Included ✅ :
	- `Input Edit Modals` 

### Notification

#### Global Notification
- Included ✅ :
	- `Global notification variants`

#### Inline Notification
- Included ✅ :
	- `Dismissible, Multiline`
	- `Persistent, Forced Multiline`
	- `Multiple Notification`
- Excluded ❌ :
	- `Dismissible, Positive (Kaizen Site Demo)`
	- `Dismissible, Positive, Autohide`
	- `Dismissible, Positive, Autohide, Hide Close Icon`
	- `Dismissible, Informative`
	- `Dismissible, Cautionary`
	- `Dismissible, Negative`
	- `Dismissible, Forced Multiline`
	- `Dismissible, Slim`
	- `Persistent, Positive`
	- `Persistent, Informative`
	- `Persistent, Cautionary`
	- `Persistent, Negative`
	- `Persistent, Multiline`
	- `Persistent, Slim`
	- `No Children`

#### Toast Notification (TODO)
- Excluded ❌ :
	- All
- 📘 **Note:** None of the toasts show up without a trigger

### Page Layout
- Included ✅ :
	- `Container/Content (Full-bleed background)`
	- `Skirt (Education variant)`
	- `Skirt (Title Block without navigation)`
- Excluded ❌ :
	- `Container/Content (default)`
	- `Skirt (default)`
	- `Skirt (without SkirtCard)`

###  Pagination
- Included ✅ :
	- `Default`

### Popover
- Included ✅ :
	- `Sticker Sheet`
- Excluded ❌ :
	- `Default (Kaizen Site Demo)`
	- `Overflow Scroll`

### ProgressBar
- Included ✅ :
	- `Positive (with subtext)
	- `Informative`
	- `Negative`
	- `Cautionary`
	- `No Label`
- Excluded ❌ :
	- `Positive (Kaizen Site Demo)`
	- `Positive (isAnimating)`

### Select
- Included ✅ :
	- `Single`
	- `Single Disabled`
	- `Single with ellipsizing selection`
	- `Single, Secondary`
	- `Single, Secondary, Disabled`
	- `Single, Secondary, Reversed`
 	- `Single, Secondary-Small, Reversed`
	- `Single Secondary Reversed (disabled)`
- Excluded ❌ :
	- `Single Clearable`
	- `Single Searchable`
	- `Multi-Select Searchable`
	- `Async Searchable`
	- `Multi-Async Searchable`
	- `Single Secondary with ellipsis`

### Skip Link
- Excluded ❌ :
	- `Skip Link Example`
- 📘 **Note:** a11y functionality only; nothing visual to test

### Split Button
- Included ✅ :
	- `Default (Kaizen Site Demo)`
	- `Default button disabled`
	- `Primary`
	- `Primary disabled`
	- `RTL`
	- `Primary RTL`
- Excluded ❌ :
	- `Default enabled with disabled items`
	- `Anchor link`
- 📘 **Note:** The component styles look broken

### Table
- Included ✅ :
	- `Multiline`
	- `Reversed`
	- `Data Variant`
	- `Expanded popout`
	- `No header`
	- `Default variant (extra spacing)`
	- `Header alignments and wrapping`
	- `Tooltip`
- Excluded ❌ :
	- `Default (Kaizen Site Demo)`
	- `Clickable`
	- `Anchor Link`
	- `Header row hover`

### Tabs
- Included ✅ :
	- `Uncontrolled`
- Excluded ❌ :
	- `Controlled`
	- `Manual Keyboard Activation`
	- `Usage In Card`

### Tag
- Included ✅ :
	- `Status`
	- `Sentiment`
	- `Validation`
	- `Profile`
	- `Dismissible`
- Excluded ❌ :
	- `Default - Medium (Kaizen Site Demo)`

### Tile
- Included ✅ :
	- `Multi action tile moods`
	- `Multi action tile with secondary action`
	- `Multi action tile with children`
	- `Information tile`
	- `Tile Grid`
	- `Tile Grid (less than one row)`
- Excluded ❌ :
	- `Multi action tile`
	- `Multi action tile with custom title tag`
	- `Multi action tile with information`
	- `Multi action tile with actions opening in new tabs`
	- `Information tile moods`
	- `Information tile with children`
	- `Information With Custom Title`
	- `Information tile (custom information element)`
	- `Information tile (custom title tag)`

### Title Block
- Included ✅ :
	- `With Primary Action Badge`
	- `With Default Survey Status (Tag)`
	- `Admin With Default Survey Status (Tag)`
	- `Default (Menu Button)`
	- `Admin variant`
	- `Admin variant with Navigation Tabs`
	- `Education variant`
	- `Engagement`
	- `Performance`
	- `Long Labels`
	- `Default with content`
	- `Default with report switcher`
	- `Default (collapsed navigation)`
- Excluded ❌ :
	- `Default`
	- `Performance with AvatarProps`
	- `Performance with Empty AvatarProps`
	- `Default (no secondary actions)`
	- `Default (only primary action)`
	- `Default (no link in breadcrumb)`
	- `Default (only long title)`
	- `Default (collapsed navigation with card)`
	- `Admin (collapsed navigation)`

### Tooltip
- Included ✅ :
	- `Sticker Sheet`
- Excluded ❌ :
	- `Default (Kaizen Site Demo)`
	- `Overflow Scroll`

### Typography

#### Heading
- Included ✅ :
	- All

#### Paragraph
- Included ✅ :
	- All

### Well
- Included ✅ :
	- `Default with solid border (Kaizen Site Demo)`
	- `Default with dashed border`
	- `Default without border`
	- `Default with no margin`
	- `Positive`
	- `Negative`
	- `Informative`
	- `Cautionary`
	- `Assertive`
	- `Prominent`
- Excluded ❌ :
	- `Positive with dashed border`
	- `Positive with no border`
	- `Negative with dashed border`
	- `Negative with no border`
	- `Informative with dashed border`
	- `Informative with no border`
	- `Cautionary with dashed border`
	- `Cautionary with no border`
	- `Assertive with dashed border`
	- `Assertive with no border`
	- `Prominent with dashed border`
	- `Prominent with no border`

## Helpers
Not included ❌

## Design Tokens

### Color Tokens
Included ✅ 

## Elm
Not included ❌

## Deprecated
Not included ❌