### PR TITLE
feat: Add new start and end icons

### DIFF
--- a/packages/component-library/icons/end.icon.svg
+++ b/packages/component-library/icons/end.icon.svg
@@ -1,0 +1,1 @@
+<svg width="20" height="20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M14 4h2v12h-2V4ZM10.308 9.167H2v1.666h8.308l-2.987 2.988L8.5 15l5-5-5-5-1.18 1.18 2.988 2.987Z" fill="#2F2438"/></svg>

--- a/packages/component-library/icons/start.icon.svg
+++ b/packages/component-library/icons/start.icon.svg
@@ -1,0 +1,1 @@
+<svg width="20" height="20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M6 4H4v12h2V4ZM9.692 9.167H18v1.666H9.692l2.987 2.988L11.5 15l-5-5 5-5 1.18 1.18-2.988 2.987Z" fill="#2F2438"/></svg>


### PR DESCRIPTION
Adds 2 new icons for pagination: `start` and `end`

<img width="301" alt="image" src="https://user-images.githubusercontent.com/1811583/156970826-d7d12d7e-bac0-4781-a018-a3c2c71be46e.png">
