### PR TITLE
Revert "docs: update mdx demo ids for button and icon button (#2584)"

### DIFF
--- a/draft-packages/button/KaizenDraft/Button/README.mdx
+++ b/draft-packages/button/KaizenDraft/Button/README.mdx
@@ -8,7 +8,7 @@ needToKnow:
 - Buttons perform actions.
 - If it needs to navigate somewhere and can be opened in a new tab, use a link instead.
 headerImage: button
-demoStoryId: components-button--default-kaizen-site-demo
+demoStoryId: components-button-button--default-kaizen-site-demo
 health:
   designed: true
   documented: true

--- a/packages/button/Button/README.mdx
+++ b/packages/button/Button/README.mdx
@@ -8,7 +8,7 @@ needToKnow:
 - Buttons perform actions.
 - If it needs to navigate somewhere and can be opened in a new tab, use a link instead.
 headerImage: button
-demoStoryId: components-button--default-kaizen-site-demo
+demoStoryId: components-button-button--default-kaizen-site-demo
 health:
   designed: true
   documented: true

--- a/site/docs/components/icon-button.mdx
+++ b/site/docs/components/icon-button.mdx
@@ -10,7 +10,7 @@ needToKnow:
   - Use a Primary icon button when it's the most important action to take.
   - Use a Destructive icon button when the action will result in data loss, cannot be undone, or otherwise have significant consequences.
   - Breadcrumb icon buttons use link elements to navigate and must show a destination as text on hover/focus.
-demoStoryId: components-button--default-kaizen-demo-icon
+demoStoryId: components-button-icon-button--default-kaizen-site-demo
 health:
   designed: true
   documented: true


### PR DESCRIPTION
This reverts commit 5bacb5b36664fec49d9d483d084cb64b2ffcf63c.

# Objective
<!-- Describe what this change achieves, and the details of how it works. -->
 Failed to build on master 

# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

# Screenshots (if appropriate)

# Checklist
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] If this contains visual changes, has it been reviewed by a designer?
- [ ] If this introduces either a new component or a breaking change to an existing component, has it been reviewed by an advocate? (Ask in #prod_design_systems)
- [ ] I have considered likely risks of these changes and got someone else to QA as appropriate
- [ ] I have or will communicate these changes to the front end practice

# Additional Considerations
- Does there need to be right-to-left (RTL) options for localization and internationalization?
- Has the test suite been updated?
- Have you done cross-browser testing for our [supported browsers](https://academy.cultureamp.com/hc/en-us/articles/204539569-Supported-browsers-for-Participants)?
- Have you updated any relevant documentation or left useful comments in the code?
- Have you reviewed Culture Amp's Web Accessibility guide [Current Compliance, Going Forward, Statement and Answers for Customers](https://cultureamp.atlassian.net/wiki/spaces/Prod/pages/428572998/Web+Accessibility)?
- If this contains substantial visual changes, especially far reaching ones, have you unlocked the Chromatic step in the pipeline?
- Have Storybook stories been updated?

**If you're new to Kaizen, please ask #prod_design_systems to set up an onboarding session to get you up to speed.** If you have an urgent PR to merge before that happens, it is safest to ask in #prod_design_systems to have a design system advocate review the PR to catch any issues.
