### PR TITLE
feat: Update new start and end icons

### DIFF
--- a/packages/component-library/icons/end.icon.svg
+++ b/packages/component-library/icons/end.icon.svg
@@ -1,4 +1,1 @@
-<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M14 4H16V16H14V4Z" fill="black"/>
-<path d="M10.3083 9.16667H2V10.8333H10.3083L7.32083 13.8208L8.5 15L13.5 10L8.5 5L7.32083 6.17917L10.3083 9.16667Z" fill="black"/>
-</svg>
+<svg width="20" height="20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M14 4h2v12h-2V4ZM10.3 9.17H2v1.66h8.3l-2.98 3L8.5 15l5-5-5-5-1.18 1.18 2.99 2.99Z" fill="#000"/></svg>

--- a/packages/component-library/icons/end.icon.svg
+++ b/packages/component-library/icons/end.icon.svg
@@ -1,1 +1,4 @@
-<svg width="20" height="20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M14 4h2v12h-2V4ZM10.308 9.167H2v1.666h8.308l-2.987 2.988L8.5 15l5-5-5-5-1.18 1.18 2.988 2.987Z" fill="#2F2438"/></svg>
+<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M14 4H16V16H14V4Z" fill="black"/>
+<path d="M10.3083 9.16667H2V10.8333H10.3083L7.32083 13.8208L8.5 15L13.5 10L8.5 5L7.32083 6.17917L10.3083 9.16667Z" fill="black"/>
+</svg>

--- a/packages/component-library/icons/start.icon.svg
+++ b/packages/component-library/icons/start.icon.svg
@@ -1,4 +1,1 @@
-<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M6 4H4V16H6V4Z" fill="black"/>
-<path d="M9.69167 9.16667H18V10.8333H9.69167L12.6792 13.8208L11.5 15L6.5 10L11.5 5L12.6792 6.17917L9.69167 9.16667Z" fill="black"/>
-</svg>
+<svg width="20" height="20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M6 4H4v12h2V4ZM9.7 9.17H18v1.66H9.7l2.98 3L11.5 15l-5-5 5-5 1.18 1.18-2.99 2.99Z" fill="#000"/></svg>

--- a/packages/component-library/icons/start.icon.svg
+++ b/packages/component-library/icons/start.icon.svg
@@ -1,1 +1,4 @@
-<svg width="20" height="20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M6 4H4v12h2V4ZM9.692 9.167H18v1.666H9.692l2.987 2.988L11.5 15l-5-5 5-5 1.18 1.18-2.988 2.987Z" fill="#2F2438"/></svg>
+<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M6 4H4V16H6V4Z" fill="black"/>
+<path d="M9.69167 9.16667H18V10.8333H9.69167L12.6792 13.8208L11.5 15L6.5 10L11.5 5L12.6792 6.17917L9.69167 9.16667Z" fill="black"/>
+</svg>


### PR DESCRIPTION
Update 2 new icons for pagination: `start` and `end`. 
Needed to be black fill to be able to inherit colours. 

<img width="301" alt="image" src="https://user-images.githubusercontent.com/1811583/156970826-d7d12d7e-bac0-4781-a018-a3c2c71be46e.png">
