### PR TITLE
docs: update split button stories to use storywrapper

### DIFF
--- a/draft-packages/split-button/docs/SplitButton.stories.tsx
+++ b/draft-packages/split-button/docs/SplitButton.stories.tsx
@@ -1,18 +1,14 @@
 import React from "react"
+import { Story } from "@storybook/react"
 import { MenuItem } from "@kaizen/draft-menu"
 import { SplitButton } from "@kaizen/draft-split-button"
 import { withDesign } from "storybook-addon-designs"
 import duplicateIcon from "@kaizen/component-library/icons/duplicate.icon.svg"
 import editIcon from "@kaizen/component-library/icons/edit.icon.svg"
+import { StoryWrapper } from "../../../storybook/components/StoryWrapper"
 import { figmaEmbed } from "../../../storybook/helpers"
 import { Box } from "../../../packages/component-library"
 import { CATEGORIES } from "../../../storybook/constants"
-
-const withBottomMargin = (Story: React.ComponentType) => (
-  <Box mb={4}>
-    <Story />
-  </Box>
-)
 
 export default {
   title: `${CATEGORIES.components}/Split Button`,
@@ -28,187 +24,137 @@ export default {
       "https://www.figma.com/file/eZKEE5kXbEMY3lx84oz8iN/%E2%9D%A4%EF%B8%8F-UI-Kit%3A-Heart?node-id=14512%3A404"
     ),
   },
-  decorators: [withDesign, withBottomMargin],
+  decorators: [withDesign],
 }
 
-export const DefaultKaizenSiteDemo = () => (
+export const DefaultKaizenSiteDemo = args => (
   <SplitButton
-    label="Edit"
-    onClick={() => undefined}
+    label="Edit survey"
     dropdownContent={
       <>
-        <MenuItem
-          onClick={e => undefined}
-          icon={editIcon}
-          label="Menu Item 1"
-        />
-        <MenuItem
-          onClick={e => undefined}
-          icon={duplicateIcon}
-          label="Menu Item 2"
-        />
+        <MenuItem icon={editIcon} label="Menu Item 1" />
+        <MenuItem icon={duplicateIcon} label="Menu Item 2" />
       </>
     }
     dropdownAltText="Open menu"
+    {...args}
   />
 )
 DefaultKaizenSiteDemo.storyName = "Default (Kaizen Site Demo)"
 DefaultKaizenSiteDemo.parameters = { chromatic: { disable: false } }
 
-export const Disabled = () => (
-  <SplitButton
-    label="Edit"
-    onClick={() => undefined}
-    disabled
-    dropdownContent={
-      <MenuItem onClick={e => undefined} icon={editIcon} label="Menu Item 1" />
-    }
-    dropdownAltText="Open menu"
-  />
+const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({
+  isReversed,
+}) => (
+  <StoryWrapper isReversed={isReversed}>
+    <StoryWrapper.RowHeader headings={["Base", "Disabled"]} />
+    <StoryWrapper.Row rowTitle="Default">
+      <SplitButton
+        label="Edit survey"
+        dropdownContent={
+          <>
+            <MenuItem icon={editIcon} label="Menu Item 1" />
+            <MenuItem icon={duplicateIcon} label="Menu Item 2" />
+          </>
+        }
+        dropdownAltText="Open menu"
+      />
+      <SplitButton
+        label="Edit survey"
+        disabled
+        dropdownContent={
+          <>
+            <MenuItem icon={editIcon} label="Menu Item 1" />
+            <MenuItem icon={duplicateIcon} label="Menu Item 2" />
+          </>
+        }
+        dropdownAltText="Open menu"
+      />
+    </StoryWrapper.Row>
+    <StoryWrapper.Row rowTitle="Primary">
+      <SplitButton
+        label="Edit survey"
+        variant="primary"
+        dropdownContent={
+          <>
+            <MenuItem icon={editIcon} label="Menu Item 1" />
+            <MenuItem icon={duplicateIcon} label="Menu Item 2" />
+          </>
+        }
+        dropdownAltText="Open menu"
+      />
+      <SplitButton
+        label="Edit survey"
+        variant="primary"
+        disabled
+        dropdownContent={
+          <>
+            <MenuItem icon={editIcon} label="Menu Item 1" />
+            <MenuItem icon={duplicateIcon} label="Menu Item 2" />
+          </>
+        }
+        dropdownAltText="Open menu"
+      />
+    </StoryWrapper.Row>
+    <StoryWrapper.Row rowTitle="Anchor Link">
+      <SplitButton
+        label="Edit survey"
+        href="//example.com"
+        dropdownContent={
+          <>
+            <MenuItem icon={editIcon} label="Menu Item 1" />
+            <MenuItem icon={duplicateIcon} label="Menu Item 2" />
+          </>
+        }
+        dropdownAltText="Open menu"
+      />
+      <SplitButton
+        label="Edit survey"
+        href="//example.com"
+        disabled
+        dropdownContent={
+          <>
+            <MenuItem icon={editIcon} label="Menu Item 1" />
+            <MenuItem icon={duplicateIcon} label="Menu Item 2" />
+          </>
+        }
+        dropdownAltText="Open menu"
+      />
+    </StoryWrapper.Row>
+    <StoryWrapper.Row rowTitle="With Disabled Option">
+      <SplitButton
+        label="Edit survey"
+        dropdownContent={
+          <>
+            <MenuItem icon={editIcon} disabled label="Menu Item 1" />
+            <MenuItem icon={duplicateIcon} label="Menu Item 2" />
+          </>
+        }
+        dropdownAltText="Open menu"
+      />
+      <SplitButton
+        label="Edit survey"
+        disabled
+        dropdownContent={
+          <>
+            <MenuItem icon={editIcon} label="Menu Item 1" />
+            <MenuItem icon={duplicateIcon} label="Menu Item 2" />
+          </>
+        }
+        dropdownAltText="Open menu"
+      />
+    </StoryWrapper.Row>
+  </StoryWrapper>
 )
-Disabled.storyName = "Default button disabled"
-Disabled.parameters = { chromatic: { disable: false } }
 
-export const EnabledWithDisabledItems = () => (
-  <SplitButton
-    label="Edit"
-    onClick={() => undefined}
-    dropdownContent={
-      <>
-        <MenuItem
-          onClick={e => undefined}
-          disabled
-          label="Disabled Menu Item"
-        />
-        <MenuItem
-          onClick={e => undefined}
-          icon={editIcon}
-          label="Menu Item 1"
-        />
-        <MenuItem
-          onClick={e => undefined}
-          icon={editIcon}
-          label="Menu Item 2"
-        />
-      </>
-    }
-    dropdownAltText="Open menu"
-  />
-)
-EnabledWithDisabledItems.storyName = "Default enabled with disabled items"
+export const StickerSheetDefault = StickerSheetTemplate.bind({})
+StickerSheetDefault.storyName = "Sticker Sheet (Default)"
+StickerSheetDefault.parameters = { chromatic: { disable: false } }
 
-export const Primary = () => (
-  <SplitButton
-    label="Edit"
-    variant="primary"
-    onClick={() => undefined}
-    dropdownContent={
-      <>
-        <MenuItem
-          onClick={e => undefined}
-          icon={editIcon}
-          label="Menu Item 1"
-        />
-        <MenuItem
-          onClick={e => undefined}
-          icon={duplicateIcon}
-          label="Menu Item 2"
-        />
-      </>
-    }
-    dropdownAltText="Open menu"
-  />
-)
-Primary.storyName = "Primary"
-Primary.parameters = { chromatic: { disable: false } }
-
-export const PrimaryDisabled = () => (
-  <SplitButton
-    label="Edit"
-    variant="primary"
-    onClick={() => undefined}
-    disabled
-    dropdownContent={
-      <>
-        <MenuItem
-          onClick={e => undefined}
-          icon={editIcon}
-          label="Menu Item 1"
-        />
-        <MenuItem
-          onClick={e => undefined}
-          icon={duplicateIcon}
-          label="Menu Item 2"
-        />
-      </>
-    }
-    dropdownAltText="Open menu"
-  />
-)
-PrimaryDisabled.storyName = "Primary disabled"
-PrimaryDisabled.parameters = { chromatic: { disable: false } }
-
-export const AnchorLink = () => (
-  <SplitButton
-    label="Edit"
-    href="//example.com"
-    dropdownContent={
-      <MenuItem onClick={e => undefined} icon={editIcon} label="Menu Item 1" />
-    }
-    dropdownAltText="Open menu"
-  />
-)
-AnchorLink.storyName = "Anchor link"
-
-export const Rtl = () => (
-  <SplitButton
-    label="Edit"
-    onClick={() => undefined}
-    dropdownContent={
-      <>
-        <MenuItem
-          onClick={e => undefined}
-          icon={editIcon}
-          label="Menu Item 1"
-        />
-        <MenuItem
-          onClick={e => undefined}
-          icon={duplicateIcon}
-          label="Menu Item 2"
-        />
-      </>
-    }
-    dir="rtl"
-    dropdownAltText="Open menu"
-  />
-)
-Rtl.storyName = "RTL"
-Rtl.parameters = { chromatic: { disable: false } }
-
-export const PrimaryRtl = () => (
-  <SplitButton
-    label="Edit"
-    variant="primary"
-    onClick={() => undefined}
-    dropdownContent={
-      <>
-        <MenuItem
-          onClick={e => undefined}
-          icon={editIcon}
-          label="
-          Menu Item 1
-        "
-        />
-        <MenuItem
-          onClick={e => undefined}
-          icon={duplicateIcon}
-          label="Menu Item 2"
-        />
-      </>
-    }
-    dir="rtl"
-    dropdownAltText="Open menu"
-  />
-)
-PrimaryRtl.storyName = "Primary RTL"
-PrimaryRtl.parameters = { chromatic: { disable: false } }
+export const StickerSheetReversed = StickerSheetTemplate.bind({})
+StickerSheetReversed.storyName = "Sticker Sheet (Reversed)"
+StickerSheetReversed.args = { isReversed: true }
+StickerSheetReversed.parameters = {
+  backgrounds: { default: "Purple 700" },
+  chromatic: { disable: false },
+}

--- a/draft-packages/split-button/docs/SplitButton.stories.tsx
+++ b/draft-packages/split-button/docs/SplitButton.stories.tsx
@@ -7,7 +7,6 @@ import duplicateIcon from "@kaizen/component-library/icons/duplicate.icon.svg"
 import editIcon from "@kaizen/component-library/icons/edit.icon.svg"
 import { StoryWrapper } from "../../../storybook/components/StoryWrapper"
 import { figmaEmbed } from "../../../storybook/helpers"
-import { Box } from "../../../packages/component-library"
 import { CATEGORIES } from "../../../storybook/constants"
 
 export default {
@@ -40,7 +39,7 @@ export const DefaultKaizenSiteDemo = args => (
     {...args}
   />
 )
-DefaultKaizenSiteDemo.storyName = "Default (Kaizen Site Demo)"
+DefaultKaizenSiteDemo.storyName = "Split Button"
 DefaultKaizenSiteDemo.parameters = { chromatic: { disable: false } }
 
 const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({


### PR DESCRIPTION
# Objective
<!-- Describe what this change achieves, and the details of how it works. -->

- Use storyWrapper to create stickersheet stories
note: the disabled variant is broken and there is not reversed variant
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

# Screenshots (if appropriate)
<img width="1114" alt="image" src="https://user-images.githubusercontent.com/48232362/159193195-4936766e-1c81-4299-811f-b2d044840796.png">
