### PR TITLE
fix: Restore ProgressBar isAnimating styling

### DIFF
--- a/packages/progress-bar/src/ProgressBar.scss
+++ b/packages/progress-bar/src/ProgressBar.scss
@@ -76,7 +76,7 @@ $height: 10px;
   background: $color-red-400;
 }
 
-.animating {
+.isAnimating {
   &::after {
     opacity: 1;
     content: "";


### PR DESCRIPTION
The TS part of this component is referencing an `isAnimating` className that doesn't exist.