### PR TITLE
refactor: change animated illustration scenes to not animate in Chromatic

### DIFF
--- a/draft-packages/illustration/KaizenDraft/Illustration/BrandMomentCaptureIntro.tsx
+++ b/draft-packages/illustration/KaizenDraft/Illustration/BrandMomentCaptureIntro.tsx
@@ -1,4 +1,4 @@
-import * as React from "react"
+import React from "react"
 import { AnimatedSceneProps } from "./Scene"
 import { Base } from "./Base"
 import { VideoPlayer } from "./Players/VideoPlayer"
@@ -8,12 +8,12 @@ import { VideoPlayer } from "./Players/VideoPlayer"
  *  - An "initial" animation that is only ever played once, never looping
  *  - An "ambient" animation that can be looped, depending on the props passed into it
  */
-export const BrandMomentCaptureIntro = ({
+export const BrandMomentCaptureIntro: React.VFC<AnimatedSceneProps> = ({
   isAnimated,
   alt,
   enableAspectRatio,
   ...otherProps
-}: AnimatedSceneProps) => {
+}) => {
   const [firstAnimationComplete, setFirstAnimationComplete] =
     React.useState(false)
 
@@ -51,3 +51,5 @@ export const BrandMomentCaptureIntro = ({
     />
   )
 }
+
+BrandMomentCaptureIntro.displayName = "BrandMomentCaptureIntro"

--- a/draft-packages/illustration/KaizenDraft/Illustration/Scene.tsx
+++ b/draft-packages/illustration/KaizenDraft/Illustration/Scene.tsx
@@ -27,12 +27,12 @@ export type AnimatedSceneProps = AnimatedProps | NotAnimatedProps
 
 // Brand Moments
 
-export const BrandMomentPositiveOutro = ({
+export const BrandMomentPositiveOutro: React.VFC<AnimatedSceneProps> = ({
   isAnimated,
   enableAspectRatio,
   alt,
   ...otherProps
-}: AnimatedSceneProps) => {
+}) => {
   if (isAnimated) {
     return (
       <VideoPlayer
@@ -52,13 +52,14 @@ export const BrandMomentPositiveOutro = ({
     />
   )
 }
+BrandMomentPositiveOutro.displayName = "BrandMomentPositiveOutro"
 
-export const BrandMomentLogin = ({
+export const BrandMomentLogin: React.VFC<AnimatedSceneProps> = ({
   isAnimated,
   enableAspectRatio,
   alt,
   ...otherProps
-}: AnimatedSceneProps) => {
+}) => {
   if (isAnimated) {
     return (
       <VideoPlayer
@@ -78,13 +79,14 @@ export const BrandMomentLogin = ({
     />
   )
 }
+BrandMomentLogin.displayName = "BrandMomentLogin"
 
-export const BrandMomentError = ({
+export const BrandMomentError: React.VFC<AnimatedSceneProps> = ({
   isAnimated,
   enableAspectRatio,
   alt,
   ...otherProps
-}: AnimatedSceneProps) => {
+}) => {
   if (isAnimated) {
     return (
       <VideoPlayer
@@ -104,48 +106,52 @@ export const BrandMomentError = ({
     />
   )
 }
+BrandMomentError.displayName = "BrandMomentError"
 
-export const BrandMomentNewAccountOnboarding = ({
+export const BrandMomentNewAccountOnboarding: React.VFC<SceneProps> = ({
   enableAspectRatio,
   ...props
-}: SceneProps) => (
+}) => (
   <Base
     aspectRatio={enableAspectRatio ? "landscape" : undefined}
     {...props}
     name="illustrations/heart/scene/brand-moments-new-account-onboarding.svg"
   />
 )
+BrandMomentNewAccountOnboarding.displayName = "BrandMomentNewAccountOnboarding"
 
-export const BrandMomentUploadEmployeeData = ({
+export const BrandMomentUploadEmployeeData: React.VFC<SceneProps> = ({
   enableAspectRatio,
   ...props
-}: SceneProps) => (
+}) => (
   <Base
     aspectRatio={enableAspectRatio ? "landscape" : undefined}
     {...props}
     name="illustrations/heart/scene/brand-moments-upload-employee-data.svg"
   />
 )
+BrandMomentUploadEmployeeData.displayName = "BrandMomentUploadEmployeeData"
 
-export const BrandMomentStarterKit = ({
+export const BrandMomentStarterKit: React.VFC<SceneProps> = ({
   enableAspectRatio,
   ...props
-}: SceneProps) => (
+}) => (
   <Base
     aspectRatio={enableAspectRatio ? "landscape" : undefined}
     {...props}
     name="illustrations/heart/scene/brand-moments-starter-kit.svg"
   />
 )
+BrandMomentStarterKit.displayName = "BrandMomentStarterKit"
 
 // Empty States
 
-export const EmptyStatesAction = ({
+export const EmptyStatesAction: React.VFC<AnimatedSceneProps> = ({
   isAnimated,
   enableAspectRatio,
   alt,
   ...otherProps
-}: AnimatedSceneProps) => {
+}) => {
   if (isAnimated) {
     return (
       <VideoPlayer
@@ -165,13 +171,14 @@ export const EmptyStatesAction = ({
     />
   )
 }
+EmptyStatesAction.displayName = "EmptyStatesAction"
 
-export const EmptyStatesInformative = ({
+export const EmptyStatesInformative: React.VFC<AnimatedSceneProps> = ({
   isAnimated,
   enableAspectRatio,
   alt,
   ...otherProps
-}: AnimatedSceneProps) => {
+}) => {
   if (isAnimated) {
     return (
       <VideoPlayer
@@ -191,13 +198,14 @@ export const EmptyStatesInformative = ({
     />
   )
 }
+EmptyStatesInformative.displayName = "EmptyStatesInformative"
 
-export const EmptyStatesNegative = ({
+export const EmptyStatesNegative: React.VFC<AnimatedSceneProps> = ({
   isAnimated,
   enableAspectRatio,
   alt,
   ...otherProps
-}: AnimatedSceneProps) => {
+}) => {
   if (isAnimated) {
     return (
       <VideoPlayer
@@ -217,13 +225,14 @@ export const EmptyStatesNegative = ({
     />
   )
 }
+EmptyStatesNegative.displayName = "EmptyStatesNegative"
 
-export const EmptyStatesPositive = ({
+export const EmptyStatesPositive: React.VFC<AnimatedSceneProps> = ({
   isAnimated,
   enableAspectRatio,
   alt,
   ...otherProps
-}: AnimatedSceneProps) => {
+}) => {
   if (isAnimated) {
     return (
       <VideoPlayer
@@ -243,13 +252,14 @@ export const EmptyStatesPositive = ({
     />
   )
 }
+EmptyStatesPositive.displayName = "EmptyStatesPositive"
 
-export const EmptyStatesNeutral = ({
+export const EmptyStatesNeutral: React.VFC<AnimatedSceneProps> = ({
   isAnimated,
   enableAspectRatio,
   alt,
   ...otherProps
-}: AnimatedSceneProps) => {
+}) => {
   if (isAnimated) {
     return (
       <VideoPlayer
@@ -269,380 +279,446 @@ export const EmptyStatesNeutral = ({
     />
   )
 }
+EmptyStatesNeutral.displayName = "EmptyStatesNeutral"
 
 // Information Modals
 
-export const Information360Upgrade = ({
+export const Information360Upgrade: React.VFC<SceneProps> = ({
   enableAspectRatio,
   ...props
-}: SceneProps) => (
+}) => (
   <Base
     aspectRatio={enableAspectRatio ? "landscape" : undefined}
     {...props}
     name="illustrations/heart/scene/information-modals-360-upgrade.svg"
   />
 )
+Information360Upgrade.displayName = "Information360Upgrade"
 
-export const InformationDemographicFocus = ({
+export const InformationDemographicFocus: React.VFC<SceneProps> = ({
   enableAspectRatio,
   ...props
-}: SceneProps) => (
+}) => (
   <Base
     aspectRatio={enableAspectRatio ? "landscape" : undefined}
     {...props}
     name="illustrations/heart/scene/information-modals-demographic-focus.svg"
   />
 )
+InformationDemographicFocus.displayName = "InformationDemographicFocus"
 
-export const InformationTurnoverCalculator = ({
+export const InformationTurnoverCalculator: React.VFC<SceneProps> = ({
   enableAspectRatio,
   ...props
-}: SceneProps) => (
+}) => (
   <Base
     aspectRatio={enableAspectRatio ? "landscape" : undefined}
     {...props}
     name="illustrations/heart/scene/information-modals-turnover-calculator.svg"
   />
 )
+InformationTurnoverCalculator.displayName = "InformationTurnoverCalculator"
 
-export const InformationTurnoverForecast = ({
+export const InformationTurnoverForecast: React.VFC<SceneProps> = ({
   enableAspectRatio,
   ...props
-}: SceneProps) => (
+}) => (
   <Base
     aspectRatio={enableAspectRatio ? "landscape" : undefined}
     {...props}
     name="illustrations/heart/scene/information-modals-turnover-forecast.svg"
   />
 )
+InformationTurnoverForecast.displayName = "InformationTurnoverForecast"
 
-export const InformationEmergingTrends = ({
+export const InformationEmergingTrends: React.VFC<SceneProps> = ({
   enableAspectRatio,
   ...props
-}: SceneProps) => (
+}) => (
   <Base
     aspectRatio={enableAspectRatio ? "landscape" : undefined}
     {...props}
     name="illustrations/heart/scene/information-modals-emerging-trends.svg"
   />
 )
+InformationEmergingTrends.displayName = "InformationEmergingTrends"
 
-export const InformationEmployeeLifecycle = ({
+export const InformationEmployeeLifecycle: React.VFC<SceneProps> = ({
   enableAspectRatio,
   ...props
-}: SceneProps) => (
+}) => (
   <Base
     aspectRatio={enableAspectRatio ? "landscape" : undefined}
     {...props}
     name="illustrations/heart/scene/information-modals-employee-lifecycle.svg"
   />
 )
+InformationEmployeeLifecycle.displayName = "InformationEmployeeLifecycle"
 
-export const InformationReportOwner = ({
+export const InformationReportOwner: React.VFC<SceneProps> = ({
   enableAspectRatio,
   ...props
-}: SceneProps) => (
+}) => (
   <Base
     aspectRatio={enableAspectRatio ? "landscape" : undefined}
     {...props}
     name="illustrations/heart/scene/information-modals-report-owner.svg"
   />
 )
+InformationReportOwner.displayName = "InformationReportOwner"
 
-export const InformationReportOwnerByRule = ({
+export const InformationReportOwnerByRule: React.VFC<SceneProps> = ({
   enableAspectRatio,
   ...props
-}: SceneProps) => (
+}) => (
   <Base
     aspectRatio={enableAspectRatio ? "landscape" : undefined}
     {...props}
     name="illustrations/heart/scene/information-modals-report-owner-by-rule.svg"
   />
 )
+InformationReportOwnerByRule.displayName = "InformationReportOwnerByRule"
 
 // Miscellaneous
 
-export const Collaboration = ({ enableAspectRatio, ...props }: SceneProps) => (
+export const Collaboration: React.VFC<SceneProps> = ({
+  enableAspectRatio,
+  ...props
+}) => (
   <Base
     aspectRatio={enableAspectRatio ? "landscape" : undefined}
     {...props}
     name="illustrations/heart/scene/miscellaneous-collaboration.svg"
   />
 )
+Collaboration.displayName = "Collaboration"
 
-export const Communication = ({ enableAspectRatio, ...props }: SceneProps) => (
+export const Communication: React.VFC<SceneProps> = ({
+  enableAspectRatio,
+  ...props
+}) => (
   <Base
     aspectRatio={enableAspectRatio ? "landscape" : undefined}
     {...props}
     name="illustrations/heart/scene/miscellaneous-communications.svg"
   />
 )
+Communication.displayName = "Communication"
 
-export const CompanyValues = ({ enableAspectRatio, ...props }: SceneProps) => (
+export const CompanyValues: React.VFC<SceneProps> = ({
+  enableAspectRatio,
+  ...props
+}) => (
   <Base
     aspectRatio={enableAspectRatio ? "landscape" : undefined}
     {...props}
     name="illustrations/heart/scene/miscellaneous-company-values.svg"
   />
 )
+CompanyValues.displayName = "CompanyValues"
 
-export const ConnectTheDots = ({ enableAspectRatio, ...props }: SceneProps) => (
+export const ConnectTheDots: React.VFC<SceneProps> = ({
+  enableAspectRatio,
+  ...props
+}) => (
   <Base
     aspectRatio={enableAspectRatio ? "landscape" : undefined}
     {...props}
     name="illustrations/heart/scene/miscellaneous-connect-the-dots.svg"
   />
 )
+ConnectTheDots.displayName = "ConnectTheDots"
 
-export const CultureLab = ({ enableAspectRatio, ...props }: SceneProps) => (
+export const CultureLab: React.VFC<SceneProps> = ({
+  enableAspectRatio,
+  ...props
+}) => (
   <Base
     aspectRatio={enableAspectRatio ? "landscape" : undefined}
     {...props}
     name="illustrations/heart/scene/miscellaneous-culture-lab.svg"
   />
 )
+CultureLab.displayName = "CultureLab"
 
-export const DataCatching = ({ enableAspectRatio, ...props }: SceneProps) => (
+export const DataCatching: React.VFC<SceneProps> = ({
+  enableAspectRatio,
+  ...props
+}) => (
   <Base
     aspectRatio={enableAspectRatio ? "landscape" : undefined}
     {...props}
     name="illustrations/heart/scene/miscellaneous-data-catching.svg"
   />
 )
+DataCatching.displayName = "DataCatching"
 
-export const HumanityAtWork = ({ enableAspectRatio, ...props }: SceneProps) => (
+export const HumanityAtWork: React.VFC<SceneProps> = ({
+  enableAspectRatio,
+  ...props
+}) => (
   <Base
     aspectRatio={enableAspectRatio ? "landscape" : undefined}
     {...props}
     name="illustrations/heart/scene/miscellaneous-humanity-at-work.svg"
   />
 )
+HumanityAtWork.displayName = "HumanityAtWork"
 
-export const TermsAgreement = ({ enableAspectRatio, ...props }: SceneProps) => (
+export const TermsAgreement: React.VFC<SceneProps> = ({
+  enableAspectRatio,
+  ...props
+}) => (
   <Base
     aspectRatio={enableAspectRatio ? "landscape" : undefined}
     {...props}
     name="illustrations/heart/scene/miscellaneous-terms-agreement.svg"
   />
 )
+TermsAgreement.displayName = "TermsAgreement"
 
 // Skills Coach
 
-export const SkillsCoach1On1Meetings = ({
+export const SkillsCoach1On1Meetings: React.VFC<SceneProps> = ({
   enableAspectRatio,
   ...props
-}: SceneProps) => (
+}) => (
   <Base
     aspectRatio={enableAspectRatio ? "landscape" : undefined}
     {...props}
     name="illustrations/heart/scene/skills-coach-1-on-1-meetings.svg"
   />
 )
+SkillsCoach1On1Meetings.displayName = "SkillsCoach1On1Meetings"
 
-export const SkillsCoachCoaching = ({
+export const SkillsCoachCoaching: React.VFC<SceneProps> = ({
   enableAspectRatio,
   ...props
-}: SceneProps) => (
+}) => (
   <Base
     aspectRatio={enableAspectRatio ? "landscape" : undefined}
     {...props}
     name="illustrations/heart/scene/skills-coach-coaching.svg"
   />
 )
+SkillsCoachCoaching.displayName = "SkillsCoachCoaching"
 
-export const SkillsCoachEmployeeDevelopment = ({
+export const SkillsCoachEmployeeDevelopment: React.VFC<SceneProps> = ({
   enableAspectRatio,
   ...props
-}: SceneProps) => (
+}) => (
   <Base
     aspectRatio={enableAspectRatio ? "landscape" : undefined}
     {...props}
     name="illustrations/heart/scene/skills-coach-employee-development.svg"
   />
 )
+SkillsCoachEmployeeDevelopment.displayName = "SkillsCoachEmployeeDevelopment"
 
-export const SkillsCoachEssentialFeedback = ({
+export const SkillsCoachEssentialFeedback: React.VFC<SceneProps> = ({
   enableAspectRatio,
   ...props
-}: SceneProps) => (
+}) => (
   <Base
     aspectRatio={enableAspectRatio ? "portrait" : undefined}
     {...props}
     name="illustrations/heart/scene/skills-coach-essential-feedback.svg"
   />
 )
+SkillsCoachEssentialFeedback.displayName = "SkillsCoachEssentialFeedback"
 
-export const SkillsCoachEssentialProductivity = ({
+export const SkillsCoachEssentialProductivity: React.VFC<SceneProps> = ({
   enableAspectRatio,
   ...props
-}: SceneProps) => (
+}) => (
   <Base
     aspectRatio={enableAspectRatio ? "portrait" : undefined}
     {...props}
     name="illustrations/heart/scene/skills-coach-essential-productivity.svg"
   />
 )
+SkillsCoachEssentialProductivity.displayName =
+  "SkillsCoachEssentialProductivity"
 
-export const SkillsCoachEssentialResilience = ({
+export const SkillsCoachEssentialResilience: React.VFC<SceneProps> = ({
   enableAspectRatio,
   ...props
-}: SceneProps) => (
+}) => (
   <Base
     aspectRatio={enableAspectRatio ? "portrait" : undefined}
     {...props}
     name="illustrations/heart/scene/skills-coach-essential-resilience.svg"
   />
 )
+SkillsCoachEssentialResilience.displayName = "SkillsCoachEssentialResilience"
 
-export const SkillsCoachInfluentialCommunication = ({
+export const SkillsCoachInfluentialCommunication: React.VFC<SceneProps> = ({
   enableAspectRatio,
   ...props
-}: SceneProps) => (
+}) => (
   <Base
     aspectRatio={enableAspectRatio ? "portrait" : undefined}
     {...props}
     name="illustrations/heart/scene/skills-coach-influential-communication.svg"
   />
 )
+SkillsCoachInfluentialCommunication.displayName =
+  "SkillsCoachInfluentialCommunication"
 
-export const SkillsCoachLeadingChange = ({
+export const SkillsCoachLeadingChange: React.VFC<SceneProps> = ({
   enableAspectRatio,
   ...props
-}: SceneProps) => (
+}) => (
   <Base
     aspectRatio={enableAspectRatio ? "portrait" : undefined}
     {...props}
     name="illustrations/heart/scene/skills-coach-leading-change.svg"
   />
 )
+SkillsCoachLeadingChange.displayName = "SkillsCoachLeadingChange"
 
-export const SkillsCoachFeedback = ({
+export const SkillsCoachFeedback: React.VFC<SceneProps> = ({
   enableAspectRatio,
   ...props
-}: SceneProps) => (
+}) => (
   <Base
     aspectRatio={enableAspectRatio ? "landscape" : undefined}
     {...props}
     name="illustrations/heart/scene/skills-coach-feedback.svg"
   />
 )
+SkillsCoachFeedback.displayName = "SkillsCoachFeedback"
 
-export const SkillsCoachManagerHub = ({
+export const SkillsCoachManagerHub: React.VFC<SceneProps> = ({
   enableAspectRatio,
   ...props
-}: SceneProps) => (
+}) => (
   <Base
     aspectRatio={enableAspectRatio ? "landscape" : undefined}
     {...props}
     name="illustrations/heart/scene/skills-coach-manager-hub.svg"
   />
 )
+SkillsCoachManagerHub.displayName = "SkillsCoachManagerHub"
 
-export const SkillsCoachProductivity = ({
+export const SkillsCoachProductivity: React.VFC<SceneProps> = ({
   enableAspectRatio,
   ...props
-}: SceneProps) => (
+}) => (
   <Base
     aspectRatio={enableAspectRatio ? "landscape" : undefined}
     {...props}
     name="illustrations/heart/scene/skills-coach-productivity.svg"
   />
 )
+SkillsCoachProductivity.displayName = "SkillsCoachProductivity"
 
-export const SkillsCoachRemoteManager = ({
+export const SkillsCoachRemoteManager: React.VFC<SceneProps> = ({
   enableAspectRatio,
   ...props
-}: SceneProps) => (
+}) => (
   <Base
     aspectRatio={enableAspectRatio ? "landscape" : undefined}
     {...props}
     name="illustrations/heart/scene/skills-coach-remote-manager.svg"
   />
 )
+SkillsCoachRemoteManager.displayName = "SkillsCoachRemoteManager"
 
-export const SkillsCoachResilience = ({
+export const SkillsCoachResilience: React.VFC<SceneProps> = ({
   enableAspectRatio,
   ...props
-}: SceneProps) => (
+}) => (
   <Base
     aspectRatio={enableAspectRatio ? "landscape" : undefined}
     {...props}
     name="illustrations/heart/scene/skills-coach-resilience.svg"
   />
 )
+SkillsCoachResilience.displayName = "SkillsCoachResilience"
 
-export const SkillsCoachStrategy = ({
+export const SkillsCoachStrategy: React.VFC<SceneProps> = ({
   enableAspectRatio,
   ...props
-}: SceneProps) => (
+}) => (
   <Base
     aspectRatio={enableAspectRatio ? "portrait" : undefined}
     {...props}
     name="illustrations/heart/scene/skills-coach-strategy.svg"
   />
 )
+SkillsCoachStrategy.displayName = "SkillsCoachStrategy"
 
 // Engagement
 
-export const Programs = ({ enableAspectRatio, ...props }: SceneProps) => (
+export const Programs: React.VFC<SceneProps> = ({
+  enableAspectRatio,
+  ...props
+}) => (
   <Base
     aspectRatio={enableAspectRatio ? "landscape" : undefined}
     {...props}
     name="illustrations/heart/scene/engagement-programs.svg"
   />
 )
+Programs.displayName = "Programs"
 
-export const EngagementSurveySummaryFemale = ({
+export const EngagementSurveySummaryFemale: React.VFC<SceneProps> = ({
   enableAspectRatio,
   ...props
-}: SceneProps) => (
+}) => (
   <Base
     aspectRatio={enableAspectRatio ? "landscape" : undefined}
     {...props}
     name="illustrations/heart/scene/engagement-survey-summary-female.svg"
   />
 )
+EngagementSurveySummaryFemale.displayName = "EngagementSurveySummaryFemale"
 
-export const EngagementSurveySummaryMale = ({
+export const EngagementSurveySummaryMale: React.VFC<SceneProps> = ({
   enableAspectRatio,
   ...props
-}: SceneProps) => (
+}) => (
   <Base
     aspectRatio={enableAspectRatio ? "landscape" : undefined}
     {...props}
     name="illustrations/heart/scene/engagement-survey-summary-male.svg"
   />
 )
+EngagementSurveySummaryMale.displayName = "EngagementSurveySummaryMale"
 
-export const SurveyOverviewClosed = ({
+export const SurveyOverviewClosed: React.VFC<SceneProps> = ({
   enableAspectRatio,
   ...props
-}: SceneProps) => (
+}) => (
   <Base
     aspectRatio={enableAspectRatio ? "portrait" : undefined}
     {...props}
     name="illustrations/heart/scene/survey-overview-closed.svg"
   />
 )
+SurveyOverviewClosed.displayName = "SurveyOverviewClosed"
 
-export const SurveyGetStarted = ({
+export const SurveyGetStarted: React.VFC<SceneProps> = ({
   enableAspectRatio,
   ...props
-}: SceneProps) => (
+}) => (
   <Base
     aspectRatio={enableAspectRatio ? "portrait" : undefined}
     {...props}
     name="illustrations/heart/scene/getting-started.svg"
   />
 )
+SurveyGetStarted.displayName = "SurveyGetStarted"
 
-export const PerformanceCompanySettings = ({
+export const PerformanceCompanySettings: React.VFC<SceneProps> = ({
   enableAspectRatio,
   ...props
-}: SceneProps) => (
+}) => (
   <Base
     aspectRatio={enableAspectRatio ? "landscape" : undefined}
     {...props}
     name="illustrations/heart/scene/performance-company-settings.svg"
   />
 )
+PerformanceCompanySettings.displayName = "PerformanceCompanySettings"

--- a/draft-packages/illustration/docs/IllustrationScene.stories.tsx
+++ b/draft-packages/illustration/docs/IllustrationScene.stories.tsx
@@ -1,6 +1,7 @@
 import React from "react"
 import { Box } from "@kaizen/component-library"
 import { Heading } from "@kaizen/typography"
+import { Story } from "@storybook/react"
 import {
   EmptyStatesAction,
   EmptyStatesInformative,
@@ -50,18 +51,23 @@ import {
   SkillsCoachStrategy,
   SurveyGetStarted,
   SurveyOverviewClosed,
+  AnimatedSceneProps,
+  SceneProps,
 } from ".."
 import { CATEGORIES, SUB_CATEGORIES } from "../../../storybook/constants"
 
-const withFixedWidth = Story => (
-  <div style={{ width: "500px" }}>
-    <Story />
-  </div>
-)
+const STATIC_SCENE_CONTROLS = {
+  argTypes: {
+    isAnimated: { table: { disable: true } },
+    loop: { table: { disable: true } },
+    autoplay: { table: { disable: true } },
+    onEnded: { table: { disable: true } },
+  },
+}
 
 export default {
   title: `${CATEGORIES.components}/${SUB_CATEGORIES.illustration}/Scene`,
-  component: EmptyStatesInformative,
+  component: BrandMomentCaptureIntro,
   parameters: {
     chromatic: { disable: false },
     docs: {
@@ -70,529 +76,320 @@ export default {
           'import { SurveyOverviewClosed } from "@kaizen/draft-illustration"',
       },
     },
-    decorators: [withFixedWidth],
+  },
+  argTypes: {
+    sceneComponents: { table: { disable: true } },
+    fallback: { table: { disable: true } },
+    source: { table: { disable: true } },
   },
 }
 
-export const BrandMoments = args => (
+const SceneWrapper: React.VFC<{
+  children: React.ReactNode
+  heading: string
+  width: string
+}> = ({ children, heading, width }) => (
+  <Box mb={3}>
+    <div style={{ width }}>
+      <Box mb={1}>
+        <Heading variant="heading-4" tag="div">
+          {heading}
+        </Heading>
+      </Box>
+      {children}
+    </div>
+  </Box>
+)
+
+type AnimatedScene = React.VFC<AnimatedSceneProps>
+type StaticScene = React.VFC<SceneProps>
+type IllustrationScene = AnimatedScene | StaticScene
+
+type SceneComponents = Array<{
+  Component: IllustrationScene
+  heading: string
+  width?: string
+}>
+
+const isAnimatedBrandMoment = (
+  Component: IllustrationScene
+): Component is AnimatedScene => Component.toString().includes("isAnimated")
+
+const IllustrationScenesTemplate: Story<
+  AnimatedSceneProps & SceneProps & { sceneComponents: SceneComponents }
+> = ({ sceneComponents, isAnimated, loop, autoplay, ...props }) => (
   <>
-    <Box mb={3}>
-      <div style={{ width: "450px" }}>
-        <Box mb={1}>
-          <Heading variant="heading-4" tag="div">
-            Capture Intro
-          </Heading>
-        </Box>
-        <BrandMomentCaptureIntro {...args} />
-      </div>
-    </Box>
-    <Box mb={3}>
-      <div style={{ width: "450px" }}>
-        <Box mb={1}>
-          <Heading variant="heading-4" tag="div">
-            Positive Outro
-          </Heading>
-        </Box>
-        <BrandMomentPositiveOutro {...args} />
-      </div>
-    </Box>
-    <Box mb={3}>
-      <div style={{ width: "800px" }}>
-        <Box mb={1}>
-          <Heading variant="heading-4" tag="div">
-            Login
-          </Heading>
-        </Box>
-        <BrandMomentLogin {...args} />
-      </div>
-    </Box>
-    <Box mb={3}>
-      <div style={{ width: "450px" }}>
-        <Box mb={1}>
-          <Heading variant="heading-4" tag="div">
-            Error
-          </Heading>
-        </Box>
-        <BrandMomentError {...args} />
-      </div>
-    </Box>
-    <Box mb={3}>
-      <div style={{ width: "450px" }}>
-        <Box mb={1}>
-          <Heading variant="heading-4" tag="div">
-            Starter Kit
-          </Heading>
-        </Box>
-        <BrandMomentStarterKit {...args} />
-      </div>
-    </Box>
-    <Box mb={3}>
-      <div style={{ width: "450px" }}>
-        <Box mb={1}>
-          <Heading variant="heading-4" tag="div">
-            New Account Onboarding
-          </Heading>
-        </Box>
-        <BrandMomentNewAccountOnboarding {...args} />
-      </div>
-    </Box>
-    <Box mb={3}>
-      <div style={{ width: "450px" }}>
-        <Box mb={1}>
-          <Heading variant="heading-4" tag="div">
-            Upload Employee Data
-          </Heading>
-        </Box>
-        <BrandMomentUploadEmployeeData {...args} />
-      </div>
-    </Box>
+    {sceneComponents.map(({ Component, heading, width }) => (
+      <SceneWrapper key={heading} width={width || "450px"} heading={heading}>
+        {isAnimatedBrandMoment(Component) && isAnimated ? (
+          <Component
+            isAnimated={isAnimated}
+            loop={loop}
+            autoplay={autoplay}
+            {...props}
+          />
+        ) : (
+          <Component {...props} />
+        )}
+      </SceneWrapper>
+    ))}
   </>
 )
+
+const BRAND_MOMENTS_COMPONENTS: SceneComponents = [
+  {
+    Component: BrandMomentCaptureIntro,
+    heading: "Capture Intro",
+  },
+  {
+    Component: BrandMomentPositiveOutro,
+    heading: "Positive Outro",
+  },
+  {
+    Component: BrandMomentLogin,
+    heading: "Login",
+    width: "800px",
+  },
+  {
+    Component: BrandMomentError,
+    heading: "Error",
+  },
+  {
+    Component: BrandMomentStarterKit,
+    heading: "Starter Kit",
+  },
+  {
+    Component: BrandMomentNewAccountOnboarding,
+    heading: "New Account Onboarding",
+  },
+  {
+    Component: BrandMomentUploadEmployeeData,
+    heading: "Upload Employee Data",
+  },
+]
+
+export const BrandMoments = IllustrationScenesTemplate.bind({})
 BrandMoments.args = {
+  sceneComponents: BRAND_MOMENTS_COMPONENTS,
   isAnimated: true,
   loop: true,
 }
 
-export const EmptyState = args => (
-  <>
-    <Box mb={3}>
-      <div style={{ width: "450px" }}>
-        <Box mb={1}>
-          <Heading variant="heading-4" tag="div">
-            Action
-          </Heading>
-        </Box>
-        <EmptyStatesAction {...args} />
-      </div>
-    </Box>
-    <Box mb={3}>
-      <div style={{ width: "450px" }}>
-        <Box mb={1}>
-          <Heading variant="heading-4" tag="div">
-            Informative
-          </Heading>
-        </Box>
-        <EmptyStatesInformative {...args} />
-      </div>
-    </Box>
-    <Box mb={3}>
-      <div style={{ width: "450px" }}>
-        <Box mb={1}>
-          <Heading variant="heading-4" tag="div">
-            Negative
-          </Heading>
-        </Box>
-        <EmptyStatesNegative {...args} />
-      </div>
-    </Box>
-    <Box mb={3}>
-      <div style={{ width: "450px" }}>
-        <Box mb={1}>
-          <Heading variant="heading-4" tag="div">
-            Positive
-          </Heading>
-        </Box>
-        <EmptyStatesPositive {...args} />
-      </div>
-    </Box>
-    <Box mb={3}>
-      <div style={{ width: "450px" }}>
-        <Box mb={1}>
-          <Heading variant="heading-4" tag="div">
-            Neutral
-          </Heading>
-        </Box>
-        <EmptyStatesNeutral {...args} />
-      </div>
-    </Box>
-  </>
-)
+const EMPTY_STATE_COMPONENTS: SceneComponents = [
+  {
+    Component: EmptyStatesAction,
+    heading: "Action",
+  },
+  {
+    Component: EmptyStatesInformative,
+    heading: "Informative",
+  },
+  {
+    Component: EmptyStatesNegative,
+    heading: "Negative",
+  },
+  {
+    Component: EmptyStatesPositive,
+    heading: "Positive",
+  },
+  {
+    Component: EmptyStatesNeutral,
+    heading: "Neutral",
+  },
+]
+
+export const EmptyState = IllustrationScenesTemplate.bind({})
 EmptyState.args = {
+  sceneComponents: EMPTY_STATE_COMPONENTS,
   isAnimated: true,
   loop: true,
 }
 
-export const InformationModals = args => (
-  <>
-    <Box mb={3}>
-      <div style={{ width: "450px" }}>
-        <Box mb={1}>
-          <Heading variant="heading-4" tag="div">
-            360 Upgrade
-          </Heading>
-        </Box>
-        <Information360Upgrade {...args} />
-      </div>
-    </Box>
-    <Box mb={3}>
-      <div style={{ width: "450px" }}>
-        <Box mb={1}>
-          <Heading variant="heading-4" tag="div">
-            Demographic Focus
-          </Heading>
-        </Box>
-        <InformationDemographicFocus {...args} />
-      </div>
-    </Box>
-    <Box mb={3}>
-      <div style={{ width: "450px" }}>
-        <Box mb={1}>
-          <Heading variant="heading-4" tag="div">
-            Turnover Calculator
-          </Heading>
-        </Box>
-        <InformationTurnoverCalculator {...args} />
-      </div>
-    </Box>
-    <Box mb={3}>
-      <div style={{ width: "450px" }}>
-        <Box mb={1}>
-          <Heading variant="heading-4" tag="div">
-            Turnover Forecast
-          </Heading>
-        </Box>
-        <InformationTurnoverForecast {...args} />
-      </div>
-    </Box>
-    <Box mb={3}>
-      <div style={{ width: "450px" }}>
-        <Box mb={1}>
-          <Heading variant="heading-4" tag="div">
-            Emerging Trends
-          </Heading>
-        </Box>
-        <InformationEmergingTrends {...args} />
-      </div>
-    </Box>
-    <Box mb={3}>
-      <div style={{ width: "450px" }}>
-        <Box mb={1}>
-          <Heading variant="heading-4" tag="div">
-            Employee Lifecycle
-          </Heading>
-        </Box>
-        <InformationEmployeeLifecycle {...args} />
-      </div>
-    </Box>
-    <Box mb={3}>
-      <div style={{ width: "450px" }}>
-        <Box mb={1}>
-          <Heading variant="heading-4" tag="div">
-            Report Owner
-          </Heading>
-        </Box>
-        <InformationReportOwner {...args} />
-      </div>
-    </Box>
-    <Box mb={3}>
-      <div style={{ width: "450px" }}>
-        <Box mb={1}>
-          <Heading variant="heading-4" tag="div">
-            Report Owner By Rule
-          </Heading>
-        </Box>
-        <InformationReportOwnerByRule {...args} />
-      </div>
-    </Box>
-  </>
-)
+const INFORMATION_MODALS_COMPONENTS: SceneComponents = [
+  {
+    Component: Information360Upgrade,
+    heading: "360 Upgrade",
+  },
+  {
+    Component: InformationDemographicFocus,
+    heading: "Demographic Focus",
+  },
+  {
+    Component: InformationTurnoverCalculator,
+    heading: "Turnover Calculator",
+  },
+  {
+    Component: InformationTurnoverForecast,
+    heading: "Turnover Forecast",
+  },
+  {
+    Component: InformationEmergingTrends,
+    heading: "Emerging Trends",
+  },
+  {
+    Component: InformationEmployeeLifecycle,
+    heading: "Employee Lifecycle",
+  },
+  {
+    Component: InformationReportOwner,
+    heading: "Report Owner",
+  },
+  {
+    Component: InformationReportOwnerByRule,
+    heading: "Report Owner By Rule",
+  },
+]
 
-export const Miscellaneous = args => (
-  <>
-    <Box mb={3}>
-      <div style={{ width: "450px" }}>
-        <Box mb={1}>
-          <Heading variant="heading-4" tag="div">
-            Collaboration
-          </Heading>
-        </Box>
-        <Collaboration {...args} />
-      </div>
-    </Box>
-    <Box mb={3}>
-      <div style={{ width: "450px" }}>
-        <Box mb={1}>
-          <Heading variant="heading-4" tag="div">
-            Communication
-          </Heading>
-        </Box>
-        <Communication {...args} />
-      </div>
-    </Box>
-    <Box mb={3}>
-      <div style={{ width: "450px" }}>
-        <Box mb={1}>
-          <Heading variant="heading-4" tag="div">
-            Company Values
-          </Heading>
-        </Box>
-        <CompanyValues {...args} />
-      </div>
-    </Box>
-    <Box mb={3}>
-      <div style={{ width: "450px" }}>
-        <Box mb={1}>
-          <Heading variant="heading-4" tag="div">
-            Connect The Dots
-          </Heading>
-        </Box>
-        <ConnectTheDots {...args} />
-      </div>
-    </Box>
-    <Box mb={3}>
-      <div style={{ width: "450px" }}>
-        <Box mb={1}>
-          <Heading variant="heading-4" tag="div">
-            Culture Lab
-          </Heading>
-        </Box>
-        <CultureLab {...args} />
-      </div>
-    </Box>
-    <Box mb={3}>
-      <div style={{ width: "450px" }}>
-        <Box mb={1}>
-          <Heading variant="heading-4" tag="div">
-            Data Catching
-          </Heading>
-        </Box>
-        <DataCatching {...args} />
-      </div>
-    </Box>
-    <Box mb={3}>
-      <div style={{ width: "450px" }}>
-        <Box mb={1}>
-          <Heading variant="heading-4" tag="div">
-            Humanity At Work
-          </Heading>
-        </Box>
-        <HumanityAtWork {...args} />
-      </div>
-    </Box>
-    <Box mb={3}>
-      <div style={{ width: "450px" }}>
-        <Box mb={1}>
-          <Heading variant="heading-4" tag="div">
-            Terms Agreement
-          </Heading>
-        </Box>
-        <TermsAgreement {...args} />
-      </div>
-    </Box>
-    <Box mb={3}>
-      <div style={{ width: "450px" }}>
-        <Box mb={1}>
-          <Heading variant="heading-4" tag="div">
-            Performance Company Settings
-          </Heading>
-        </Box>
-        <PerformanceCompanySettings {...args} />
-      </div>
-    </Box>
-  </>
-)
+export const InformationModals = IllustrationScenesTemplate.bind({})
+InformationModals.story = { ...STATIC_SCENE_CONTROLS }
+InformationModals.args = {
+  sceneComponents: INFORMATION_MODALS_COMPONENTS,
+}
 
-export const SkillsCoach = args => (
-  <>
-    <Box mb={3}>
-      <div style={{ width: "450px" }}>
-        <Box mb={1}>
-          <Heading variant="heading-4" tag="div">
-            1-on-1 Meetings
-          </Heading>
-        </Box>
-        <SkillsCoach1On1Meetings alt="" {...args} />
-      </div>
-    </Box>
-    <Box mb={3}>
-      <div style={{ width: "450px" }}>
-        <Box mb={1}>
-          <Heading variant="heading-4" tag="div">
-            Coaching
-          </Heading>
-        </Box>
-        <SkillsCoachCoaching alt="" {...args} />
-      </div>
-    </Box>
-    <Box mb={3}>
-      <div style={{ width: "450px" }}>
-        <Box mb={1}>
-          <Heading variant="heading-4" tag="div">
-            Employee Development
-          </Heading>
-        </Box>
-        <SkillsCoachEmployeeDevelopment alt="" {...args} />
-      </div>
-    </Box>
-    <Box mb={3}>
-      <div style={{ width: "450px" }}>
-        <Box mb={1}>
-          <Heading variant="heading-4" tag="div">
-            Essential Feedback
-          </Heading>
-        </Box>
-        <SkillsCoachEssentialFeedback alt="" {...args} />
-      </div>
-    </Box>
-    <Box mb={3}>
-      <div style={{ width: "450px" }}>
-        <Box mb={1}>
-          <Heading variant="heading-4" tag="div">
-            Feedback
-          </Heading>
-        </Box>
-        <SkillsCoachFeedback alt="" {...args} />
-      </div>
-    </Box>
-    <Box mb={3}>
-      <div style={{ width: "450px" }}>
-        <Box mb={1}>
-          <Heading variant="heading-4" tag="div">
-            Manager Hub
-          </Heading>
-        </Box>
-        <SkillsCoachManagerHub alt="" {...args} />
-      </div>
-    </Box>
-    <Box mb={3}>
-      <div style={{ width: "450px" }}>
-        <Box mb={1}>
-          <Heading variant="heading-4" tag="div">
-            Productivity
-          </Heading>
-        </Box>
-        <SkillsCoachProductivity alt="" {...args} />
-      </div>
-    </Box>
-    <Box mb={3}>
-      <div style={{ width: "450px" }}>
-        <Box mb={1}>
-          <Heading variant="heading-4" tag="div">
-            Remote Manager
-          </Heading>
-        </Box>
-        <SkillsCoachRemoteManager alt="" {...args} />
-      </div>
-    </Box>
-    <Box mb={3}>
-      <div style={{ width: "450px" }}>
-        <Box mb={1}>
-          <Heading variant="heading-4" tag="div">
-            Resilience
-          </Heading>
-        </Box>
-        <SkillsCoachResilience alt="" {...args} />
-      </div>
-    </Box>
-    <Box mb={3}>
-      <div style={{ width: "450px" }}>
-        <Box mb={1}>
-          <Heading variant="heading-4" tag="div">
-            Strategy
-          </Heading>
-        </Box>
-        <SkillsCoachStrategy alt="" {...args} />
-      </div>
-    </Box>
-    <Box mb={3}>
-      <div style={{ width: "450px" }}>
-        <Box mb={1}>
-          <Heading variant="heading-4" tag="div">
-            Essential Productivity
-          </Heading>
-        </Box>
-        <SkillsCoachEssentialProductivity alt="" {...args} />
-      </div>
-    </Box>
-    <Box mb={3}>
-      <div style={{ width: "450px" }}>
-        <Box mb={1}>
-          <Heading variant="heading-4" tag="div">
-            Essential Resilience
-          </Heading>
-        </Box>
-        <SkillsCoachEssentialResilience alt="" {...args} />
-      </div>
-    </Box>
-    <Box mb={3}>
-      <div style={{ width: "450px" }}>
-        <Box mb={1}>
-          <Heading variant="heading-4" tag="div">
-            Influential Communication
-          </Heading>
-        </Box>
-        <SkillsCoachInfluentialCommunication alt="" {...args} />
-      </div>
-    </Box>
-    <Box mb={3}>
-      <div style={{ width: "450px" }}>
-        <Box mb={1}>
-          <Heading variant="heading-4" tag="div">
-            Leading Change
-          </Heading>
-        </Box>
-        <SkillsCoachLeadingChange alt="" {...args} />
-      </div>
-    </Box>
-  </>
-)
+const MISCELLANEOUS_COMPONENTS: SceneComponents = [
+  {
+    Component: Collaboration,
+    heading: "Collaboration",
+  },
+  {
+    Component: Communication,
+    heading: "Communication",
+  },
+  {
+    Component: CompanyValues,
+    heading: "Company Values",
+  },
+  {
+    Component: ConnectTheDots,
+    heading: "Connect The Dots",
+  },
+  {
+    Component: CultureLab,
+    heading: "Culture Lab",
+  },
+  {
+    Component: DataCatching,
+    heading: "Data Catching",
+  },
+  {
+    Component: HumanityAtWork,
+    heading: "Humanity At Work",
+  },
+  {
+    Component: TermsAgreement,
+    heading: "Terms Agreement",
+  },
+  {
+    Component: PerformanceCompanySettings,
+    heading: "Performance Company Settings",
+  },
+]
 
-export const Survey = args => (
-  <>
-    <Box mb={3}>
-      <div style={{ width: "450px" }}>
-        <Box mb={1}>
-          <Heading variant="heading-4" tag="div">
-            Survey Get Started
-          </Heading>
-        </Box>
-        <SurveyGetStarted alt="" {...args} />
-      </div>
-    </Box>
-    <Box mb={3}>
-      <div style={{ width: "450px" }}>
-        <Box mb={1}>
-          <Heading variant="heading-4" tag="div">
-            Survey Overview Closed
-          </Heading>
-        </Box>
-        <SurveyOverviewClosed alt="" {...args} />
-      </div>
-    </Box>
-  </>
-)
+export const Miscellaneous = IllustrationScenesTemplate.bind({})
+Miscellaneous.story = { ...STATIC_SCENE_CONTROLS }
+Miscellaneous.args = {
+  sceneComponents: MISCELLANEOUS_COMPONENTS,
+}
 
-export const Engagement = args => (
-  <>
-    <Box mb={3}>
-      <div style={{ width: "450px" }}>
-        <Box mb={1}>
-          <Heading variant="heading-4" tag="div">
-            Programs
-          </Heading>
-        </Box>
-        <Programs alt="" {...args} />
-      </div>
-    </Box>
-    <Box mb={3}>
-      <div style={{ width: "450px" }}>
-        <Box mb={1}>
-          <Heading variant="heading-4" tag="div">
-            Survey Summary (Female)
-          </Heading>
-        </Box>
-        <EngagementSurveySummaryFemale alt="" {...args} />
-      </div>
-    </Box>
-    <Box mb={3}>
-      <div style={{ width: "450px" }}>
-        <Box mb={1}>
-          <Heading variant="heading-4" tag="div">
-            Survey Summary (Male)
-          </Heading>
-        </Box>
-        <EngagementSurveySummaryMale alt="" {...args} />
-      </div>
-    </Box>
-  </>
-)
+const SKILLS_COACH_COMPONENTS: SceneComponents = [
+  {
+    Component: SkillsCoach1On1Meetings,
+    heading: "1-on-1 Meetings",
+  },
+  {
+    Component: SkillsCoachCoaching,
+    heading: "Coaching",
+  },
+  {
+    Component: SkillsCoachEmployeeDevelopment,
+    heading: "Employee Development",
+  },
+  {
+    Component: SkillsCoachEssentialFeedback,
+    heading: "Essential Feedback",
+  },
+  {
+    Component: SkillsCoachFeedback,
+    heading: "Feedback",
+  },
+  {
+    Component: SkillsCoachManagerHub,
+    heading: "Manager Hub",
+  },
+  {
+    Component: SkillsCoachProductivity,
+    heading: "Productivity",
+  },
+  {
+    Component: SkillsCoachRemoteManager,
+    heading: "Remote Manager",
+  },
+  {
+    Component: SkillsCoachResilience,
+    heading: "Resilience",
+  },
+  {
+    Component: SkillsCoachStrategy,
+    heading: "Strategy",
+  },
+  {
+    Component: SkillsCoachEssentialProductivity,
+    heading: "Essential Productivity",
+  },
+  {
+    Component: SkillsCoachEssentialResilience,
+    heading: "Essential Resilience",
+  },
+  {
+    Component: SkillsCoachInfluentialCommunication,
+    heading: "Influential Communication",
+  },
+  {
+    Component: SkillsCoachLeadingChange,
+    heading: "Leading Change",
+  },
+]
+
+export const SkillsCoach = IllustrationScenesTemplate.bind({})
+SkillsCoach.story = { ...STATIC_SCENE_CONTROLS }
+SkillsCoach.args = {
+  sceneComponents: SKILLS_COACH_COMPONENTS,
+}
+
+const SURVEY_COMPONENTS: SceneComponents = [
+  {
+    Component: SurveyGetStarted,
+    heading: "Survey Get Started",
+  },
+  {
+    Component: SurveyOverviewClosed,
+    heading: "Survey Overview Closed",
+  },
+]
+
+export const Survey = IllustrationScenesTemplate.bind({})
+Survey.story = { ...STATIC_SCENE_CONTROLS }
+Survey.args = {
+  sceneComponents: SURVEY_COMPONENTS,
+}
+
+const ENGAGEMENT_COMPONENTS: SceneComponents = [
+  {
+    Component: Programs,
+    heading: "Programs",
+  },
+  {
+    Component: EngagementSurveySummaryFemale,
+    heading: "Survey Summary (Female)",
+  },
+  {
+    Component: EngagementSurveySummaryMale,
+    heading: "Survey Summary (Male)",
+  },
+]
+
+export const Engagement = IllustrationScenesTemplate.bind({})
+Engagement.story = { ...STATIC_SCENE_CONTROLS }
+Engagement.args = {
+  sceneComponents: ENGAGEMENT_COMPONENTS,
+}


### PR DESCRIPTION
# What

Change animated illustration scenes to not animate in Chromatic.

[New Chromatic snapshots](https://www.chromatic.com/build?appId=60a1e4a102f0cb003b5d19d6&number=339)

Refactored stories file to use templates and adjust the controls to be more relevant (it's not perfect as there's a bit of manual overriding required since animated/non-animated use different props, so having them share a file is a little conflicting by nature).

# Why

Animated scene illustrations were not showing up in the Chromatic snapshots (eg. [here](https://www.chromatic.com/component?buildNumber=316&historyLengthAtIndex=44&distanceToMoveBack=-13&appId=60a1e4a102f0cb003b5d19d6&name=Components%2FIllustration%2FScene&specName=Brand+Moments&componentInspectorKey=6227e05c07cc90003a2f97dd-1200-snapshot-true)).

# Changes

- Add display name to illustration scenes and changed to use VFC
	- Changed during wip as I was using the values; figured I just leave the changes instead of reverting
- Turn off animations for Chromatic snapshots