### PR TITLE
feat: add `component-base` package and extend Collapsible with HTML attributes and className override

### DIFF
--- a/docs/basic-component.md
+++ b/docs/basic-component.md
@@ -102,11 +102,11 @@ A basic component will follow this template:
 // PancakeStack.tsx
 import React, { HTMLAttributes } from "react"
 import classnames from "classnames"
+import { OverrideClassName } from "@kaizen/component-base"
 import styles from "./PancakeStack.scss"
 
-export interface PancakeStackProps extends Omit<HTMLAttributes<HTMLDivElement>, "className"> {
+export interface PancakeStackProps extends OverrideClassName<HTMLAttributes<HTMLDivElement>> {
   children: React.ReactNode
-  classNameOverride?: string
   isBooleanProp: boolean
   hasOptionalBooleanProp?: boolean
   onCustomFunction: () => void
@@ -114,10 +114,10 @@ export interface PancakeStackProps extends Omit<HTMLAttributes<HTMLDivElement>, 
 
 export const PancakeStack: React.VFC<PancakeStackProps> = ({
   children,
-  classNameOverride,
   isBooleanProp,
   hasOptionalBooleanProp = false,
   onCustomFunction,
+  classNameOverride,
   ...props
 }) => {
   const [hasSyrup, setHasSyrup] = useState<boolean>(false)
@@ -149,10 +149,10 @@ PancakeStack.displayName = "PancakeStack"
 
 ```tsx
 import { HTMLAttributes } from "react"
+import { OverrideClassName } from "@kaizen/component-base"
 
-export interface PancakeStackProps extends Omit<HTMLAttributes<HTMLDivElement>, "className"> {
+export interface PancakeStackProps extends OverrideClassName<HTMLAttributes<HTMLDivElement>> {
   children: React.ReactNode
-  classNameOverride?: string
   isBooleanProp: boolean
   hasOptionalBooleanProp?: boolean
   onCustomFunction: () => void
@@ -162,7 +162,7 @@ export interface PancakeStackProps extends Omit<HTMLAttributes<HTMLDivElement>, 
 - Create and export an `interface` for your props in the format of `{PascalComponentName}Props`
   - You can restrict a prop's type signature by redeclaring it (eg. changing a prop from `string | undefined` to `string`)
   - If you need to change the type signature of an extended prop, ensure you `Omit` it otherwise it will become `never` (eg. changing a prop from `string | undefined` to `number`)
-- `Omit` `"className"` as we re-add it with the alias `classNameOverride`
+- Use our custom type `OverrideClassName` to replace `className` with the alias `classNameOverride`
   - The alias allows us to easier track usage (as ideally teams should not need to use this) and allows us to not be a bottleneck if the component does not meet their needs in the interim
   - Previously `classNameAndIHaveSpokenToDST`
 - Extend the native attributes of the closest HTML element of your component (eg. `<section>` will use `<div>` attributes)
@@ -170,11 +170,11 @@ export interface PancakeStackProps extends Omit<HTMLAttributes<HTMLDivElement>, 
 ```tsx
 // Extending <section>
 import { HTMLAttributes } from "react"
-export type SectionProps = Omit<HTMLAttributes<HTMLDivElement>, "className">
+export type SectionProps = OverrideClassName<HTMLAttributes<HTMLDivElement>>
 
 // Extending <button>
 import { ButtonHTMLAttributes } from "react"
-export type ButtonProps = Omit<ButtonHTMLAttributes<HTMLButtonElement>, "className">
+export type ButtonProps = OverrideClassName<ButtonHTMLAttributes<HTMLButtonElement>>
 ```
 
 - If your component is mainly extending another component, extend the props of that component and spread the props
@@ -190,7 +190,7 @@ export const NewComponent: React.VFC<NewComponentProps> = ({ ...props }) => <Pan
 - Declare the `children` prop if you require it
   - Usually it is `React.ReactNode`, however you can customise it to your needs
   - [ReactNode vs ReactElement vs JSX.Element](https://stackoverflow.com/questions/58123398/when-to-use-jsx-element-vs-reactnode-vs-reactelement)
-- Add `classNameOverride` to replace the omitted `className`
+- If you are extending third party props which contain `className`, wrap it in `OverrideClassName` to replace it with `classNameOverride`
 - Prefix boolean props with `is` or `has`
 - Declare a default value for optional boolean props
   - Unless you specifically have a need to differentiate between `false` and `undefined`, this allows you to have the type safety of only needing to cater for a boolean value in any usages (eg. in a util)
@@ -214,10 +214,10 @@ import React from "react"
 
 export const PancakeStack: React.VFC<PancakeStackProps> = ({
   children,
-  classNameOverride,
   isBooleanProp,
   hasOptionalBooleanProp = false,
   onCustomFunction,
+  classNameOverride,
   ...props
 }) => {
   const [hasSyrup, setHasSyrup] = useState<boolean>(false)

--- a/docs/package-structure.md
+++ b/docs/package-structure.md
@@ -85,15 +85,15 @@ The base package.json will look like this, where:
     "**/*.d.ts",
     "!**/*.spec.*",
     "!**/*.snap",
-    "!draft-templates",
-    "!stories",
     "!docs",
     "!tsconfig.dist.json"
   ],
   "author": "",
   "private": false,
   "license": "MIT",
-  "dependencies": {},
+  "devDependencies": {
+    "@kaizen/component-base": "^1.0.0"
+  },
   "peerDependencies": {
     "@kaizen/design-tokens": "^2.10.3 || ^3.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0",
     "react": "^16.9.0 || ^17.0.0"

--- a/draft-packages/collapsible/KaizenDraft/Collapsible/Collapsible.tsx
+++ b/draft-packages/collapsible/KaizenDraft/Collapsible/Collapsible.tsx
@@ -1,17 +1,17 @@
-import { Heading, Icon } from "@kaizen/component-library"
+import React, { HTMLAttributes } from "react"
 import classnames from "classnames"
-import * as React from "react"
 import AnimateHeight from "react-animate-height"
-
+import { OverrideClassName } from "@kaizen/component-base"
+import { Heading, Icon } from "@kaizen/component-library"
 import chevronUp from "@kaizen/component-library/icons/chevron-up.icon.svg"
 import chevronDown from "@kaizen/component-library/icons/chevron-down.icon.svg"
 import { Sticky } from "./CollapsibleGroup"
-
 import styles from "./styles.scss"
 
 type Variant = "default" | "clear"
 
-export type CollapsibleProps = {
+export interface CollapsibleProps
+  extends OverrideClassName<HTMLAttributes<HTMLDivElement>> {
   id: string
   children: JSX.Element | JSX.Element[] | string
   title: string
@@ -21,21 +21,27 @@ export type CollapsibleProps = {
   separated?: boolean
   sticky?: Sticky
   noSectionPadding?: boolean
+  /**
+   * **Deprecated:** Use test id compatible with your testing library (eg. `data-testid`).
+   * @deprecated
+   */
   automationId?: string
   onToggle?: (open: boolean, id: string) => void
-
   /**
    * By default, the header will change background colour when open. When the variant
-    is set to 'clear', it will not have a background but a border-bottom will appear
-    to separate the heading from the content.
+   * is set to 'clear', it will not have a background but a border-bottom will appear
+   * to separate the heading from the content.
    */
   variant?: Variant
-
-  /* Will avoid rendering the content until required (especially important when you have queries inside sections).
-  Removes animation. */
+  /**
+   * Will avoid rendering the content until required (especially important when you
+   * have queries inside sections).
+   * Removes animation.
+   */
   lazyLoad?: boolean
-
-  /* Disables internal `open` state, allowing it to be controlled in the usage */
+  /**
+   * Disables internal `open` state, allowing it to be controlled in the usage.
+   */
   controlled?: boolean
 }
 
@@ -43,7 +49,7 @@ type State = {
   open: boolean
 }
 
-class Collapsible extends React.Component<CollapsibleProps, State> {
+export class Collapsible extends React.Component<CollapsibleProps, State> {
   public state = {
     open: !!this.props.open,
   }
@@ -51,25 +57,31 @@ class Collapsible extends React.Component<CollapsibleProps, State> {
   public render() {
     const {
       id,
+      children,
+      title,
+      renderHeader,
+      open: propsOpen, // Unused, but extracted so as not to spread into the container
       group,
       separated,
       sticky,
       noSectionPadding,
-      title,
-      renderHeader,
       automationId,
-      children,
-      lazyLoad,
+      onToggle, // Unused, but extracted so as not to spread into the container
       variant = "default",
+      lazyLoad,
+      controlled, // Unused, but extracted so as not to spread into the container
+      classNameOverride,
+      ...props
     } = this.props
-    const buttonId = `${this.props.id}-button`
-    const sectionId = `${this.props.id}-section`
+    const buttonId = `${id}-button`
+    const sectionId = `${id}-section`
     const open = this.getOpen()
     const isContainer = !group || separated
 
     return (
       <div
-        className={classnames({
+        id={id}
+        className={classnames(classNameOverride, {
           [styles.container]: isContainer,
           [styles.stickyContainer]: isContainer && sticky,
           [styles.groupItem]: group && !separated,
@@ -78,6 +90,7 @@ class Collapsible extends React.Component<CollapsibleProps, State> {
           [styles.single]: !group,
         })}
         data-automation-id={automationId || `collapsible-container-${id}`}
+        {...props} // `title` is missing because it is used for the header; requires breaking change to fix
       >
         <button
           type="button"
@@ -94,23 +107,18 @@ class Collapsible extends React.Component<CollapsibleProps, State> {
           aria-controls={sectionId}
           data-automation-id={`collapsible-button-${id}`}
         >
-          {
-            // If a renderHeader prop has been provided: use that to render the header
-            renderHeader && renderHeader(title)
-          }
-          {
-            // Otherwise, use a prescribed structure for the title
-            !renderHeader && (
-              <div
-                className={styles.title}
-                data-automation-id={`collapsible-button-title-${id}`}
-              >
-                <Heading variant="heading-4" tag="span">
-                  {title}
-                </Heading>
-              </div>
-            )
-          }
+          {renderHeader !== undefined ? (
+            renderHeader(title)
+          ) : (
+            <div
+              className={styles.title}
+              data-automation-id={`collapsible-button-title-${id}`}
+            >
+              <Heading variant="heading-4" tag="span">
+                {title}
+              </Heading>
+            </div>
+          )}
           <div>
             <Icon icon={open ? chevronUp : chevronDown} role="presentation" />
           </div>
@@ -121,6 +129,7 @@ class Collapsible extends React.Component<CollapsibleProps, State> {
             data-automation-id={`collapsible-section-${id}`}
           >
             <div
+              id={sectionId}
               className={classnames(styles.section, {
                 [styles.noPadding]: noSectionPadding,
               })}
@@ -151,5 +160,3 @@ class Collapsible extends React.Component<CollapsibleProps, State> {
     }
   }
 }
-
-export default Collapsible

--- a/draft-packages/collapsible/KaizenDraft/Collapsible/__snapshots__/Collapsible.spec.tsx.snap
+++ b/draft-packages/collapsible/KaizenDraft/Collapsible/__snapshots__/Collapsible.spec.tsx.snap
@@ -9,6 +9,7 @@ exports[`matches snapshot with everything enabled 1`] = `
     <div
       class="container stickyContainer separated"
       data-automation-id="collapsible-container-1"
+      id="1"
     >
       <button
         aria-controls="1-section"
@@ -47,6 +48,7 @@ exports[`matches snapshot with everything enabled 1`] = `
           <div
             aria-labelledby="1-button"
             class="section noPadding"
+            id="1-section"
             role="region"
           >
             First panel content
@@ -57,6 +59,7 @@ exports[`matches snapshot with everything enabled 1`] = `
     <div
       class="container stickyContainer separated open"
       data-automation-id="another-bogus-test-id"
+      id="2"
     >
       <button
         aria-controls="2-section"
@@ -100,6 +103,7 @@ exports[`matches snapshot with everything enabled 1`] = `
           <div
             aria-labelledby="2-button"
             class="section noPadding"
+            id="2-section"
             role="region"
           >
             Second panel content

--- a/draft-packages/collapsible/KaizenDraft/Collapsible/index.ts
+++ b/draft-packages/collapsible/KaizenDraft/Collapsible/index.ts
@@ -1,2 +1,2 @@
-export { default as Collapsible } from "./Collapsible"
+export * from "./Collapsible"
 export { CollapsibleGroup } from "./CollapsibleGroup"

--- a/draft-packages/collapsible/package.json
+++ b/draft-packages/collapsible/package.json
@@ -33,11 +33,12 @@
   "license": "MIT",
   "dependencies": {
     "@kaizen/component-library": "^12.6.0",
-    "@types/classnames": "^2.3.0",
     "classnames": "^2.3.1",
     "react-animate-height": "^2.0.23"
   },
   "devDependencies": {
+    "@kaizen/component-base": "^1.0.0",
+    "@types/classnames": "^2.3.0",
     "elm-storybook": "cultureamp/elm-storybook#0.3.0",
     "rimraf": "^3.0.2"
   },

--- a/packages/component-base/index.ts
+++ b/packages/component-base/index.ts
@@ -1,0 +1,1 @@
+export * from "./src/types"

--- a/packages/component-base/package.json
+++ b/packages/component-base/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@kaizen/component-base",
+  "version": "1.0.0",
+  "description": "Base setup and shared helpers for components",
+  "scripts": {
+    "prepublish": "tsc --project tsconfig.dist.json",
+    "build": "yarn clean && yarn prepublish",
+    "build:watch": "yarn clean && yarn prepublish --watch",
+    "clean": "rimraf '**/*.d.ts' '**/*.js' '**/*.map'"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/cultureamp/kaizen-design-system.git",
+    "directory": "packages/component-base"
+  },
+  "bugs": {
+    "url": "https://github.com/cultureamp/kaizen-design-system/issues"
+  },
+  "files": [
+    "**/*",
+    "!**/*.ts",
+    "!**/*.tsx",
+    "**/*.d.ts",
+    "!**/*.spec.*",
+    "!docs",
+    "!tsconfig.dist.json"
+  ],
+  "author": "",
+  "private": false,
+  "license": "MIT",
+  "devDependencies": {
+    "rimraf": "^3.0.2"
+  }
+}

--- a/packages/component-base/src/types.ts
+++ b/packages/component-base/src/types.ts
@@ -1,0 +1,3 @@
+export type OverrideClassName<T> = Omit<T, "className"> & {
+  classNameOverride?: string
+}

--- a/packages/component-base/tsconfig.dist.json
+++ b/packages/component-base/tsconfig.dist.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.dist.json",
+  "compilerOptions": {
+    "allowJs": false,
+    "declaration": true,
+    "noEmit": false,
+    "sourceMap": true
+  },
+  "exclude": ["docs"]
+}


### PR DESCRIPTION
# What

Add `component-base` package and new generic type `OverrideClassName` which removes `className` and adds `classNameOverride`.

Update `Collapsible` to extend HTML attributes with className override.

# Why

New `component-base` package will house any generic helpers and types.

Update made to `Collapsible` to ensure the new package does what we want it to.

# Changes

- Add `component-base` package
	- Omitted the `peerDependencies` of `react` and `design-tokens` until they are needed
- Update `Collapsible` to extend HTML attributes with className override
- Update code guidelines to reflect new component base