### PR TITLE
fix: draft-card classNameAndIHaveSpokenToDST prop

### DIFF
--- a/draft-packages/card/KaizenDraft/Card/Card.tsx
+++ b/draft-packages/card/KaizenDraft/Card/Card.tsx
@@ -46,10 +46,14 @@ export const Card = ({
   const Tag = tag
   return (
     <Tag
-      className={cx(styles.wrapper, styles[variant], {
+      className={cx(
+        styles.wrapper,
+        styles[variant],
         classNameAndIHaveSpokenToDST,
-        [styles.elevated]: isElevated,
-      })}
+        {
+          [styles.elevated]: isElevated,
+        }
+      )}
       {...otherProps}
     >
       {children}


### PR DESCRIPTION
# Objective
<!-- Describe what this change achieves, and the details of how it works. -->
classNameAndIHaveSpokenToDST property was incorrectly resolved in `classNames` as `classNameAndIHaveSpokenToDST` instead of the value because it was passed as an object (aka `{ classNameAndIHaveSpokenToDST: true }`

# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The custom styles were ignored so it resulted in broken UIs in murmur after updating the package to the latest version
https://cultureamp.atlassian.net/browse/MO-109

