### PR TITLE
feat: Add description prop to Select

### DIFF
--- a/draft-packages/select/KaizenDraft/Select/Select.tsx
+++ b/draft-packages/select/KaizenDraft/Select/Select.tsx
@@ -28,6 +28,8 @@ export interface SelectProps extends ReactSelectProps<any, boolean> {
 
   validationMessage?: React.ReactNode
 
+  description?: React.ReactNode
+
   /**
    * Use a reversed colour scheme
    * `variant="default" reversed="true" is not implemented and will throw a "not implemented" error
@@ -62,6 +64,7 @@ export const Select = React.forwardRef<any, SelectProps>((props, ref) => {
     reversed = false,
     label,
     validationMessage,
+    description,
   } = props
 
   // the default for fullWidth depends on the variant
@@ -111,6 +114,7 @@ export const Select = React.forwardRef<any, SelectProps>((props, ref) => {
       {validationMessage ? (
         <FieldMessage message={validationMessage} status={status} />
       ) : null}
+      {description ? <FieldMessage message={description} /> : null}
     </>
   )
 })

--- a/draft-packages/select/docs/Select.stories.tsx
+++ b/draft-packages/select/docs/Select.stories.tsx
@@ -90,6 +90,38 @@ export const Single = () => (
 )
 Single.parameters = { chromatic: { disable: false } }
 
+export const SingleWithDescription = () => (
+  <StoryContainer>
+    <Select
+      options={options}
+      placeholder="Placeholder"
+      isSearchable={false}
+      isDisabled={false}
+      defaultValue={options[0]}
+      description="My cool description"
+    />
+  </StoryContainer>
+)
+SingleWithDescription.parameters = { chromatic: { disable: false } }
+
+export const SingleWithDescriptionAndErrorMessage = () => (
+  <StoryContainer>
+    <Select
+      options={options}
+      placeholder="Placeholder"
+      isSearchable={false}
+      isDisabled={false}
+      defaultValue={options[0]}
+      status="error"
+      validationMessage="Oh no!"
+      description="My cool description"
+    />
+  </StoryContainer>
+)
+SingleWithDescriptionAndErrorMessage.parameters = {
+  chromatic: { disable: false },
+}
+
 export const SingleDisabled = () => (
   <StoryContainer>
     <Select


### PR DESCRIPTION
Adds optional `description` prop to the `<Select/>` component, and stories to demonstrate

With description:
![image](https://user-images.githubusercontent.com/34709943/158523593-13b36132-8e60-4811-b242-915a93806218.png)

With description + error message:
![image](https://user-images.githubusercontent.com/34709943/158523674-0c4eace4-69c4-4012-bcaf-ec10a757291c.png)

