### PR TITLE
feat: update components to extend HTML attributes with classNameOverride (part 1)

### DIFF
--- a/draft-packages/avatar/KaizenDraft/Avatar/AvatarGroup.tsx
+++ b/draft-packages/avatar/KaizenDraft/Avatar/AvatarGroup.tsx
@@ -1,16 +1,18 @@
-import * as React from "react"
-import cx from "classnames"
+import React, { HTMLAttributes } from "react"
+import classnames from "classnames"
+import { OverrideClassName } from "@kaizen/component-base"
 import { Avatar, GenericAvatarProps, CompanyAvatarProps } from "./Avatar"
 import styles from "./AvatarGroup.module.scss"
 
-export type AvatarProps =
+export type AvatarGroupAvatarProps =
   | Omit<GenericAvatarProps, "size">
   | Omit<CompanyAvatarProps, "size">
 
 export type AvatarGroupSize = "small" | "medium" | "large"
-export type AvatarList = [AvatarProps, ...AvatarProps[]]
+export type AvatarList = [AvatarGroupAvatarProps, ...AvatarGroupAvatarProps[]]
 
-export interface AvatarGroupProps {
+export interface AvatarGroupProps
+  extends OverrideClassName<HTMLAttributes<HTMLUListElement>> {
   /**
    * There are 3 fixed sizes available. `"small"` will remove border and box shadow to save space.
    * @default "medium"
@@ -23,7 +25,7 @@ export interface AvatarGroupProps {
   maxVisible: 2 | 3 | 4 | 5 | 6
   /**
    * Takes a array of `AvatarProps` that must have at least item.
-   * Note that 'size' is ommited from the `AvatarProps` type so it will throw a type error if size is provided.
+   * Note that 'size' is omitted from the `AvatarProps` type so it will throw a type error if size is provided.
    * */
   avatars: AvatarList
 }
@@ -64,14 +66,17 @@ const renderAvatars = (
   </>
 )
 
-export const AvatarGroup = ({
+export const AvatarGroup: React.VFC<AvatarGroupProps> = ({
   size = "medium",
   maxVisible = 2,
   avatars,
-}: AvatarGroupProps) => (
+  classNameOverride,
+  ...restProps
+}) => (
   <ul
-    className={cx(styles.AvatarGroup, styles[size])}
+    className={classnames(styles.AvatarGroup, styles[size], classNameOverride)}
     aria-label="Avatar Group"
+    {...restProps}
   >
     {renderAvatars(avatars, maxVisible, size)}
   </ul>

--- a/draft-packages/avatar/KaizenDraft/Avatar/index.ts
+++ b/draft-packages/avatar/KaizenDraft/Avatar/index.ts
@@ -1,0 +1,2 @@
+export * from "./Avatar"
+export * from "./AvatarGroup"

--- a/draft-packages/avatar/docs/AvatarGroup.stories.tsx
+++ b/draft-packages/avatar/docs/AvatarGroup.stories.tsx
@@ -5,42 +5,42 @@ import {
   AvatarGroup,
   AvatarGroupSize,
   AvatarList,
-  AvatarProps,
+  AvatarGroupAvatarProps,
 } from "../KaizenDraft/Avatar/AvatarGroup"
 import { figmaEmbed } from "../../../storybook/helpers"
 import { CATEGORIES } from "../../../storybook/constants"
 import { StoryWrapper } from "../../../storybook/components/StoryWrapper"
 
-const EXAMPLE_USER_1: AvatarProps = {
+const EXAMPLE_USER_1: AvatarGroupAvatarProps = {
   fullName: "Adirana Aniseed",
   disableInitials: false,
   avatarSrc:
     "https://www.cultureampcom-preview-1.usw2.wp-dev-us.cultureamp-cdn.com/assets/slices/main/assets/public/media/chapters-card-1@2x.05e547444387f29f14df0b82634bf2b6.png",
   isCurrentUser: false,
 }
-const EXAMPLE_USER_2: AvatarProps = {
+const EXAMPLE_USER_2: AvatarGroupAvatarProps = {
   fullName: "Bethany Blueberry",
   disableInitials: false,
   isCurrentUser: false,
 }
-const EXAMPLE_USER_3: AvatarProps = {
+const EXAMPLE_USER_3: AvatarGroupAvatarProps = {
   fullName: "Carey Cringle",
   disableInitials: false,
   avatarSrc:
     "https://www.cultureampcom-preview-1.usw2.wp-dev-us.cultureamp-cdn.com/assets/slices/main/assets/public/media/chapters-card-1@2x.05e547444387f29f14df0b82634bf2b6.png",
   isCurrentUser: false,
 }
-const EXAMPLE_USER_4: AvatarProps = {
+const EXAMPLE_USER_4: AvatarGroupAvatarProps = {
   fullName: "Derrick Doolittle",
   disableInitials: false,
   isCurrentUser: false,
 }
-const EXAMPLE_USER_5: AvatarProps = {
+const EXAMPLE_USER_5: AvatarGroupAvatarProps = {
   fullName: "Evan Eavesdrop",
   disableInitials: false,
   isCurrentUser: false,
 }
-const EXAMPLE_USER_6: AvatarProps = {
+const EXAMPLE_USER_6: AvatarGroupAvatarProps = {
   fullName: "Fern Furlow",
   disableInitials: false,
   avatarSrc:

--- a/draft-packages/avatar/index.ts
+++ b/draft-packages/avatar/index.ts
@@ -1,1 +1,1 @@
-export * from "./KaizenDraft/Avatar/Avatar"
+export * from "./KaizenDraft/Avatar"

--- a/draft-packages/avatar/package.json
+++ b/draft-packages/avatar/package.json
@@ -32,10 +32,14 @@
   "private": false,
   "license": "MIT",
   "dependencies": {
+    "@kaizen/component-base": "^1.0.0",
     "@kaizen/component-library": "^13.0.0",
     "@types/classnames": "^2.3.0",
     "classnames": "^2.3.1",
     "react-textfit": "^1.1.1"
+  },
+  "devDependencies": {
+    "@types/react-textfit": "^1.1.0"
   },
   "peerDependencies": {
     "@kaizen/design-tokens": "^2.10.3 || ^3.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0",

--- a/draft-packages/badge/KaizenDraft/Badge/Badge.tsx
+++ b/draft-packages/badge/KaizenDraft/Badge/Badge.tsx
@@ -1,50 +1,52 @@
-import React, { useLayoutEffect, useState, useRef } from "react"
+import React, { HTMLAttributes, useLayoutEffect, useState } from "react"
 import classNames from "classnames"
-
+import { OverrideClassName } from "@kaizen/component-base"
 import styles from "./styles.module.scss"
 
-interface CommonProps {
-  readonly children?: string
+interface CommonProps
+  extends OverrideClassName<HTMLAttributes<HTMLSpanElement>> {
+  children?: string
   /**
    * The "dark" variant is no longer in the UI kit
    */
-  readonly variant?: "default" | "active" | "dark"
+  variant?: "default" | "active" | "dark"
   /**
    * renders reversed colors. Use on purple background
    */
-  readonly reversed?: boolean
+  reversed?: boolean
   /**
    * Supports "small" and "large" sizes - defaults to "small"
    */
-  readonly size?: "small" | "large"
+  size?: "small" | "large"
 }
-interface DotProps extends Omit<CommonProps, "children" | "variant"> {
-  readonly variant: "dot"
-  readonly children?: undefined
+
+interface DotProps extends Omit<CommonProps, "variant"> {
+  children?: undefined
+  variant: "dot"
 }
 
 export type BadgeProps = CommonProps | DotProps
 
-export const Badge = (props: BadgeProps) => {
-  const { children, variant = "default", reversed, size = "small" } = props
+export const Badge: React.VFC<BadgeProps> = ({
+  children,
+  variant = "default",
+  reversed = false,
+  size = "small",
+  classNameOverride,
+  ...restProps
+}) => (
+  <span
+    className={classNames(styles.badge, styles[variant], classNameOverride, {
+      [styles.reversed]: reversed,
+      [styles.large]: size === "large",
+    })}
+    {...restProps}
+  >
+    {variant !== "dot" && children}
+  </span>
+)
 
-  return (
-    <span
-      className={classNames(styles.badge, {
-        [styles.default]: variant === "default",
-        [styles.active]: variant === "active",
-        [styles.dark]: variant === "dark",
-        [styles.dot]: variant === "dot",
-        [styles.reversed]: reversed,
-        [styles.large]: size === "large",
-      })}
-    >
-      {variant != "dot" && children}
-    </span>
-  )
-}
-
-export const BadgeAnimated: React.FunctionComponent<BadgeProps> = props => {
+export const BadgeAnimated: React.VFC<BadgeProps> = props => {
   const [isFocused, setIsFocused] = useState(false)
 
   useLayoutEffect(() => {
@@ -64,4 +66,3 @@ export const BadgeAnimated: React.FunctionComponent<BadgeProps> = props => {
     </span>
   )
 }
-export default Badge

--- a/draft-packages/badge/KaizenDraft/Badge/index.ts
+++ b/draft-packages/badge/KaizenDraft/Badge/index.ts
@@ -1,0 +1,1 @@
+export * from "./Badge"

--- a/draft-packages/badge/docs/Badge.stories.tsx
+++ b/draft-packages/badge/docs/Badge.stories.tsx
@@ -86,7 +86,7 @@ const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({
         </Badge>
       </div>
       <div>
-        <Badge size="small" variant="dot" reversed={isReversed}></Badge>
+        <Badge size="small" variant="dot" reversed={isReversed} />
       </div>
     </StoryWrapper.Row>
     <StoryWrapper.Row rowTitle="Large">

--- a/draft-packages/badge/index.ts
+++ b/draft-packages/badge/index.ts
@@ -1,1 +1,1 @@
-export * from "./KaizenDraft/Badge/Badge"
+export * from "./KaizenDraft/Badge"

--- a/draft-packages/badge/package.json
+++ b/draft-packages/badge/package.json
@@ -32,6 +32,7 @@
   "private": false,
   "license": "MIT",
   "dependencies": {
+    "@kaizen/component-base": "^1.0.0",
     "classnames": "^2.3.1"
   },
   "peerDependencies": {

--- a/packages/brand-moment/package.json
+++ b/packages/brand-moment/package.json
@@ -42,6 +42,7 @@
     "classnames": "^2.3.1"
   },
   "devDependencies": {
+    "@kaizen/component-base": "^1.0.0",
     "@kaizen/design-tokens": "^7.1.1",
     "@kaizen/draft-select": "^1.25.1",
     "rimraf": "^3.0.2"

--- a/packages/brand-moment/src/BrandMoment.tsx
+++ b/packages/brand-moment/src/BrandMoment.tsx
@@ -1,4 +1,5 @@
-import React, { ReactNode, ReactElement } from "react"
+import React, { ReactNode, ReactElement, HTMLAttributes } from "react"
+import { OverrideClassName } from "@kaizen/component-base"
 import { Box } from "@kaizen/component-library"
 import { Heading, Paragraph } from "@kaizen/typography"
 import { Button, ButtonProps } from "@kaizen/button"
@@ -8,7 +9,8 @@ import { assetUrl } from "@kaizen/hosted-assets"
 import classnames from "classnames"
 import styles from "./BrandMoment.scss"
 
-export interface BrandMomentProps {
+export interface BrandMomentProps
+  extends OverrideClassName<HTMLAttributes<HTMLDivElement>> {
   mood: "informative" | "positive" | "negative"
   illustration: ReactElement<SceneProps>
   header: ReactNode
@@ -23,63 +25,68 @@ export interface BrandMomentProps {
   }
 }
 
-export const BrandMoment = (props: BrandMomentProps) => {
+export const BrandMoment: React.VFC<BrandMomentProps> = ({
+  mood,
+  illustration,
+  header,
+  body,
+  primaryAction,
+  secondaryAction,
+  text,
+  classNameOverride,
+  ...restProps
+}) => {
   const { queries } = useMediaQueries()
 
   return (
     <div
-      className={classnames(styles.body, {
-        [styles.informative]: props.mood === "informative",
-        [styles.positive]: props.mood === "positive",
-        [styles.negative]: props.mood === "negative",
-      })}
+      className={classnames(styles.body, styles[mood], classNameOverride)}
+      {...restProps}
     >
-      <header className={styles.header}>{props.header}</header>
+      <header className={styles.header}>{header}</header>
       <main className={styles.main}>
         <div className={styles.container}>
           <div className={styles.mainInner}>
             <div className={styles.left}>
-              <div className={styles.leftInner}>{props.illustration}</div>
+              <div className={styles.leftInner}>{illustration}</div>
             </div>
             <div className={styles.right}>
               <div className={styles.rightInner}>
-                {props.text.subtitle && (
+                {text.subtitle && (
                   <Box mb={0.5}>
                     <Heading variant="heading-3" tag="h1">
-                      {props.text.subtitle}
+                      {text.subtitle}
                     </Heading>
                   </Box>
                 )}
                 <Box mb={1.5}>
                   <Heading
                     variant="display-0"
-                    tag={props.text.subtitle ? "h2" : "h1"}
+                    tag={text.subtitle ? "h2" : "h1"}
                   >
-                    {props.text.title}
+                    {text.title}
                   </Heading>
                 </Box>
-                {props.text.body && (
+                {text.body && (
                   <Box mb={1.5}>
-                    <Paragraph variant="intro-lede">
-                      {props.text.body}
-                    </Paragraph>
+                    <Paragraph variant="intro-lede">{text.body}</Paragraph>
                   </Box>
                 )}
-                {props.body && <Box mb={1.5}>{props.body}</Box>}
+                {body && <Box mb={1.5}>{body}</Box>}
                 <div className={styles.actions}>
-                  {props.primaryAction && (
+                  {primaryAction && (
                     <Button
                       primary
                       fullWidth={queries.isSmall}
-                      {...props.primaryAction}
+                      {...primaryAction}
                     />
                   )}
-                  {props.secondaryAction && (
+                  {secondaryAction && (
                     <div className={styles.secondaryAction}>
                       <Button
                         secondary
                         fullWidth={queries.isSmall}
-                        {...props.secondaryAction}
+                        {...secondaryAction}
                       />
                     </div>
                   )}
@@ -89,7 +96,7 @@ export const BrandMoment = (props: BrandMomentProps) => {
           </div>
         </div>
       </main>
-      {props.text.footer && (
+      {text.footer && (
         <footer className={styles.footer}>
           <div className={styles.container}>
             <div className={styles.footerInner}>
@@ -108,7 +115,7 @@ export const BrandMoment = (props: BrandMomentProps) => {
                 </a>
               </div>
               <div className={styles.footerTextContainer}>
-                <Paragraph variant="extra-small">{props.text.footer}</Paragraph>
+                <Paragraph variant="extra-small">{text.footer}</Paragraph>
               </div>
             </div>
           </div>

--- a/packages/brand/package.json
+++ b/packages/brand/package.json
@@ -31,10 +31,11 @@
   "author": "",
   "private": false,
   "license": "MIT",
+  "dependencies": {
+    "@kaizen/component-base": "^1.0.0",
+    "@kaizen/hosted-assets": "^1.2.0"
+  },
   "peerDependencies": {
     "react": "^16.9.0 || ^17.0.0"
-  },
-  "dependencies": {
-    "@kaizen/hosted-assets": "^1.2.0"
   }
 }

--- a/packages/brand/src/Brand/Brand.tsx
+++ b/packages/brand/src/Brand/Brand.tsx
@@ -1,33 +1,41 @@
-import React from "react"
+import React, { HTMLAttributes } from "react"
+import { OverrideClassName } from "@kaizen/component-base"
 import { assetUrl } from "@kaizen/hosted-assets"
 import styles from "./Brand.scss"
 
-export interface BrandProps {
+export interface BrandProps
+  extends OverrideClassName<HTMLAttributes<HTMLElement>> {
   variant:
     | "logo-horizontal"
     | "logo-vertical"
     | "enso"
     | "collective-intelligence"
-  reversed?: boolean
   alt: string
+  reversed?: boolean
 }
 
-export const Brand = (props: BrandProps) => {
-  const brandTheme = props.reversed ? "-reversed" : "-default"
+export const Brand: React.VFC<BrandProps> = ({
+  variant,
+  alt,
+  reversed = false,
+  classNameOverride,
+  ...restProps
+}) => {
+  const brandTheme = reversed ? "-reversed" : "-default"
 
   return (
-    <picture>
+    <picture className={classNameOverride} {...restProps}>
       <source
-        srcSet={assetUrl(`brand/${props.variant}-reversed.svg`)}
+        srcSet={assetUrl(`brand/${variant}-reversed.svg`)}
         media="(forced-colors: active) and (prefers-color-scheme: dark)"
       />
       <source
-        srcSet={assetUrl(`brand/${props.variant}-default.svg`)}
+        srcSet={assetUrl(`brand/${variant}-default.svg`)}
         media="(forced-colors: active) and (prefers-color-scheme: light)"
       />
       <img
-        src={assetUrl(`brand/${props.variant}${brandTheme}.svg`)}
-        alt={props.alt}
+        src={assetUrl(`brand/${variant}${brandTheme}.svg`)}
+        alt={alt}
         className={styles.img}
       />
     </picture>

--- a/packages/component-library/components/Box/Box.tsx
+++ b/packages/component-library/components/Box/Box.tsx
@@ -1,14 +1,12 @@
+import React, { HTMLAttributes } from "react"
 import classnames from "classnames"
-import * as React from "react"
+import { OverrideClassName } from "@kaizen/component-base"
 import { marginClasses, paddingClasses, Spacing } from "../Spacing"
 
-export interface BoxProps {
+export interface BoxProps
+  extends Spacing,
+    OverrideClassName<HTMLAttributes<HTMLDivElement>> {
   children: React.ReactNode
-  /**
-   * Not recommended. A short-circuit for overriding styles in a pinch
-   * @default ""
-   */
-  classNameOverride?: string
   /**
    * Support for languages that read right to left. This will flip margins and paddings on the x-axis.
    * @default "false"
@@ -16,9 +14,8 @@ export interface BoxProps {
   rtl?: boolean
 }
 
-export const Box = ({
+export const Box: React.VFC<BoxProps> = ({
   children,
-  classNameOverride,
   rtl = false,
   m,
   mt,
@@ -34,17 +31,16 @@ export const Box = ({
   pl,
   px,
   py,
-  ...otherProps
-}: // otherProps accounts for data attributes, which are not valid JS identifiers
-// https://www.typescriptlang.org/docs/handbook/jsx.html#attribute-type-checking
-BoxProps & Spacing) => {
+  classNameOverride,
+  ...restProps
+}) => {
   const classes: string[] = [
     ...paddingClasses({ p, pt, pr, pb, pl, px, py, rtl }),
     ...marginClasses({ m, mt, mr, mb, ml, mx, my, rtl }),
   ]
 
   return (
-    <div {...otherProps} className={classnames(classes, classNameOverride)}>
+    <div className={classnames(classes, classNameOverride)} {...restProps}>
       {children}
     </div>
   )

--- a/packages/component-library/package.json
+++ b/packages/component-library/package.json
@@ -31,6 +31,7 @@
     "react": "^16.9.0 || ^17.0.0"
   },
   "dependencies": {
+    "@kaizen/component-base": "^1.0.0",
     "@kaizen/deprecated-component-library-helpers": "^2.5.2",
     "@kaizen/draft-button": "^5.6.15",
     "@kaizen/hosted-assets": "^1.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5533,6 +5533,13 @@
   dependencies:
     "@types/react" "*"
 
+"@types/react-textfit@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@types/react-textfit/-/react-textfit-1.1.0.tgz#81a6564c17d555b20c91e28547241fd21930df50"
+  integrity sha512-iF49wuf4TMUKxcQjKyZcaJRN8rKFrXUBIAo0KQ0O/orHLQpwCyxpiD8NlPRqmcRN3FOAxSiRAOENbEQF1bhqiQ==
+  dependencies:
+    "@types/react" "*"
+
 "@types/react-transition-group@*":
   version "4.4.4"
   resolved "https://registry.yarnpkg.com/@types/react-transition-group/-/react-transition-group-4.4.4.tgz#acd4cceaa2be6b757db61ed7b432e103242d163e"


### PR DESCRIPTION
# What

Part 1

Updates following components to extend HTML attributes with `classNameOverride`:
- Avatar
- AvatarGroup
- Badge
- Box
- Brand
- BrandMoment

# Why

To prevent us being roadblocks for our consumers