### PR TITLE
fix(deps): move `@kaizen/component-base` to deps instead of devDeps

### DIFF
--- a/draft-packages/collapsible/package.json
+++ b/draft-packages/collapsible/package.json
@@ -32,13 +32,13 @@
   "private": false,
   "license": "MIT",
   "dependencies": {
+    "@kaizen/component-base": "^1.1.0",
     "@kaizen/component-library": "^13.0.0",
     "@kaizen/typography": "^2.0.0",
     "classnames": "^2.3.1",
     "react-animate-height": "^2.0.23"
   },
   "devDependencies": {
-    "@kaizen/component-base": "^1.1.0",
     "@types/classnames": "^2.3.0",
     "elm-storybook": "cultureamp/elm-storybook#0.3.0",
     "rimraf": "^3.0.2"


### PR DESCRIPTION
# What

Move `@kaizen/component-base` to deps instead of devDeps for `Collapsible`.

# Why

The `.d.ts` still needs to know what the type `OverrideClassName` looks like.