### PR TITLE
feat: update components to extend HTML attributes with classNameOverride (part 3)

### DIFF
--- a/draft-packages/page-layout/KaizenDraft/Content/Content.tsx
+++ b/draft-packages/page-layout/KaizenDraft/Content/Content.tsx
@@ -1,24 +1,13 @@
-import * as React from "react"
+import React, { HTMLAttributes } from "react"
 import classNames from "classnames"
+import { OverrideClassName } from "@kaizen/component-base"
 import styles from "./styles.scss"
 
-export interface ContentProps {
-  /**
-   * Uniquely identify this component for testing purposes
-   * @default ""
-   */
-  automationId?: string
+export interface ContentProps
+  extends OverrideClassName<HTMLAttributes<HTMLDivElement>> {
   children?: React.ReactNode
-
-  /**
-   * Not recommended. A short-circuit for overriding styles in a pinch
-   * @default ""
-   */
-  classNameOverride?: string
-
   /**
    * Not recommended. A short-circuit for dynamically overriding layout in a pinch
-   * @default ""
    */
   style?: Pick<
     React.CSSProperties,
@@ -42,36 +31,41 @@ export interface ContentProps {
     | "transformOrigin"
     | "transformStyle"
   >
+  /**
+   * **Deprecated:** Use test id compatible with your testing library (eg. `data-testid`).
+   * @deprecated
+   */
+  automationId?: string
 }
 
-export const Container = React.forwardRef(
-  (
-    { automationId, children, classNameOverride, style }: ContentProps,
-    ref: React.Ref<HTMLDivElement>
-  ) => (
+export const Container = React.forwardRef<HTMLDivElement, ContentProps>(
+  ({ children, style, automationId, classNameOverride, ...restProps }, ref) => (
     <div
       data-automation-id={automationId}
       ref={ref}
       className={classNames(styles.container, classNameOverride)}
       style={style}
+      {...restProps}
     >
       {children}
     </div>
   )
 )
 
-export const Content = React.forwardRef(
-  (
-    { automationId, children, classNameOverride, style }: ContentProps,
-    ref: React.Ref<HTMLDivElement>
-  ) => (
+Container.displayName = "Container"
+
+export const Content = React.forwardRef<HTMLDivElement, ContentProps>(
+  ({ children, style, automationId, classNameOverride, ...restProps }, ref) => (
     <div
       data-automation-id={automationId}
       ref={ref}
       className={classNames(styles.content, classNameOverride)}
       style={style}
+      {...restProps}
     >
       {children}
     </div>
   )
 )
+
+Content.displayName = "Content"

--- a/draft-packages/page-layout/KaizenDraft/Content/index.ts
+++ b/draft-packages/page-layout/KaizenDraft/Content/index.ts
@@ -1,0 +1,1 @@
+export * from "./Content"

--- a/draft-packages/page-layout/KaizenDraft/Skirt/Skirt.tsx
+++ b/draft-packages/page-layout/KaizenDraft/Skirt/Skirt.tsx
@@ -1,6 +1,6 @@
-import * as React from "react"
+import React from "react"
 import classNames from "classnames"
-import { Container, Content } from "../../"
+import { Container, Content, ContentProps } from "../../"
 import { DOMRectReadOnly, useResizeObserver } from "../useResizeObserver"
 import styles from "./styles.scss"
 
@@ -10,19 +10,24 @@ const fallbackPercentage = 0.8
 
 type Variant = "default" | "education"
 
-type SkirtProps = {
+export interface SkirtProps extends ContentProps {
   children: React.ReactNode
+  /**
+   * **Deprecated:** Use `classNameOverride` instead.
+   */
   className?: string
   variant?: Variant
   titleBlockHasNavigation?: boolean
 }
 
-export const Skirt = ({
+export const Skirt: React.VFC<SkirtProps> = ({
   children,
   className,
   variant = "default",
   titleBlockHasNavigation = true,
-}: SkirtProps) => {
+  classNameOverride,
+  ...restProps
+}) => {
   const [ref, skirtHeight] = useResizeObserver<number, HTMLDivElement>(
     entry => {
       if (entry.contentRect) {
@@ -35,7 +40,12 @@ export const Skirt = ({
   return (
     <Container
       ref={ref}
-      classNameOverride={classNames(styles.container, className)}
+      classNameOverride={classNames(
+        styles.container,
+        className,
+        classNameOverride
+      )}
+      {...restProps}
     >
       <div
         style={{ ...(skirtHeight && { height: `${skirtHeight}px` }) }}
@@ -48,6 +58,8 @@ export const Skirt = ({
     </Container>
   )
 }
+
+Skirt.displayName = "Skirt"
 
 const deriveSkirtHeight = (
   rect: DOMRectReadOnly,

--- a/draft-packages/page-layout/KaizenDraft/Skirt/SkirtCard.tsx
+++ b/draft-packages/page-layout/KaizenDraft/Skirt/SkirtCard.tsx
@@ -1,14 +1,18 @@
-import * as React from "react"
+import React from "react"
 import { Card, CardProps } from "@kaizen/draft-card"
 import classNames from "classnames"
 import styles from "./SkirtCard.scss"
 
-export const SkirtCard = (props: CardProps) => {
-  const { classNameOverride } = props
+export type SkirtCardProps = CardProps
+
+export const SkirtCard: React.VFC<SkirtCardProps> = props => {
+  const { classNameOverride, ...restProps } = props
   return (
     <Card
-      {...props}
       classNameOverride={classNames(styles.wrapper, classNameOverride)}
-    ></Card>
+      {...restProps}
+    />
   )
 }
+
+SkirtCard.displayName = "SkirtCard"

--- a/draft-packages/page-layout/index.ts
+++ b/draft-packages/page-layout/index.ts
@@ -1,3 +1,3 @@
-export * from "./KaizenDraft/Content/Content"
+export * from "./KaizenDraft/Content"
 export * from "./KaizenDraft/Skirt/Skirt"
 export * from "./KaizenDraft/Skirt/SkirtCard"

--- a/draft-packages/page-layout/package.json
+++ b/draft-packages/page-layout/package.json
@@ -32,6 +32,7 @@
   "private": false,
   "license": "MIT",
   "dependencies": {
+    "@kaizen/component-base": "^1.1.0",
     "@kaizen/draft-card": "^2.1.0",
     "classnames": "^2.3.1",
     "resize-observer-polyfill": "^1.5.1"

--- a/draft-packages/popover/KaizenDraft/Popover/Popover.tsx
+++ b/draft-packages/popover/KaizenDraft/Popover/Popover.tsx
@@ -1,11 +1,10 @@
-import { usePopper } from "react-popper"
-import { Icon } from "@kaizen/component-library"
-import { Heading, Paragraph } from "@kaizen/typography"
-import closeIcon from "@kaizen/component-library/icons/close.icon.svg"
-
+import React, { HTMLAttributes, useMemo, useState } from "react"
 import classNames from "classnames"
-import React, { useMemo, useState } from "react"
-import styles from "./styles.scss"
+import { usePopper } from "react-popper"
+import { OverrideClassName } from "@kaizen/component-base"
+import { Icon } from "@kaizen/component-library"
+import closeIcon from "@kaizen/component-library/icons/close.icon.svg"
+import { Heading, Paragraph } from "@kaizen/typography"
 import { Size, Variant, Placement } from "./types"
 import {
   mapArrowVariantToClass,
@@ -15,31 +14,36 @@ import {
   mapVariantToIcon,
   mapVariantToIconClass,
 } from "./classMappers"
+import styles from "./styles.scss"
 
-export type PopoverProps = {
-  readonly automationId?: string
-  readonly onClose?: (event: React.MouseEvent<HTMLButtonElement>) => any
-  readonly variant?: Variant
-  readonly placement?: Placement
-  readonly size?: Size
-  readonly heading?: string
-  readonly dismissible?: boolean
-  readonly singleLine?: boolean
-  readonly children: React.ReactNode
-  /** For almost all intents and purposes, you should be using a pre-defined variant.
-   Please avoid using a custom icon unless you have a very good reason to do so. **/
-  readonly customIcon?: React.SVGAttributes<SVGSymbolElement>
-  readonly referenceElement: HTMLElement | null
+export interface PopoverProps
+  extends OverrideClassName<HTMLAttributes<HTMLDivElement>> {
+  children: React.ReactNode
+  variant?: Variant
+  placement?: Placement
+  size?: Size
+  heading?: string
+  dismissible?: boolean
+  onClose?: (event: React.MouseEvent<HTMLButtonElement>) => any
+  singleLine?: boolean
+  /**
+   * For almost all intents and purposes, you should be using a pre-defined variant.
+   * Please avoid using a custom icon unless you have a very good reason to do so.
+   */
+  customIcon?: React.SVGAttributes<SVGSymbolElement>
+  referenceElement: HTMLElement | null
+  /**
+   * **Deprecated:** Use test id compatible with your testing library (eg. `data-testid`).
+   * @deprecated
+   */
+  automationId?: string
 }
-
-type PopoverModernType = React.FunctionComponent<PopoverProps>
 
 // Sync with styles.scss
 const arrowWidth = 14
 const arrowHeight = 7
 
-export const Popover: PopoverModernType = ({
-  automationId,
+export const Popover: React.VFC<PopoverProps> = ({
   children,
   variant = "default",
   placement = "top",
@@ -50,7 +54,10 @@ export const Popover: PopoverModernType = ({
   singleLine = false,
   customIcon,
   referenceElement,
-}: PopoverProps) => {
+  automationId,
+  classNameOverride,
+  ...restProps
+}) => {
   const [popperElement, setPopperElement] = useState<HTMLDivElement | null>(
     null
   )
@@ -104,8 +111,13 @@ export const Popover: PopoverModernType = ({
       ref={setPopperElement}
       style={popperStyles.popper}
       {...attributes.popper}
-      className={classNames(styles.root, mapSizeToClass(size))}
+      className={classNames(
+        styles.root,
+        mapSizeToClass(size),
+        classNameOverride
+      )}
       data-automation-id={automationId}
+      {...restProps}
     >
       <div className={mapVariantToBoxClass(variant)}>
         {heading && (
@@ -155,6 +167,8 @@ export const Popover: PopoverModernType = ({
     </div>
   )
 }
+
+Popover.displayName = "Popover"
 
 type PopoverPropsWithoutRef = Omit<PopoverProps, "referenceElement">
 

--- a/draft-packages/popover/package.json
+++ b/draft-packages/popover/package.json
@@ -32,6 +32,7 @@
   "private": false,
   "license": "MIT",
   "dependencies": {
+    "@kaizen/component-base": "^1.1.0",
     "@kaizen/component-library": "^13.2.0",
     "@kaizen/deprecated-component-library-helpers": "^2.5.2",
     "@kaizen/typography": "^2.0.0",

--- a/packages/pagination/package.json
+++ b/packages/pagination/package.json
@@ -32,6 +32,7 @@
   "private": false,
   "license": "MIT",
   "dependencies": {
+    "@kaizen/component-base": "^1.1.0",
     "@kaizen/component-library": "^13.2.0",
     "classnames": "^2.3.1"
   },

--- a/packages/pagination/src/Pagination.tsx
+++ b/packages/pagination/src/Pagination.tsx
@@ -1,5 +1,6 @@
-import React from "react"
-import cx from "classnames"
+import React, { HTMLAttributes } from "react"
+import classnames from "classnames"
+import { OverrideClassName } from "@kaizen/component-base"
 import arrowBackward from "@kaizen/component-library/icons/arrow-backward.icon.svg"
 import arrowForward from "@kaizen/component-library/icons/arrow-forward.icon.svg"
 import { Icon } from "@kaizen/component-library"
@@ -8,7 +9,8 @@ import { TruncateIndicator } from "./TruncateIndicator"
 import styles from "./Pagination.scss"
 import { createRange } from "./utils"
 
-export interface PaginationProps {
+export interface PaginationProps
+  extends OverrideClassName<HTMLAttributes<HTMLElement>> {
   currentPage: number
   pageCount: number
   ariaLabelNextPage: string
@@ -22,14 +24,16 @@ export enum PageAction {
   NEXT = "next",
 }
 
-export const Pagination = ({
+export const Pagination: React.VFC<PaginationProps> = ({
   currentPage = 1,
   pageCount,
   ariaLabelNextPage,
   ariaLabelPreviousPage,
   ariaLabelPage,
   onPageChange,
-}: PaginationProps) => {
+  classNameOverride,
+  ...restProps
+}) => {
   // Click event for all pagination buttons (next, prev, and the actual numbers)
   const handleButtonClick = (newPage: number | PageAction) => {
     if (newPage === PageAction.PREV) {
@@ -137,9 +141,12 @@ export const Pagination = ({
   const nextPageDisabled = currentPage >= pageCount
 
   return (
-    <nav className={styles.container}>
+    <nav
+      className={classnames(styles.container, classNameOverride)}
+      {...restProps}
+    >
       <button
-        className={cx(styles.arrowIconWrapper)}
+        className={classnames(styles.arrowIconWrapper)}
         aria-label={ariaLabelPreviousPage}
         disabled={previousPageDisabled}
         onClick={() => handleButtonClick(PageAction.PREV)}
@@ -149,7 +156,7 @@ export const Pagination = ({
       </button>
       <div className={styles.pagesIndicatorWrapper}>{pagination()}</div>
       <button
-        className={cx(styles.arrowIconWrapper, {
+        className={classnames(styles.arrowIconWrapper, {
           [styles.arrowIconWrapperDisabled]: nextPageDisabled,
         })}
         aria-label={ariaLabelNextPage}

--- a/packages/progress-bar/package.json
+++ b/packages/progress-bar/package.json
@@ -36,6 +36,7 @@
     "react": "^16.9.0 || ^17.0.0"
   },
   "dependencies": {
+    "@kaizen/component-base": "^1.1.0",
     "@kaizen/component-library": "^13.2.0",
     "@kaizen/typography": "^2.0.0",
     "classnames": "^2.3.1"

--- a/packages/progress-bar/src/ProgressBar.tsx
+++ b/packages/progress-bar/src/ProgressBar.tsx
@@ -1,10 +1,14 @@
+import React, { HTMLAttributes, ReactNode } from "react"
+import classnames from "classnames"
+import { OverrideClassName } from "@kaizen/component-base"
 import { Box } from "@kaizen/component-library"
 import { Heading } from "@kaizen/typography"
-import React, { ReactNode } from "react"
-import classnames from "classnames"
 import styles from "./ProgressBar.scss"
 
-type Props = {
+type Mood = "positive" | "informative" | "negative" | "cautionary"
+
+export interface ProgressBarProps
+  extends OverrideClassName<HTMLAttributes<HTMLDivElement>> {
   value: number
   max: number
   isAnimating: boolean
@@ -13,9 +17,7 @@ type Props = {
   label?: string
 }
 
-type Mood = "positive" | "informative" | "negative" | "cautionary"
-
-const progressClassNames = (props: Props) => {
+const progressClassNames = (props: ProgressBarProps): string => {
   const { mood } = props
   return classnames({
     [styles.positive]: mood === "positive",
@@ -26,12 +28,21 @@ const progressClassNames = (props: Props) => {
   })
 }
 
-function calculatePercentage({ value, max }: Props) {
+function calculatePercentage({ value, max }: ProgressBarProps) {
   return (value / max) * 100.0
 }
 
-export function ProgressBar(props: Props) {
-  const { subtext } = props
+export const ProgressBar: React.VFC<ProgressBarProps> = props => {
+  const {
+    value,
+    max,
+    isAnimating,
+    mood,
+    subtext,
+    label,
+    classNameOverride,
+    ...restProps
+  } = props
   const percentage = calculatePercentage(props)
   return (
     <div
@@ -39,15 +50,17 @@ export function ProgressBar(props: Props) {
       aria-valuenow={percentage}
       aria-valuemin={0}
       aria-valuemax={100}
+      className={classNameOverride}
+      {...restProps}
     >
-      {props.label == null ? null : <Label content={props.label} />}
+      {label && <Label content={label} />}
       <div className={styles.progressBackground}>
         <div
           className={progressClassNames(props)}
           style={{ transform: `translateX(-${100 - percentage}%` }}
         />
       </div>
-      {subtext != null ? (
+      {subtext && (
         <div className={styles.subtext}>
           <Box pt={0.25}>
             <Heading variant="heading-6" tag="p">
@@ -55,10 +68,12 @@ export function ProgressBar(props: Props) {
             </Heading>
           </Box>
         </div>
-      ) : null}
+      )}
     </div>
   )
 }
+
+ProgressBar.displayName = "ProgressBar"
 
 function Label({ content }: { content: ReactNode }) {
   return (


### PR DESCRIPTION
# What

Part 3

Updates following components to extend HTML attributes with `classNameOverride`:

- PageLayout
	- Container
	- Content
	- Skirt
	- SkirtCard
- Pagination
- Popover
- ProgressBar

# Why

To prevent us being roadblocks for our consumers