### PR TITLE
feat: update components to extend HTML attributes with classNameOverride (part 4)

### DIFF
--- a/draft-packages/split-button/KaizenDraft/SplitButton/SplitButton.spec.tsx
+++ b/draft-packages/split-button/KaizenDraft/SplitButton/SplitButton.spec.tsx
@@ -1,8 +1,7 @@
-import { MenuItem, MenuList } from "@kaizen/component-library"
-
+import React from "react"
 import { cleanup, render } from "@testing-library/react"
-import * as React from "react"
-import SplitButton, { SplitButtonProps } from "./SplitButton"
+import { MenuItem, MenuList } from "@kaizen/component-library"
+import { SplitButton, SplitButtonProps } from "./SplitButton"
 const editIcon = require("../../../icons/edit.icon.svg")
 const duplicateIcon = require("../../../icons/duplicate.icon.svg")
 

--- a/draft-packages/split-button/KaizenDraft/SplitButton/SplitButton.tsx
+++ b/draft-packages/split-button/KaizenDraft/SplitButton/SplitButton.tsx
@@ -1,5 +1,6 @@
+import React, { HTMLAttributes } from "react"
 import classnames from "classnames"
-import * as React from "react"
+import { OverrideClassName } from "@kaizen/component-base"
 import Dropdown from "./Dropdown"
 import DropdownMenu from "./DropdownMenu"
 import { Dir } from "./types"
@@ -10,8 +11,8 @@ type ButtonCallback = (event: React.MouseEvent<HTMLButtonElement>) => void
 
 type Variant = "default" | "primary"
 
-export type SplitButtonProps = {
-  automationId?: string
+export interface SplitButtonProps
+  extends OverrideClassName<Omit<HTMLAttributes<HTMLDivElement>, "onClick">> {
   label: string
   href?: string
   onClick?: AnchorCallback | ButtonCallback
@@ -21,18 +22,25 @@ export type SplitButtonProps = {
   dir?: Dir
   disabled?: boolean
   dropdownAltText: string // recommended text: "Open menu"
+  /**
+   * **Deprecated:** Use test id compatible with your testing library (eg. `data-testid`).
+   * @deprecated
+   */
+  automationId?: string
 }
 
-const SplitButton: React.FunctionComponent<SplitButtonProps> = ({
-  automationId,
+export const SplitButton: React.FunctionComponent<SplitButtonProps> = ({
+  label,
   href,
-  disabled,
   onClick,
   dropdownContent,
-  label,
-  dir = "ltr" as Dir,
-  dropdownAltText,
   variant = "default",
+  dir = "ltr",
+  disabled,
+  dropdownAltText,
+  automationId,
+  classNameOverride,
+  ...restProps
 }) => {
   // If the button has a route, it should be an `a` tag, since it is better
   // accessibility and routing. Otherwise, it should be a `button`.
@@ -61,7 +69,12 @@ const SplitButton: React.FunctionComponent<SplitButtonProps> = ({
       : null
 
   return (
-    <div className={styles.root} dir={dir} data-automation-id={automationId}>
+    <div
+      className={classnames(styles.root, classNameOverride)}
+      dir={dir}
+      data-automation-id={automationId}
+      {...restProps}
+    >
       <div
         className={styles.buttonsContainer}
         ref={dropdownButtonsContainerRef}
@@ -103,5 +116,3 @@ const SplitButton: React.FunctionComponent<SplitButtonProps> = ({
     </div>
   )
 }
-
-export default SplitButton

--- a/draft-packages/split-button/KaizenDraft/SplitButton/index.ts
+++ b/draft-packages/split-button/KaizenDraft/SplitButton/index.ts
@@ -1,1 +1,1 @@
-export { default as SplitButton, SplitButtonProps } from "./SplitButton"
+export * from "./SplitButton"

--- a/draft-packages/split-button/package.json
+++ b/draft-packages/split-button/package.json
@@ -32,6 +32,7 @@
   "private": false,
   "license": "MIT",
   "dependencies": {
+    "@kaizen/component-base": "^1.1.0",
     "@kaizen/component-library": "^13.2.0",
     "@kaizen/deprecated-component-library-helpers": "^2.5.2",
     "@types/classnames": "^2.3.0",

--- a/draft-packages/tile/KaizenDraft/Tile/InformationTile.tsx
+++ b/draft-packages/tile/KaizenDraft/Tile/InformationTile.tsx
@@ -1,32 +1,10 @@
 import React from "react"
+import { GenericTile, GenericTileProps } from "./components/GenericTile"
 
-import GenericTile, { GenericTileProps } from "./components/GenericTile"
+export type InformationTileProps = GenericTileProps
 
-export interface InformationTileProps extends GenericTileProps {
-  readonly footer?: React.ReactNode
-}
-
-type InformationTile = React.FunctionComponent<InformationTileProps>
-
-const InformationTile: InformationTile = ({
-  title,
-  titleTag,
-  metadata,
-  children,
-  information,
-  footer,
-  mood,
-}) => (
-  <GenericTile
-    title={title}
-    titleTag={titleTag}
-    metadata={metadata}
-    information={information}
-    footer={footer}
-    mood={mood}
-  >
-    {children}
-  </GenericTile>
+export const InformationTile: React.VFC<InformationTileProps> = props => (
+  <GenericTile {...props} />
 )
 
-export default InformationTile
+InformationTile.displayName = "InformationTile"

--- a/draft-packages/tile/KaizenDraft/Tile/MultiActionTile.tsx
+++ b/draft-packages/tile/KaizenDraft/Tile/MultiActionTile.tsx
@@ -1,20 +1,17 @@
 import React from "react"
-
 import { Box } from "@kaizen/component-library"
-import GenericTile, {
+import {
+  GenericTile,
   GenericTileProps,
   TileAction,
 } from "./components/GenericTile"
 import Action from "./components/Action"
-
 import styles from "./MultiActionTile.scss"
 
-export interface MultiActionTileProps extends GenericTileProps {
-  readonly primaryAction: TileAction
-  readonly secondaryAction?: TileAction
+export interface MultiActionTileProps extends Omit<GenericTileProps, "footer"> {
+  primaryAction: TileAction
+  secondaryAction?: TileAction
 }
-
-type MultiActionTile = React.FunctionComponent<MultiActionTileProps>
 
 const renderActions = (
   primaryAction: TileAction,
@@ -30,26 +27,18 @@ const renderActions = (
   </div>
 )
 
-const MultiActionTile: MultiActionTile = ({
-  title,
-  titleTag,
-  metadata,
+export const MultiActionTile: React.VFC<MultiActionTileProps> = ({
   children,
   primaryAction,
   secondaryAction,
-  information,
-  mood,
+  ...restProps
 }) => (
   <GenericTile
-    title={title}
-    titleTag={titleTag}
-    metadata={metadata}
-    information={information}
     footer={renderActions(primaryAction, secondaryAction)}
-    mood={mood}
+    {...restProps}
   >
     {children}
   </GenericTile>
 )
 
-export default MultiActionTile
+MultiActionTile.displayName = "MultiActionTile"

--- a/draft-packages/tile/KaizenDraft/Tile/TileGrid.tsx
+++ b/draft-packages/tile/KaizenDraft/Tile/TileGrid.tsx
@@ -1,21 +1,31 @@
-import React, { ReactElement } from "react"
+import React, { HTMLAttributes, ReactElement } from "react"
+import classnames from "classnames"
+import { OverrideClassName } from "@kaizen/component-base"
 import { InformationTileProps } from "./InformationTile"
 import { MultiActionTileProps } from "./MultiActionTile"
-
 import styles from "./TileGrid.scss"
 
 type TileProps = InformationTileProps | MultiActionTileProps
 
 export type TileElement = ReactElement<TileProps>
 
-export interface TileGridProps {
+export interface TileGridProps
+  extends OverrideClassName<HTMLAttributes<HTMLDivElement>> {
   children: TileElement[] | TileElement
 }
 
-const TileGrid: React.FunctionComponent<TileGridProps> = ({ children }) => (
-  <div className={styles.grid} data-tile-grid>
+export const TileGrid: React.VFC<TileGridProps> = ({
+  children,
+  classNameOverride,
+  ...restProps
+}) => (
+  <div
+    className={classnames(styles.grid, classNameOverride)}
+    data-tile-grid
+    {...restProps}
+  >
     {children}
   </div>
 )
 
-export default TileGrid
+TileGrid.displayName = "TileGrid"

--- a/draft-packages/tile/KaizenDraft/Tile/components/GenericTile.tsx
+++ b/draft-packages/tile/KaizenDraft/Tile/components/GenericTile.tsx
@@ -1,58 +1,56 @@
-import React, { useState, MouseEvent } from "react"
+import React, { useState, MouseEvent, HTMLAttributes } from "react"
+import classnames from "classnames"
+import { OverrideClassName } from "@kaizen/component-base"
 import { Box } from "@kaizen/component-library"
-import { Heading, Paragraph, AllowedHeadingTags } from "@kaizen/typography"
-import { IconButton } from "@kaizen/button"
-import classNames from "classnames"
-
 import informationIcon from "@kaizen/component-library/icons/information.icon.svg"
 import arrowBackwardIcon from "@kaizen/component-library/icons/arrow-backward.icon.svg"
+import { IconButton } from "@kaizen/button"
+import { Heading, Paragraph, AllowedHeadingTags } from "@kaizen/typography"
 import Action from "./Action"
 import styles from "./GenericTile.scss"
 
 export interface TileAction {
-  readonly label: string
-  readonly onClick?: (e: MouseEvent) => void
-  readonly href?: string
-  readonly icon?: React.SVGAttributes<SVGSymbolElement>
-  readonly automationId?: string
-  readonly newTabAndIUnderstandTheAccessibilityImplications?: boolean
+  label: string
+  onClick?: (e: MouseEvent) => void
+  href?: string
+  icon?: React.SVGAttributes<SVGSymbolElement>
+  automationId?: string
+  newTabAndIUnderstandTheAccessibilityImplications?: boolean
 }
 
 export interface TileInformation {
-  readonly text: string
-  readonly primaryAction?: TileAction
-  readonly secondaryAction?: TileAction
+  text: string
+  primaryAction?: TileAction
+  secondaryAction?: TileAction
 }
 
-export interface GenericTileProps {
-  readonly title: React.ReactNode
-  readonly titleTag?: AllowedHeadingTags
-  readonly metadata?: string
-  readonly children?: React.ReactNode
-  readonly information?: TileInformation | React.ReactNode
-  readonly mood?:
+export interface GenericTileProps
+  extends OverrideClassName<Omit<HTMLAttributes<HTMLDivElement>, "title">> {
+  children?: React.ReactNode
+  title: React.ReactNode
+  titleTag?: AllowedHeadingTags
+  metadata?: string
+  information?: TileInformation | React.ReactNode
+  mood?:
     | "positive"
     | "informative"
     | "cautionary"
     | "assertive"
     | "negative"
     | "prominent"
+  footer: React.ReactNode
 }
 
-interface Props extends GenericTileProps {
-  readonly footer: React.ReactNode
-}
-
-type GenericTile = React.FunctionComponent<Props>
-
-const GenericTile: GenericTile = ({
+export const GenericTile: React.VFC<GenericTileProps> = ({
   children,
   title,
   titleTag = "h3",
   metadata,
   information,
-  footer,
   mood,
+  footer,
+  classNameOverride,
+  ...restProps
 }) => {
   const [isFlipped, setIsFlipped] = useState<boolean>(false)
 
@@ -86,7 +84,7 @@ const GenericTile: GenericTile = ({
 
   const renderFront = () => (
     <div
-      className={classNames(styles.face, styles.faceFront, {
+      className={classnames(styles.face, styles.faceFront, {
         [styles.faceMoodPositive]: mood === "positive",
         [styles.faceMoodInformative]: mood === "informative",
         [styles.faceMoodCautionary]: mood === "cautionary",
@@ -137,7 +135,7 @@ const GenericTile: GenericTile = ({
     if (!information) return
 
     return (
-      <div className={classNames(styles.face, styles.faceBack)}>
+      <div className={classnames(styles.face, styles.faceBack)}>
         <div className={styles.informationBtn}>
           <IconButton
             label="Information"
@@ -154,9 +152,9 @@ const GenericTile: GenericTile = ({
   }
 
   return (
-    <div className={styles.root}>
+    <div className={classnames(styles.root, classNameOverride)} {...restProps}>
       <div
-        className={classNames(styles.tile, {
+        className={classnames(styles.tile, {
           [styles.isFlipped]: isFlipped,
         })}
       >
@@ -167,4 +165,4 @@ const GenericTile: GenericTile = ({
   )
 }
 
-export default GenericTile
+GenericTile.displayName = "GenericTile"

--- a/draft-packages/tile/KaizenDraft/Tile/index.ts
+++ b/draft-packages/tile/KaizenDraft/Tile/index.ts
@@ -1,0 +1,5 @@
+export * from "./InformationTile"
+export * from "./MultiActionTile"
+export * from "./TileGrid"
+
+export type { TileAction, TileInformation } from "./components/GenericTile"

--- a/draft-packages/tile/index.ts
+++ b/draft-packages/tile/index.ts
@@ -1,8 +1,1 @@
-export { default as MultiActionTile } from "./KaizenDraft/Tile/MultiActionTile"
-export { default as InformationTile } from "./KaizenDraft/Tile/InformationTile"
-export { default as TileGrid, TileElement } from "./KaizenDraft/Tile/TileGrid"
-
-export {
-  TileAction,
-  TileInformation,
-} from "./KaizenDraft/Tile/components/GenericTile"
+export * from "./KaizenDraft/Tile"

--- a/draft-packages/tile/package.json
+++ b/draft-packages/tile/package.json
@@ -31,14 +31,15 @@
   "author": "",
   "private": false,
   "license": "MIT",
-  "peerDependencies": {
-    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0",
-    "react": "^16.9.0 || ^17.0.0"
-  },
   "dependencies": {
     "@kaizen/button": "^1.0.19",
+    "@kaizen/component-base": "^1.1.0",
     "@kaizen/component-library": "^13.2.0",
     "@kaizen/typography": "^2.0.0",
     "classnames": "^2.3.1"
+  },
+  "peerDependencies": {
+    "@kaizen/design-tokens": "^2.10.3 || ^3.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0",
+    "react": "^16.9.0 || ^17.0.0"
   }
 }

--- a/draft-packages/well/Well.tsx
+++ b/draft-packages/well/Well.tsx
@@ -1,9 +1,9 @@
+import React, { HTMLAttributes } from "react"
 import classnames from "classnames"
-import * as React from "react"
-
+import { OverrideClassName } from "@kaizen/component-base"
 import styles from "./styles.scss"
 
-export type VariantType =
+type VariantType =
   | "positive"
   | "negative"
   | "informative"
@@ -12,38 +12,43 @@ export type VariantType =
   | "assertive"
   | "prominent"
 
-export type BorderStyleType = "solid" | "dashed" | "none"
+type BorderStyleType = "solid" | "dashed" | "none"
 
-export type WellProps = {
-  id?: string
-  automationId?: string
+export interface WellProps
+  extends OverrideClassName<HTMLAttributes<HTMLDivElement>> {
+  children?: React.ReactNode
   variant?: VariantType
   borderStyle?: BorderStyleType
   noMargin?: boolean
+  /**
+   * **Deprecated:** Use test id compatible with your testing library (eg. `data-testid`).
+   * @deprecated
+   */
+  automationId?: string
 }
 
-type Well = React.FunctionComponent<WellProps>
-
-const Well: Well = ({
-  id,
-  automationId,
+export const Well: React.VFC<WellProps> = ({
   children,
   variant = "default",
   borderStyle = "solid",
   noMargin = false,
+  automationId,
+  classNameOverride,
+  ...restProps
 }) => (
   <div
-    id={id}
     data-automation-id={automationId}
     className={classnames(
       styles.container,
       styles[borderStyle],
       styles[variant],
-      noMargin && styles.noMargin
+      noMargin && styles.noMargin,
+      classNameOverride
     )}
+    {...restProps}
   >
     {children}
   </div>
 )
 
-export default Well
+Well.displayName = "Well"

--- a/draft-packages/well/index.ts
+++ b/draft-packages/well/index.ts
@@ -1,1 +1,1 @@
-export { default as Well } from "./Well"
+export * from "./Well"

--- a/draft-packages/well/package.json
+++ b/draft-packages/well/package.json
@@ -32,6 +32,7 @@
   "private": false,
   "license": "MIT",
   "dependencies": {
+    "@kaizen/component-base": "^1.1.0",
     "@kaizen/component-library": "^13.2.0",
     "@types/classnames": "^2.3.0",
     "classnames": "^2.3.1"

--- a/packages/typography/package.json
+++ b/packages/typography/package.json
@@ -32,6 +32,7 @@
   "private": false,
   "license": "MIT",
   "dependencies": {
+    "@kaizen/component-base": "^1.1.0",
     "classnames": "^2.3.1"
   },
   "devDependencies": {

--- a/packages/typography/src/Heading/Heading.tsx
+++ b/packages/typography/src/Heading/Heading.tsx
@@ -1,6 +1,6 @@
-import classNames from "classnames"
 import { createElement, HTMLAttributes } from "react"
-
+import classnames from "classnames"
+import { OverrideClassName } from "@kaizen/component-base"
 import styles from "./Heading.scss"
 
 const VARIANTS_24PX_OR_GREATER = ["display-0", "heading-1", "heading-2"]
@@ -36,12 +36,7 @@ export type AllowedHeadingColors =
   | "negative"
 
 export interface HeadingProps
-  extends Omit<HTMLAttributes<HTMLElement>, "className"> {
-  /**
-   * Not recommended. A short-circuit for overriding styles in a pinch
-   * @default ""
-   */
-  classNameOverride?: string
+  extends OverrideClassName<HTMLAttributes<HTMLElement>> {
   children: React.ReactNode
   /**
    * HTML elements that are allowed on Headings. When not supplied, the tag is inferred from
@@ -55,18 +50,18 @@ export interface HeadingProps
   color?: AllowedHeadingColors
 }
 
-export const Heading = ({
-  classNameOverride,
+export const Heading: React.VFC<HeadingProps> = ({
   children,
   tag,
   variant,
   color = "dark",
-  ...otherProps
-}: HeadingProps) => {
+  classNameOverride,
+  ...restProps
+}) => {
   const inferredTag =
     tag === undefined ? translateHeadingLevelToTag(variant) : tag
 
-  const className = classNames([
+  const className = classnames([
     styles.heading,
     styles[variant],
     classNameOverride,
@@ -74,8 +69,10 @@ export const Heading = ({
     VARIANTS_24PX_OR_GREATER.includes(variant) ? styles.large : styles.small,
   ])
 
-  return createElement(inferredTag, { ...otherProps, className }, children)
+  return createElement(inferredTag, { ...restProps, className }, children)
 }
+
+Heading.displayName = "Heading"
 
 /**
  * A helper to infer the tag when not explicitly passed as a prop

--- a/packages/typography/src/Paragraph/Paragraph.tsx
+++ b/packages/typography/src/Paragraph/Paragraph.tsx
@@ -1,6 +1,6 @@
-import classNames from "classnames"
 import { createElement, HTMLAttributes } from "react"
-
+import classnames from "classnames"
+import { OverrideClassName } from "@kaizen/component-base"
 import styles from "./Paragraph.scss"
 
 export type ParagraphVariants = "intro-lede" | "body" | "small" | "extra-small"
@@ -27,12 +27,7 @@ export type AllowedParagraphColors =
   | "negative"
 
 export interface ParagraphProps
-  extends Omit<HTMLAttributes<HTMLElement>, "className"> {
-  /**
-   * Not recommended. A short-circuit for overriding styles in a pinch
-   * @default ""
-   */
-  classNameOverride?: string
+  extends OverrideClassName<HTMLAttributes<HTMLElement>> {
   children: React.ReactNode
   /**
    * HTML elements that are allowed on Paragraphs
@@ -46,15 +41,15 @@ export interface ParagraphProps
   color?: AllowedParagraphColors
 }
 
-export const Paragraph = ({
-  classNameOverride,
+export const Paragraph: React.VFC<ParagraphProps> = ({
   children,
   tag,
   variant,
   color = "dark",
-  ...otherProps
-}: ParagraphProps) => {
-  const className = classNames([
+  classNameOverride,
+  ...restProps
+}) => {
+  const className = classnames([
     styles.paragraph,
     styles[variant],
     styles[color],
@@ -63,7 +58,9 @@ export const Paragraph = ({
 
   return createElement(
     tag === undefined ? "p" : tag,
-    { ...otherProps, className },
+    { ...restProps, className },
     children
   )
 }
+
+Paragraph.displayName = "Paragraph"


### PR DESCRIPTION
# What

Part 4

Updates following components to extend HTML attributes with `classNameOverride`:

- SplitButton
- Tile
	- InformationTile
	- MultiActionTile
	- TileGrid
- Typography (just updated these to use `OverrideClassName`)
	- Heading
	- Paragraph
- Well

# Why

To prevent us being roadblocks for our consumers