### PR TITLE
refactor(herocard): soft deprecate HeroCard and remove from health metrics

### DIFF
--- a/draft-packages/hero-card/KaizenDraft/HeroCard/HeroCard.tsx
+++ b/draft-packages/hero-card/KaizenDraft/HeroCard/HeroCard.tsx
@@ -21,6 +21,10 @@ export interface HeroCardProps
   leftBackgroundColor?: BackgroundColors
 }
 
+/**
+ * @deprecated HeroCard is deprecated.
+ * No further changes will be made to it as it will be superseded by Tile.
+ */
 export const HeroCard: React.VFC<HeroCardProps> = ({
   children,
   leftContent,

--- a/draft-packages/hero-card/KaizenDraft/HeroCard/README.mdx
+++ b/draft-packages/hero-card/KaizenDraft/HeroCard/README.mdx
@@ -1,23 +1,16 @@
 ---
+deprecated: true
 title: Hero Card
 navTitle: Hero Card
 summaryParagraph: Hero Cards are a large structural component for organizing primary content. They are used to create visual interest and draw attention.
 tags: ["Panel", "Card", "Container", "Box", "Table"]
 githubLabels: ["component:hero-card"]
 needToKnow:
+- ⛔️ HeroCard is deprecated. No further changes will be made to it as it will be superseded by Tile.
 - The badge contains a number, ideally 1 character, showing a micro bit of information such as a step.
 - For the image, use a graphic illustration that supports what's going on in the rest of the card.
 - For the title, aim for 1 line of text.
-demoStoryId: components-hero-card--default-kaizen-site-demo
-health:
-  designed: true
-  documented: true
-  implemented: true
-  latestDesign: false
-  allVariants: true
-  responsive: false
-  internationalized: false
-  accessible: true
+demoStoryId: deprecated-hero-card--default-kaizen-site-demo
 ---
 
 import WhenToUseAndWhenNotToUse from "docs-components/WhenToUseAndWhenNotToUse"

--- a/draft-packages/hero-card/docs/HeroCard.stories.tsx
+++ b/draft-packages/hero-card/docs/HeroCard.stories.tsx
@@ -24,12 +24,13 @@ const renderContent = () => (
 )
 
 export default {
-  title: `${CATEGORIES.components}/Hero Card`,
+  title: `${CATEGORIES.deprecated}/Hero Card`,
   component: HeroCard,
   parameters: {
     docs: {
       description: {
-        docs: 'import { HeroCard } from "@kaizen/draft-hero-card";',
+        component:
+          '⛔️ This component is deprecated. No further changes will be made to it as it will be superseded by `Tile`.<br/><br/>`import { HeroCard } from "@kaizen/draft-hero-card"`',
       },
     },
     ...figmaEmbed(

--- a/site/src/pages/component-health.tsx
+++ b/site/src/pages/component-health.tsx
@@ -1,11 +1,8 @@
-import { graphql } from "gatsby"
 import * as React from "react"
+import { graphql } from "gatsby"
 import { Icon } from "@kaizen/component-library"
-import { Heading, Paragraph } from "@kaizen/typography"
-
 import successIcon from "@kaizen/component-library/icons/success-white.icon.svg"
-import subtractIcon from "@kaizen/component-library/icons/subtract-white.icon.svg"
-
+import { Heading, Paragraph } from "@kaizen/typography"
 import Layout from "../components/Layout"
 import PageHeader from "../components/PageHeader"
 import { ContentOnly, Content } from "../components/ContentOnly"
@@ -24,7 +21,9 @@ const ComponentPageHeader = (
 export default ({ data, location }) => {
   const componentsSorted = sortSidebarTabs(data.allMdx.edges)
   const componentsFiltered = componentsSorted.filter(
-    component => component.node?.frontmatter.navTitle !== "Overview"
+    component =>
+      component.node?.frontmatter.navTitle !== "Overview" &&
+      component.node.frontmatter.deprecated !== true
   )
   const totals = calculateHealthTotals(
     componentsFiltered.map(component => component.node.frontmatter),
@@ -107,7 +106,7 @@ export default ({ data, location }) => {
                         {count}
                       </Heading>
 
-                      <Paragraph as="span" variant="small">
+                      <Paragraph tag="span" variant="small">
                         ({percentage.toFixed(0)}%)
                       </Paragraph>
                     </td>
@@ -128,6 +127,7 @@ export const query = graphql`
       edges {
         node {
           frontmatter {
+            deprecated
             navTitle
             title
             health {

--- a/site/src/templates/componentPage.tsx
+++ b/site/src/templates/componentPage.tsx
@@ -30,6 +30,7 @@ const renderSidebarTabs = (pages, currentPath) =>
       key={`sidebarTab-${i}`}
     >
       {node!.node!.frontmatter!.navTitle}
+      {node.node.frontmatter.deprecated === true && " (deprecated)"}
     </SidebarTab>
   ))
 
@@ -76,7 +77,11 @@ export default ({ data, location }) => {
 
   const ComponentPageHeader = (
     <PageHeader
-      headingText={md.frontmatter.title}
+      headingText={
+        md.frontmatter.deprecated === true
+          ? `${md.frontmatter.title} (deprecated)`
+          : md.frontmatter.title
+      }
       summaryParagraph={md.frontmatter.summaryParagraph}
       tags={md.frontmatter.tags}
       headerImageName={md.frontmatter.headerImage}
@@ -126,6 +131,7 @@ export const query = graphql`
             slug
           }
           frontmatter {
+            deprecated
             navTitle
             title
           }
@@ -135,6 +141,7 @@ export const query = graphql`
     mdx(fields: { slug: { eq: $slug } }) {
       body
       frontmatter {
+        deprecated
         title
         tags
         needToKnow


### PR DESCRIPTION
## Why

As per UI Kit, `HeroCard` is to be superseded by `Tile` when it is rebuilt.

## What

- Soft deprecate `HeroCard`
- Update site component health and page to accept `deprecated` frontmatter