### PR TITLE
refactor(splitbutton): deprecate draft SplitButton

### DIFF
--- a/draft-packages/split-button/KaizenDraft/SplitButton/Dropdown.tsx
+++ b/draft-packages/split-button/KaizenDraft/SplitButton/Dropdown.tsx
@@ -16,6 +16,9 @@ export type DropdownProps = {
   onOpenDropdown: () => void
 }
 
+/**
+ * @deprecated Draft SplitButton/Dropdown is deprecated.
+ */
 class Dropdown extends React.Component<DropdownProps> {
   static displayName = "Dropdown"
   static defaultProps = {

--- a/draft-packages/split-button/KaizenDraft/SplitButton/DropdownMenu.tsx
+++ b/draft-packages/split-button/KaizenDraft/SplitButton/DropdownMenu.tsx
@@ -31,6 +31,9 @@ export const calculateMenuTop = (
   return buttonsBoundingRect.height + gapSize
 }
 
+/**
+ * @deprecated Draft SplitButton/DropdownMenu is deprecated.
+ */
 class DropdownMenu extends React.Component<Props> {
   static displayName = "DropdownMenu"
   static defaultProps = {

--- a/draft-packages/split-button/KaizenDraft/SplitButton/SplitButton.tsx
+++ b/draft-packages/split-button/KaizenDraft/SplitButton/SplitButton.tsx
@@ -29,6 +29,9 @@ export interface SplitButtonProps
   automationId?: string
 }
 
+/**
+ * @deprecated Draft SplitButton is deprecated. Use "@kaizen/split-button" instead.
+ */
 export const SplitButton: React.FunctionComponent<SplitButtonProps> = ({
   label,
   href,

--- a/draft-packages/split-button/docs/SplitButton.stories.tsx
+++ b/draft-packages/split-button/docs/SplitButton.stories.tsx
@@ -10,13 +10,14 @@ import { figmaEmbed } from "../../../storybook/helpers"
 import { CATEGORIES } from "../../../storybook/constants"
 
 export default {
-  title: `${CATEGORIES.components}/Split Button`,
+  title: `${CATEGORIES.deprecated}/Split Button`,
   component: SplitButton,
   argTypes: { onClick: { action: "clicked" } },
   parameters: {
     docs: {
       description: {
-        component: 'import { SplitButton } from "@kaizen/draft-split-button"',
+        component:
+          "⛔️ This component is deprecated. Use the `@kaizen/split-button` package instead.",
       },
     },
     ...figmaEmbed(
@@ -40,7 +41,6 @@ export const DefaultKaizenSiteDemo = args => (
   />
 )
 DefaultKaizenSiteDemo.storyName = "Split Button"
-DefaultKaizenSiteDemo.parameters = { chromatic: { disable: false } }
 
 const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({
   isReversed,
@@ -148,12 +148,10 @@ const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({
 
 export const StickerSheetDefault = StickerSheetTemplate.bind({})
 StickerSheetDefault.storyName = "Sticker Sheet (Default)"
-StickerSheetDefault.parameters = { chromatic: { disable: false } }
 
 export const StickerSheetReversed = StickerSheetTemplate.bind({})
 StickerSheetReversed.storyName = "Sticker Sheet (Reversed)"
 StickerSheetReversed.args = { isReversed: true }
 StickerSheetReversed.parameters = {
   backgrounds: { default: "Purple 700" },
-  chromatic: { disable: false },
 }


### PR DESCRIPTION
## Why

Will be refactoring `SplitButton` as a blessed package.

## What

Deprecate draft `SplitButton` and subcomponents.

## Next steps

- Merge in #2654 (best to merge these on the same day)
- https://cultureamp.atlassian.net/wiki/spaces/DesignSystem/pages/2769650898/Deprecation+warnings+-+how+to+guide
