### PR TITLE
fix: update heading 3 line height to match figma token update

### DIFF
--- a/packages/design-tokens/less/typography.less
+++ b/packages/design-tokens/less/typography.less
@@ -262,7 +262,7 @@
 @typography-heading-3-font-size-id: --typography-heading-3-font-size;
 @typography-heading-3-line-height: var(
   --typography-heading-3-line-height,
-  1.5rem
+  1.875rem
 );
 @typography-heading-3-line-height-id: --typography-heading-3-line-height;
 @typography-heading-3-letter-spacing: var(

--- a/packages/design-tokens/sass/typography.scss
+++ b/packages/design-tokens/sass/typography.scss
@@ -262,7 +262,7 @@ $typography-heading-3-font-size: var(
 $typography-heading-3-font-size-id: --typography-heading-3-font-size;
 $typography-heading-3-line-height: var(
   --typography-heading-3-line-height,
-  1.5rem
+  1.875rem
 );
 $typography-heading-3-line-height-id: --typography-heading-3-line-height;
 $typography-heading-3-letter-spacing: var(

--- a/packages/design-tokens/src/themes/heart.ts
+++ b/packages/design-tokens/src/themes/heart.ts
@@ -213,7 +213,7 @@ export const heartTheme: Theme = {
       fontFamily: '"Inter", "Noto Sans", Helvetica, Arial, sans-serif',
       fontWeight: 700,
       fontSize: "1.375rem",
-      lineHeight: "1.5rem",
+      lineHeight: "1.875rem",
       letterSpacing: "normal",
     },
     heading4: {

--- a/packages/design-tokens/tokens/typography.json
+++ b/packages/design-tokens/tokens/typography.json
@@ -115,7 +115,7 @@
       "fontWeight-id": "--typography-heading-3-font-weight",
       "fontSize": "var(--typography-heading-3-font-size, 1.375rem)",
       "fontSize-id": "--typography-heading-3-font-size",
-      "lineHeight": "var(--typography-heading-3-line-height, 1.5rem)",
+      "lineHeight": "var(--typography-heading-3-line-height, 1.875rem)",
       "lineHeight-id": "--typography-heading-3-line-height",
       "letterSpacing": "var(--typography-heading-3-letter-spacing, normal)",
       "letterSpacing-id": "--typography-heading-3-letter-spacing"


### PR DESCRIPTION
## Why
- There was a minor update to the heading 3 line height in the Heart design tokens. The updated to the design token is required to reach parity with the design system
- It was decided that this constitutes such a minor change it is a fix


## What
- `typography-heading-3-line-height` has been changed from 1.5rem to 1.875 to reflect the the change from 24px to 30px
