### PR TITLE
fix: Component-Base to become dependency not dev only [KDS-360]

### DIFF
--- a/draft-packages/card/package.json
+++ b/draft-packages/card/package.json
@@ -31,7 +31,7 @@
   "author": "",
   "private": false,
   "license": "MIT",
-  "devDependencies": {
+  "dependencies": {
     "@kaizen/component-base": "^1.1.0"
   },
   "peerDependencies": {

--- a/draft-packages/divider/package.json
+++ b/draft-packages/divider/package.json
@@ -32,10 +32,10 @@
   "private": false,
   "license": "MIT",
   "dependencies": {
+    "@kaizen/component-base": "^1.1.0",
     "classnames": "^2.3.1"
   },
   "peerDependencies": {
-    "@kaizen/component-base": "^1.1.0",
     "@kaizen/design-tokens": "^2.10.3 || ^3.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0",
     "react": "^16.9.0 || ^17.0.0"
   }

--- a/draft-packages/divider/package.json
+++ b/draft-packages/divider/package.json
@@ -34,10 +34,8 @@
   "dependencies": {
     "classnames": "^2.3.1"
   },
-  "devDependencies": {
-    "@kaizen/component-base": "^1.1.0"
-  },
   "peerDependencies": {
+    "@kaizen/component-base": "^1.1.0",
     "@kaizen/design-tokens": "^2.10.3 || ^3.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0",
     "react": "^16.9.0 || ^17.0.0"
   }

--- a/draft-packages/empty-state/package.json
+++ b/draft-packages/empty-state/package.json
@@ -32,11 +32,11 @@
   "private": false,
   "license": "MIT",
   "dependencies": {
+    "@kaizen/component-base": "^1.1.0",
     "@kaizen/component-library": "^13.2.4",
     "@kaizen/draft-illustration": "^4.1.5",
     "@types/classnames": "^2.3.0",
-    "classnames": "^2.3.1",
-    "@kaizen/component-base": "^1.1.0"
+    "classnames": "^2.3.1"
   },
   "devDependencies": {
     "elm-storybook": "cultureamp/elm-storybook#0.3.0",

--- a/draft-packages/empty-state/package.json
+++ b/draft-packages/empty-state/package.json
@@ -35,10 +35,10 @@
     "@kaizen/component-library": "^13.2.4",
     "@kaizen/draft-illustration": "^4.1.5",
     "@types/classnames": "^2.3.0",
-    "classnames": "^2.3.1"
+    "classnames": "^2.3.1",
+    "@kaizen/component-base": "^1.1.0"
   },
   "devDependencies": {
-    "@kaizen/component-base": "^1.1.0",
     "elm-storybook": "cultureamp/elm-storybook#0.3.0",
     "rimraf": "^3.0.2"
   },

--- a/draft-packages/hero-card/package.json
+++ b/draft-packages/hero-card/package.json
@@ -33,12 +33,12 @@
   "license": "MIT",
   "dependencies": {
     "@kaizen/component-library": "^13.2.4",
+    "@kaizen/component-base": "^1.1.0",
     "@kaizen/deprecated-component-library-helpers": "^2.5.2",
     "@types/classnames": "^2.3.0",
     "classnames": "^2.3.1"
   },
   "devDependencies": {
-    "@kaizen/component-base": "^1.1.0",
     "elm-storybook": "cultureamp/elm-storybook#0.3.0",
     "rimraf": "^3.0.2"
   },

--- a/draft-packages/hero-card/package.json
+++ b/draft-packages/hero-card/package.json
@@ -32,8 +32,8 @@
   "private": false,
   "license": "MIT",
   "dependencies": {
-    "@kaizen/component-library": "^13.2.4",
     "@kaizen/component-base": "^1.1.0",
+    "@kaizen/component-library": "^13.2.4",
     "@kaizen/deprecated-component-library-helpers": "^2.5.2",
     "@types/classnames": "^2.3.0",
     "classnames": "^2.3.1"

--- a/draft-packages/loading-placeholder/package.json
+++ b/draft-packages/loading-placeholder/package.json
@@ -32,12 +32,12 @@
   "private": false,
   "license": "MIT",
   "dependencies": {
+    "@kaizen/component-base": "^1.1.0",
     "@kaizen/component-library": "^13.2.4",
     "@types/classnames": "^2.3.0",
     "classnames": "^2.3.1"
   },
   "devDependencies": {
-    "@kaizen/component-base": "^1.1.0",
     "elm-storybook": "cultureamp/elm-storybook#0.3.0",
     "rimraf": "^3.0.2"
   },

--- a/packages/brand-moment/package.json
+++ b/packages/brand-moment/package.json
@@ -33,6 +33,7 @@
   "license": "MIT",
   "dependencies": {
     "@kaizen/button": "^1.0.23",
+    "@kaizen/component-base": "^1.1.0",
     "@kaizen/component-library": "^13.2.4",
     "@kaizen/draft-illustration": "^4.1.5",
     "@kaizen/hosted-assets": "^1.2.0",
@@ -42,7 +43,6 @@
     "classnames": "^2.3.1"
   },
   "devDependencies": {
-    "@kaizen/component-base": "^1.0.0",
     "@kaizen/design-tokens": "^7.2.0",
     "@kaizen/draft-select": "^1.25.12",
     "rimraf": "^3.0.2"

--- a/packages/component-library/package.json
+++ b/packages/component-library/package.json
@@ -31,7 +31,7 @@
     "react": "^16.9.0 || ^17.0.0"
   },
   "dependencies": {
-    "@kaizen/component-base": "^1.0.0",
+    "@kaizen/component-base": "^1.1.0",
     "@kaizen/deprecated-component-library-helpers": "^2.5.2",
     "@kaizen/draft-button": "^5.6.23",
     "@kaizen/hosted-assets": "^1.2.0",
@@ -42,7 +42,6 @@
     "motion-ui": "cultureamp/motion-ui"
   },
   "devDependencies": {
-    "@kaizen/component-base": "^1.1.0",
     "@testing-library/dom": "^8.11.4",
     "elm-storybook": "cultureamp/elm-storybook#0.3.0",
     "rimraf": "^3.0.2"

--- a/packages/loading-spinner/package.json
+++ b/packages/loading-spinner/package.json
@@ -32,10 +32,8 @@
   "private": false,
   "license": "MIT",
   "dependencies": {
+    "@kaizen/component-base": "^1.1.0",
     "classnames": "^2.3.1"
-  },
-  "devDependencies": {
-    "@kaizen/component-base": "^1.1.0"
   },
   "peerDependencies": {
     "@kaizen/design-tokens": "^2.10.3 || ^3.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0",

--- a/packages/rich-text-editor/package.json
+++ b/packages/rich-text-editor/package.json
@@ -32,11 +32,11 @@
   "private": false,
   "license": "MIT",
   "dependencies": {
+    "@kaizen/component-base": "^1.0.0",
     "@kaizen/component-library": "^13.2.4",
     "classnames": "^2.3.1"
   },
   "devDependencies": {
-    "@kaizen/component-base": "^1.0.0",
     "@kaizen/draft-tooltip": "^4.0.7",
     "@types/classnames": "^2.3.0",
     "rimraf": "^3.0.2"


### PR DESCRIPTION
## Why
- See card https://cultureamp.atlassian.net/jira/software/projects/KDS/boards/289?selectedIssue=KDS-360
- When `component-base` is a dev dependency only, it can cause TypeScript issues


## What
- Moved `@kaizen/component-library` to `dependencies` in `package.json` where it wasn't yet
