### PR TITLE
feat: Add inputrules to RTE

### DIFF
--- a/packages/rich-text-editor/package.json
+++ b/packages/rich-text-editor/package.json
@@ -43,6 +43,7 @@
     "prosemirror-keymap": "^1.1.5",
     "prosemirror-model": "^1.16.1",
     "prosemirror-state": "^1.3.4",
+    "prosemirror-inputrules": "^1.1.3",
     "uuid": "^8.3.2"
   },
   "devDependencies": {
@@ -52,6 +53,7 @@
     "@types/prosemirror-keymap": "^1.0.4",
     "@types/prosemirror-model": "^1.16.1",
     "@types/prosemirror-state": "^1.2.8",
+    "@types/prosemirror-inputrules": "^1.0.4",
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {

--- a/packages/rich-text-editor/src/RichTextEditor/RichTextEditor.tsx
+++ b/packages/rich-text-editor/src/RichTextEditor/RichTextEditor.tsx
@@ -7,10 +7,12 @@ import { EditorState } from "prosemirror-state"
 import { Node, Schema } from "prosemirror-model"
 import { Label } from "@kaizen/draft-form"
 import { baseKeymap } from "prosemirror-commands"
-import { buildKeymap, useRichTextEditor } from "@cultureamp/rich-text-toolkit"
+import { useRichTextEditor } from "@cultureamp/rich-text-toolkit"
 import { OverrideClassName } from "@kaizen/component-base"
 import { EditorContentArray } from "./types"
 import { createSchemaFromControls } from "./schema"
+import { buildKeymap } from "./keymap"
+import { buildInputRules } from "./inputrules"
 import styles from "./RichTextEditor.scss"
 
 export interface RichTextEditorProps
@@ -39,6 +41,7 @@ export const RichTextEditor: React.VFC<RichTextEditorProps> = props => {
           ...baseKeymap,
           ...buildKeymap(schema),
         }),
+        buildInputRules(),
       ],
     }),
     { "aria-labelledby": labelId }

--- a/packages/rich-text-editor/src/RichTextEditor/inputrules.ts
+++ b/packages/rich-text-editor/src/RichTextEditor/inputrules.ts
@@ -1,0 +1,11 @@
+import {
+  inputRules,
+  smartQuotes,
+  emDash,
+  ellipsis,
+} from "prosemirror-inputrules"
+
+export function buildInputRules() {
+  const rules = smartQuotes.concat(ellipsis, emDash)
+  return inputRules({ rules })
+}

--- a/packages/rich-text-editor/src/RichTextEditor/keymap.ts
+++ b/packages/rich-text-editor/src/RichTextEditor/keymap.ts
@@ -1,0 +1,78 @@
+import { EditorState, Transaction } from "prosemirror-state"
+import { Schema } from "prosemirror-model"
+import {
+  chainCommands,
+  exitCode,
+  joinDown,
+  joinUp,
+  lift,
+  selectParentNode,
+  setBlockType,
+  toggleMark,
+} from "prosemirror-commands"
+import { redo, undo } from "prosemirror-history"
+import { undoInputRule } from "prosemirror-inputrules"
+
+const mac =
+  // eslint-disable-next-line ssr-friendly/no-dom-globals-in-module-scope
+  typeof navigator != "undefined" ? /Mac/.test(navigator.platform) : false
+
+export function buildKeymap(schema: Schema) {
+  const keys: {
+    [key: string]: (
+      state: EditorState<any>,
+      dispatch?: ((tr: Transaction<any>) => void) | undefined
+    ) => boolean
+  } = {
+    "Mod-z": undo,
+    "Shift-Mod-z": redo,
+    Backspace: undoInputRule,
+    "Alt-ArrowUp": joinUp,
+    "Alt-ArrowDown": joinDown,
+    "Mod-BracketLeft": lift,
+    Escape: selectParentNode,
+  }
+
+  if (!mac) {
+    keys["Mod-y"] = redo
+  }
+
+  if (schema.marks.strong) {
+    const type = schema.marks.strong
+    keys["Mod-b"] = toggleMark(type)
+    keys["Mod-B"] = toggleMark(type)
+  }
+
+  if (schema.marks.em) {
+    const type = schema.marks.em
+    keys["Mod-i"] = toggleMark(type)
+    keys["Mod-I"] = toggleMark(type)
+  }
+
+  if (schema.marks.underline) {
+    const type = schema.marks.underline
+    keys["Mod-u"] = toggleMark(type)
+    keys["Mod-U"] = toggleMark(type)
+  }
+
+  if (schema.nodes.hard_break) {
+    const br = schema.nodes.hard_break
+    const cmd = chainCommands(exitCode, (state, dispatch) => {
+      dispatch &&
+        dispatch(state.tr.replaceSelectionWith(br.create()).scrollIntoView())
+      return true
+    })
+    keys["Mod-Enter"] = cmd
+    keys["Shift-Enter"] = cmd
+    if (mac) {
+      keys["Ctrl-Enter"] = cmd
+    }
+  }
+
+  if (schema.nodes.paragraph) {
+    const type = schema.nodes.paragraph
+    keys["Shift-Ctrl-0"] = setBlockType(type)
+  }
+
+  return keys
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5570,6 +5570,14 @@
     "@types/prosemirror-model" "*"
     "@types/prosemirror-state" "*"
 
+"@types/prosemirror-inputrules@^1.0.4":
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/@types/prosemirror-inputrules/-/prosemirror-inputrules-1.0.4.tgz#4cb75054d954aa0f6f42099be05eb6c0e6958bae"
+  integrity sha512-lJIMpOjO47SYozQybUkpV6QmfuQt7GZKHtVrvS+mR5UekA8NMC5HRIVMyaIauJLWhKU6oaNjpVaXdw41kh165g==
+  dependencies:
+    "@types/prosemirror-model" "*"
+    "@types/prosemirror-state" "*"
+
 "@types/prosemirror-keymap@^1.0.4":
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/@types/prosemirror-keymap/-/prosemirror-keymap-1.0.4.tgz#f73c79810e8d0e0a20d153d84f998f02e5afbc0c"
@@ -20506,6 +20514,14 @@ prosemirror-history@^1.2.0:
     prosemirror-state "^1.2.2"
     prosemirror-transform "^1.0.0"
     rope-sequence "^1.3.0"
+
+prosemirror-inputrules@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/prosemirror-inputrules/-/prosemirror-inputrules-1.1.3.tgz#93f9199ca02473259c30d7e352e4c14022d54638"
+  integrity sha512-ZaHCLyBtvbyIHv0f5p6boQTIJjlD6o2NPZiEaZWT2DA+j591zS29QQEMT4lBqwcLW3qRSf7ZvoKNbf05YrsStw==
+  dependencies:
+    prosemirror-state "^1.0.0"
+    prosemirror-transform "^1.0.0"
 
 prosemirror-keymap@^1.1.5:
   version "1.1.5"


### PR DESCRIPTION
## What
Adds 'inputrules' to the RichTextEditor, including:
* Smart quotes
* Two hyphens into an emdash
* Three full stops into an ellipsis

## Why
Because these things are expected from rich text editors, and sets us up for adding list functionality.


