### PR TITLE
fix: Set pointer-events to none on RTE focus ring

### DIFF
--- a/packages/rich-text-editor/src/RichTextEditor/RichTextEditor.scss
+++ b/packages/rich-text-editor/src/RichTextEditor/RichTextEditor.scss
@@ -39,6 +39,7 @@
   &:global(.focus-visible)::after {
     $focus-ring-offset: 5px;
     content: "";
+    pointer-events: none;
     position: absolute;
     background: transparent;
     border-radius: $border-focus-ring-border-radius;


### PR DESCRIPTION
## What
Removes pointer events from the psuedo element created for the RTE focus ring.

## Why
This element is getting in the way of selecting text.
