### PR TITLE
fix: Breadcrumb link in Title Block to use correct underline color [KDS-240]

### DIFF
--- a/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/TitleBlockZen.scss
+++ b/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/TitleBlockZen.scss
@@ -623,6 +623,7 @@ $tab-container-height-medium-and-small-collapsed: $ca-grid * 0.75;
 }
 
 .breadcrumb,
+.breadcrumb:hover,
 .breadcrumbText {
   color: $color-white;
   .educationVariant &,


### PR DESCRIPTION
## Why
- Fixes [KDS-240](https://cultureamp.atlassian.net/jira/software/projects/KDS/boards/289?selectedIssue=KDS-240)
- Issue: The underline the Title Block breadcrumb link sometimes has the wrong color:
<img width="277" alt="image" src="https://user-images.githubusercontent.com/763385/161484482-fdd6d418-d1b6-442c-818e-0976901fab64.png">



## What
A bit of a CSS mindtwister here:
Turns out there is a global `a:hover { color: blue; }` CSS rule which overrides the color set in the class for the `a` tag wrapping the breadcrumb link (because the class didn't have an explicit `.className:hover` providing greater specificity). This then leads to the color mixup because of how the DOM is nested and `text-decoration: underline` uses `currentColor` by default for the underline's color:
```
<a href="#"> <!-- has `blue` color on hover -->
  <span> <!-- has `text-decoration: underline;`, underline color is `currentColor` by default -->
    <span> <!-- has `color: white`, but it's not the `currentColor` used above 🤦 -->
      Back to report
    </span>
  </span>
</a>
```
See this[ Codepen for a demo](https://codepen.io/christian314159/pen/gOooMod)

### Solution
I simply amended the classname setting the color on the `a` tag to include the `:hover` case and it works out.
You can verify this locally or in the dev tools by adding a global `a:hover { color: pink; }` rule to the stylesheet.