### PR TITLE
fix: Set TitleBlock to 6.0.15 to fix deploy issues

### DIFF
--- a/draft-packages/title-block-zen/package.json
+++ b/draft-packages/title-block-zen/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kaizen/draft-title-block-zen",
-  "version": "6.0.14",
+  "version": "6.0.15",
   "description": "The draft Title Block (Zen) component",
   "scripts": {
     "prepublish": "tsc --project tsconfig.dist.json",


### PR DESCRIPTION
## Why
- Lerna complaining that tag already exists


## What
Manually setting it to 6.0.15 hoping it'll tag it correctly now
