### PR TITLE
feat: Add rows prop to RichTextEditor for setting min-height

### DIFF
--- a/packages/rich-text-editor/docs/RichTextEditor.stories.tsx
+++ b/packages/rich-text-editor/docs/RichTextEditor.stories.tsx
@@ -22,6 +22,7 @@ export const Default = () => {
         labelText="Label"
         value={rteData}
         onChange={data => setRTEData(data)}
+        rows={1}
       />
     </>
   )

--- a/packages/rich-text-editor/docs/RichTextEditor.stories.tsx
+++ b/packages/rich-text-editor/docs/RichTextEditor.stories.tsx
@@ -14,17 +14,18 @@ export default {
   },
 }
 
-export const Default = () => {
+export const Default = args => {
   const [rteData, setRTEData] = useState<EditorContentArray>([])
   return (
-    <>
-      <RichTextEditor
-        labelText="Label"
-        value={rteData}
-        onChange={data => setRTEData(data)}
-        rows={1}
-      />
-    </>
+    <RichTextEditor
+      value={rteData}
+      onChange={data => setRTEData(data)}
+      {...args}
+    />
   )
 }
 Default.storyName = "Default (Kaizen Demo)"
+Default.args = {
+  labelText: "Label",
+  rows: 3,
+}

--- a/packages/rich-text-editor/src/RichTextEditor/RichTextEditor.scss
+++ b/packages/rich-text-editor/src/RichTextEditor/RichTextEditor.scss
@@ -52,3 +52,9 @@
     bottom: calc(-1 * #{$focus-ring-offset});
   }
 }
+
+@for $i from 1 through 20 {
+  .editor.rows#{$i} > :global(.ProseMirror) {
+    min-height: calc($typography-paragraph-body-line-height * $i);
+  }
+}

--- a/packages/rich-text-editor/src/RichTextEditor/RichTextEditor.tsx
+++ b/packages/rich-text-editor/src/RichTextEditor/RichTextEditor.tsx
@@ -20,10 +20,42 @@ export interface RichTextEditorProps
   onChange: (content: EditorContentArray) => void
   value: EditorContentArray
   labelText: ReactNode
+  /**
+   * Sets a default min-height for the editable area in units of body paragraph line height, similar to the 'rows' attribute on <textarea>.
+   * The editable area will autogrow, so this only affects the component when the content doesn't exceed this height.
+   */
+  rows?:
+    | 1
+    | 2
+    | 3
+    | 4
+    | 5
+    | 6
+    | 7
+    | 8
+    | 9
+    | 10
+    | 11
+    | 12
+    | 13
+    | 14
+    | 15
+    | 16
+    | 17
+    | 18
+    | 19
+    | 20
 }
 
 export const RichTextEditor: React.VFC<RichTextEditorProps> = props => {
-  const { onChange, value, labelText, classNameOverride, ...restProps } = props
+  const {
+    onChange,
+    value,
+    labelText,
+    rows = 3,
+    classNameOverride,
+    ...restProps
+  } = props
   const [schema] = useState<Schema>(createSchemaFromControls([]))
   const [labelId] = useState<string>(v4())
   const [editorRef, editorState] = useRichTextEditor(
@@ -56,7 +88,11 @@ export const RichTextEditor: React.VFC<RichTextEditorProps> = props => {
       {/* TODO: add a bit of margin here once we have a classNameOverride on Label */}
       <div
         ref={editorRef}
-        className={classnames(styles.editor, classNameOverride)}
+        className={classnames(
+          styles.editor,
+          styles[`rows${rows}`],
+          classNameOverride
+        )}
         {...restProps}
       />
     </>


### PR DESCRIPTION
## What
Adds a `rows` prop to `RichTextEditor`, which will set a min-height on the editable area, in units of body paragraph line height. Pretty much the same as we've done on `TextAreaField`, but this component has autogrow enabled all the time. 

The default value has been set to 3, in line with `TextAreaField` and roughly matching the UI Kit.

## Why
Gives users a good way to set a min height on the text area.
