### PR TITLE
chore(docs): Made interactive CheckboxGroup story actually interactive [KDS-378]

### DIFF
--- a/draft-packages/form/docs/CheckboxGroup.stories.tsx
+++ b/draft-packages/form/docs/CheckboxGroup.stories.tsx
@@ -15,18 +15,20 @@ interface RenderProps {
   onCheckHandler: (event: React.ChangeEvent<HTMLInputElement>) => any
 }
 
-interface Props {
+interface CheckboxGroupExampleProps {
   render: (props: RenderProps) => JSX.Element
 }
 
-function CheckboxGroupExample({ render }) {
+const CheckboxGroupExample: React.VFC<CheckboxGroupExampleProps> = ({
+  render,
+}) => {
   const [checkedStatus, setCheckedStatus] = useState("mixed")
   const onCheckHandler = () => {
     const newStatus = checkedStatus === "on" ? "off" : "on"
     setCheckedStatus(newStatus)
   }
 
-  return <>{render({ checkedStatus, onCheckHandler })}</>
+  return render({ checkedStatus, onCheckHandler })
 }
 
 export default {

--- a/draft-packages/form/docs/CheckboxGroup.stories.tsx
+++ b/draft-packages/form/docs/CheckboxGroup.stories.tsx
@@ -1,4 +1,4 @@
-import React from "react"
+import React, { useState } from "react"
 import { CheckboxGroup, CheckboxField, Label } from "@kaizen/draft-form"
 import { withDesign } from "storybook-addon-designs"
 import { figmaEmbed } from "../../../storybook/helpers"
@@ -19,33 +19,14 @@ interface Props {
   render: (props: RenderProps) => JSX.Element
 }
 
-class CheckboxGroupExample extends React.Component<Props> {
-  public state = {
-    checkedStatus: "mixed",
-  }
-  constructor(props: Props) {
-    super(props)
-
-    this.onCheckHandler = this.onCheckHandler.bind(this)
+function CheckboxGroupExample({ render }) {
+  const [checkedStatus, setCheckedStatus] = useState("mixed")
+  const onCheckHandler = () => {
+    const newStatus = checkedStatus === "on" ? "off" : "on"
+    setCheckedStatus(newStatus)
   }
 
-  public onCheckHandler(event: React.ChangeEvent<HTMLInputElement>) {
-    this.setState({
-      checkedStatus: this.state.checkedStatus === "on" ? "off" : "on",
-    })
-  }
-
-  public render() {
-    const { render } = this.props
-    return (
-      <div>
-        {render({
-          checkedStatus: this.state.checkedStatus,
-          onCheckHandler: this.onCheckHandler,
-        })}
-      </div>
-    )
-  }
+  return <>{render({ checkedStatus, onCheckHandler })}</>
 }
 
 export default {

--- a/draft-packages/form/docs/CheckboxGroup.stories.tsx
+++ b/draft-packages/form/docs/CheckboxGroup.stories.tsx
@@ -52,9 +52,6 @@ export default {
   title: `${CATEGORIES.components}/${SUB_CATEGORIES.form}/Checkbox Group`,
   component: CheckboxField,
   parameters: {
-    actions: {
-      argTypesRegex: "^on.*",
-    },
     docs: {
       description: {
         component: 'import { CheckboxGroup } from "@kaizen/draft-form";',


### PR DESCRIPTION
## Why
I noticed that the ["interactive" story](https://cultureamp.design/storybook/?path=/story/components-form-checkbox-group--interactive-kaizen-site-demo) for `CheckboxGroup` wasn't actually that interactive, it could only be toggled from `mixed` to `off`, but not `on`.

## What
- removed the `actions` config option that caught the event callbacks that would set the state
- refactored the story helper component from a class to a functional component
