### PR TITLE
chore(deps): remove react-intersection-observer from design-tokens

### DIFF
--- a/packages/design-tokens/package.json
+++ b/packages/design-tokens/package.json
@@ -45,7 +45,6 @@
     "postcss": "^8.4.12",
     "prettier": "*",
     "react-highlight": "^0.14.0",
-    "react-intersection-observer": "^8.32.5",
     "react-map-interaction": "^2.1.0",
     "ts-node": "^10.4.0",
     "yargs": "^16.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -21017,11 +21017,6 @@ react-inspector@^5.1.0:
     is-dom "^1.0.0"
     prop-types "^15.0.0"
 
-react-intersection-observer@^8.32.5:
-  version "8.32.5"
-  resolved "https://registry.yarnpkg.com/react-intersection-observer/-/react-intersection-observer-8.32.5.tgz#92e8d8888b0b43a5c10c398e0d483d574bce7f3e"
-  integrity sha512-4xKdUWRNdPueXXxTyMOV41w6qIa4tsV7BbWOW+IYsvGPP7wxOj9V6o3cKywie+/VDr5Qs7pCzi5Wom78dUxj1w==
-
 react-is@17.0.2, "react-is@^16.12.0 || ^17.0.0", react-is@^17.0.1, react-is@^17.0.2:
   version "17.0.2"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"


### PR DESCRIPTION
## Why

Questioning whether we should continue upgrading `react-intersection-observer` (https://github.com/cultureamp/kaizen-design-system/pull/2697) or just remove it since it appears to never be used.

## What

Remove `react-intersection-observer`