### PR TITLE
chore(deps): remove loader-utils

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,7 +96,6 @@
     "jest-circus": "^27.4.2",
     "jest-static-stubs": "^0.0.1",
     "lerna": "^3.22.1",
-    "loader-utils": "^1.4.0",
     "node-fetch": "^2.6.7",
     "postcss-loader": "^3.0.0",
     "postcss-preset-env": "^6.7.1",


### PR DESCRIPTION
## Why

Looking at whether [this dependency update](https://github.com/cultureamp/kaizen-design-system/pull/2455) was required, and found that `loader-utils` was [introduced for elm](https://github.com/cultureamp/kaizen-design-system/commit/aed5a3869badb8d69ecd4ad4c69968c06412405a#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R130).

## What

Remove `loader-utils` (yes there's no `yarn.lock` update apparently)
