### PR TITLE
fix: button focus styling

### DIFF
--- a/packages/button/Button/components/GenericButton.module.scss
+++ b/packages/button/Button/components/GenericButton.module.scss
@@ -89,10 +89,6 @@
   visibility: hidden;
 }
 
-.circleButtonFocus {
-  @extend %caCircleButtonFocus;
-}
-
 .circleButton {
   @extend %caCircleButton;
 }

--- a/packages/button/Button/components/GenericButton.tsx
+++ b/packages/button/Button/components/GenericButton.tsx
@@ -106,8 +106,6 @@ const GenericButton = forwardRef(
       <span
         className={classNames(styles.container, {
           [styles.fullWidth]: props.fullWidth,
-          [styles.circleButtonFocus]:
-            props.directionalLink || props.paginationLink,
         })}
       >
         {determineButtonRenderer()}

--- a/packages/button/Button/styles.scss
+++ b/packages/button/Button/styles.scss
@@ -725,9 +725,9 @@ $caButtonCircle-radius: 30px;
       :global(.js-focus-visible) &:global(.focus-visible) {
         border: $border-solid-border-width $border-solid-border-style
           $color-blue-400;
-          &::after {
-            border-radius: $caButtonCircle-radius;
-          }
+        &::after {
+          border-radius: $caButtonCircle-radius;
+        }
       }
 
       &%caButtonReversed {

--- a/packages/button/Button/styles.scss
+++ b/packages/button/Button/styles.scss
@@ -234,11 +234,6 @@ $caButtonCircle-radius: 30px;
         right: calc(-1 * #{$focus-ring-offset});
         bottom: calc(-1 * #{$focus-ring-offset});
       }
-
-      &:global(.focus-visible)::after,
-      %caCircleButtonFocus {
-        border-radius: $caButtonCircle-radius;
-      }
     }
   }
 
@@ -730,6 +725,9 @@ $caButtonCircle-radius: 30px;
       :global(.js-focus-visible) &:global(.focus-visible) {
         border: $border-solid-border-width $border-solid-border-style
           $color-blue-400;
+          &::after {
+            border-radius: $caButtonCircle-radius;
+          }
       }
 
       &%caButtonReversed {


### PR DESCRIPTION
## Why
<!-- Why have you created this PR? - Is it a new feature, or a bug fix? Or something else? -->
<!-- Reference any relevant Jira tickets so your reviewer can find more context if needed. -->
<!-- Fixing a GitHub issue? Add "Fixes [issue URL]". -->
Button focus styles broken as the pagination style border-radius was over riding it.

## What
<!-- What do your changes do? How do they change/fix the current behavior? -->
<!-- Add screenshots, GIFs or videos to illustrate the changes.  -->

- Remove the styling that is overriding all focus-visible border-radius styles. 
- Add the pagination border-radius styles under the %caCircleButton class styles.
- Remove %caCircleButtonFocus as it's no longer needed