### PR TITLE
feat(draft-modal): remove padding from ModalAccessibleDescription

### DIFF
--- a/draft-packages/modal/KaizenDraft/Modal/Primitives/ModalAccessibleDescription.scss
+++ b/draft-packages/modal/KaizenDraft/Modal/Primitives/ModalAccessibleDescription.scss
@@ -2,5 +2,4 @@
 
 .modalDescription {
   grid-column-start: 2;
-  padding-bottom: $spacing-md;
 }

--- a/draft-packages/modal/KaizenDraft/Modal/Primitives/ModalAccessibleDescription.tsx
+++ b/draft-packages/modal/KaizenDraft/Modal/Primitives/ModalAccessibleDescription.tsx
@@ -1,17 +1,14 @@
-import * as React from "react"
+import React from "react"
 import { ModalAccessibleContext } from "./ModalAccessibleContext"
 import styles from "./ModalAccessibleDescription.scss"
 
 export interface ModalAccessibleDescriptionProps {
-  readonly children: React.ReactNode
+  children: React.ReactNode
 }
 
-type ModalAccessibleDescription =
-  React.FunctionComponent<ModalAccessibleDescriptionProps>
-
-const ModalAccessibleDescription: ModalAccessibleDescription = ({
-  children,
-}) => (
+export const ModalAccessibleDescription: React.VFC<
+  ModalAccessibleDescriptionProps
+> = ({ children }) => (
   <ModalAccessibleContext.Consumer>
     {({ describedByID }) => (
       <div id={describedByID} className={styles.modalDescription}>
@@ -21,4 +18,4 @@ const ModalAccessibleDescription: ModalAccessibleDescription = ({
   </ModalAccessibleContext.Consumer>
 )
 
-export default ModalAccessibleDescription
+ModalAccessibleDescription.displayName = "ModalAccessibleDescription"

--- a/draft-packages/modal/KaizenDraft/Modal/index.ts
+++ b/draft-packages/modal/KaizenDraft/Modal/index.ts
@@ -11,10 +11,7 @@ export {
   default as ModalHeader,
   ModalHeaderProps,
 } from "./Primitives/ModalHeader"
-export {
-  default as ModalAccessibleDescription,
-  ModalAccessibleDescriptionProps,
-} from "./Primitives/ModalAccessibleDescription"
+export * from "./Primitives/ModalAccessibleDescription"
 export {
   default as ModalAccessibleLabel,
   ModalAccessibleLabelProps,

--- a/draft-packages/modal/docs/ConfirmationModal.stories.tsx
+++ b/draft-packages/modal/docs/ConfirmationModal.stories.tsx
@@ -1,49 +1,29 @@
-import React from "react"
-import { Paragraph } from "@kaizen/typography"
-import { Button } from "@kaizen/button"
-import { ConfirmationModal } from "@kaizen/draft-modal"
+import React, { useState } from "react"
 import isChromatic from "chromatic/isChromatic"
 import { withDesign } from "storybook-addon-designs"
+import { ComponentStory } from "@storybook/react"
+import { Button } from "@kaizen/button"
+import { ConfirmationModal } from "@kaizen/draft-modal"
+import { Paragraph } from "@kaizen/typography"
 import { figmaEmbed } from "../../../storybook/helpers"
 import { CATEGORIES } from "../../../storybook/constants"
+
+const IS_CHROMATIC = isChromatic()
 
 // Add additional height to the stories when running in Chromatic only.
 // Modals have fixed position and would be cropped from snapshot tests.
 // Setting height to 100vh ensures we capture as much content of the
 // modal, as it's height responds to the content within it.
 const withMinHeight = Story => {
-  if (!isChromatic()) return <Story />
-  return (
-    <div style={{ minHeight: "100vh" }}>
-      <Story />
-    </div>
-  )
-}
-class ModalStateContainer extends React.Component<
-  {
-    isInitiallyOpen: boolean
-    children: (renderProps: {
-      open: () => void
-      close: () => void
-      isOpen: boolean
-    }) => React.ReactNode
-  },
-  { isOpen: boolean }
-> {
-  state = { isOpen: this.props.isInitiallyOpen }
-  open = () => this.setState({ isOpen: true })
-  close = () => this.setState({ isOpen: false })
-  render() {
-    return this.props.children({
-      open: this.open,
-      close: this.close,
-      isOpen: this.state.isOpen,
-    })
+  if (IS_CHROMATIC) {
+    return <div style={{ minHeight: "100vh" }}>{Story()}</div>
   }
+
+  return Story()
 }
 
 export default {
-  title: `${CATEGORIES.components}/Modal/Confirmation Modal`,
+  title: `${CATEGORIES.components}/Modal`,
   component: ConfirmationModal,
   args: {
     mood: "cautionary",
@@ -56,7 +36,7 @@ export default {
     },
     docs: {
       description: {
-        component: "import { ConfirmationModal } from @kaizen/draft-modal",
+        component: 'import { ConfirmationModal } from "@kaizen/draft-modal"',
       },
     },
     ...figmaEmbed(
@@ -69,26 +49,39 @@ export default {
   decorators: [withDesign, withMinHeight],
 }
 
-export const ConfirmationModals = args => (
-  <ModalStateContainer isInitiallyOpen={isChromatic()}>
-    {({ open, close, isOpen }) => (
-      <div>
-        <Button label="Open modal" onClick={open} />
-        <ConfirmationModal
-          isOpen={isOpen}
-          mood="cautionary"
-          title="Confirmation modal title"
-          onConfirm={close}
-          onDismiss={close}
-          confirmLabel="Label"
-          {...args}
-        >
-          <Paragraph variant="body">
-            Confirmation modals contain smaller pieces of content and can
-            provide additional information to aide the user.
-          </Paragraph>
-        </ConfirmationModal>
-      </div>
-    )}
-  </ModalStateContainer>
-)
+const ConfirmationModalTemplate: ComponentStory<
+  typeof ConfirmationModal
+> = args => {
+  const [isOpen, setIsOpen] = useState<boolean>(IS_CHROMATIC)
+
+  const handleOpen = () => setIsOpen(true)
+  const handleClose = () => setIsOpen(false)
+
+  return (
+    <>
+      <Button label="Open modal" onClick={handleOpen} />
+      <ConfirmationModal
+        {...args}
+        isOpen={args.isOpen === undefined ? isOpen : args.isOpen}
+        onConfirm={handleClose}
+        onDismiss={handleClose}
+      >
+        <Paragraph variant="body">
+          Confirmation modals contain smaller pieces of content and can provide
+          additional information to aide the user.
+        </Paragraph>
+      </ConfirmationModal>
+    </>
+  )
+}
+
+export const ConfirmationModalExample = ConfirmationModalTemplate.bind({})
+ConfirmationModalExample.storyName = "Confirmation Modal"
+ConfirmationModalExample.args = {
+  mood: "cautionary",
+  title: "Confirmation modal title",
+  confirmLabel: "Confirm label",
+}
+ConfirmationModalExample.parameters = {
+  docs: { source: { type: "code" } },
+}

--- a/draft-packages/modal/docs/ContextModal.stories.tsx
+++ b/draft-packages/modal/docs/ContextModal.stories.tsx
@@ -1,51 +1,31 @@
-import React from "react"
-import { Paragraph } from "@kaizen/typography"
-import { Button } from "@kaizen/button"
-import { ContextModal, ModalAccessibleDescription } from "@kaizen/draft-modal"
+import React, { useState } from "react"
 import isChromatic from "chromatic/isChromatic"
 import { withDesign } from "storybook-addon-designs"
+import { ComponentStory } from "@storybook/react"
+import { Button } from "@kaizen/button"
 import { AddImage } from "@kaizen/draft-illustration"
+import { ContextModal, ModalAccessibleDescription } from "@kaizen/draft-modal"
+import { Paragraph } from "@kaizen/typography"
 import { figmaEmbed } from "../../../storybook/helpers"
 import { CATEGORIES } from "../../../storybook/constants"
 import styles from "./ContextModal.stories.scss"
+
+const IS_CHROMATIC = isChromatic()
 
 // Add additional height to the stories when running in Chromatic only.
 // Modals have fixed position and would be cropped from snapshot tests.
 // Setting height to 100vh ensures we capture as much content of the
 // modal, as it's height responds to the content within it.
 const withMinHeight = Story => {
-  if (!isChromatic()) return <Story />
-  return (
-    <div style={{ minHeight: "100vh" }}>
-      <Story />
-    </div>
-  )
-}
-class ModalStateContainer extends React.Component<
-  {
-    isInitiallyOpen: boolean
-    children: (renderProps: {
-      open: () => void
-      close: () => void
-      isOpen: boolean
-    }) => React.ReactNode
-  },
-  { isOpen: boolean }
-> {
-  state = { isOpen: this.props.isInitiallyOpen }
-  open = () => this.setState({ isOpen: true })
-  close = () => this.setState({ isOpen: false })
-  render() {
-    return this.props.children({
-      open: this.open,
-      close: this.close,
-      isOpen: this.state.isOpen,
-    })
+  if (IS_CHROMATIC) {
+    return <div style={{ minHeight: "100vh" }}>{Story()}</div>
   }
+
+  return Story()
 }
 
 export default {
-  title: `${CATEGORIES.components}/Modal/Context Modal`,
+  title: `${CATEGORIES.components}/Modal`,
   component: ContextModal,
   parameters: {
     chromatic: {
@@ -56,9 +36,7 @@ export default {
     docs: {
       description: {
         component:
-          "import { ContextModal, " +
-          "ModalAccessibleDescription" +
-          '} from "@kaizen/draft-modal"',
+          'import { ContextModal, ModalAccessibleDescription } from "@kaizen/draft-modal"',
       },
     },
     ...figmaEmbed(
@@ -71,59 +49,71 @@ export default {
   decorators: [withDesign, withMinHeight],
 }
 
-export const ContextModals = args => (
-  <ModalStateContainer isInitiallyOpen={isChromatic()}>
-    {({ open, close, isOpen }) => (
-      <div>
-        <Button label="Open modal" onClick={open} />
-        <ContextModal
-          isOpen={isOpen}
-          title="Context modal title"
-          onConfirm={close}
-          onDismiss={close}
-          secondaryLabel="Cancel"
-          onSecondaryAction={close}
-          confirmLabel="Label"
-          layout="portrait"
-          image={
-            <AddImage
-              classNameOverride={
-                args.layout === "landscape" ? styles.landscape : ""
-              }
-              alt="placeholder"
-            />
-          }
-          {...args}
-        >
-          <ModalAccessibleDescription>
-            <Paragraph variant="body">
-              Intro defining what the modal is trying to explain or depict.
-              Intro defining what the modal is trying to explain or depict.
-            </Paragraph>
-          </ModalAccessibleDescription>
-          <ul>
-            <li>
-              <Paragraph variant="body">
-                Key point to the benefits of the feature
-              </Paragraph>
-            </li>
-            <li>
-              <Paragraph variant="body">
-                Key point to the benefits of the feature
-              </Paragraph>
-            </li>
-            <li>
-              <Paragraph variant="body">
-                Key point to the benefits of the feature
-              </Paragraph>
-            </li>
-          </ul>
+const ContextModalTemplate: ComponentStory<typeof ContextModal> = args => {
+  const [isOpen, setIsOpen] = useState<boolean>(IS_CHROMATIC)
+
+  const handleOpen = () => setIsOpen(true)
+  const handleClose = () => setIsOpen(false)
+
+  return (
+    <>
+      <Button label="Open modal" onClick={handleOpen} />
+      <ContextModal
+        {...args}
+        isOpen={args.isOpen === undefined ? isOpen : args.isOpen}
+        onConfirm={handleClose}
+        onDismiss={handleClose}
+        secondaryLabel={args.secondaryLabel || "Cancel"}
+        onSecondaryAction={handleClose}
+        image={
+          <AddImage
+            classNameOverride={
+              args.layout === "landscape" ? styles.landscape : undefined
+            }
+            alt="placeholder"
+          />
+        }
+      >
+        <ModalAccessibleDescription>
           <Paragraph variant="body">
-            More information to conclude can go here. More information to
-            conclude can go here. More information to conclude can go here.
+            Intro defining what the modal is trying to explain or depict. Intro
+            defining what the modal is trying to explain or depict.
           </Paragraph>
-        </ContextModal>
-      </div>
-    )}
-  </ModalStateContainer>
-)
+        </ModalAccessibleDescription>
+        <ul>
+          <li>
+            <Paragraph variant="body">
+              Key point to the benefits of the feature
+            </Paragraph>
+          </li>
+          <li>
+            <Paragraph variant="body">
+              Key point to the benefits of the feature
+            </Paragraph>
+          </li>
+          <li>
+            <Paragraph variant="body">
+              Key point to the benefits of the feature
+            </Paragraph>
+          </li>
+        </ul>
+        <Paragraph variant="body">
+          More information to conclude can go here. More information to conclude
+          can go here. More information to conclude can go here.
+        </Paragraph>
+      </ContextModal>
+    </>
+  )
+}
+
+export const ContextModalExample = ContextModalTemplate.bind({})
+ContextModalExample.storyName = "Context Modal"
+ContextModalExample.args = {
+  title: "Context modal title",
+  secondaryLabel: "Cancel",
+  confirmLabel: "Label",
+  layout: "portrait",
+}
+ContextModalExample.parameters = {
+  docs: { source: { type: "code" } },
+}

--- a/draft-packages/modal/docs/InputEditModal.stories.tsx
+++ b/draft-packages/modal/docs/InputEditModal.stories.tsx
@@ -3,6 +3,7 @@ import isChromatic from "chromatic/isChromatic"
 import { ComponentStory } from "@storybook/react"
 import { withDesign } from "storybook-addon-designs"
 import { Button } from "@kaizen/button"
+import { Box } from "@kaizen/component-library"
 import { InputEditModal, ModalAccessibleDescription } from "@kaizen/draft-modal"
 import { Select } from "@kaizen/draft-select"
 import { Paragraph } from "@kaizen/typography"
@@ -73,11 +74,13 @@ const InputEditModalTemplate: ComponentStory<typeof InputEditModal> = args => {
         onSubmit={handleClose}
         onDismiss={handleClose}
       >
-        <ModalAccessibleDescription>
-          <Paragraph variant="body">
-            Instructive text to drive user selection goes here.
-          </Paragraph>
-        </ModalAccessibleDescription>
+        <Box mb={1}>
+          <ModalAccessibleDescription>
+            <Paragraph variant="body">
+              Instructive text to drive user selection goes here.
+            </Paragraph>
+          </ModalAccessibleDescription>
+        </Box>
         <Select
           options={SELECT_OPTIONS}
           placeholder="Placeholder"


### PR DESCRIPTION
## Why

Support ticket: https://cultureamp.atlassian.net/jira/software/projects/KDS/boards/289?selectedIssue=KDS-427

`ModalAccessibleDescription` is embedded within `ConfirmationModal`, and was adding extra unnecessary space.

## What

- Remove padding from `ModalAccessibleDescription`
- Fix modal stories to show code snippets