### PR TITLE
fix: Enable noUncheckedIndexedAccess for design tokens and fix TS errors

### DIFF
--- a/packages/design-tokens/src/lib/makeCssVariableTheme.ts
+++ b/packages/design-tokens/src/lib/makeCssVariableTheme.ts
@@ -47,6 +47,9 @@ export function makeCSSVariableTheme<
         (child[segment] || (child[segment] = {})) as Record<string, unknown>,
       augmentedTheme as Record<string, unknown>
     )
+    if (!leafKey) {
+      throw new Error("leafKey is undefined")
+    }
     const cssVariablesOfToken = addExtraThemeEntries(
       leafPath,
       leafKey,

--- a/packages/design-tokens/tsconfig.dist.json
+++ b/packages/design-tokens/tsconfig.dist.json
@@ -8,7 +8,8 @@
     "declarationMap": true,
     "declaration": true,
     "target": "es5",
-    "module": "CommonJS"
+    "module": "CommonJS",
+    "noUncheckedIndexedAccess": true
   },
   "include": ["index.ts"],
   "exclude": ["**/*.spec.ts"]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,8 +9,7 @@
     "noImplicitAny": false,
     "strict": true,
     "allowJs": false,
-    "noEmit": true,
-    "noUncheckedIndexedAccess": true
+    "noEmit": true
   },
   "files": ["./types.d.ts"],
   "include": [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,8 @@
     "noImplicitAny": false,
     "strict": true,
     "allowJs": false,
-    "noEmit": true
+    "noEmit": true,
+    "noUncheckedIndexedAccess": true
   },
   "files": ["./types.d.ts"],
   "include": [


### PR DESCRIPTION
## Why
<!-- Why have you created this PR? - Is it a new feature, or a bug fix? Or something else? -->
<!-- Reference any relevant Jira tickets so your reviewer can find more context if needed. -->
<!-- Fixing a GitHub issue? Add "Fixes [issue URL]". -->
We had an incident on unified-home recently and that was caused by a piece of code accessing item in an array via index like this `items[0]` but not checking whether that can be undefined before using it. Because of that, we are enabling [noUncheckedIndexedAccess](https://www.typescriptlang.org/tsconfig#noUncheckedIndexedAccess) for TS so that it warns us of this potential issue ([trello ticket](https://trello.com/c/lj3dwRpy/341-add-nouncheckedindexedaccess-true-to-tsconfigts-and-fix-ts-errors)). While we enabling that config, we got this error from `design-tokens` so we created this PR to address it. This TS config is helpful and recommended to avoid potential issue
![image](https://user-images.githubusercontent.com/23372284/167988899-a6bc8f13-39da-4e97-9046-ae92ac940198.png)

Another way to fix it could be to exclude `src` from the published package but would still recommend to switch this option to true



## What
<!-- What do your changes do? How do they change/fix the current behavior? -->
<!-- Add screenshots, GIFs or videos to illustrate the changes.  -->
The changes that I made basically handle scenario where `leafKey` can be `undefined` because of the below so I added a check so that if it is `undefined` just throw an error. From my understanding, this piece of code is being ran at build time before publish so we will get quick feedback.
```
const leafKey = leafPath[leafPath.length - 1]
```

I tried to turn on this TS option for all packages but there are a few other errors there