### PR TITLE
feat: Add validation to DatePicker

### DIFF
--- a/packages/date-picker/docs/DatePicker.stories.tsx
+++ b/packages/date-picker/docs/DatePicker.stories.tsx
@@ -2,8 +2,9 @@ import React, { useState } from "react"
 import { Story } from "@storybook/react"
 import { usePopper } from "react-popper"
 import { Paragraph } from "@kaizen/typography"
+import { Button } from "@kaizen/button"
 import { CATEGORIES, SUB_CATEGORIES } from "../../../storybook/constants"
-import { DatePicker } from "../src/DatePicker"
+import { DatePicker, DatePickerValidation } from "../src/DatePicker"
 import { Calendar } from "../src/DatePicker/components/Calendar"
 import { StoryWrapper } from "../../../storybook/components/StoryWrapper"
 
@@ -33,6 +34,69 @@ export const DefaultStory = props => {
   )
 }
 DefaultStory.storyName = "Date Picker"
+
+export const ValidationStory = props => {
+  const [selectedDate, setValueDate] = useState<Date | undefined>()
+  const [status, setStatus] = useState<"default" | "error">("default")
+  const [validationMessage, setValidationMessage] = useState<
+    string | undefined
+  >(undefined)
+
+  const [validation, setValidation] = useState<DatePickerValidation>({
+    status: "default",
+    validationMessage: undefined,
+  })
+
+  const submitRequest = () => {
+    console.log("VALUE ON SUBMIT ", selectedDate)
+
+    if (selectedDate === undefined) {
+      setValidation({
+        status: "error",
+        validationMessage: "Please enter a valid date.",
+      })
+      return
+    } else if (validation.status === "error") {
+      alert("There is an error within form")
+    }
+  }
+
+  return (
+    <>
+      <DatePicker
+        id="datepicker-default"
+        labelText="Label"
+        selectedDay={selectedDate}
+        onDayChange={day => {
+          setValueDate(day)
+          if (day?.getFullYear() !== new Date().getFullYear()) {
+            setValidation({
+              status: "error",
+              validationMessage: "Date is not this year.",
+            })
+          } else {
+            setValidation({
+              status: "default",
+              validationMessage: undefined,
+            })
+          }
+          console.log("VALUE ", selectedDate)
+        }}
+        onValidation={setValidation}
+        status={validation.status}
+        validationMessage={validation.validationMessage}
+        disabledBefore={new Date()}
+        disabledValidationMessage="Custom Disabled Date message."
+        invalidDateValidationMessage="Custom invalid Date message."
+        {...props}
+      />
+      <Button onClick={submitRequest} label="Submit" />
+    </>
+  )
+}
+
+ValidationStory.storyName = "Validation Story"
+
 DefaultStory.parameters = {
   docs: { source: { type: "code" } },
 }
@@ -96,6 +160,7 @@ const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({
             labelText="Label"
             selectedDay={selectedDate}
             onDayChange={setValueDate}
+            onValidation={e => e}
             isReversed={isReversed}
           />
           <DatePicker
@@ -103,6 +168,7 @@ const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({
             labelText="Label"
             selectedDay={new Date(2022, 1, 5)}
             onDayChange={e => e}
+            onValidation={e => e}
             isReversed={isReversed}
           />
           <DatePicker
@@ -110,6 +176,7 @@ const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({
             labelText="Label"
             selectedDay={undefined}
             onDayChange={e => e}
+            onValidation={e => e}
             isReversed={isReversed}
             description={
               <>
@@ -127,6 +194,7 @@ const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({
             labelText="Label"
             selectedDay={undefined}
             onDayChange={e => e}
+            onValidation={e => e}
             isReversed={isReversed}
             isDisabled
           />
@@ -135,6 +203,7 @@ const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({
             labelText="Label"
             selectedDay={new Date("potato")}
             onDayChange={e => e}
+            onValidation={e => e}
             isReversed={isReversed}
           />
         </StoryWrapper.Row>

--- a/packages/date-picker/docs/DatePicker.stories.tsx
+++ b/packages/date-picker/docs/DatePicker.stories.tsx
@@ -78,10 +78,11 @@ export const ValidationStory = props => {
 
   const submitRequest = () => {
     // An example of a form submit request
-    if (selectedDate === undefined) {
-      setStatus("error")
+    if (status === "error" || status === "caution") {
       setValidationMessage("There is an error.")
-      return
+      alert("Error")
+    } else {
+      alert("Success")
     }
   }
 
@@ -96,7 +97,7 @@ export const ValidationStory = props => {
   return (
     <>
       <p>
-        We have added additional validation to this DatePicker to provide some
+        We have added additional validation to this story to provide some
         guidance when dealing with validation other than date isInvalid or
         isDisabled.
       </p>

--- a/packages/date-picker/docs/DatePicker.stories.tsx
+++ b/packages/date-picker/docs/DatePicker.stories.tsx
@@ -52,7 +52,9 @@ export const DefaultStory = props => {
 DefaultStory.storyName = "Date Picker"
 
 export const ValidationStory = props => {
-  const [selectedDate, setValueDate] = useState<Date | undefined>()
+  const [selectedDate, setValueDate] = useState<Date | undefined>(
+    new Date(2022, 1, 5)
+  )
   const [status, setStatus] = useState<FieldMessageStatus | undefined>()
   const [response, setResponse] = useState<ValidationResponse | undefined>()
   const [validationMessage, setValidationMessage] = useState<

--- a/packages/date-picker/docs/DatePicker.stories.tsx
+++ b/packages/date-picker/docs/DatePicker.stories.tsx
@@ -212,7 +212,7 @@ const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({
             id="datepicker-selected"
             labelText="Label"
             selectedDay={new Date(2022, 1, 5)}
-            onDayChange={e => e}
+            onDayChange={() => undefined}
             onValidate={() => undefined}
             isReversed={isReversed}
             status="default"
@@ -222,7 +222,7 @@ const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({
             id="datepicker-description"
             labelText="Label"
             selectedDay={undefined}
-            onDayChange={e => e}
+            onDayChange={() => undefined}
             onValidate={() => undefined}
             isReversed={isReversed}
             description={
@@ -242,7 +242,7 @@ const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({
             id="datepicker-disabled"
             labelText="Label"
             selectedDay={undefined}
-            onDayChange={e => e}
+            onDayChange={() => undefined}
             onValidate={() => undefined}
             isReversed={isReversed}
             status="default"
@@ -253,7 +253,7 @@ const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({
             id="datepicker-error"
             labelText="Label"
             selectedDay={new Date("potato")}
-            onDayChange={e => e}
+            onDayChange={() => undefined}
             onValidate={() => undefined}
             isReversed={isReversed}
             status="error"

--- a/packages/date-picker/docs/DatePicker.stories.tsx
+++ b/packages/date-picker/docs/DatePicker.stories.tsx
@@ -90,14 +90,6 @@ export const ValidationStory = props => {
     }
   }
 
-  const baseResponse = {
-    inputValue: "",
-    isInvalid: false,
-    isDisabled: false,
-    isEmpty: true,
-    isValidDate: false,
-  }
-
   return (
     <>
       <DatePicker
@@ -141,11 +133,7 @@ export const ValidationStory = props => {
         </p>
         <CodeBlock
           language="json"
-          code={
-            response
-              ? JSON.stringify(response, null, "\t")
-              : JSON.stringify(baseResponse, null, "\t")
-          }
+          code={JSON.stringify(response, null, "\t")}
         />
       </div>
     </>

--- a/packages/date-picker/docs/DatePicker.stories.tsx
+++ b/packages/date-picker/docs/DatePicker.stories.tsx
@@ -31,7 +31,7 @@ export const DefaultStory = props => {
     string | undefined
   >()
 
-  const handleValidation = (validationResponse: ValidationResponse) => {
+  const handleValidation = (validationResponse: ValidationResponse): void => {
     setStatus(validationResponse.status)
     setValidationMessage(validationResponse.validationMessage)
   }
@@ -50,6 +50,9 @@ export const DefaultStory = props => {
   )
 }
 DefaultStory.storyName = "Date Picker"
+DefaultStory.parameters = {
+  docs: { source: { type: "code" } },
+}
 
 export const ValidationStory = props => {
   const [selectedDate, setValueDate] = useState<Date | undefined>(
@@ -61,7 +64,7 @@ export const ValidationStory = props => {
     string | undefined
   >()
 
-  const handleValidation = (validationResponse: ValidationResponse) => {
+  const handleValidation = (validationResponse: ValidationResponse): void => {
     setResponse(validationResponse)
     // An example of additional validation
     if (
@@ -115,25 +118,26 @@ export const ValidationStory = props => {
       </div>
       <div>
         <p>
-          We have added additional validation to this story to provide some
+          This story includes additional custom validation to provide some
           guidance when dealing with validation other than date isInvalid or
           isDisabled.
         </p>
         <ul>
           <li>
-            There will be a caution when the selectedDay is not within this
-            year.
+            There will be a caution when the selectedDay{" "}
+            <strong>is valid</strong> but{" "}
+            <strong>is not within this year</strong>.
           </li>
           <li>
-            There will be an error when the submit button is clicked and there
-            is an error status within the DatePicker.
+            There will be an error when the{" "}
+            <strong>submit button is clicked</strong> and there is a{" "}
+            <strong>current error</strong> within the DatePicker.
           </li>
         </ul>
         <p>
-          The <code>onValidate</code> callback returns a
-          <code>validationResponse</code> object which can be used to provide
-          additional validation as well as update our default validation message
-          if neccessary.
+          The <code>onValidate</code> callback returns a{" "}
+          <code>validationResponse</code> object which provides data such as a
+          default validation message, and can be utilised for custom validation.
         </p>
         <CodeBlock
           language="json"
@@ -211,27 +215,27 @@ const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({
             labelText="Label"
             selectedDay={selectedDate}
             onDayChange={setValueDate}
-            onValidate={e => e}
+            onValidate={() => undefined}
             isReversed={isReversed}
             status="default"
-            validationMessage="This is a validation message"
+            validationMessage={undefined}
           />
           <DatePicker
             id="datepicker-selected"
             labelText="Label"
             selectedDay={new Date(2022, 1, 5)}
             onDayChange={e => e}
-            onValidate={e => e}
+            onValidate={() => undefined}
             isReversed={isReversed}
             status="default"
-            validationMessage="This is a validation message"
+            validationMessage={undefined}
           />
           <DatePicker
             id="datepicker-description"
             labelText="Label"
             selectedDay={undefined}
             onDayChange={e => e}
-            onValidate={e => e}
+            onValidate={() => undefined}
             isReversed={isReversed}
             description={
               <>
@@ -244,17 +248,17 @@ const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({
               </>
             }
             status="default"
-            validationMessage="This is a validation message"
+            validationMessage={undefined}
           />
           <DatePicker
             id="datepicker-disabled"
             labelText="Label"
             selectedDay={undefined}
             onDayChange={e => e}
-            onValidate={e => e}
+            onValidate={() => undefined}
             isReversed={isReversed}
             status="default"
-            validationMessage="This is a validation message"
+            validationMessage={undefined}
             isDisabled
           />
           <DatePicker
@@ -262,7 +266,7 @@ const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({
             labelText="Label"
             selectedDay={new Date("potato")}
             onDayChange={e => e}
-            onValidate={e => e}
+            onValidate={() => undefined}
             isReversed={isReversed}
             status="error"
             validationMessage="Invalid Date."

--- a/packages/date-picker/docs/DatePicker.stories.tsx
+++ b/packages/date-picker/docs/DatePicker.stories.tsx
@@ -3,14 +3,18 @@ import { Story } from "@storybook/react"
 import { usePopper } from "react-popper"
 import { Paragraph } from "@kaizen/typography"
 import { Button } from "@kaizen/button"
+import { FieldMessageStatus } from "@kaizen/draft-form"
+import { CodeBlock } from "@kaizen/design-tokens/docs/DocsComponents"
+import { DateInput } from "../src/DatePicker/components/DateInput"
 import { CATEGORIES, SUB_CATEGORIES } from "../../../storybook/constants"
-import { DatePicker, DatePickerValidation } from "../src/DatePicker"
+import { DatePicker, ValidationResponse } from "../src/DatePicker"
 import { Calendar } from "../src/DatePicker/components/Calendar"
 import { StoryWrapper } from "../../../storybook/components/StoryWrapper"
 
 export default {
   title: `${CATEGORIES.components}/${SUB_CATEGORIES.datePicker}/Date Picker`,
   component: DatePicker,
+  subcomponents: { DateInput, Calendar },
   parameters: {
     docs: {
       description: {
@@ -22,6 +26,15 @@ export default {
 
 export const DefaultStory = props => {
   const [selectedDate, setValueDate] = useState<Date | undefined>()
+  const [status, setStatus] = useState<FieldMessageStatus | undefined>()
+  const [validationMessage, setValidationMessage] = useState<
+    string | undefined
+  >()
+
+  const handleValidation = (validationResponse: ValidationResponse) => {
+    setStatus(validationResponse.status)
+    setValidationMessage(validationResponse.validationMessage)
+  }
 
   return (
     <DatePicker
@@ -29,6 +42,9 @@ export const DefaultStory = props => {
       labelText="Label"
       selectedDay={selectedDate}
       onDayChange={setValueDate}
+      onValidate={handleValidation}
+      status={status}
+      validationMessage={validationMessage}
       {...props}
     />
   )
@@ -37,67 +53,98 @@ DefaultStory.storyName = "Date Picker"
 
 export const ValidationStory = props => {
   const [selectedDate, setValueDate] = useState<Date | undefined>()
-  const [status, setStatus] = useState<"default" | "error">("default")
+  const [status, setStatus] = useState<FieldMessageStatus | undefined>()
+  const [response, setResponse] = useState<ValidationResponse | undefined>()
   const [validationMessage, setValidationMessage] = useState<
     string | undefined
-  >(undefined)
+  >()
 
-  const [validation, setValidation] = useState<DatePickerValidation>({
-    status: "default",
-    validationMessage: undefined,
-  })
+  const handleValidation = (validationResponse: ValidationResponse) => {
+    setResponse(validationResponse)
+    // An example of additional validation
+    if (
+      validationResponse.isValidDate &&
+      validationResponse.date?.getFullYear() !== new Date().getFullYear()
+    ) {
+      setStatus("caution")
+      setValidationMessage("Date is not this year.")
+      return
+    }
+    setStatus(validationResponse.status)
+    setValidationMessage(validationResponse.validationMessage)
+  }
 
   const submitRequest = () => {
-    console.log("VALUE ON SUBMIT ", selectedDate)
-
+    // An example of a form submit request
     if (selectedDate === undefined) {
-      setValidation({
-        status: "error",
-        validationMessage: "Please enter a valid date.",
-      })
+      setStatus("error")
+      setValidationMessage("There is an error.")
       return
-    } else if (validation.status === "error") {
-      alert("There is an error within form")
     }
+  }
+
+  const baseResponse = {
+    inputValue: "",
+    isInvalid: false,
+    isDisabled: false,
+    isEmpty: true,
+    isValidDate: false,
   }
 
   return (
     <>
+      <p>
+        We have added additional validation to this DatePicker to provide some
+        guidance when dealing with validation other than date isInvalid or
+        isDisabled.
+      </p>
+      <ul>
+        <li>
+          There will be a caution when the selectedDay is not within this year.
+        </li>
+        <li>
+          There will be an error when the submit button is clicked and there is
+          an error status within the DatePicker.
+        </li>
+      </ul>
       <DatePicker
         id="datepicker-default"
         labelText="Label"
         selectedDay={selectedDate}
         onDayChange={day => {
           setValueDate(day)
-          if (day?.getFullYear() !== new Date().getFullYear()) {
-            setValidation({
-              status: "error",
-              validationMessage: "Date is not this year.",
-            })
-          } else {
-            setValidation({
-              status: "default",
-              validationMessage: undefined,
-            })
-          }
-          console.log("VALUE ", selectedDate)
         }}
-        onValidation={setValidation}
-        status={validation.status}
-        validationMessage={validation.validationMessage}
+        onValidate={handleValidation}
+        status={status}
+        validationMessage={validationMessage}
         disabledBefore={new Date()}
-        disabledValidationMessage="Custom Disabled Date message."
-        invalidDateValidationMessage="Custom invalid Date message."
         {...props}
       />
-      <Button onClick={submitRequest} label="Submit" />
+      <div style={{ marginTop: "2rem", marginBottom: "2rem" }}>
+        <Button onClick={submitRequest} label="Submit" />
+      </div>
+      <div>
+        <p>
+          The <code>onValidate</code> callback returns a
+          <code>validationResponse</code> object which can be used to provide
+          additional validation as well as update our default validation message
+          if neccessary.
+        </p>
+        <CodeBlock
+          language="json"
+          code={
+            response
+              ? JSON.stringify(response, null, "\t")
+              : JSON.stringify(baseResponse, null, "\t")
+          }
+        />
+      </div>
     </>
   )
 }
+ValidationStory.storyName = "Validation"
 
-ValidationStory.storyName = "Validation Story"
-
-DefaultStory.parameters = {
+ValidationStory.parameters = {
   docs: { source: { type: "code" } },
 }
 
@@ -136,7 +183,6 @@ const CalendarTemplate: Story = props => {
     </div>
   )
 }
-
 const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({
   isReversed,
 }) => {
@@ -160,7 +206,7 @@ const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({
             labelText="Label"
             selectedDay={selectedDate}
             onDayChange={setValueDate}
-            onValidation={e => e}
+            onValidate={e => e}
             isReversed={isReversed}
           />
           <DatePicker
@@ -168,7 +214,7 @@ const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({
             labelText="Label"
             selectedDay={new Date(2022, 1, 5)}
             onDayChange={e => e}
-            onValidation={e => e}
+            onValidate={e => e}
             isReversed={isReversed}
           />
           <DatePicker
@@ -176,7 +222,7 @@ const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({
             labelText="Label"
             selectedDay={undefined}
             onDayChange={e => e}
-            onValidation={e => e}
+            onValidate={e => e}
             isReversed={isReversed}
             description={
               <>
@@ -194,7 +240,7 @@ const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({
             labelText="Label"
             selectedDay={undefined}
             onDayChange={e => e}
-            onValidation={e => e}
+            onValidate={e => e}
             isReversed={isReversed}
             isDisabled
           />
@@ -203,8 +249,10 @@ const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({
             labelText="Label"
             selectedDay={new Date("potato")}
             onDayChange={e => e}
-            onValidation={e => e}
+            onValidate={e => e}
             isReversed={isReversed}
+            status="error"
+            validationMessage="Invalid Date."
           />
         </StoryWrapper.Row>
       </StoryWrapper>

--- a/packages/date-picker/docs/DatePicker.stories.tsx
+++ b/packages/date-picker/docs/DatePicker.stories.tsx
@@ -53,7 +53,7 @@ DefaultStory.storyName = "Date Picker"
 
 export const ValidationStory = props => {
   const [selectedDate, setValueDate] = useState<Date | undefined>(
-    new Date(2022, 1, 5)
+    new Date(2022, 4, 5)
   )
   const [status, setStatus] = useState<FieldMessageStatus | undefined>()
   const [response, setResponse] = useState<ValidationResponse | undefined>()

--- a/packages/date-picker/docs/DatePicker.stories.tsx
+++ b/packages/date-picker/docs/DatePicker.stories.tsx
@@ -213,6 +213,8 @@ const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({
             onDayChange={setValueDate}
             onValidate={e => e}
             isReversed={isReversed}
+            status="default"
+            validationMessage="This is a validation message"
           />
           <DatePicker
             id="datepicker-selected"
@@ -221,6 +223,8 @@ const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({
             onDayChange={e => e}
             onValidate={e => e}
             isReversed={isReversed}
+            status="default"
+            validationMessage="This is a validation message"
           />
           <DatePicker
             id="datepicker-description"
@@ -239,6 +243,8 @@ const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({
                 </Paragraph>
               </>
             }
+            status="default"
+            validationMessage="This is a validation message"
           />
           <DatePicker
             id="datepicker-disabled"
@@ -247,6 +253,8 @@ const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({
             onDayChange={e => e}
             onValidate={e => e}
             isReversed={isReversed}
+            status="default"
+            validationMessage="This is a validation message"
             isDisabled
           />
           <DatePicker

--- a/packages/date-picker/docs/DatePicker.stories.tsx
+++ b/packages/date-picker/docs/DatePicker.stories.tsx
@@ -80,6 +80,7 @@ export const ValidationStory = props => {
     // An example of a form submit request
     if (status === "error" || status === "caution") {
       setValidationMessage("There is an error.")
+      setStatus("error")
       alert("Error")
     } else {
       alert("Success")
@@ -96,20 +97,6 @@ export const ValidationStory = props => {
 
   return (
     <>
-      <p>
-        We have added additional validation to this story to provide some
-        guidance when dealing with validation other than date isInvalid or
-        isDisabled.
-      </p>
-      <ul>
-        <li>
-          There will be a caution when the selectedDay is not within this year.
-        </li>
-        <li>
-          There will be an error when the submit button is clicked and there is
-          an error status within the DatePicker.
-        </li>
-      </ul>
       <DatePicker
         id="datepicker-default"
         labelText="Label"
@@ -127,6 +114,21 @@ export const ValidationStory = props => {
         <Button onClick={submitRequest} label="Submit" />
       </div>
       <div>
+        <p>
+          We have added additional validation to this story to provide some
+          guidance when dealing with validation other than date isInvalid or
+          isDisabled.
+        </p>
+        <ul>
+          <li>
+            There will be a caution when the selectedDay is not within this
+            year.
+          </li>
+          <li>
+            There will be an error when the submit button is clicked and there
+            is an error status within the DatePicker.
+          </li>
+        </ul>
         <p>
           The <code>onValidate</code> callback returns a
           <code>validationResponse</code> object which can be used to provide

--- a/packages/date-picker/docs/DateRangePicker.stories.tsx
+++ b/packages/date-picker/docs/DateRangePicker.stories.tsx
@@ -91,7 +91,7 @@ const CalendarRangeTemplate: Story = props => {
         styles={styles}
         attributes={attributes}
         firstDayOfWeek={0}
-        onDayChange={e => e}
+        onDayChange={() => undefined}
         initialMonth={new Date(2022, 2)}
         range
         selectedRange={selectedDateRange}

--- a/packages/date-picker/index.ts
+++ b/packages/date-picker/index.ts
@@ -1,2 +1,1 @@
-export * from "./src/DatePicker/DatePicker"
-export * from "./src/DatePicker/DateRangePicker"
+export * from "./src/DatePicker"

--- a/packages/date-picker/src/DatePicker/DatePicker.spec.tsx
+++ b/packages/date-picker/src/DatePicker/DatePicker.spec.tsx
@@ -47,7 +47,7 @@ describe("<DatePicker />", () => {
   })
 
   it("should pre-fill the input when an initial date is provided", async () => {
-    render(<DatePickerWrapper selectedDay={new Date(2022, 2, 1)} />)
+    render(<DatePickerWrapper selectedDay={new Date("2022-03-1")} />)
 
     expect(screen.getByDisplayValue("Mar 1, 2022")).toBeInTheDocument()
   })
@@ -57,10 +57,8 @@ describe("<DatePicker />", () => {
 
     const button = screen.getByRole("button")
 
-    // Make sure calendar popup is not in the DOM
     expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
 
-    // Click button and test calendar popup is showing
     await act(async () => button.click())
     expect(screen.getByRole("dialog")).toBeVisible()
   })
@@ -70,10 +68,8 @@ describe("<DatePicker />", () => {
 
     const input = screen.getByRole("combobox")
 
-    // Make sure calendar popup is not in the DOM
     expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
 
-    // Click button and test calendar popup is showing
     await act(async () => {
       input.focus()
       userEvent.keyboard("{arrowdown}")
@@ -82,13 +78,12 @@ describe("<DatePicker />", () => {
   })
 
   it("is able to select date and shows in input", async () => {
-    render(<DatePickerWrapper />)
+    render(<DatePickerWrapper initialMonth={new Date("2022-03-01")} />)
 
     const button = screen.getByRole("button")
 
     await act(async () => button.click())
 
-    // Focus on date and select
     const selectedDate = screen.getByRole("gridcell", {
       name: "Sun Mar 06 2022",
     })
@@ -101,13 +96,12 @@ describe("<DatePicker />", () => {
   })
 
   it("returns focus to the button once date has been selected", async () => {
-    render(<DatePickerWrapper />)
+    render(<DatePickerWrapper initialMonth={new Date("2022-03-01")} />)
 
     const button = screen.getByRole("button")
 
     await act(async () => button.click())
 
-    // Focus on date and select
     const selectedDate = screen.getByRole("gridcell", {
       name: "Sun Mar 06 2022",
     })
@@ -119,62 +113,65 @@ describe("<DatePicker />", () => {
     expect(button).toHaveFocus()
   })
 
-  it("displays the message when status is error", async () => {
-    render(
-      <DatePickerWrapper status="error" validationMessage="Invalid Date." />
-    )
-
-    describe("Validation", () => {
-      expect(screen.getByText("Invalid Date.")).toBeInTheDocument()
+  describe("Validation", () => {
+    describe("Custom Validation", () => {
+      it("displays the message when status is error", async () => {
+        render(
+          <DatePickerWrapper status="error" validationMessage="Invalid Date." />
+        )
+        expect(screen.getByText("Invalid Date.")).toBeInTheDocument()
+      })
     })
 
-    it("displays error message when selected day is invalid", async () => {
-      render(<DatePickerWrapper selectedDay={new Date("potato")} />)
+    describe("Inbuilt Validation", () => {
+      it("displays error message when selected day is invalid", async () => {
+        render(<DatePickerWrapper selectedDay={new Date("potato")} />)
 
-      expect(screen.getByText("Date is invalid")).toBeInTheDocument()
-    })
-
-    it("displays error message when selected day is disabled", async () => {
-      render(
-        <DatePickerWrapper
-          disabledBefore={new Date(2022, 4, 15)}
-          selectedDay={new Date(2022, 4, 5)}
-        />
-      )
-
-      expect(
-        screen.getByText("05/05/2022 is not available, try another date")
-      ).toBeInTheDocument()
-    })
-
-    it("displays error message when input date is invalid", async () => {
-      render(<DatePickerWrapper />)
-
-      const input = screen.getByRole("combobox")
-      userEvent.type(input, "05/05/2022Blah")
-
-      await act(async () => {
-        userEvent.tab()
+        expect(screen.getByText("Date is invalid")).toBeInTheDocument()
       })
 
-      expect(
-        screen.getByText("05/05/2022Blah is an invalid date")
-      ).toBeInTheDocument()
-    })
+      it("displays error message when selected day is disabled", async () => {
+        render(
+          <DatePickerWrapper
+            disabledBefore={new Date("2022-05-15")}
+            selectedDay={new Date("2022-05-05")}
+          />
+        )
 
-    it("displays error message when input date is disabled", async () => {
-      render(<DatePickerWrapper disabledBefore={new Date(2022, 4, 15)} />)
-
-      const input = screen.getByRole("combobox")
-      userEvent.type(input, "05/05/2022")
-
-      await act(async () => {
-        userEvent.tab()
+        expect(
+          screen.getByText("05/05/2022 is not available, try another date")
+        ).toBeInTheDocument()
       })
 
-      expect(
-        screen.getByText("05/05/2022 is not available, try another date")
-      ).toBeInTheDocument()
+      it("displays error message when input date is invalid", async () => {
+        render(<DatePickerWrapper />)
+
+        const input = screen.getByRole("combobox")
+        userEvent.type(input, "05/05/2022Blah")
+
+        await act(async () => {
+          userEvent.tab()
+        })
+
+        expect(
+          screen.getByText("05/05/2022Blah is an invalid date")
+        ).toBeInTheDocument()
+      })
+
+      it("displays error message when input date is disabled", async () => {
+        render(<DatePickerWrapper disabledBefore={new Date("2022-05-15")} />)
+
+        const input = screen.getByRole("combobox")
+        userEvent.type(input, "05/05/2022")
+
+        await act(async () => {
+          userEvent.tab()
+        })
+
+        expect(
+          screen.getByText("05/05/2022 is not available, try another date")
+        ).toBeInTheDocument()
+      })
     })
   })
 })

--- a/packages/date-picker/src/DatePicker/DatePicker.spec.tsx
+++ b/packages/date-picker/src/DatePicker/DatePicker.spec.tsx
@@ -10,6 +10,7 @@ const defaultProps = {
   selectedDay: undefined,
   initialMonth: new Date(2022, 2),
   onDayChange: jest.fn(),
+  onValidation: () => jest.fn(),
 }
 
 describe("<DatePicker />", () => {

--- a/packages/date-picker/src/DatePicker/DatePicker.spec.tsx
+++ b/packages/date-picker/src/DatePicker/DatePicker.spec.tsx
@@ -1,4 +1,4 @@
-import { act, render, screen } from "@testing-library/react"
+import { act, fireEvent, render, screen } from "@testing-library/react"
 import React from "react"
 import userEvent from "@testing-library/user-event"
 import { DatePicker } from "./DatePicker"
@@ -10,7 +10,7 @@ const defaultProps = {
   selectedDay: undefined,
   initialMonth: new Date(2022, 2),
   onDayChange: jest.fn(),
-  onValidation: () => jest.fn(),
+  onValidate: jest.fn(),
 }
 
 describe("<DatePicker />", () => {
@@ -90,5 +90,19 @@ describe("<DatePicker />", () => {
     })
 
     expect(button).toHaveFocus()
+  })
+
+  describe("Validation", () => {
+    it("Error message when status is error", async () => {
+      render(
+        <DatePicker
+          {...defaultProps}
+          status="error"
+          validationMessage="Invalid Date."
+        />
+      )
+
+      expect(screen.getByText("Invalid Date.")).toBeInTheDocument()
+    })
   })
 })

--- a/packages/date-picker/src/DatePicker/DatePicker.spec.tsx
+++ b/packages/date-picker/src/DatePicker/DatePicker.spec.tsx
@@ -93,7 +93,7 @@ describe("<DatePicker />", () => {
   })
 
   describe("Validation", () => {
-    it("Error message when status is error", async () => {
+    it("displays error message when status is error", async () => {
       render(
         <DatePicker
           {...defaultProps}

--- a/packages/date-picker/src/DatePicker/DatePicker.spec.tsx
+++ b/packages/date-picker/src/DatePicker/DatePicker.spec.tsx
@@ -1,27 +1,24 @@
-import { act, fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { act, render, screen } from "@testing-library/react"
 import React, { useState } from "react"
 import { FieldMessageStatus } from "@kaizen/draft-form"
 import userEvent from "@testing-library/user-event"
 import { DatePicker, ValidationResponse } from "./DatePicker"
-import "@testing-library/jest-dom"
 import { DatePickerProps } from "."
 
-const defaultProps = {
-  id: "date-picker",
-  labelText: "Choose date",
-  selectedDay: undefined,
-  initialMonth: new Date(2022, 2),
-  onDayChange: jest.fn(),
-  onValidate: jest.fn(),
-}
-
-const MockDatePicker = ({
-  selectedDay,
+const DatePickerWrapper = ({
+  status: propsStatus,
+  validationMessage: propsValidationMessage,
   ...restProps
 }: Partial<DatePickerProps>) => {
-  const [status, setStatus] = useState<FieldMessageStatus>("default")
-  const [validationMessage, setValidationMessage] = useState<string>()
-  const [selectedDate, setValueDate] = useState<Date | undefined>(selectedDay)
+  const [status, setStatus] = useState<FieldMessageStatus>(
+    propsStatus || "default"
+  )
+  const [validationMessage, setValidationMessage] = useState<React.ReactNode>(
+    propsValidationMessage
+  )
+  const [selectedDate, setValueDate] = useState<Date | undefined>(
+    restProps.selectedDay
+  )
 
   const handleValidation = (validationResponse: ValidationResponse) => {
     validationResponse.status && setStatus(validationResponse.status)
@@ -30,7 +27,8 @@ const MockDatePicker = ({
   }
   return (
     <DatePicker
-      {...defaultProps}
+      id="test__date-picker"
+      labelText="Choose date"
       {...restProps}
       onValidate={handleValidation}
       onDayChange={setValueDate}
@@ -42,23 +40,20 @@ const MockDatePicker = ({
 }
 
 describe("<DatePicker />", () => {
-  it("renders DatePicker with an empty input value", async () => {
-    render(<MockDatePicker {...defaultProps} />)
+  it("should have an empty input value when a date is not provided", async () => {
+    render(<DatePickerWrapper />)
 
     expect(screen.getByRole("combobox")).toHaveValue("")
   })
 
-  it("renders DatePicker and displays inital date within input", async () => {
-    render(
-      <MockDatePicker {...defaultProps} selectedDay={new Date(2022, 2, 1)} />
-    )
+  it("should pre-fill the input when an initial date is provided", async () => {
+    render(<DatePickerWrapper selectedDay={new Date(2022, 2, 1)} />)
 
-    // Make sure date renders in the button
     expect(screen.getByDisplayValue("Mar 1, 2022")).toBeInTheDocument()
   })
 
-  it("renders DatePicker and shows/hides calendar on button press", async () => {
-    render(<MockDatePicker {...defaultProps} />)
+  it("shows/hides calendar on button press", async () => {
+    render(<DatePickerWrapper />)
 
     const button = screen.getByRole("button")
 
@@ -70,8 +65,8 @@ describe("<DatePicker />", () => {
     expect(screen.getByRole("dialog")).toBeVisible()
   })
 
-  it("renders DatePicker and shows/hides calendar on arrow down keydown", async () => {
-    render(<MockDatePicker {...defaultProps} />)
+  it("shows/hides calendar on arrow down keydown", async () => {
+    render(<DatePickerWrapper />)
 
     const input = screen.getByRole("combobox")
 
@@ -87,7 +82,7 @@ describe("<DatePicker />", () => {
   })
 
   it("is able to select date and shows in input", async () => {
-    render(<MockDatePicker {...defaultProps} />)
+    render(<DatePickerWrapper />)
 
     const button = screen.getByRole("button")
 
@@ -106,7 +101,7 @@ describe("<DatePicker />", () => {
   })
 
   it("returns focus to the button once date has been selected", async () => {
-    render(<MockDatePicker {...defaultProps} />)
+    render(<DatePickerWrapper />)
 
     const button = screen.getByRole("button")
 
@@ -124,29 +119,25 @@ describe("<DatePicker />", () => {
     expect(button).toHaveFocus()
   })
 
-  describe("Validation", () => {
-    it("displays error message when status is error", async () => {
-      render(
-        <DatePicker
-          {...defaultProps}
-          status="error"
-          validationMessage="Invalid Date."
-        />
-      )
+  it("displays the message when status is error", async () => {
+    render(
+      <DatePickerWrapper status="error" validationMessage="Invalid Date." />
+    )
 
+    describe("Validation", () => {
       expect(screen.getByText("Invalid Date.")).toBeInTheDocument()
     })
 
     it("displays error message when selected day is invalid", async () => {
-      render(<MockDatePicker selectedDay={new Date("potato")} />)
+      render(<DatePickerWrapper selectedDay={new Date("potato")} />)
 
       expect(screen.getByText("Date is invalid")).toBeInTheDocument()
     })
 
     it("displays error message when selected day is disabled", async () => {
       render(
-        <MockDatePicker
-          disabledBefore={new Date()}
+        <DatePickerWrapper
+          disabledBefore={new Date(2022, 4, 15)}
           selectedDay={new Date(2022, 4, 5)}
         />
       )
@@ -157,7 +148,7 @@ describe("<DatePicker />", () => {
     })
 
     it("displays error message when input date is invalid", async () => {
-      render(<MockDatePicker />)
+      render(<DatePickerWrapper />)
 
       const input = screen.getByRole("combobox")
       userEvent.type(input, "05/05/2022Blah")
@@ -172,7 +163,7 @@ describe("<DatePicker />", () => {
     })
 
     it("displays error message when input date is disabled", async () => {
-      render(<MockDatePicker disabledBefore={new Date()} />)
+      render(<DatePickerWrapper disabledBefore={new Date(2022, 4, 15)} />)
 
       const input = screen.getByRole("combobox")
       userEvent.type(input, "05/05/2022")

--- a/packages/date-picker/src/DatePicker/DatePicker.spec.tsx
+++ b/packages/date-picker/src/DatePicker/DatePicker.spec.tsx
@@ -13,21 +13,22 @@ const defaultProps = {
   initialMonth: new Date(2022, 2),
   onDayChange: jest.fn(),
   onValidate: jest.fn(),
+  status: "default",
+  validationMessage: "This is a validation message",
 }
 
 const MockDatePicker = ({
   selectedDay,
   ...restProps
 }: Partial<DatePickerProps>) => {
-  const [status, setStatus] = useState<FieldMessageStatus | undefined>()
-  const [validationMessage, setValidationMessage] = useState<
-    string | undefined
-  >()
+  const [status, setStatus] = useState<FieldMessageStatus>("default")
+  const [validationMessage, setValidationMessage] = useState<string>()
   const [selectedDate, setValueDate] = useState<Date | undefined>(selectedDay)
 
   const handleValidation = (validationResponse: ValidationResponse) => {
-    setStatus(validationResponse.status)
-    setValidationMessage(validationResponse.validationMessage)
+    validationResponse.status && setStatus(validationResponse.status)
+    validationResponse.validationMessage &&
+      setValidationMessage(validationResponse.validationMessage)
   }
   return (
     <DatePicker

--- a/packages/date-picker/src/DatePicker/DatePicker.spec.tsx
+++ b/packages/date-picker/src/DatePicker/DatePicker.spec.tsx
@@ -13,8 +13,6 @@ const defaultProps = {
   initialMonth: new Date(2022, 2),
   onDayChange: jest.fn(),
   onValidate: jest.fn(),
-  status: "default",
-  validationMessage: "This is a validation message",
 }
 
 const MockDatePicker = ({

--- a/packages/date-picker/src/DatePicker/DatePicker.tsx
+++ b/packages/date-picker/src/DatePicker/DatePicker.tsx
@@ -206,8 +206,7 @@ export const DatePicker: React.VFC<DatePickerProps> = ({
       onValidate({
         ...baseResponse,
         status: "error",
-        /** @TODO Ask Jason for validation messages*/
-        validationMessage: "Date isn’t valid",
+        validationMessage: "Date not valid, try again",
         isInvalid: true,
       })
       return onDayChange(undefined)
@@ -217,7 +216,6 @@ export const DatePicker: React.VFC<DatePickerProps> = ({
       onValidate({
         ...baseResponse,
         status: "error",
-        /** @TODO Ask Jason for validation messages*/
         validationMessage: "Date not available, choose another",
         isDisabled: true,
       })

--- a/packages/date-picker/src/DatePicker/DatePicker.tsx
+++ b/packages/date-picker/src/DatePicker/DatePicker.tsx
@@ -100,11 +100,11 @@ export interface DatePickerProps
   /**
    * Updates the styling of the validation FieldMessage.
    */
-  status?: FieldMessageStatus
+  status: FieldMessageStatus
   /**
    * A descriptive message for the 'status' states.
    */
-  validationMessage?: string | React.ReactNode
+  validationMessage: string | React.ReactNode
 }
 
 export type ValidationResponse = {

--- a/packages/date-picker/src/DatePicker/DatePicker.tsx
+++ b/packages/date-picker/src/DatePicker/DatePicker.tsx
@@ -206,7 +206,7 @@ export const DatePicker: React.VFC<DatePickerProps> = ({
       onValidate({
         ...baseResponse,
         status: "error",
-        validationMessage: `${inputValue} is an invalid date.`,
+        validationMessage: `${inputValue} is an invalid date`,
         isInvalid: true,
       })
       return onDayChange(undefined)
@@ -218,7 +218,7 @@ export const DatePicker: React.VFC<DatePickerProps> = ({
         status: "error",
         validationMessage: `${
           inputValue ? inputValue : "Date"
-        } not available, choose another.`,
+        } is not available, try another date`,
         isDisabled: true,
       })
       return onDayChange(undefined)

--- a/packages/date-picker/src/DatePicker/DatePicker.tsx
+++ b/packages/date-picker/src/DatePicker/DatePicker.tsx
@@ -206,7 +206,7 @@ export const DatePicker: React.VFC<DatePickerProps> = ({
       onValidate({
         ...baseResponse,
         status: "error",
-        validationMessage: "Date not valid, try again",
+        validationMessage: `${inputValue} is an invalid date.`,
         isInvalid: true,
       })
       return onDayChange(undefined)
@@ -216,7 +216,9 @@ export const DatePicker: React.VFC<DatePickerProps> = ({
       onValidate({
         ...baseResponse,
         status: "error",
-        validationMessage: "Date not available, choose another",
+        validationMessage: `${
+          inputValue ? inputValue : "Date"
+        } not available, choose another.`,
         isDisabled: true,
       })
       return onDayChange(undefined)

--- a/packages/date-picker/src/DatePicker/DatePicker.tsx
+++ b/packages/date-picker/src/DatePicker/DatePicker.tsx
@@ -35,7 +35,6 @@ export interface DatePickerProps
   /**
    * Accepts a DayOfWeek value to start the week on that day. By default,
    * it's set to Monday.
-   *  @default 1
    */
   firstDayOfWeek?: DayOfWeek
 
@@ -93,18 +92,16 @@ export interface DatePickerProps
   disabledDaysOfWeek?: DayOfWeek[]
   /**
    * Callback when a date is attempted to be selected.
-   * ValidationResponse object will be returned.
-   * @returns {ValidationResponse}
    */
   onValidate: (validationResponse: ValidationResponse) => void
   /**
    * Updates the styling of the validation FieldMessage.
    */
-  status: FieldMessageStatus
+  status: FieldMessageStatus | undefined
   /**
    * A descriptive message for the 'status' states.
    */
-  validationMessage: string | React.ReactNode
+  validationMessage: string | React.ReactNode | undefined
 }
 
 export type ValidationResponse = {
@@ -240,9 +237,7 @@ export const DatePicker: React.VFC<DatePickerProps> = ({
   const handleInputChange = (
     date: Date | undefined,
     inputValue: string
-  ): void => {
-    handleDayChange(date, inputValue)
-  }
+  ): void => handleDayChange(date, inputValue)
 
   const handleOpenClose = (): void => setIsOpen(!isOpen)
 
@@ -345,3 +340,5 @@ export const DatePicker: React.VFC<DatePickerProps> = ({
     </div>
   )
 }
+
+DatePicker.displayName = "DatePicker"

--- a/packages/date-picker/src/DatePicker/DatePicker.tsx
+++ b/packages/date-picker/src/DatePicker/DatePicker.tsx
@@ -269,7 +269,7 @@ export const DatePicker: React.VFC<DatePickerProps> = ({
 
   useEffect(() => {
     if (selectedDay && isInvalidDate(selectedDay)) {
-      return onValidate({
+      onValidate({
         date: undefined,
         inputValue: "Invalid Date",
         status: "error",
@@ -282,7 +282,7 @@ export const DatePicker: React.VFC<DatePickerProps> = ({
     }
     if (selectedDay && isDisabledDate(selectedDay, disabledDays)) {
       const inputValue = format(selectedDay, DateFormat.Numeral)
-      return onValidate({
+      onValidate({
         date: undefined,
         inputValue,
         status: "error",

--- a/packages/date-picker/src/DatePicker/DatePicker.tsx
+++ b/packages/date-picker/src/DatePicker/DatePicker.tsx
@@ -279,6 +279,7 @@ export const DatePicker: React.VFC<DatePickerProps> = ({
         isEmpty: false,
         isValidDate: false,
       })
+      return
     }
     if (selectedDay && isDisabledDate(selectedDay, disabledDays)) {
       const inputValue = format(selectedDay, DateFormat.Numeral)
@@ -292,6 +293,7 @@ export const DatePicker: React.VFC<DatePickerProps> = ({
         isEmpty: false,
         isValidDate: false,
       })
+      return
     }
   }, [])
 

--- a/packages/date-picker/src/DatePicker/DateRangePicker.spec.tsx
+++ b/packages/date-picker/src/DatePicker/DateRangePicker.spec.tsx
@@ -7,7 +7,7 @@ import "@testing-library/jest-dom"
 const defaultProps = {
   id: "date-picker-range",
   labelText: "Choose date",
-  initialMonth: new Date(2022, 2),
+  initialMonth: new Date("2022-03-01"),
   onChange: () => jest.fn(),
 }
 

--- a/packages/date-picker/src/DatePicker/components/Calendar/Calendar.spec.tsx
+++ b/packages/date-picker/src/DatePicker/components/Calendar/Calendar.spec.tsx
@@ -5,8 +5,8 @@ import "@testing-library/jest-dom"
 
 const defaultProps: CalendarProps = {
   id: "calendar-dialog",
-  value: new Date(2022, 2, 1),
-  initialMonth: new Date(2022, 2),
+  value: new Date("2022-03-01"),
+  initialMonth: new Date("2022-03-01"),
   onDayChange: jest.fn(),
   firstDayOfWeek: 1,
   setPopperElement: jest.fn(),

--- a/packages/date-picker/src/DatePicker/components/DateInput/DateInput.spec.tsx
+++ b/packages/date-picker/src/DatePicker/components/DateInput/DateInput.spec.tsx
@@ -17,6 +17,7 @@ const defaultProps = {
   onBlur: () => jest.fn(),
   calendarId: "calendar-dialog",
   valueDate: undefined,
+  onValidation: () => jest.fn(),
 }
 
 describe("<DateInput />", () => {

--- a/packages/date-picker/src/DatePicker/components/DateInput/DateInput.spec.tsx
+++ b/packages/date-picker/src/DatePicker/components/DateInput/DateInput.spec.tsx
@@ -17,7 +17,7 @@ const defaultProps = {
   onBlur: () => jest.fn(),
   calendarId: "calendar-dialog",
   valueDate: undefined,
-  onValidation: () => jest.fn(),
+  onValidation: jest.fn(),
 }
 
 describe("<DateInput />", () => {

--- a/packages/date-picker/src/DatePicker/components/DateInput/DateInput.spec.tsx
+++ b/packages/date-picker/src/DatePicker/components/DateInput/DateInput.spec.tsx
@@ -34,7 +34,7 @@ describe("<DateInput />", () => {
   })
 
   it("formats values when focus is on the input", async () => {
-    render(<DateInput {...defaultProps} valueDate={new Date(2022, 2, 1)} />)
+    render(<DateInput {...defaultProps} valueDate={new Date("2022-03-01")} />)
 
     expect(screen.getByDisplayValue("Mar 1, 2022")).toBeInTheDocument()
 
@@ -47,7 +47,7 @@ describe("<DateInput />", () => {
   })
 
   it("formats values when the input loses focus - onBlur", async () => {
-    render(<DateInput {...defaultProps} valueDate={new Date(2022, 2, 1)} />)
+    render(<DateInput {...defaultProps} valueDate={new Date("2022-03-01")} />)
 
     expect(screen.getByDisplayValue("Mar 1, 2022")).toBeInTheDocument()
 
@@ -67,7 +67,7 @@ describe("<DateInput />", () => {
   })
 
   it("updates calendar button aria-label with selected day", async () => {
-    render(<DateInput {...defaultProps} valueDate={new Date(2022, 2, 1)} />)
+    render(<DateInput {...defaultProps} valueDate={new Date("2022-03-01")} />)
 
     expect(
       screen.getByLabelText("Change date, Mar 1, 2022")

--- a/packages/date-picker/src/DatePicker/components/DateInput/DateInput.spec.tsx
+++ b/packages/date-picker/src/DatePicker/components/DateInput/DateInput.spec.tsx
@@ -17,7 +17,6 @@ const defaultProps = {
   onBlur: () => jest.fn(),
   calendarId: "calendar-dialog",
   valueDate: undefined,
-  onValidation: jest.fn(),
 }
 
 describe("<DateInput />", () => {

--- a/packages/date-picker/src/DatePicker/components/DateInput/DateInput.tsx
+++ b/packages/date-picker/src/DatePicker/components/DateInput/DateInput.tsx
@@ -100,6 +100,23 @@ export const DateInput: React.VFC<DateInputProps> = ({
   const [valueString, setValueString] = useState<string>("")
 
   useEffect(() => {
+    if (
+      (valueDate && isInvalidDate(valueDate)) ||
+      (valueDate && isDisabledDate(valueDate, disabledDays))
+    ) {
+      let invalidDateString: string
+      try {
+        invalidDateString = format(valueDate, DateFormat.Text)
+        setValueString(invalidDateString)
+        onBlur(valueDate, invalidDateString)
+      } catch (error) {
+        setValueString("")
+        onBlur(valueDate, "Date")
+      }
+    }
+  }, [])
+
+  useEffect(() => {
     valueDate && formatDateAsText(valueDate, disabledDays, setValueString)
   }, [valueDate])
 
@@ -206,5 +223,3 @@ export const DateInput: React.VFC<DateInputProps> = ({
     </FieldGroup>
   )
 }
-
-DateInput.displayName = "DateInput"

--- a/packages/date-picker/src/DatePicker/components/DateInput/DateInput.tsx
+++ b/packages/date-picker/src/DatePicker/components/DateInput/DateInput.tsx
@@ -135,6 +135,8 @@ export const DateInput: React.VFC<DateInputProps> = ({
     }
   }
 
+  const shouldShowValidationMessage = !disabled && validationMessage
+
   return (
     <FieldGroup inline={true}>
       <Label
@@ -182,19 +184,12 @@ export const DateInput: React.VFC<DateInputProps> = ({
         onFocus={handleFocus}
         {...inputProps}
       />
-      {status && (
-        <div
-          className={classnames(styles.message, {
-            [styles.disabled]: disabled,
-          })}
-        >
-          <FieldMessage
-            id={`${id}-field-message`}
-            message={validationMessage}
-            status={status}
-            reversed={isReversed}
-          />
-        </div>
+      {shouldShowValidationMessage && (
+        <FieldMessage
+          message={validationMessage}
+          status={status}
+          reversed={isReversed}
+        />
       )}
       <div
         className={classnames(styles.message, {

--- a/packages/date-picker/src/DatePicker/components/DateInput/DateInput.tsx
+++ b/packages/date-picker/src/DatePicker/components/DateInput/DateInput.tsx
@@ -20,6 +20,7 @@ type OmittedInputProps =
   | "startIconAdornment"
   | "endIconAdornment"
   | "inputType"
+  | "status"
   | "inputValue"
   | "reversed"
   | "onBlur"
@@ -60,7 +61,7 @@ export interface DateInputProps extends Omit<InputProps, OmittedInputProps> {
    */
   validationMessage?: string | React.ReactNode
   /**
-   * Updates the styling of the validation FieldMessage.
+   * Updates the styling of the validation FieldMessage
    */
   status?: FieldMessageStatus
 }
@@ -68,15 +69,15 @@ export interface DateInputProps extends Omit<InputProps, OmittedInputProps> {
 const formatDateAsText = (
   date: Date,
   disabledDays: Modifier | Modifier[],
-  onValidDate: (newFormattedDate: string) => void
+  onFormat: (newFormattedDate: string) => void
 ): void => {
   if (isDisabledDate(date, disabledDays)) {
-    return onValidDate(format(date, DateFormat.Numeral))
+    return onFormat(format(date, DateFormat.Numeral))
   }
   if (isInvalidDate(date)) {
-    return onValidDate("Invalid Date")
+    return onFormat("Invalid Date")
   }
-  onValidDate(format(date, DateFormat.Text))
+  onFormat(format(date, DateFormat.Text))
 }
 
 export const DateInput: React.VFC<DateInputProps> = ({
@@ -189,7 +190,6 @@ export const DateInput: React.VFC<DateInputProps> = ({
         >
           <FieldMessage
             id={`${id}-field-message`}
-            automationId={`${id}-field-validation-message`}
             message={validationMessage}
             status={status}
             reversed={isReversed}

--- a/packages/date-picker/src/DatePicker/components/DateInput/DateInput.tsx
+++ b/packages/date-picker/src/DatePicker/components/DateInput/DateInput.tsx
@@ -11,7 +11,7 @@ import {
 
 import { format, parse } from "date-fns"
 import { Modifier } from "react-day-picker"
-import { DateFormat } from "../../DatePicker"
+import { DateFormat, DatePickerValidation } from "../../DatePicker"
 import { isInvalidDate } from "../../../utils/isInvalidDate"
 import { isDisabledDate } from "../../../utils/isDisabledDate"
 import styles from "./DateInput.scss"
@@ -41,6 +41,12 @@ export interface DateInputProps extends Omit<InputProps, OmittedInputProps> {
   valueDate: Date | undefined
   onBlur: (date: Date | undefined) => void
   disabledDays?: Modifier | Modifier[]
+  /**
+   * A descriptive message for `error` states
+   */
+  validationMessage?: string | React.ReactNode
+  status?: "default" | "error"
+  onValidation: (validationObj: DatePickerValidation) => void
 }
 
 const formatDateAsText = (
@@ -62,11 +68,14 @@ export const DateInput: React.VFC<DateInputProps> = ({
   isReversed = false,
   icon,
   onButtonClick,
+  onValidation,
   calendarId,
   isOpen,
   valueDate,
   onBlur,
   disabledDays,
+  validationMessage,
+  status,
   ...inputProps
 }) => {
   const [valueString, setValueString] = useState<string>("")
@@ -150,7 +159,21 @@ export const DateInput: React.VFC<DateInputProps> = ({
         onFocus={handleFocus}
         {...inputProps}
       />
-
+      {status !== "default" && (
+        <div
+          className={classnames(styles.message, {
+            [styles.disabled]: disabled,
+          })}
+        >
+          <FieldMessage
+            id={`${id}-field-message`}
+            automationId={`${id}-field-validation-message`}
+            message={validationMessage}
+            status={status}
+            reversed={isReversed}
+          />
+        </div>
+      )}
       <div
         className={classnames(styles.message, {
           [styles.disabled]: disabled,

--- a/packages/date-picker/src/DatePicker/enums.ts
+++ b/packages/date-picker/src/DatePicker/enums.ts
@@ -1,0 +1,4 @@
+export enum DateFormat {
+  Numeral = "P", // eg. 01/15/2022
+  Text = "PP", // eg. Jan 15, 2022
+}

--- a/packages/date-picker/src/DatePicker/index.ts
+++ b/packages/date-picker/src/DatePicker/index.ts
@@ -1,2 +1,3 @@
 export * from "./DatePicker"
+export * from "./enums"
 export * from "./DateRangePicker"

--- a/packages/date-picker/src/utils/isInvalidDate.spec.ts
+++ b/packages/date-picker/src/utils/isInvalidDate.spec.ts
@@ -1,5 +1,5 @@
 import { parse } from "date-fns"
-import { DateFormat } from "../DatePicker/DatePicker"
+import { DateFormat } from "../DatePicker/components/DateInput"
 import { isInvalidDate } from "./isInvalidDate"
 
 describe("isInvalidDate", () => {

--- a/packages/date-picker/src/utils/isInvalidDate.spec.ts
+++ b/packages/date-picker/src/utils/isInvalidDate.spec.ts
@@ -1,5 +1,5 @@
 import { parse } from "date-fns"
-import { DateFormat } from "../DatePicker/components/DateInput"
+import { DateFormat } from "../DatePicker/enums"
 import { isInvalidDate } from "./isInvalidDate"
 
 describe("isInvalidDate", () => {


### PR DESCRIPTION
## Why
<!-- Why have you created this PR? - Is it a new feature, or a bug fix? Or something else? -->
<!-- Reference any relevant Jira tickets so your reviewer can find more context if needed. -->
<!-- Fixing a GitHub issue? Add "Fixes [issue URL]". -->

- Handle validation for whether the date is valid and not disabled. 
- Still allow the consumer to override the `status` and the `validationMessage`.

## What
<!-- What do your changes do? How do they change/fix the current behavior? -->
<!-- Add screenshots, GIFs or videos to illustrate the changes.  -->

- Add `onValidate` callback function as a prop of DatePicker. 
- `onValidate` provides an `validationResponse` object back to the consumer.
- Update stories to include an error state example on the sticker sheet
- Add a Validation story that provides an example of how to add additional validation on top the `isValid` and `isDisabled`.
- Add extra doc comments to props.
- Remove deprecated Input Props

**An Example of Validation with the validationResponse printed out**

<img width="1396" alt="image" src="https://user-images.githubusercontent.com/48232362/168211838-a0e0cca4-afba-4a07-b21a-e005393f3179.png">
