### PR TITLE
fix: Kds 267 checkbox adds a div into span when clicked

### DIFF
--- a/draft-packages/form/KaizenDraft/Form/Primitives/Checkbox/Checkbox.tsx
+++ b/draft-packages/form/KaizenDraft/Form/Primitives/Checkbox/Checkbox.tsx
@@ -27,28 +27,17 @@ const renderCheckOrMixedIcon = (
   status: CheckedStatus,
   reversed: boolean
 ): React.ReactNode => {
-  if (status === "on") {
-    return (
-      <span
-        className={classnames(styles.icon, {
-          [styles.reversed]: reversed,
-        })}
-      >
-        <Icon icon={checkIcon} role="presentation" inheritSize />
-      </span>
-    )
-  } else if (status === "mixed") {
-    return (
-      <span
-        className={classnames(styles.icon, {
-          [styles.reversed]: reversed,
-        })}
-      >
-        <Icon icon={minusIcon} role="presentation" inheritSize />
-      </span>
-    )
-  }
-  return
+  if (status === "off") return
+  const icon = status === "on" ? checkIcon : minusIcon
+  return (
+    <span
+      className={classnames(styles.icon, {
+        [styles.reversed]: reversed,
+      })}
+    >
+      <Icon icon={icon} role="presentation" inheritSize />
+    </span>
+  )
 }
 
 const getCheckedFromStatus = (checkedStatus: CheckedStatus): boolean =>

--- a/draft-packages/form/KaizenDraft/Form/Primitives/Checkbox/Checkbox.tsx
+++ b/draft-packages/form/KaizenDraft/Form/Primitives/Checkbox/Checkbox.tsx
@@ -29,23 +29,23 @@ const renderCheckOrMixedIcon = (
 ): React.ReactNode => {
   if (status === "on") {
     return (
-      <div
+      <span
         className={classnames(styles.icon, {
           [styles.reversed]: reversed,
         })}
       >
         <Icon icon={checkIcon} role="presentation" inheritSize />
-      </div>
+      </span>
     )
   } else if (status === "mixed") {
     return (
-      <div
+      <span
         className={classnames(styles.icon, {
           [styles.reversed]: reversed,
         })}
       >
         <Icon icon={minusIcon} role="presentation" inheritSize />
-      </div>
+      </span>
     )
   }
   return


### PR DESCRIPTION
## Why
We can't have a div inside a span, for accessibility reasons

## What
- Change inner div to span
- Refactor a render method for less code-duplication