### PR TITLE
refactor: fix dart-sass division errors

### DIFF
--- a/draft-packages/form/KaizenDraft/Form/CheckboxGroup/styles.scss
+++ b/draft-packages/form/KaizenDraft/Form/CheckboxGroup/styles.scss
@@ -2,12 +2,12 @@
 @import "~@kaizen/deprecated-component-library-helpers/styles/type";
 
 .checkboxGroupLabel {
-  margin-bottom: $ca-grid / 2;
+  margin-bottom: calc($ca-grid / 2);
 }
 .checkboxGroupContainer {
   display: flex;
   flex-direction: column;
-  margin-bottom: $ca-grid / 2;
+  margin-bottom: calc($ca-grid / 2);
   &.noBottomMargin {
     margin-bottom: 0;
   }

--- a/draft-packages/form/KaizenDraft/Form/Primitives/Input/styles.scss
+++ b/draft-packages/form/KaizenDraft/Form/Primitives/Input/styles.scss
@@ -12,13 +12,13 @@
 
 // Vars
 $input-height: 48px;
-$input-base-padding-horizontal: $ca-grid / 2;
+$input-base-padding-horizontal: calc($ca-grid / 2);
 $input-icon-size: 1.25rem; // 20px
 $input-placeholder-opacity: 0.5;
 $input-disabled-background: $color-gray-300;
 $input-disabled-opacity: 0.3;
 $input-disabled-border-alpha: 50%;
-$input-with-icon-padding: $input-icon-size + $ca-grid * 0.75;
+$input-with-icon-padding: calc($input-icon-size + calc($ca-grid * 0.75));
 
 // Helpers
 
@@ -104,7 +104,7 @@ $input-with-icon-padding: $input-icon-size + $ca-grid * 0.75;
 .withStartIconAdornment {
   .startIconAdornment {
     @include vertically-center-icon;
-    @include ca-position($start: $ca-grid / 2);
+    @include ca-position($start: calc($ca-grid / 2));
   }
 
   &.withDisabled {
@@ -124,7 +124,7 @@ $input-with-icon-padding: $input-icon-size + $ca-grid * 0.75;
 .withEndIconAdornment {
   .endIconAdornment {
     @include vertically-center-icon;
-    @include ca-position($end: $ca-grid / 2);
+    @include ca-position($end: calc($ca-grid / 2));
   }
 
   &.isDisabled {

--- a/draft-packages/form/KaizenDraft/Form/Primitives/InputSearch/styles.scss
+++ b/draft-packages/form/KaizenDraft/Form/Primitives/InputSearch/styles.scss
@@ -14,7 +14,7 @@
 
 // Vars
 $input-height: 48px;
-$input-base-padding-horizontal: $ca-grid / 2;
+$input-base-padding-horizontal: calc($ca-grid / 2);
 $input-icon-size: 1.25rem; // 20px
 $input-placeholder-opacity: 0.5;
 $input-disabled-background: $color-gray-300;
@@ -105,7 +105,7 @@ $border-solid-border-radius-curved: $input-height;
 .withStartIconAdornment {
   .startIconAdornment {
     @include vertically-center-icon;
-    @include ca-position($start: $ca-grid / 2);
+    @include ca-position($start: calc($ca-grid / 2));
   }
 
   &.withDisabled {
@@ -125,7 +125,7 @@ $border-solid-border-radius-curved: $input-height;
 .withEndIconAdornment {
   .endIconAdornment {
     @include vertically-center-icon;
-    @include ca-position($end: $ca-grid / 2);
+    @include ca-position($end: calc($ca-grid / 2));
   }
 
   &.isDisabled {

--- a/draft-packages/form/KaizenDraft/Form/RadioField/styles.scss
+++ b/draft-packages/form/KaizenDraft/Form/RadioField/styles.scss
@@ -8,7 +8,7 @@
   overflow-wrap: break-word;
   word-wrap: break-word;
   word-break: break-word;
-  margin-bottom: $ca-grid / 2;
+  margin-bottom: calc($ca-grid / 2);
 
   label {
     -webkit-tap-highlight-color: transparent;

--- a/draft-packages/form/KaizenDraft/Form/RadioGroup/styles.scss
+++ b/draft-packages/form/KaizenDraft/Form/RadioGroup/styles.scss
@@ -2,7 +2,7 @@
 @import "~@kaizen/deprecated-component-library-helpers/styles/type";
 
 .radioGroupLabel {
-  margin-bottom: $ca-grid / 2;
+  margin-bottom: calc($ca-grid / 2);
   label {
     :global(.ideal-sans) & {
       // This is to override bootstrap styles. Remove when appropriate
@@ -16,7 +16,7 @@
 .radioGroupContainer {
   display: flex;
   flex-direction: column;
-  margin-bottom: $ca-grid / 2;
+  margin-bottom: calc($ca-grid / 2);
   &.noBottomMargin {
     margin-bottom: 0;
   }

--- a/draft-packages/guidance-block/KaizenDraft/GuidanceBlock/GuidanceBlock.scss
+++ b/draft-packages/guidance-block/KaizenDraft/GuidanceBlock/GuidanceBlock.scss
@@ -251,7 +251,7 @@ $scene-illustration-size: 300px;
 
   .buttonContainer {
     padding-left: $spacing-sm;
-    justify-content: flex-end;
+    justify-content: flex-start;
     width: unset;
     min-width: unset;
 

--- a/draft-packages/guidance-block/KaizenDraft/GuidanceBlock/GuidanceBlock.scss
+++ b/draft-packages/guidance-block/KaizenDraft/GuidanceBlock/GuidanceBlock.scss
@@ -251,7 +251,7 @@ $scene-illustration-size: 300px;
 
   .buttonContainer {
     padding-left: $spacing-sm;
-    justify-content: end;
+    justify-content: flex-end;
     width: unset;
     min-width: unset;
 

--- a/draft-packages/hero-card/KaizenDraft/HeroCard/HeroCard.scss
+++ b/draft-packages/hero-card/KaizenDraft/HeroCard/HeroCard.scss
@@ -26,7 +26,7 @@ $left-content__width: 221px;
   display: flex;
   border-radius: $border-solid-border-radius 0 0 $border-solid-border-radius;
   color: $color-white;
-  padding: ($ca-grid / 2) ($ca-grid * 2);
+  padding: calc($ca-grid / 2) calc($ca-grid * 2);
   flex-direction: column;
   flex-shrink: 0;
   align-items: flex-start;

--- a/draft-packages/modal/KaizenDraft/Modal/Presets/ConfirmationModal.scss
+++ b/draft-packages/modal/KaizenDraft/Modal/Presets/ConfirmationModal.scss
@@ -74,7 +74,7 @@ $dt-assertive-header-background: $color-orange-100;
     }
   }
   .iconContainer {
-    align-self: start;
+    align-self: flex-start;
     @media (min-width: $layout-breakpoints-medium) {
       align-self: center;
     }

--- a/draft-packages/tag/KaizenDraft/Tag/Tag.scss
+++ b/draft-packages/tag/KaizenDraft/Tag/Tag.scss
@@ -247,8 +247,8 @@ $pulse-size-after: $pulse-size-initial * $pulse-scale-factor;
   width: $pulse-size-after;
   height: $pulse-size-after;
   // this positioning has to be calculated as an exact value as scaling will mess with percentage values
-  left: -($pulse-size-after / 2) + ($pulse-size-initial / 2);
-  top: -($pulse-size-after / 2) + ($pulse-size-initial / 2);
+  left: calc(-1 * calc($pulse-size-after / 2)) + calc($pulse-size-initial / 2);
+  top: calc(-1 * calc($pulse-size-after / 2)) + calc($pulse-size-initial / 2);
   border-radius: 50%;
   background-color: $color-green-500;
   animation: pulsate infinite 2.5s ease-out;

--- a/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/MobileActions.scss
+++ b/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/MobileActions.scss
@@ -62,10 +62,10 @@ $space-for-focus-ring: ($focus-ring-border-width * 2) + ($focus-spacing * 2);
   display: flex;
   justify-content: center;
   align-items: center;
-  @include ca-margin($end: $ca-grid / 2);
+  @include ca-margin($end: calc($ca-grid / 2));
 
   .drawerHandleLabelText + & {
-    @include ca-margin($start: $ca-grid / 2);
+    @include ca-margin($start: calc($ca-grid / 2));
   }
 }
 

--- a/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/NavigationTabs.scss
+++ b/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/NavigationTabs.scss
@@ -14,7 +14,7 @@
 
 .linkAnchor {
   display: flex;
-  padding: 0 ($ca-grid / 2);
+  padding: 0 calc($ca-grid / 2);
   @include ca-margin($end: $ca-grid);
   color: rgba($color-white-rgb, 0.7);
   text-decoration: none;
@@ -70,8 +70,8 @@
       height: 5px;
       position: absolute;
       top: 0;
-      left: -($ca-grid / 2);
-      right: -($ca-grid / 2);
+      left: calc(-1 * calc($ca-grid / 2));
+      right: calc(-1 * calc($ca-grid / 2));
       background-color: $color-white;
       transition: transform cubic-bezier(0.55, 0.085, 0.68, 0.53) 150ms;
       border-radius: 0 0 $border-solid-border-radius $border-solid-border-radius;

--- a/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/TitleBlockZen.scss
+++ b/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/TitleBlockZen.scss
@@ -139,7 +139,7 @@ $tab-container-height-medium-and-small-collapsed: $ca-grid * 0.75;
       align-items: normal;
       flex-direction: column;
       justify-content: space-between;
-      transform: translateY($ca-grid / 3);
+      transform: translateY(calc($ca-grid / 3));
     }
   }
 
@@ -151,7 +151,7 @@ $tab-container-height-medium-and-small-collapsed: $ca-grid * 0.75;
       align-items: normal;
       flex-direction: column;
       justify-content: space-between;
-      transform: translateY($ca-grid / 3);
+      transform: translateY(calc($ca-grid / 3));
 
       .hasLongTitle.hasLongSubtitle & {
         align-items: baseline;
@@ -159,7 +159,7 @@ $tab-container-height-medium-and-small-collapsed: $ca-grid * 0.75;
     }
 
     @include title-block-medium-and-small {
-      transform: translateY($ca-grid / 2);
+      transform: translateY(calc($ca-grid / 2));
     }
   }
 }
@@ -209,7 +209,7 @@ $tab-container-height-medium-and-small-collapsed: $ca-grid * 0.75;
   overflow: hidden;
   height: $ca-grid * 2;
   width: $ca-grid * 2;
-  @include ca-margin($end: $ca-grid / 2);
+  @include ca-margin($end: calc($ca-grid / 2));
 
   > * {
     max-width: 100%;
@@ -254,7 +254,7 @@ $tab-container-height-medium-and-small-collapsed: $ca-grid * 0.75;
     color: $color-purple-800;
   }
 
-  @include ca-margin($start: $ca-grid / 2);
+  @include ca-margin($start: calc($ca-grid / 2));
 
   @include title-block-under-1366 {
     white-space: nowrap;
@@ -365,7 +365,7 @@ $tab-container-height-medium-and-small-collapsed: $ca-grid * 0.75;
 }
 
 .tag {
-  @include ca-margin($start: $ca-grid / 2);
+  @include ca-margin($start: calc($ca-grid / 2));
   display: flex;
   align-items: center;
 
@@ -379,7 +379,7 @@ $tab-container-height-medium-and-small-collapsed: $ca-grid * 0.75;
 }
 
 .pageSwitcherSelectNextToTitle {
-  @include ca-margin($start: $ca-grid / 2);
+  @include ca-margin($start: calc($ca-grid / 2));
   flex-shrink: 0;
   width: 10 * $ca-grid;
 }
@@ -488,7 +488,7 @@ $tab-container-height-medium-and-small-collapsed: $ca-grid * 0.75;
   flex-grow: 1;
   flex-shrink: 0;
 
-  @include ca-margin($start: $ca-grid / 2);
+  @include ca-margin($start: calc($ca-grid / 2));
 
   @include title-block-small {
     display: none;
@@ -499,7 +499,7 @@ $tab-container-height-medium-and-small-collapsed: $ca-grid * 0.75;
   display: flex;
   align-items: flex-start;
   justify-content: flex-end;
-  padding: ($ca-grid / 2) 0;
+  padding: (calc($ca-grid / 2)) 0;
   @include ca-margin($start: $ca-grid * 1.5);
 
   // To be removed eventually – the Dropdown does not
@@ -547,7 +547,7 @@ $tab-container-height-medium-and-small-collapsed: $ca-grid * 0.75;
 
   @media only screen and (max-width: $breadcrumb-breakpoint-width) {
     position: relative;
-    @include ca-margin($end: $ca-grid / 2);
+    @include ca-margin($end: calc($ca-grid / 2));
     @include ca-position($start: 0);
     transform: translateY(0);
   }

--- a/legacy-packages/title-block/KaizenDraft/TitleBlock/TitleBlock.scss
+++ b/legacy-packages/title-block/KaizenDraft/TitleBlock/TitleBlock.scss
@@ -208,7 +208,7 @@
 }
 
 .buttonWrapper {
-  margin: 0 ($ca-grid / 2);
+  margin: 0 calc($ca-grid / 2);
 
   &:last-child {
     margin-right: 0;

--- a/packages/component-library/components/Dropdown/Dropdown.module.scss
+++ b/packages/component-library/components/Dropdown/Dropdown.module.scss
@@ -6,7 +6,7 @@
 
 $width: 248px;
 $caButton-border-width: $border-solid-border-width;
-$caButton-verticalPadding: calc(#{$ca-grid / 2} - #{$caButton-border-width});
+$caButton-verticalPadding: calc($ca-grid / 2) - #{$caButton-border-width};
 
 .dropdown {
   position: relative;

--- a/packages/component-library/components/MenuList/Menu.module.scss
+++ b/packages/component-library/components/MenuList/Menu.module.scss
@@ -8,7 +8,7 @@
 @import "../../styles/layers";
 @import "../../styles/animation";
 
-$side-padding: 3/4 * $ca-grid;
+$side-padding: calc(calc(3 / 4) * $ca-grid);
 
 .menuList {
   background: white;
@@ -81,7 +81,7 @@ $side-padding: 3/4 * $ca-grid;
   flex: 1;
 
   :not(:only-child) {
-    @include ca-margin($end: $ca-grid / 2);
+    @include ca-margin($end: calc($ca-grid / 2));
   }
 }
 

--- a/packages/component-library/components/Spacing/Base.module.scss
+++ b/packages/component-library/components/Spacing/Base.module.scss
@@ -8,7 +8,7 @@ $spacing-list: (
   ("0-point-5", 0.5 * $ca-grid),
   ("0-point-75", 0.75 * $ca-grid),
   ("1", $ca-grid),
-  ("1-point-25", 1.25 * ($ca-grid/4)),
+  ("1-point-25", 1.25 * calc($ca-grid/4)),
   ("1-point-5", 1.5 * $ca-grid),
   ("1-point-75", 1.75 * $ca-grid),
   ("2", $ca-grid * 2),

--- a/packages/component-library/styles/type.scss
+++ b/packages/component-library/styles/type.scss
@@ -64,7 +64,9 @@ $ca-locale-ar-font-family: $ca-inter-locale-he-font-family;
 
   $font-size: $base-size * $size-ratio; // in rem
   $absolute-line-height: $ca-grid * $line-height-in-grid-units; // in rem
-  $line-height-ratio: $absolute-line-height / $font-size; // unitless number
+  $line-height-ratio: calc(
+    $absolute-line-height / $font-size
+  ); // unitless number
   $line-spacing: $line-height-ratio - 1;
   font-size: $font-size;
   line-height: $line-height-ratio;
@@ -119,15 +121,23 @@ $ca-locale-ar-font-family: $ca-inter-locale-he-font-family;
 }
 
 @mixin ca-type-display($args...) {
-  @include ca-type($size-ratio: 10/7, $weight: $ca-weight-medium, $args...);
+  @include ca-type(
+    $size-ratio: calc(10 / 7),
+    $weight: $ca-weight-medium,
+    $args...
+  );
 }
 
 @mixin ca-type-heading($args...) {
-  @include ca-type($size-ratio: 8/7, $weight: $ca-weight-medium, $args...);
+  @include ca-type(
+    $size-ratio: calc(8 / 7),
+    $weight: $ca-weight-medium,
+    $args...
+  );
 }
 
 @mixin ca-type-lede($args...) {
-  @include ca-type($size-ratio: 8/7, $args...);
+  @include ca-type($size-ratio: calc(8 / 7), $args...);
 }
 
 @mixin ca-type-body($args...) {
@@ -139,11 +149,11 @@ $ca-locale-ar-font-family: $ca-inter-locale-he-font-family;
 }
 
 @mixin ca-type-small($args...) {
-  @include ca-type($size-ratio: 6/7, $args...);
+  @include ca-type($size-ratio: calc(6 / 7), $args...);
 }
 
 @mixin ca-type-labels-and-legends($args...) {
-  @include ca-type($size-ratio: 6/7, $letter-spacing: 0.04em, $args...);
+  @include ca-type($size-ratio: calc(6 / 7), $letter-spacing: 0.04em, $args...);
   text-transform: uppercase;
 }
 
@@ -157,7 +167,7 @@ $ca-locale-ar-font-family: $ca-inter-locale-he-font-family;
   $args...
 ) {
   @include ca-type(
-    $size-ratio: $size / 16,
+    $size-ratio: calc($size / 16),
     $family: $ca-ideal-sans-font-family,
     $base-size: $ca-ideal-sans-font-base-size,
     $descender-height: $ca-ideal-sans-font-descender-height,
@@ -234,7 +244,7 @@ $ca-locale-ar-font-family: $ca-inter-locale-he-font-family;
   @include ca-type-ideal(
     $size: $size,
     $weight: $ca-weight-medium,
-    $letter-spacing: $letter-spacing-in-px / $size * 1em,
+    $letter-spacing: calc($letter-spacing-in-px / calc($size * 1em)),
     $args...
   );
   text-transform: uppercase;
@@ -270,7 +280,7 @@ $ca-locale-ar-font-family: $ca-inter-locale-he-font-family;
   $args...
 ) {
   @include ca-type(
-    $size-ratio: $size / 16,
+    $size-ratio: calc($size / 16),
     $family: $ca-inter-font-family,
     $base-size: $ca-inter-font-base-size,
     $descender-height: $ca-inter-font-descender-height,
@@ -337,7 +347,7 @@ $ca-locale-ar-font-family: $ca-inter-locale-he-font-family;
   @include ca-type-inter(
     $size: $size,
     $weight: $ca-weight-light,
-    $line-height-in-grid-units: 3/4,
+    $line-height-in-grid-units: calc(3 / 4),
     $args...
   );
 }

--- a/packages/deprecated-component-library-helpers/styles/type.scss
+++ b/packages/deprecated-component-library-helpers/styles/type.scss
@@ -65,13 +65,15 @@ $ca-locale-ar-font-family: $ca-inter-locale-he-font-family;
 
   // Migrating the following two lines to use CSS vars causes Gatsby to fail with a very ambiguous error, around trying to divide by a "rem".
   $absolute-line-height: $ca-grid * $line-height-in-grid-units; // in rem
-  $line-height-ratio: $absolute-line-height / $font-size; // unitless number
+  $line-height-ratio: calc(
+    $absolute-line-height / $font-size
+  ); // unitless number
   $line-spacing: $line-height-ratio - 1;
   font-size: $font-size;
   line-height: $line-height-ratio;
 
   position: relative;
-  top: #{$descender-height + $line-spacing / 2}em;
+  top: #{$descender-height + calc($line-spacing / 2)}em;
   // If `position: relative` creates issues, we could alternatively use a transform,
   // though this creates a new stacking context which can break z-index based layers:
   // transform: translateY(#{$descender-height + $line-spacing / 2}em);
@@ -99,7 +101,7 @@ $ca-locale-ar-font-family: $ca-inter-locale-he-font-family;
 
 @mixin ca-type-title($args...) {
   @include ca-type(
-    $size-ratio: 12/7,
+    $size-ratio: calc(12 / 7),
     $line-height-in-grid-units: 1.5,
     $weight: $ca-weight-medium,
     $args...
@@ -117,15 +119,23 @@ $ca-locale-ar-font-family: $ca-inter-locale-he-font-family;
 }
 
 @mixin ca-type-display($args...) {
-  @include ca-type($size-ratio: 10/7, $weight: $ca-weight-medium, $args...);
+  @include ca-type(
+    $size-ratio: calc(10 / 7),
+    $weight: $ca-weight-medium,
+    $args...
+  );
 }
 
 @mixin ca-type-heading($args...) {
-  @include ca-type($size-ratio: 8/7, $weight: $ca-weight-medium, $args...);
+  @include ca-type(
+    $size-ratio: calc(8 / 7),
+    $weight: $ca-weight-medium,
+    $args...
+  );
 }
 
 @mixin ca-type-lede($args...) {
-  @include ca-type($size-ratio: 8/7, $args...);
+  @include ca-type($size-ratio: calc(8 / 7), $args...);
 }
 
 @mixin ca-type-body($args...) {
@@ -137,11 +147,11 @@ $ca-locale-ar-font-family: $ca-inter-locale-he-font-family;
 }
 
 @mixin ca-type-small($args...) {
-  @include ca-type($size-ratio: 6/7, $args...);
+  @include ca-type($size-ratio: calc(6 / 7), $args...);
 }
 
 @mixin ca-type-labels-and-legends($args...) {
-  @include ca-type($size-ratio: 6/7, $letter-spacing: 0.04em, $args...);
+  @include ca-type($size-ratio: calc(6 / 7), $letter-spacing: 0.04em, $args...);
   text-transform: uppercase;
 }
 
@@ -155,7 +165,7 @@ $ca-locale-ar-font-family: $ca-inter-locale-he-font-family;
   $args...
 ) {
   @include ca-type(
-    $size-ratio: $size / 16,
+    $size-ratio: calc($size / 16),
     $family: $ca-ideal-sans-font-family,
     $base-size: $ca-ideal-sans-font-base-size,
     $descender-height: $ca-ideal-sans-font-descender-height,
@@ -222,7 +232,7 @@ $ca-locale-ar-font-family: $ca-inter-locale-he-font-family;
   @include ca-type-ideal(
     $size: $size,
     $weight: $ca-weight-light,
-    $line-height-in-grid-units: 3/4,
+    $line-height-in-grid-units: calc(3 / 4),
     $args...
   );
 }
@@ -268,7 +278,7 @@ $ca-locale-ar-font-family: $ca-inter-locale-he-font-family;
   $args...
 ) {
   @include ca-type(
-    $size-ratio: $size / 16,
+    $size-ratio: calc($size / 16),
     $family: $ca-inter-font-family,
     $base-size: $ca-inter-font-base-size,
     $descender-height: $ca-inter-font-descender-height,
@@ -335,7 +345,7 @@ $ca-locale-ar-font-family: $ca-inter-locale-he-font-family;
   @include ca-type-inter(
     $size: $size,
     $weight: $ca-weight-light,
-    $line-height-in-grid-units: 3/4,
+    $line-height-in-grid-units: calc(3 / 4),
     $args...
   );
 }
@@ -345,7 +355,7 @@ $ca-locale-ar-font-family: $ca-inter-locale-he-font-family;
   @include ca-type-inter(
     $size: $size,
     $weight: 600,
-    $letter-spacing: $letter-spacing-in-px / $size * 1em,
+    $letter-spacing: calc($letter-spacing-in-px / $size) * 1em,
     $args...
   );
   text-transform: uppercase;
@@ -404,7 +414,7 @@ $ca-locale-ar-font-family: $ca-inter-locale-he-font-family;
 }
 
 @function to-grid-units($value-in-rems) {
-  @return $value-in-rems / $ca-grid;
+  @return calc($value-in-rems / $ca-grid);
 }
 
 /*
@@ -420,7 +430,7 @@ $ca-locale-ar-font-family: $ca-inter-locale-he-font-family;
   $args...
 ) {
   @include ca-type(
-    $size-ratio: $size / 16,
+    $size-ratio: calc($size / 16),
     $family:
       unquote(
         "#{$typography-heading-1-font-family}, Helvetica, Arial, sans-serif"
@@ -442,7 +452,7 @@ $ca-locale-ar-font-family: $ca-inter-locale-he-font-family;
   $args...
 ) {
   @include ca-type(
-    $size-ratio: $size / 16,
+    $size-ratio: calc($size / 16),
     $family:
       unquote(
         "#{$typography-paragraph-body-font-family}, Helvetica, Arial, sans-serif"

--- a/site/src/components/NavigationBar/NavigationBar.module.scss
+++ b/site/src/components/NavigationBar/NavigationBar.module.scss
@@ -35,7 +35,7 @@
 .links {
   display: inline-flex;
   flex: 1 0 0;
-  @include ca-margin($start: 2 * $ca-grid);
+  @include ca-margin($start: calc(2 * $ca-grid));
 
   > ul {
     margin: 0;
@@ -58,7 +58,7 @@
   }
 
   @include ca-media-tablet {
-    @include ca-margin($start: $ca-grid / 2);
+    @include ca-margin($start: calc($ca-grid / 2));
   }
 }
 
@@ -67,7 +67,7 @@
   position: relative;
   flex: 0 0 auto;
   text-decoration: none;
-  margin: 0 ($ca-grid / 4);
+  margin: 0 calc($ca-grid / 4);
 }
 
 .kaizen .active {

--- a/site/src/components/NavigationBar/_styles.scss
+++ b/site/src/components/NavigationBar/_styles.scss
@@ -12,9 +12,9 @@ $ca-navigation-bar__animation-ease: cubic-bezier(0.55, 0.085, 0.68, 0.53);
 $ca-navigation-bar__animation-timing: 150ms;
 
 $ca-navigation-bar__link-item-indicator-height: 3px;
-$ca-navigation-bar__link-item-margin: $ca-grid / 4;
+$ca-navigation-bar__link-item-margin: calc($ca-grid / 4);
 
-$link-margin: $ca-grid / 4;
+$link-margin: calc($ca-grid / 4);
 
 @mixin ca-navigation-bar__link-item {
   @extend %ca-navigation-bar__menu-item-focus;
@@ -29,7 +29,7 @@ $link-margin: $ca-grid / 4;
   // fill parent
   display: flex;
   min-width: 2 * $ca-grid;
-  margin: ($ca-grid / 4) 0;
+  margin: calc($ca-grid / 4) 0;
 
   // center child
   align-items: center;
@@ -101,7 +101,7 @@ $link-margin: $ca-grid / 4;
       @include ca-type-inter-body;
       @include ca-inherit-baseline;
 
-      padding: 0 $ca-grid / 2;
+      padding: 0 calc($ca-grid / 2);
 
       .linkIcon {
         @include ca-media-tablet {

--- a/site/src/components/NavigationBar/components/Link.module.scss
+++ b/site/src/components/NavigationBar/components/Link.module.scss
@@ -55,18 +55,21 @@ $indicator-height: 3px;
 }
 
 .badge {
-  @include ca-margin($start: $ca-grid * 0.25);
+  @include ca-margin($start: calc($ca-grid * 0.25));
   @include ca-type-inter-small-bold;
   @include ca-inherit-baseline;
 
   border-radius: $ca-grid;
   &.badgeNew {
-    @include ca-padding($start: $ca-grid * 0.5, $end: $ca-grid * 0.5);
+    @include ca-padding(
+      $start: calc($ca-grid * 0.5),
+      $end: calc($ca-grid * 0.5)
+    );
     background-color: $dt-color-badge-background-color-new;
     color: $color-purple-800;
   }
   &.badgeNotification {
-    @include ca-padding($start: $ca-grid / 3, $end: $ca-grid / 3);
+    @include ca-padding($start: calc($ca-grid / 3), $end: calc($ca-grid / 3));
     background-color: $dt-color-badge-background-color;
     color: $color-white;
   }

--- a/site/src/components/OffCanvas/OffCanvas.module.scss
+++ b/site/src/components/OffCanvas/OffCanvas.module.scss
@@ -35,7 +35,7 @@ $menu-footer-height: 100px;
   @include button-reset;
   position: absolute;
   top: $ca-grid;
-  left: $ca-grid / 2;
+  left: calc($ca-grid / 2);
   color: $color-blue-500;
 }
 

--- a/site/src/components/OffCanvas/components/Header.module.scss
+++ b/site/src/components/OffCanvas/components/Header.module.scss
@@ -14,8 +14,8 @@
 
 .close {
   position: absolute;
-  top: $ca-grid / 2;
-  right: $ca-grid / 2;
+  top: calc($ca-grid / 2);
+  right: calc($ca-grid / 2);
 }
 
 .heading {

--- a/site/src/components/PageHeader.scss
+++ b/site/src/components/PageHeader.scss
@@ -51,8 +51,8 @@
 
 .image {
   display: flex;
-  justify-content: start;
-  align-items: end;
+  justify-content: flex-start;
+  align-items: flex-end;
   position: relative;
 
   @include ca-media-mobile() {


### PR DESCRIPTION
## Why

There is a lot of noise when building the site.

## What

Reduce as much dart-sass warnings as possible.

We could not fix the `strip-unit` function because it's not doing a recommended calculation. Also could not ignore it, so it's still there.