### PR TITLE
chore(deps): Pin headlessui/react to <1.5 until bug is fixed

### DIFF
--- a/draft-packages/modal/package.json
+++ b/draft-packages/modal/package.json
@@ -32,7 +32,7 @@
   "private": false,
   "license": "MIT",
   "dependencies": {
-    "@headlessui/react": "^1.4.3",
+    "@headlessui/react": "<=1.5.0",
     "@kaizen/button": "^1.1.3",
     "@kaizen/component-library": "^14.1.0",
     "@kaizen/deprecated-component-library-helpers": "^2.5.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2547,10 +2547,10 @@
   dependencies:
     "@hapi/hoek" "^9.0.0"
 
-"@headlessui/react@^1.4.3":
-  version "1.4.3"
-  resolved "https://registry.yarnpkg.com/@headlessui/react/-/react-1.4.3.tgz#f77c6bb5cb4a614a5d730fb880cab502d48abf37"
-  integrity sha512-n2IQkaaw0aAAlQS5MEXsM4uRK+w18CrM72EqnGRl/UBOQeQajad8oiKXR9Nk15jOzTFQjpxzrZMf1NxHidFBiw==
+"@headlessui/react@<=1.5.0":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/@headlessui/react/-/react-1.5.0.tgz#483b44ba2c8b8d4391e1d2c863898d7dd0cc0296"
+  integrity sha512-aaRnYxBb3MU2FNJf3Ut9RMTUqqU3as0aI1lQhgo2n9Fa67wRu14iOGqx93xB+uMNVfNwZ5B3y/Ndm7qZGuFeMQ==
 
 "@humanwhocodes/config-array@^0.5.0":
   version "0.5.0"


### PR DESCRIPTION
## What
Pin the `headlessui/react` package to <=1.5 while we wait for this issue to be fixed in headlessui.

Also updates headlessui/react from 1.4 to 1.5 as a side effect.

## Why
`headlessui/react` v1.6 has a bug causing the modal backdrop to not be removed, which means user can't interact with the page at all after closing a modal.

https://github.com/tailwindlabs/headlessui/issues/1417



