### PR TITLE
ci: Deploy storybook build to the root of branch deploys

### DIFF
--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -7,11 +7,6 @@ extract_artifact() {
 }
 
 main() {
-  export KAIZEN_BASE_PATH=""
-  if [[ $BUILDKITE_BRANCH != "master" ]]; then
-    KAIZEN_BASE_PATH="/${BUILDKITE_BRANCH}"
-  fi
-
   if [[ -n $KAIZEN_EXTRACT_ARTIFACTS ]]; then
     echo "Extracting build artifacts..."
     extract_artifact "site.tar.gz"

--- a/.github/workflows/add_branch_preview_link_to_pr.yml
+++ b/.github/workflows/add_branch_preview_link_to_pr.yml
@@ -52,15 +52,13 @@ jobs:
         with:
           issue-number: ${{ steps.findPr.outputs.number }}
           body: |
-            :sparkles: Here are your branch previews! :sparkles:
+            :sparkles: Here is your branch preview! :sparkles:
 
-            - [Kaizen site][1]
-            - [Storybook][2]
+            - [Storybook][1]
 
             Last updated for commit ${{ github.event.sha }}: ${{ github.event.commit.commit.message }}
 
             [1]: https://dev.cultureamp.design/${{ github.event.branches[0].name }}
-            [2]: https://dev.cultureamp.design/${{ github.event.branches[0].name }}/storybook
 
       - name: Update an existing comment
         if: success() && steps.find_comment.outputs.comment-id != 0
@@ -69,12 +67,10 @@ jobs:
           comment-id: ${{ steps.find_comment.outputs.comment-id }}
           edit-mode: replace
           body: |
-            :sparkles: Here are your branch previews! :sparkles:
+            :sparkles: Here is your branch preview! :sparkles:
 
-            - [Kaizen site][1]
-            - [Storybook][2]
+            - [Storybook][1]
 
             Last updated for commit ${{ github.event.sha }}: ${{ github.event.commit.commit.message }}
 
             [1]: https://dev.cultureamp.design/${{ github.event.branches[0].name }}
-            [2]: https://dev.cultureamp.design/${{ github.event.branches[0].name }}/storybook

--- a/site/gatsby-config.js
+++ b/site/gatsby-config.js
@@ -1,7 +1,7 @@
 const { resolve } = require("path")
 
 module.exports = {
-  pathPrefix: process.env.KAIZEN_BASE_PATH || "/",
+  pathPrefix: "/",
   siteMetadata: {
     title: "Kaizen Design System",
     author: "Culture Amp",


### PR DESCRIPTION
## Why
We're about to break site deploys in this repo (as part of moving the site into a new repo), but we don't want branch previews of storybook builds to stop being available.

## What
- Write storybook assets to the root of branch deploys
  - This allows us to remove the site deploy from the design system repo
without breaking storybook deploys in dev.
- Update PR annotations for branch previews