### PR TITLE
ci: Publish storybook site only in dev

### DIFF
--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -7,11 +7,6 @@ extract_artifact() {
 }
 
 main() {
-  export KAIZEN_BASE_PATH=""
-  if [[ $BUILDKITE_BRANCH != "master" ]]; then
-    KAIZEN_BASE_PATH="/${BUILDKITE_BRANCH}"
-  fi
-
   if [[ -n $KAIZEN_EXTRACT_ARTIFACTS ]]; then
     echo "Extracting build artifacts..."
     extract_artifact "site.tar.gz"

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -62,7 +62,7 @@ steps:
 
   - wait
 
-  - name: ":seedling: Publish: ${KAIZEN_DOMAIN_NAME}${KAIZEN_BASE_PATH}"
+  - name: ":seedling: Publish: ${KAIZEN_DOMAIN_NAME}"
     command: ".buildkite/scripts/publish.sh"
     timeout_in_minutes: 15
     # The canary branch is not able to update dev.cultureamp.design

--- a/.buildkite/scripts/publish.sh
+++ b/.buildkite/scripts/publish.sh
@@ -7,18 +7,12 @@ echo "Publishing to ${KAIZEN_DOMAIN_NAME}"
 
 # if we're publishing to the production bucket...
 if [ "$KAIZEN_DOMAIN_NAME" = "cultureamp.design" ]; then
-    # publish the site to the bucket root
-    # note: doesn't delete the bucket contents
-    aws s3 sync \
-        "site/public" \
-        "s3://${KAIZEN_DOMAIN_NAME}"
     aws s3 sync --delete \
         "storybook/public" \
         "s3://${KAIZEN_DOMAIN_NAME}/storybook"
 else
     KAIZEN_BASE_PATH="/${BUILDKITE_BRANCH}"
     # publish storybook to the root of the path corresponding to the branch
-    # note: no site deploy when targeting the dev bucket
     aws s3 sync --delete \
         "storybook/public" \
         "s3://${KAIZEN_DOMAIN_NAME}${KAIZEN_BASE_PATH}"

--- a/.buildkite/scripts/publish.sh
+++ b/.buildkite/scripts/publish.sh
@@ -1,17 +1,28 @@
 #!/bin/sh
 set -e
 
-destination=${KAIZEN_DOMAIN_NAME}${KAIZEN_BASE_PATH}
+KAIZEN_BASE_PATH=""
 
-echo "Publishing to ${destination}"
+echo "Publishing to ${KAIZEN_DOMAIN_NAME}"
 
-aws s3 sync --delete \
-    "site/public" \
-    "s3://${KAIZEN_DOMAIN_NAME}${KAIZEN_BASE_PATH}"
-
-aws s3 sync --delete \
-    "storybook/public" \
-    "s3://${KAIZEN_DOMAIN_NAME}${KAIZEN_BASE_PATH}/storybook"
+# if we're publishing to the production bucket...
+if [ "$KAIZEN_DOMAIN_NAME" = "cultureamp.design" ]; then
+    # publish the site to the bucket root
+    # note: doesn't delete the bucket contents
+    aws s3 sync \
+        "site/public" \
+        "s3://${KAIZEN_DOMAIN_NAME}"
+    aws s3 sync --delete \
+        "storybook/public" \
+        "s3://${KAIZEN_DOMAIN_NAME}/storybook"
+else
+    KAIZEN_BASE_PATH="/${BUILDKITE_BRANCH}"
+    # publish storybook to the root of the path corresponding to the branch
+    # note: no site deploy when targeting the dev bucket
+    aws s3 sync --delete \
+        "storybook/public" \
+        "s3://${KAIZEN_DOMAIN_NAME}${KAIZEN_BASE_PATH}"
+fi
 
 aws cloudfront create-invalidation \
     --distribution-id "${KAIZEN_DISTRIBUTION_ID}" \
@@ -20,6 +31,7 @@ aws cloudfront create-invalidation \
 
 echo "Reporting the deployed URL via the GitHub status API"
 
+destination=${KAIZEN_DOMAIN_NAME}${KAIZEN_BASE_PATH}
 commit_hash=$(git rev-parse --verify HEAD)
 curl --fail -s "https://api.github.com/repos/cultureamp/kaizen-design-system/statuses/$commit_hash" \
   --header "authorization: Bearer $GITHUB_STATUS_TOKEN" \

--- a/.github/workflows/add_branch_preview_link_to_pr.yml
+++ b/.github/workflows/add_branch_preview_link_to_pr.yml
@@ -52,15 +52,13 @@ jobs:
         with:
           issue-number: ${{ steps.findPr.outputs.number }}
           body: |
-            :sparkles: Here are your branch previews! :sparkles:
+            :sparkles: Here is your branch preview! :sparkles:
 
-            - [Kaizen site][1]
-            - [Storybook][2]
+            - [Storybook][1]
 
             Last updated for commit ${{ github.event.sha }}: ${{ github.event.commit.commit.message }}
 
             [1]: https://dev.cultureamp.design/${{ github.event.branches[0].name }}
-            [2]: https://dev.cultureamp.design/${{ github.event.branches[0].name }}/storybook
 
       - name: Update an existing comment
         if: success() && steps.find_comment.outputs.comment-id != 0
@@ -69,12 +67,10 @@ jobs:
           comment-id: ${{ steps.find_comment.outputs.comment-id }}
           edit-mode: replace
           body: |
-            :sparkles: Here are your branch previews! :sparkles:
+            :sparkles: Here is your branch preview! :sparkles:
 
-            - [Kaizen site][1]
-            - [Storybook][2]
+            - [Storybook][1]
 
             Last updated for commit ${{ github.event.sha }}: ${{ github.event.commit.commit.message }}
 
             [1]: https://dev.cultureamp.design/${{ github.event.branches[0].name }}
-            [2]: https://dev.cultureamp.design/${{ github.event.branches[0].name }}/storybook

--- a/site/gatsby-config.js
+++ b/site/gatsby-config.js
@@ -1,7 +1,7 @@
 const { resolve } = require("path")
 
 module.exports = {
-  pathPrefix: process.env.KAIZEN_BASE_PATH || "/",
+  pathPrefix: "/",
   siteMetadata: {
     title: "Kaizen Design System",
     author: "Culture Amp",


### PR DESCRIPTION
See: #2735
## Why
This lays the groundwork for the split of the Gatsby site and ensures that branch previews are still available for storybook.

## What
- removes the site deploy from this repo (moved to [cultureamp/kaizen-site](https://github.com/cultureamp/kaizen-site))
- writes storybook to the root of the branch deploy in dev (i.e. to `dev.cultureamp.design/my-branch/`)
- updates branch previews comments to reflect change to storybook deploys