### PR TITLE
refactor: remove to-unitless-pixels function to clean up sass err

### DIFF
--- a/packages/deprecated-component-library-helpers/styles/type.scss
+++ b/packages/deprecated-component-library-helpers/styles/type.scss
@@ -399,20 +399,6 @@ $ca-locale-ar-font-family: $ca-inter-locale-he-font-family;
 
 // Greycliff styles
 
-// A utility to strip the unit from a value. Eg: `1.5rem` to `1.5`
-@function strip-unit($value) {
-  @return $value / ($value * 0 + 1);
-}
-
-// Given a rem unit like `1.5rem`, convert to pixels, but without the unit,
-// (eg `24`). This is to maintain backwards compatibility with existing usages
-// of the mixins, which are specified in unitless pixels. Eg: `ca-type-inter-heading(32)`
-// will become `kz-typography-heading-4(32)` which would be converted internally to `2rem`.
-
-@function to-unitless-pixels($value-in-rems) {
-  @return strip-unit($value-in-rems) * 16;
-}
-
 @function to-grid-units($value-in-rems) {
   @return calc($value-in-rems / $ca-grid);
 }
@@ -466,7 +452,7 @@ $ca-locale-ar-font-family: $ca-inter-locale-he-font-family;
   );
 }
 
-@mixin kz-typography-data-large($size: to-unitless-pixels(5.25rem), $args...) {
+@mixin kz-typography-data-large($size: 84, $args...) {
   @include kz-typography-greycliff(
     $size: $size,
     $weight: $typography-data-large-font-weight,
@@ -476,10 +462,7 @@ $ca-locale-ar-font-family: $ca-inter-locale-he-font-family;
   );
 }
 
-@mixin kz-typography-data-large-units(
-  $size: to-unitless-pixels(2.625rem),
-  $args...
-) {
+@mixin kz-typography-data-large-units($size: 42, $args...) {
   @include kz-typography-greycliff(
     $size: $size,
     $weight: $typography-data-large-units-font-weight,
@@ -489,7 +472,7 @@ $ca-locale-ar-font-family: $ca-inter-locale-he-font-family;
   );
 }
 
-@mixin kz-typography-data-medium($size: to-unitless-pixels(3rem), $args...) {
+@mixin kz-typography-data-medium($size: 48, $args...) {
   @include kz-typography-greycliff(
     $size: $size,
     $weight: $typography-data-medium-font-weight,
@@ -499,10 +482,7 @@ $ca-locale-ar-font-family: $ca-inter-locale-he-font-family;
   );
 }
 
-@mixin kz-typography-data-medium-units(
-  $size: to-unitless-pixels(1.5rem),
-  $args...
-) {
+@mixin kz-typography-data-medium-units($size: 24, $args...) {
   @include kz-typography-greycliff(
     $size: $size,
     $weight: $typography-data-medium-units-font-weight,
@@ -512,7 +492,7 @@ $ca-locale-ar-font-family: $ca-inter-locale-he-font-family;
   );
 }
 
-@mixin kz-typography-data-small($size: to-unitless-pixels(1.5rem), $args...) {
+@mixin kz-typography-data-small($size: 24, $args...) {
   @include kz-typography-greycliff(
     $size: $size,
     $weight: $typography-data-small-font-weight,
@@ -522,10 +502,7 @@ $ca-locale-ar-font-family: $ca-inter-locale-he-font-family;
   );
 }
 
-@mixin kz-typography-data-small-units(
-  $size: to-unitless-pixels(1.125rem),
-  $args...
-) {
+@mixin kz-typography-data-small-units($size: 18, $args...) {
   @include kz-typography-greycliff(
     $size: $size,
     $weight: $typography-data-small-units-font-weight,
@@ -535,7 +512,7 @@ $ca-locale-ar-font-family: $ca-inter-locale-he-font-family;
   );
 }
 
-@mixin kz-typography-display-0($size: to-unitless-pixels(4.5rem), $args...) {
+@mixin kz-typography-display-0($size: 72, $args...) {
   @include kz-typography-greycliff(
     $size: $size,
     $weight: $typography-display-0-font-weight,
@@ -545,7 +522,7 @@ $ca-locale-ar-font-family: $ca-inter-locale-he-font-family;
   );
 }
 
-@mixin kz-typography-heading-1($size: to-unitless-pixels(2.25rem), $args...) {
+@mixin kz-typography-heading-1($size: 36, $args...) {
   @include kz-typography-greycliff(
     $size: $size,
     $weight: $typography-heading-1-font-weight,
@@ -555,7 +532,7 @@ $ca-locale-ar-font-family: $ca-inter-locale-he-font-family;
   );
 }
 
-@mixin kz-typography-heading-2($size: to-unitless-pixels(1.875rem), $args...) {
+@mixin kz-typography-heading-2($size: 30, $args...) {
   @include kz-typography-greycliff(
     $size: $size,
     $weight: $typography-heading-2-font-weight,
@@ -565,7 +542,7 @@ $ca-locale-ar-font-family: $ca-inter-locale-he-font-family;
   );
 }
 
-@mixin kz-typography-heading-3($size: to-unitless-pixels(1.375rem), $args...) {
+@mixin kz-typography-heading-3($size: 22, $args...) {
   @include kz-typography-greycliff(
     $size: $size,
     $weight: $typography-heading-3-font-weight,
@@ -575,7 +552,7 @@ $ca-locale-ar-font-family: $ca-inter-locale-he-font-family;
   );
 }
 
-@mixin kz-typography-heading-4($size: to-unitless-pixels(1.125rem), $args...) {
+@mixin kz-typography-heading-4($size: 18, $args...) {
   @include kz-typography-inter(
     $size: $size,
     $weight: $typography-heading-4-font-weight,
@@ -585,7 +562,7 @@ $ca-locale-ar-font-family: $ca-inter-locale-he-font-family;
   );
 }
 
-@mixin kz-typography-heading-5($size: to-unitless-pixels(1rem), $args...) {
+@mixin kz-typography-heading-5($size: 16, $args...) {
   @include kz-typography-inter(
     $size: $size,
     $weight: $typography-heading-5-font-weight,
@@ -595,7 +572,7 @@ $ca-locale-ar-font-family: $ca-inter-locale-he-font-family;
   );
 }
 
-@mixin kz-typography-heading-6($size: to-unitless-pixels(0.875rem), $args...) {
+@mixin kz-typography-heading-6($size: 14, $args...) {
   @include kz-typography-inter(
     $size: $size,
     $weight: $typography-heading-6-font-weight,
@@ -605,7 +582,7 @@ $ca-locale-ar-font-family: $ca-inter-locale-he-font-family;
   );
 }
 
-@mixin kz-typography-paragraph-body($size: to-unitless-pixels(1rem), $args...) {
+@mixin kz-typography-paragraph-body($size: 16, $args...) {
   @include kz-typography-inter(
     $size: $size,
     $weight: $typography-paragraph-body-font-weight,
@@ -615,10 +592,7 @@ $ca-locale-ar-font-family: $ca-inter-locale-he-font-family;
   );
 }
 
-@mixin kz-typography-paragraph-body-bold(
-  $size: to-unitless-pixels(1rem),
-  $args...
-) {
+@mixin kz-typography-paragraph-body-bold($size: 16, $args...) {
   @include kz-typography-inter(
     $size: $size,
     $weight: $typography-paragraph-body-font-weight,
@@ -629,10 +603,7 @@ $ca-locale-ar-font-family: $ca-inter-locale-he-font-family;
   font-weight: $typography-paragraph-bold-font-weight;
 }
 
-@mixin kz-typography-paragraph-small(
-  $size: to-unitless-pixels(0.875rem),
-  $args...
-) {
+@mixin kz-typography-paragraph-small($size: 14, $args...) {
   @include kz-typography-inter(
     $size: $size,
     $weight: $typography-paragraph-small-font-weight,


### PR DESCRIPTION
## Why
The to unitless pixels function was throwing a sass dart warning and prevents us from upgrading to the next major version. The intention of this PR is to clean up the last of the console warning for Kaizen relating to scss.

## What
- refactoring the styles to no longer use unitless pixels function and just hardcode the values instead. 