### PR TITLE
chore(deps): Move react-dom from direct to peer dependency in modal

### DIFF
--- a/draft-packages/modal/package.json
+++ b/draft-packages/modal/package.json
@@ -43,7 +43,6 @@
     "@kaizen/typography": "^2.2.0",
     "@types/classnames": "^2.3.0",
     "classnames": "^2.3.1",
-    "react-dom": "^16.13.1",
     "react-focus-lock": "^2.9.1",
     "uuid": "^3.4.0"
   },
@@ -52,6 +51,7 @@
   },
   "peerDependencies": {
     "@kaizen/design-tokens": "^2.10.3 || ^3.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0",
-    "react": "^16.9.0 || ^17.0.0 || ^18.0.0"
+    "react": "^16.9.0 || ^17.0.0 || ^18.0.0",
+    "react-dom": "^16.9.0 || ^17.0.0 || ^18.0.0"
   }
 }


### PR DESCRIPTION
## What
Moves a `react-dom` dependency from a direct dep to a peer dep in the modal package.

## Why
This can cause consuming repos to include a separate version of react-dom just for this, bloating bundle size. We can expect our FE repos to have this already, and it can be any of these listed versions.
