### PR TITLE
fix: Supply correct property name for prepopulating RTE

### DIFF
--- a/packages/rich-text-editor/src/RichTextEditor/RichTextEditor.tsx
+++ b/packages/rich-text-editor/src/RichTextEditor/RichTextEditor.tsx
@@ -55,7 +55,7 @@ export const RichTextEditor: React.VFC<RichTextEditorProps> = props => {
       doc: value
         ? Node.fromJSON(schema, {
             type: "doc",
-            contentObject: value,
+            content: value,
           })
         : null,
       schema,


### PR DESCRIPTION
## What
Uses the property name `content` instead of `contentObject` when creating editor state from the `value` prop.

## Why
This was broken, when passing an existing `value`, the editor wasn't showing the content.



