### PR TITLE
fix: Use interpolation for RTE height calculation

### DIFF
--- a/packages/rich-text-editor/src/RichTextEditor/RichTextEditor.scss
+++ b/packages/rich-text-editor/src/RichTextEditor/RichTextEditor.scss
@@ -59,6 +59,6 @@
 
 @for $i from 1 through 20 {
   .editor.rows#{$i} > :global(.ProseMirror) {
-    min-height: calc($typography-paragraph-body-line-height * $i);
+    min-height: calc(#{$typography-paragraph-body-line-height} * #{$i});
   }
 }


### PR DESCRIPTION
## Why
This doesn't currently work in perf-ui
![image](https://user-images.githubusercontent.com/1811583/169959190-502a8fa6-9560-4bd5-8158-cab01db3d286.png)


## What
Use interpolation for RTE height calculation