### PR TITLE
fix: manually bump draft-avatar to 2.6.0 to correct failed lerna publish to npm

### DIFF
--- a/draft-packages/avatar/docs/AvatarGroup.stories.tsx
+++ b/draft-packages/avatar/docs/AvatarGroup.stories.tsx
@@ -12,7 +12,7 @@ import { CATEGORIES } from "../../../storybook/constants"
 import { StoryWrapper } from "../../../storybook/components/StoryWrapper"
 
 const EXAMPLE_USER_1: AvatarGroupAvatarProps = {
-  fullName: "Adirana Aniseed",
+  fullName: "Adirana Appleseed",
   disableInitials: false,
   avatarSrc:
     "https://www.cultureampcom-preview-1.usw2.wp-dev-us.cultureamp-cdn.com/assets/slices/main/assets/public/media/chapters-card-1@2x.05e547444387f29f14df0b82634bf2b6.png",

--- a/draft-packages/avatar/package.json
+++ b/draft-packages/avatar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kaizen/draft-avatar",
-  "version": "2.5.1",
+  "version": "2.6.0",
   "description": "The draft avatar component",
   "scripts": {
     "prepublish": "tsc --project tsconfig.dist.json",


### PR DESCRIPTION
## Why
Lerna and NPM versions are out of sync


## What
manually bumps the version of draft avatar to 2.6.0
