### PR TITLE
chore: force version bump of out of sync packages

### DIFF
--- a/draft-packages/avatar/package.json
+++ b/draft-packages/avatar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kaizen/draft-avatar",
-  "version": "2.6.1",
+  "version": "2.7.0",
   "description": "The draft avatar component",
   "scripts": {
     "prepublish": "tsc --project tsconfig.dist.json",

--- a/draft-packages/menu/package.json
+++ b/draft-packages/menu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kaizen/draft-menu",
-  "version": "4.6.1",
+  "version": "4.7.0",
   "description": "The draft Menu component",
   "scripts": {
     "prepublish": "tsc --project tsconfig.dist.json",

--- a/draft-packages/tooltip/package.json
+++ b/draft-packages/tooltip/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kaizen/draft-tooltip",
-  "version": "5.1.1",
+  "version": "5.2.0",
   "description": "The draft Tooltip component",
   "scripts": {
     "prepublish": "tsc --project tsconfig.dist.json",

--- a/packages/rich-text-editor/package.json
+++ b/packages/rich-text-editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kaizen/rich-text-editor",
-  "version": "1.9.3",
+  "version": "1.10.0",
   "description": "The RichTextEditor component",
   "scripts": {
     "prepublish": "tsc --project tsconfig.dist.json",


### PR DESCRIPTION
## Why
Lerna is out of sync with npm packages


## What
sync up lerna versions with npm by manually updating each package