### PR TITLE
ci(chromatic): update GH action to trigger Chromatic build on label add

### DIFF
--- a/.github/workflows/chromatic.yaml
+++ b/.github/workflows/chromatic.yaml
@@ -3,6 +3,8 @@
 name: "chromatic"
 
 on:
+  pull_request:
+    types: [labeled]
   pull_request_review:
     types: [submitted]
   push:
@@ -13,7 +15,7 @@ on:
 
 jobs:
   visual-testing:
-    if: github.event.review.state == 'approved' || github.ref == 'refs/heads/master'
+    if: (github.event.action == 'labeled' && github.event.label.name == 'run chromatic') || github.event.review.state == 'approved' || github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/yarn.lock
+++ b/yarn.lock
@@ -20950,7 +20950,7 @@ react-docgen@^5.0.0:
     node-dir "^0.1.10"
     strip-indent "^3.0.0"
 
-"react-dom-16@npm:react-dom@^16.9.0", react-dom@^16.13.1, react-dom@^16.9.0:
+"react-dom-16@npm:react-dom@^16.9.0", react-dom@^16.9.0:
   name react-dom-16
   version "16.14.0"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.14.0.tgz#7ad838ec29a777fb3c75c3a190f661cf92ab8b89"


### PR DESCRIPTION
## What

Update GH action to trigger Chromatic build when label `run chromatic` is added.

Also added the missing `yarn.lock` changes.

## Why

Provides a manual trigger in PRs for Chromatic so we don't need to wait for an approval to see if we broke anything.