### PR TITLE
ci: add wait step back into pipeline to link build with release

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -37,7 +37,6 @@ steps:
           run: release
 
   - name: ":package: Build (storybook)"
-    key: "build-storybook"
     command: ".buildkite/scripts/build-storybook.sh"
     timeout_in_minutes: 15
     artifact_paths: "./storybook.tar.gz"
@@ -54,8 +53,9 @@ steps:
           environment:
             - GITHUB_REGISTRY_TOKEN
 
+  - wait
+
   - name: ":seedling: Publish: ${KAIZEN_DOMAIN_NAME}"
-    depends_on: "build-storybook"
     command: ".buildkite/scripts/publish.sh"
     timeout_in_minutes: 15
     # The canary branch is not able to update dev.cultureamp.design


### PR DESCRIPTION
## Why
We temporarily decouple the release and link step to allow the site to publish testing new ci flow. This revert our pipeline workflow back to it original state.


## What
- adds `wait` back to pipeline yml
- remove `depends_upon` and `key` in the build and publish step