### PR TITLE
chore: Add links to Guidance and Storyboard to component JSDoc

### DIFF
--- a/draft-packages/avatar/KaizenDraft/Avatar/Avatar.tsx
+++ b/draft-packages/avatar/KaizenDraft/Avatar/Avatar.tsx
@@ -114,6 +114,10 @@ const renderInitials = (
   )
 }
 
+/**
+ * {@link https://cultureamp.design/components/avatar/ Guidance} |
+ * {@link https://cultureamp.design/storybook/?path=/docs/components-avatar-avatar--default-story Storybook}
+ */
 export const Avatar: React.VFC<AvatarProps> = ({
   fullName,
   size = "medium",

--- a/draft-packages/avatar/KaizenDraft/Avatar/AvatarGroup.tsx
+++ b/draft-packages/avatar/KaizenDraft/Avatar/AvatarGroup.tsx
@@ -66,6 +66,10 @@ const renderAvatars = (
   </>
 )
 
+/**
+ * {@link https://cultureamp.design/components/avatar-group/ Guidance} |
+ * {@link https://cultureamp.design/storybook/?path=/docs/components-avatar-avatar-group--default-story Storybook}
+ */
 export const AvatarGroup: React.VFC<AvatarGroupProps> = ({
   size = "medium",
   maxVisible = 2,

--- a/draft-packages/badge/KaizenDraft/Badge/Badge.tsx
+++ b/draft-packages/badge/KaizenDraft/Badge/Badge.tsx
@@ -27,6 +27,10 @@ interface DotProps extends Omit<CommonProps, "variant"> {
 
 export type BadgeProps = CommonProps | DotProps
 
+/**
+ * {@link https://cultureamp.design/components/badge/ Guidance} |
+ * {@link https://cultureamp.design/storybook/?path=/docs/components-badge--default-story Storybook}
+ */
 export const Badge: React.VFC<BadgeProps> = ({
   children,
   variant = "default",

--- a/draft-packages/card/KaizenDraft/Card/Card.tsx
+++ b/draft-packages/card/KaizenDraft/Card/Card.tsx
@@ -29,6 +29,10 @@ export interface CardProps
   isElevated?: boolean
 }
 
+/**
+ * {@link https://cultureamp.design/components/card/ Guidance} |
+ * {@link https://cultureamp.design/storybook/?path=/story/components-card--default-story Storybook}
+ */
 export const Card = ({
   children,
   tag = "div",

--- a/draft-packages/collapsible/KaizenDraft/Collapsible/Collapsible.tsx
+++ b/draft-packages/collapsible/KaizenDraft/Collapsible/Collapsible.tsx
@@ -50,6 +50,10 @@ type State = {
   open: boolean
 }
 
+/**
+ * {@link https://cultureamp.design/components/collapsible/ Guidance} |
+ * {@link https://cultureamp.design/storybook/?path=/docs/components-collapsible--single-collapsible-kaizen-site-demo Storybook}
+ */
 export class Collapsible extends React.Component<CollapsibleProps, State> {
   public state = {
     open: !!this.props.open,

--- a/draft-packages/collapsible/KaizenDraft/Collapsible/CollapsibleGroup.tsx
+++ b/draft-packages/collapsible/KaizenDraft/Collapsible/CollapsibleGroup.tsx
@@ -23,6 +23,10 @@ export interface CollapsibleGroupProps
   automationId?: string
 }
 
+/**
+ * {@link https://cultureamp.design/components/collapsible/ Guidance} |
+ * {@link https://cultureamp.design/storybook/?path=/docs/components-collapsible--collapsible-group-default Storybook}
+ */
 export const CollapsibleGroup: React.VFC<CollapsibleGroupProps> = ({
   children,
   separated = false,

--- a/draft-packages/divider/KaizenDraft/Divider/Divider.tsx
+++ b/draft-packages/divider/KaizenDraft/Divider/Divider.tsx
@@ -9,6 +9,10 @@ export interface DividerProps
   isReversed?: boolean
 }
 
+/**
+ * {@link https://cultureamp.design/components/divider/ Guidance} |
+ * {@link https://cultureamp.design/storybook/?path=/docs/components-divider--default-story Storybook}
+ */
 export const Divider: React.VFC<DividerProps> = ({
   variant,
   isReversed = false,

--- a/draft-packages/empty-state/KaizenDraft/EmptyState/EmptyState.tsx
+++ b/draft-packages/empty-state/KaizenDraft/EmptyState/EmptyState.tsx
@@ -45,6 +45,10 @@ export interface EmptyStateProps
   automationId?: string
 }
 
+/**
+ * {@link https://cultureamp.design/components/empty-state/ Guidance} |
+ * {@link https://cultureamp.design/storybook/?path=/docs/components-empty-state--default-kaizen-site-demo Storybook}
+ */
 export const EmptyState: React.VFC<EmptyStateProps> = ({
   children,
   id,

--- a/draft-packages/form/KaizenDraft/Form/CheckboxField/CheckboxField.tsx
+++ b/draft-packages/form/KaizenDraft/Form/CheckboxField/CheckboxField.tsx
@@ -17,6 +17,10 @@ export interface CheckboxFieldProps extends CheckboxProps {
   automationId?: string
 }
 
+/**
+ * {@link https://cultureamp.design/components/checkbox-field/ Guidance} |
+ * {@link https://cultureamp.design/storybook/?path=/docs/components-form-checkbox-field--interactive-kaizen-site-demo Storybook}
+ */
 export const CheckboxField: React.VFC<CheckboxFieldProps> = ({
   id = "",
   labelText,

--- a/draft-packages/form/KaizenDraft/Form/CheckboxGroup/CheckboxGroup.tsx
+++ b/draft-packages/form/KaizenDraft/Form/CheckboxGroup/CheckboxGroup.tsx
@@ -17,6 +17,10 @@ export interface CheckboxGroupProps
   automationId?: string
 }
 
+/**
+ * {@link https://cultureamp.design/components/checkbox-group/ Guidance} |
+ * {@link https://cultureamp.design/storybook/?path=/docs/components-form-checkbox-group--interactive-kaizen-site-demo Storybook}
+ */
 export const CheckboxGroup: React.VFC<CheckboxGroupProps> = ({
   children,
   labelText,

--- a/draft-packages/form/KaizenDraft/Form/RadioField/RadioField.tsx
+++ b/draft-packages/form/KaizenDraft/Form/RadioField/RadioField.tsx
@@ -18,6 +18,10 @@ export interface RadioFieldProps extends RadioProps {
   automationId?: string
 }
 
+/**
+ * {@link https://cultureamp.design/components/radio-field/ Guidance} |
+ * {@link https://cultureamp.design/storybook/?path=/docs/components-form-radio-field--interactive-kaizen-site-demo Storybook}
+ */
 export const RadioField: React.VFC<RadioFieldProps> = ({
   children, // Not used
   id,

--- a/draft-packages/form/KaizenDraft/Form/SearchField/SearchField.tsx
+++ b/draft-packages/form/KaizenDraft/Form/SearchField/SearchField.tsx
@@ -8,6 +8,10 @@ export interface SearchFieldProps extends InputSearchProps {
   secondary?: boolean
 }
 
+/**
+ * {@link https://cultureamp.design/components/search-field/ Guidance} |
+ * {@link https://cultureamp.design/storybook/?path=/docs/components-form-search-field--default-kaizen-demo Storybook}
+ */
 export const SearchField: React.VFC<SearchFieldProps> = ({
   id,
   labelText,

--- a/draft-packages/form/KaizenDraft/Form/Slider/Slider.tsx
+++ b/draft-packages/form/KaizenDraft/Form/Slider/Slider.tsx
@@ -15,6 +15,10 @@ export interface SliderFieldProps extends InputRangeProps {
   readOnlyMessage?: ReactNode
 }
 
+/**
+ * {@link https://cultureamp.design/components/slider/ Guidance} |
+ * {@link https://cultureamp.design/storybook/?path=/docs/components-form-slider--controlled Storybook}
+ */
 export const Slider: React.VFC<SliderFieldProps> = props => {
   const {
     id,

--- a/draft-packages/form/KaizenDraft/Form/TextAreaField/TextAreaField.tsx
+++ b/draft-packages/form/KaizenDraft/Form/TextAreaField/TextAreaField.tsx
@@ -18,6 +18,10 @@ export interface TextAreaFieldProps
   variant?: "default" | "prominent"
 }
 
+/**
+ * {@link https://cultureamp.design/components/text-area-field/ Guidance} |
+ * {@link https://cultureamp.design/storybook/?path=/docs/components-form-text-area-field--default-story Storybook}
+ */
 export const TextAreaField: React.VFC<TextAreaFieldProps> = ({
   labelText,
   inline = false,

--- a/draft-packages/form/KaizenDraft/Form/TextField/TextField.tsx
+++ b/draft-packages/form/KaizenDraft/Form/TextField/TextField.tsx
@@ -36,6 +36,10 @@ export interface TextFieldProps extends Omit<InputProps, OmittedInputProps> {
   description?: string | React.ReactNode
 }
 
+/**
+ * {@link https://cultureamp.design/components/text-field/ Guidance} |
+ * {@link https://cultureamp.design/storybook/?path=/docs/components-form-text-field--default-story Storybook}
+ */
 export const TextField: React.VFC<TextFieldProps> = ({
   id,
   labelText,

--- a/draft-packages/form/KaizenDraft/Form/ToggleSwitchField/ToggleSwitchField.tsx
+++ b/draft-packages/form/KaizenDraft/Form/ToggleSwitchField/ToggleSwitchField.tsx
@@ -20,6 +20,10 @@ export interface ToggleSwitchFieldProps extends ToggleSwitchProps {
   fullWidth?: boolean
 }
 
+/**
+ * {@link https://cultureamp.design/components/toggle-switch-field/ Guidance} |
+ * {@link https://cultureamp.design/storybook/?path=/docs/components-form-toggle-switch-field--default Storybook}
+ */
 export const ToggleSwitchField: React.VFC<ToggleSwitchFieldProps> = ({
   id = "",
   labelText,

--- a/draft-packages/guidance-block/KaizenDraft/GuidanceBlock/GuidanceBlock.tsx
+++ b/draft-packages/guidance-block/KaizenDraft/GuidanceBlock/GuidanceBlock.tsx
@@ -85,6 +85,10 @@ const WithTooltip: React.FunctionComponent<WithTooltipProps> = ({
     <>{children}</>
   )
 
+/**
+ * {@link https://cultureamp.design/components/guidance-block/ Guidance} |
+ * {@link https://cultureamp.design/storybook/?path=/docs/components-guidance-block--default-story Storybook}
+ */
 class GuidanceBlock extends React.Component<
   GuidanceBlockProps,
   GuidanceBlockState

--- a/draft-packages/likert-scale-legacy/KaizenDraft/LikertScaleLegacy/LikertScaleLegacy.tsx
+++ b/draft-packages/likert-scale-legacy/KaizenDraft/LikertScaleLegacy/LikertScaleLegacy.tsx
@@ -23,6 +23,10 @@ export interface LikertScaleProps {
   onSelect: (value: ScaleItem | null) => void
 }
 
+/**
+ * {@link https://cultureamp.design/components/likert-scale/ Guidance} |
+ * {@link https://cultureamp.design/storybook/?path=/docs/components-likert-scale--default-story Storybook}
+ */
 export const LikertScaleLegacy = ({
   scale,
   selectedItem,

--- a/draft-packages/menu/KaizenDraft/Menu/Menu.tsx
+++ b/draft-packages/menu/KaizenDraft/Menu/Menu.tsx
@@ -20,6 +20,10 @@ export type MenuProps = Omit<
   button: React.ReactElement<ButtonPropsWithOptionalAria>
 }
 
+/**
+ * {@link https://cultureamp.design/components/menu/ Guidance} |
+ * {@link https://cultureamp.design/storybook/?path=/docs/components-menu--auto-hide-behaviours Storybook}
+ */
 const Menu: React.FunctionComponent<MenuProps> = ({
   button,
   menuVisible = false,

--- a/draft-packages/modal/KaizenDraft/Modal/Presets/ConfirmationModal.tsx
+++ b/draft-packages/modal/KaizenDraft/Modal/Presets/ConfirmationModal.tsx
@@ -87,6 +87,10 @@ const getIcon = (mood: Mood, isProminent: boolean) => {
   }
 }
 
+/**
+ * {@link https://cultureamp.design/components/modal/#confirmation-modal Guidance} |
+ * {@link https://cultureamp.design/storybook/?path=/docs/components-modal--confirmation-modal-example Storybook}
+ */
 const ConfirmationModal = ({
   isOpen,
   isProminent = false,

--- a/draft-packages/modal/KaizenDraft/Modal/Presets/ContextModal.tsx
+++ b/draft-packages/modal/KaizenDraft/Modal/Presets/ContextModal.tsx
@@ -38,6 +38,10 @@ export type ContextModalProps = Readonly<
 
 type ContextModal = React.FunctionComponent<ContextModalProps>
 
+/**
+ * {@link https://cultureamp.design/components/modal/#context-modals-previously-information-modal Guidance} |
+ * {@link https://cultureamp.design/storybook/?path=/docs/components-modal--context-modal-example Storybook}
+ */
 const ContextModal = ({
   isOpen,
   unpadded = false,

--- a/draft-packages/modal/KaizenDraft/Modal/Presets/InputEditModal.tsx
+++ b/draft-packages/modal/KaizenDraft/Modal/Presets/InputEditModal.tsx
@@ -28,6 +28,10 @@ export interface InputEditModalProps {
 
 type InputEditModal = React.FunctionComponent<InputEditModalProps>
 
+/**
+ * {@link https://cultureamp.design/components/modal/#input-edit-modal Guidance} |
+ * {@link https://cultureamp.design/storybook/?path=/docs/components-modal-input-edit-modal--input-edit-modal-example Storybook}
+ */
 const InputEditModal = ({
   isOpen,
   mood,

--- a/draft-packages/page-layout/KaizenDraft/Content/Content.tsx
+++ b/draft-packages/page-layout/KaizenDraft/Content/Content.tsx
@@ -38,6 +38,10 @@ export interface ContentProps
   automationId?: string
 }
 
+/**
+ * {@link https://cultureamp.design/components/page-layout/ Guidance} |
+ * {@link https://cultureamp.design/storybook/?path=/docs/components-page-layout--default-story Storybook}
+ */
 export const Container = React.forwardRef<HTMLDivElement, ContentProps>(
   ({ children, style, automationId, classNameOverride, ...restProps }, ref) => (
     <div
@@ -54,6 +58,10 @@ export const Container = React.forwardRef<HTMLDivElement, ContentProps>(
 
 Container.displayName = "Container"
 
+/**
+ * {@link https://cultureamp.design/components/page-layout/ Guidance} |
+ * {@link https://cultureamp.design/storybook/?path=/docs/components-page-layout--default-story Storybook}
+ */
 export const Content = React.forwardRef<HTMLDivElement, ContentProps>(
   ({ children, style, automationId, classNameOverride, ...restProps }, ref) => (
     <div

--- a/draft-packages/popover/KaizenDraft/Popover/Popover.tsx
+++ b/draft-packages/popover/KaizenDraft/Popover/Popover.tsx
@@ -43,6 +43,10 @@ export interface PopoverProps
 const arrowWidth = 14
 const arrowHeight = 7
 
+/**
+ * {@link https://cultureamp.design/components/popover/ Guidance} |
+ * {@link https://cultureamp.design/storybook/?path=/docs/components-popover--default-kaizen-site-demo Storybook}
+ */
 export const Popover: React.VFC<PopoverProps> = ({
   children,
   variant = "default",

--- a/draft-packages/select/KaizenDraft/Select/Select.tsx
+++ b/draft-packages/select/KaizenDraft/Select/Select.tsx
@@ -53,6 +53,10 @@ export type VariantType = "default" | "secondary" | "secondary-small"
 
 export type StatusType = "default" | "error"
 
+/**
+ * {@link https://cultureamp.design/components/select/ Guidance} |
+ * {@link https://cultureamp.design/storybook/?path=/docs/components-select--default-select-story Storybook}
+ */
 export const Select = React.forwardRef<any, SelectProps>((props, ref) => {
   if (props.fullWidth === false && props.variant !== "secondary") {
     throw new Error(

--- a/draft-packages/table/KaizenDraft/Table/Table.tsx
+++ b/draft-packages/table/KaizenDraft/Table/Table.tsx
@@ -14,6 +14,10 @@ type TableContainerProps = {
   children?: React.ReactNode
   variant?: "compact" | "default" | "data"
 }
+/**
+ * {@link https://cultureamp.design/components/table/ Guidance} |
+ * {@link https://cultureamp.design/storybook/?path=/docs/components-table--default-kaizen-site-demo Storybook}
+ */
 export const TableContainer: TableContainer = ({
   variant = "compact",
   children,

--- a/draft-packages/tag/KaizenDraft/Tag/Tag.tsx
+++ b/draft-packages/tag/KaizenDraft/Tag/Tag.tsx
@@ -53,6 +53,10 @@ const renderAvatar = (imageElementOrAvatarProps: JSX.Element | AvatarProps) =>
     <Avatar {...imageElementOrAvatarProps} size="small" />
   )
 
+/**
+ * {@link https://cultureamp.design/components/tag/ Guidance} |
+ * {@link https://cultureamp.design/storybook/?path=/docs/components-tag--default-story Storybook}
+ */
 const Tag = (props: TagProps) => {
   const {
     children,

--- a/draft-packages/tile/KaizenDraft/Tile/InformationTile.tsx
+++ b/draft-packages/tile/KaizenDraft/Tile/InformationTile.tsx
@@ -3,6 +3,10 @@ import { GenericTile, GenericTileProps } from "./components/GenericTile"
 
 export type InformationTileProps = GenericTileProps
 
+/**
+ * {@link https://cultureamp.design/components/tile/#informationtile Guidance} |
+ * {@link https://cultureamp.design/storybook/?path=/docs/components-tile--information Storybook}
+ */
 export const InformationTile: React.VFC<InformationTileProps> = props => (
   <GenericTile {...props} />
 )

--- a/draft-packages/tile/KaizenDraft/Tile/MultiActionTile.tsx
+++ b/draft-packages/tile/KaizenDraft/Tile/MultiActionTile.tsx
@@ -27,6 +27,10 @@ const renderActions = (
   </div>
 )
 
+/**
+ * {@link https://cultureamp.design/components/tile/#multiactiontile Guidance} |
+ * {@link https://cultureamp.design/storybook/?path=/docs/components-tile--multi-action Storybook}
+ */
 export const MultiActionTile: React.VFC<MultiActionTileProps> = ({
   children,
   primaryAction,

--- a/draft-packages/tile/KaizenDraft/Tile/TileGrid.tsx
+++ b/draft-packages/tile/KaizenDraft/Tile/TileGrid.tsx
@@ -14,6 +14,10 @@ export interface TileGridProps
   children: TileElement[] | TileElement
 }
 
+/**
+ * {@link https://cultureamp.design/components/tile/#tilegrid Guidance} |
+ * {@link https://cultureamp.design/storybook/?path=/docs/components-tile--tile-grid-with-tiles Storybook}
+ */
 export const TileGrid: React.VFC<TileGridProps> = ({
   children,
   classNameOverride,

--- a/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/TitleBlockZen.tsx
+++ b/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/TitleBlockZen.tsx
@@ -408,6 +408,9 @@ const createTabletOverflowMenuItems = (
 }
 
 /**
+ * {@link https://cultureamp.design/components/title-block/ Guidance} |
+ * {@link https://cultureamp.design/storybook/?path=/story/components-title-block--default Storybook}
+ *
  * ### primaryAction
  *
  * The primary action (the "main" button in the top right) can either be a Button,

--- a/draft-packages/tooltip/KaizenDraft/Tooltip/Tooltip.tsx
+++ b/draft-packages/tooltip/KaizenDraft/Tooltip/Tooltip.tsx
@@ -153,6 +153,10 @@ const TooltipContent = ({
   ) : null
 }
 
+/**
+ * {@link https://cultureamp.design/components/tooltip/ Guidance} |
+ * {@link https://cultureamp.design/storybook/?path=/docs/components-tooltip--default-kaizen-site-demo Storybook}
+ */
 const Tooltip = ({
   children,
   text,

--- a/draft-packages/well/Well.tsx
+++ b/draft-packages/well/Well.tsx
@@ -27,6 +27,10 @@ export interface WellProps
   automationId?: string
 }
 
+/**
+ * {@link https://cultureamp.design/components/well/ Guidance} |
+ * {@link https://cultureamp.design/storybook/?path=/docs/components-well--assertive Storybook}
+ */
 export const Well: React.VFC<WellProps> = ({
   children,
   variant = "default",

--- a/packages/button/src/Button/Button.tsx
+++ b/packages/button/src/Button/Button.tsx
@@ -22,6 +22,10 @@ export type ButtonProps = GenericProps &
     disabled?: boolean
   }
 
+/**
+ * {@link https://cultureamp.design/components/button/ Guidance} |
+ * {@link https://cultureamp.design/storybook/?path=/docs/components-button--default-kaizen-site-demo Storybook}
+ */
 const Button = forwardRef(
   (props: ButtonProps, ref: Ref<ButtonRef | undefined>) => (
     <GenericButton {...props} ref={ref} />

--- a/packages/button/src/Button/IconButton.tsx
+++ b/packages/button/src/Button/IconButton.tsx
@@ -20,6 +20,10 @@ export type IconButtonProps = GenericProps &
     disabled?: boolean
   }
 
+/**
+ * {@link https://cultureamp.design/components/icon-button/ Guidance} |
+ * {@link https://cultureamp.design/storybook/?path=/docs/components-button--default-kaizen-demo-icon Storybook}
+ */
 export const IconButton: React.VFC<IconButtonProps> = props => (
   <GenericButton iconButton {...props} />
 )

--- a/packages/component-library/components/Box/Box.tsx
+++ b/packages/component-library/components/Box/Box.tsx
@@ -14,6 +14,9 @@ export interface BoxProps
   rtl?: boolean
 }
 
+/**
+ * {@link https://cultureamp.design/storybook/?path=/docs/components-box--box-default Storybook}
+ */
 export const Box: React.VFC<BoxProps> = ({
   children,
   rtl = false,

--- a/packages/component-library/components/Icon/Icon.tsx
+++ b/packages/component-library/components/Icon/Icon.tsx
@@ -17,6 +17,10 @@ export interface IconProps
   desc?: string
 }
 
+/**
+ * {@link https://cultureamp.design/components/icon/ Guidance} |
+ * {@link https://cultureamp.design/storybook/?path=/docs/components-icon--meaningful-kaizen-site-demo Storybook}
+ */
 export const Icon: React.VFC<IconProps> = ({
   icon,
   inheritSize = false,

--- a/packages/date-picker/src/DatePicker/DatePicker.tsx
+++ b/packages/date-picker/src/DatePicker/DatePicker.tsx
@@ -97,6 +97,10 @@ export enum DayOfWeek {
   Sat = 6,
 }
 
+/**
+ * {@link https://cultureamp.design/components/date-picker/ Guidance} |
+ * {@link https://cultureamp.design/storybook/?path=/docs/components-date-picker-date-picker--default-story Storybook}
+ */
 export const DatePicker: React.VFC<DatePickerProps> = ({
   id,
   buttonRef = useRef<HTMLButtonElement>(null),

--- a/packages/date-picker/src/DatePicker/DateRangePicker.tsx
+++ b/packages/date-picker/src/DatePicker/DateRangePicker.tsx
@@ -87,6 +87,10 @@ enum DayOfWeek {
   Sat = 6,
 }
 
+/**
+ * {@link https://cultureamp.design/components/date-range-picker/ Guidance} |
+ * {@link https://cultureamp.design/storybook/?path=/docs/components-date-picker-date-range-picker--date-range-picker-sticker-sheet Storybook}
+ */
 export const DateRangePicker: React.VFC<DateRangePickerProps> = ({
   id,
   buttonRef = useRef<HTMLButtonElement>(null),

--- a/packages/loading-spinner/src/LoadingSpinner/LoadingSpinner.tsx
+++ b/packages/loading-spinner/src/LoadingSpinner/LoadingSpinner.tsx
@@ -15,6 +15,10 @@ export interface LoadingSpinnerProps
   size?: size
 }
 
+/**
+ * {@link https://cultureamp.design/components/loading-spinner/ Guidance} |
+ * {@link https://cultureamp.design/storybook/?path=/docs/components-loading-spinner--default-story Storybook}
+ */
 export const LoadingSpinner: React.VFC<LoadingSpinnerProps> = ({
   children,
   accessibilityLabel = "Loading",

--- a/packages/notification/src/InlineNotification.tsx
+++ b/packages/notification/src/InlineNotification.tsx
@@ -17,6 +17,10 @@ type Props = {
   forceMultiline?: boolean
 }
 
+/**
+ * {@link https://cultureamp.design/components/inline-notification/ Guidance} |
+ * {@link https://cultureamp.design/storybook/?path=/docs/components-notification-inline-notification--default-kaizen-demo Storybook}
+ */
 const InlineNotification = ({
   persistent,
   hideCloseIcon,

--- a/packages/notification/src/ToastNotification.tsx
+++ b/packages/notification/src/ToastNotification.tsx
@@ -8,6 +8,10 @@ type Props = Omit<ToastNotificationWithOptionals, "message"> & {
   children: React.ReactNode
 }
 
+/**
+ * {@link https://cultureamp.design/components/toast-notification/ Guidance} |
+ * {@link https://cultureamp.design/storybook/?path=/docs/components-notification-toast-notification--cautionary Storybook}
+ */
 const ToastNotification = ({
   id,
   hideCloseIcon = false,

--- a/packages/pagination/src/Pagination.tsx
+++ b/packages/pagination/src/Pagination.tsx
@@ -24,6 +24,10 @@ export enum PageAction {
   NEXT = "next",
 }
 
+/**
+ * {@link https://cultureamp.design/components/pagination/ Guidance} |
+ * {@link https://cultureamp.design/storybook/?path=/docs/components-pagination--default Storybook}
+ */
 export const Pagination: React.VFC<PaginationProps> = ({
   currentPage = 1,
   pageCount,

--- a/packages/progress-bar/src/ProgressBar.tsx
+++ b/packages/progress-bar/src/ProgressBar.tsx
@@ -32,6 +32,10 @@ function calculatePercentage({ value, max }: ProgressBarProps) {
   return (value / max) * 100.0
 }
 
+/**
+ * {@link https://cultureamp.design/components/progress-bar/ Guidance} |
+ * {@link https://cultureamp.design/storybook/?path=/docs/components-progress-bar--default-story Storybook}
+ */
 export const ProgressBar: React.VFC<ProgressBarProps> = props => {
   const {
     value,

--- a/packages/rich-text-editor/src/RichTextEditor/RichTextEditor.tsx
+++ b/packages/rich-text-editor/src/RichTextEditor/RichTextEditor.tsx
@@ -35,6 +35,10 @@ export interface RichTextEditorProps
   rows?: EditorRows
 }
 
+/**
+ * {@link https://cultureamp.design/components/rich-text-editor/ Guidance} |
+ * {@link https://cultureamp.design/storybook/?path=/docs/components-rich-text-editor--default Storybook}
+ */
 export const RichTextEditor: React.VFC<RichTextEditorProps> = props => {
   const {
     onChange,

--- a/packages/split-button/src/SplitButton/SplitButton.tsx
+++ b/packages/split-button/src/SplitButton/SplitButton.tsx
@@ -46,6 +46,10 @@ export interface SplitButtonProps
   dir?: "ltr" | "rtl"
 }
 
+/**
+ * {@link https://cultureamp.design/components/split-button/ Guidance} |
+ * {@link https://cultureamp.design/storybook/?path=/docs/components-split-button--default-kaizen-site-demo Storybook}
+ */
 export const SplitButton: React.VFC<SplitButtonProps> = ({
   actionButtonProps,
   dropdownButtonProps,

--- a/packages/tabs/src/Tabs.tsx
+++ b/packages/tabs/src/Tabs.tsx
@@ -26,6 +26,9 @@ export interface TabsProps {
 }
 
 /**
+ * {@link https://cultureamp.design/components/tabs/ Guidance} |
+ * {@link https://cultureamp.design/storybook/?path=/docs/components-tabs--controlled Storybook}
+ *
  * Wrapper around the whole thing: holds a tab list and tab panels
  */
 export const Tabs = (props: TabsProps) => {

--- a/packages/typography/src/Heading/Heading.tsx
+++ b/packages/typography/src/Heading/Heading.tsx
@@ -50,6 +50,10 @@ export interface HeadingProps
   color?: AllowedHeadingColors
 }
 
+/**
+ * {@link https://cultureamp.design/components/heading/ Guidance} |
+ * {@link https://cultureamp.design/storybook/?path=/docs/components-typography-heading--display-0 Storybook}
+ */
 export const Heading: React.VFC<HeadingProps> = ({
   children,
   tag,

--- a/packages/typography/src/Paragraph/Paragraph.tsx
+++ b/packages/typography/src/Paragraph/Paragraph.tsx
@@ -41,6 +41,10 @@ export interface ParagraphProps
   color?: AllowedParagraphColors
 }
 
+/**
+ * {@link https://cultureamp.design/components/paragraph/ Guidance} |
+ * {@link https://cultureamp.design/storybook/?path=/docs/components-typography-paragraph--body Storybook}
+ */
 export const Paragraph: React.VFC<ParagraphProps> = ({
   children,
   tag,


### PR DESCRIPTION
## Why

Add links to Guidance and Storyboard for every component as JSDoc. This means any engineer can quickly navigate to see the excellent guides that have already been written on how and when to use this component. The Figma design system also has these links.

<img width="380" alt="image" src="https://user-images.githubusercontent.com/2635733/170420650-b4c7b130-74c4-4ca2-968a-f47f742e1caf.png">



## What

```js
/**
 * {@link https://cultureamp.design/components/well/ Guidance} |
 * {@link https://cultureamp.design/storybook/?path=/docs/components-well--assertive Storybook}
 */
```

<img width="718" alt="image" src="https://user-images.githubusercontent.com/2635733/170420445-efcbbef2-df4d-47a4-ab76-d010a085ff35.png">

<img width="303" alt="image" src="https://user-images.githubusercontent.com/2635733/170420397-1e7fa302-920a-42ef-8116-5c9ea4b77014.png">
