### PR TITLE
chore(deps): Remove button dep from component-library

### DIFF
--- a/packages/component-library/package.json
+++ b/packages/component-library/package.json
@@ -31,7 +31,6 @@
     "react": "^16.9.0 || ^17.0.0 || ^18.0.0"
   },
   "dependencies": {
-    "@kaizen/button": "^1.2.2",
     "@kaizen/component-base": "^1.1.0",
     "@kaizen/deprecated-component-library-helpers": "^2.5.6",
     "@kaizen/hosted-assets": "^2.0.0",


### PR DESCRIPTION
## What
Remove unused `@kaizen/button` dep from `component-library`.

## Why
This is unused and is causing a circular dependency.