### PR TITLE
fix: focus should remain in editor when clicking toolbar buttons

### DIFF
--- a/packages/rich-text-editor/src/RichTextEditor/components/ToggleIconButton/ToggleIconButton.tsx
+++ b/packages/rich-text-editor/src/RichTextEditor/components/ToggleIconButton/ToggleIconButton.tsx
@@ -35,6 +35,7 @@ export const ToggleIconButton: React.VFC<ToggleIconButtonProps> =
       <Tooltip text={label} display="inline-block" position="above">
         <button
           ref={ref}
+          type="button"
           aria-pressed={isActive}
           aria-label={label}
           onMouseDown={e => e.preventDefault()}

--- a/packages/rich-text-editor/src/RichTextEditor/components/ToggleIconButton/ToggleIconButton.tsx
+++ b/packages/rich-text-editor/src/RichTextEditor/components/ToggleIconButton/ToggleIconButton.tsx
@@ -37,6 +37,7 @@ export const ToggleIconButton: React.VFC<ToggleIconButtonProps> =
           ref={ref}
           aria-pressed={isActive}
           aria-label={label}
+          onMouseDown={e => e.preventDefault()}
           className={classnames(styles.button, classNameOverride, {
             [styles.active]: isActive,
             [styles[mood]]: mood,


### PR DESCRIPTION
## Why

The Kaizen RTE loses focus when clicking on the toolbar button.
[JIRA CARD](https://cultureamp.atlassian.net/browse/COMP-147)

https://user-images.githubusercontent.com/48308300/171392000-8a236b72-38b2-4a6d-8cda-95eef5534e8f.mov




## What
- Added the `onMouseDown` event on `ToggleIconButton` to prevent the editor from losing focus.
https://github.com/ProseMirror/prosemirror/issues/555#issuecomment-278723624



https://user-images.githubusercontent.com/48308300/171392449-8d6dd406-9a05-4c05-8a31-28a626ac8c93.mov




