### PR TITLE
feat: Add highlight mood (purple-100) for BrandMoment

### DIFF
--- a/packages/brand-moment/src/BrandMoment.scss
+++ b/packages/brand-moment/src/BrandMoment.scss
@@ -26,6 +26,10 @@ $breakpoint-xl: 1366px; // TODO: create an xl breakpoint in design-tokens and re
   &.negative {
     background: $color-red-100;
   }
+
+  &.highlight {
+    background: $color-purple-100;
+  }
 }
 
 // --------------------------------

--- a/packages/brand-moment/src/BrandMoment.tsx
+++ b/packages/brand-moment/src/BrandMoment.tsx
@@ -11,7 +11,7 @@ import styles from "./BrandMoment.scss"
 
 export interface BrandMomentProps
   extends OverrideClassName<HTMLAttributes<HTMLDivElement>> {
-  mood: "informative" | "positive" | "negative"
+  mood: "informative" | "positive" | "negative" | "highlight"
   illustration: ReactElement<SceneProps>
   header: ReactNode
   body?: ReactNode


### PR DESCRIPTION
## Why
<!-- Why have you created this PR? - Is it a new feature, or a bug fix? Or something else? -->
<!-- Reference any relevant Jira tickets so your reviewer can find more context if needed. -->
<!-- Fixing a GitHub issue? Add "Fixes [issue URL]". -->
We are introducing a brand-moment for Develop that uses the purple-100 background colour. This is known as the 'highlight' mood in the UI kit.
https://www.figma.com/file/GDJ3KsznTE7Z7GwyJzANcB/%F0%9F%9A%A7-Develop-2021-Q3?node-id=6088%3A158270

## What
<!-- What do your changes do? How do they change/fix the current behavior? -->
<!-- Add screenshots, GIFs or videos to illustrate the changes.  -->
In line with the other moods, added as an option to the mood prop