### PR TITLE
style(title block zen): set max-width of subtitle to max-content

### DIFF
--- a/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/TitleBlockZen.scss
+++ b/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/TitleBlockZen.scss
@@ -248,7 +248,7 @@ $tab-container-height-medium-and-small-collapsed: $ca-grid * 0.75;
   font-size: $typography-paragraph-small-font-size;
   line-height: $typography-paragraph-small-line-height;
   letter-spacing: $typography-paragraph-small-letter-spacing;
-  max-width: 230px;
+  max-width: max-content;
 
   .adminVariant & {
     color: $color-purple-800;


### PR DESCRIPTION
…to stop wrapping of long subtitles

## Why
Prevent long subtitles from wrapping. See slack [conversation](https://cultureamp.slack.com/archives/C0189KBPM4Y/p1654212985638349?thread_ts=1654143872.284079&cid=C0189KBPM4Y).


## What
Set max-width of the subtitle to max-content
