### PR TITLE
fix: add white space fix to resolve spacing bug on firefox

### DIFF
--- a/packages/rich-text-editor/src/RichTextEditor/RichTextEditor.scss
+++ b/packages/rich-text-editor/src/RichTextEditor/RichTextEditor.scss
@@ -14,6 +14,7 @@
   padding: $spacing-sm calc(#{$spacing-xs} * 3);
   transition: background-color $animation-duration-immediate,
     border-color $animation-duration-immediate;
+  white-space: pre-wrap;
 
   > p {
     margin: 0 0 $spacing-sm;


### PR DESCRIPTION
## Why
On Firefox there is a bug that removes white-space between text nodes. This is a known [issue](https://github.com/ProseMirror/prosemirror/issues/651) with prosemirror as the editor requires `white-space: pre-wrap` in the editable area. It is recommended that if you are not importing prosemirrors default css file you declare this to ensure the package can interpret white-space correctly in edit mode.

## What
- adds `white-space: pre-wrap` to rich text editor styles.

