### PR TITLE
fix(rte): rte hover state causing clipping

### DIFF
--- a/packages/rich-text-editor/src/RichTextEditor/RichTextEditor.scss
+++ b/packages/rich-text-editor/src/RichTextEditor/RichTextEditor.scss
@@ -51,16 +51,16 @@
   }
 }
 
+.editor.hasToolbar > :global(.ProseMirror) {
+  border-top-left-radius: 0px;
+  border-top-right-radius: 0px;
+}
+
 .editorWrapper {
   position: relative;
   border: $border-solid-border-width $border-solid-border-style $color-gray-500;
   background: $color-white;
   border-radius: $border-solid-border-radius;
-
-  .activeToolbar > :global(.ProseMirror) {
-    border-top-left-radius: 0px;
-    border-top-right-radius: 0px;
-  }
 }
 
 @for $i from 1 through 20 {

--- a/packages/rich-text-editor/src/RichTextEditor/RichTextEditor.scss
+++ b/packages/rich-text-editor/src/RichTextEditor/RichTextEditor.scss
@@ -5,7 +5,7 @@
 @import "@kaizen/design-tokens/sass/typography";
 
 .editor > :global(.ProseMirror) {
-  border-radius: 0 0 $border-solid-border-radius $border-solid-border-radius;
+  border-radius: $border-solid-border-radius;
   font-family: $typography-paragraph-body-font-family;
   font-weight: $typography-paragraph-body-font-weight;
   font-size: $typography-paragraph-body-font-size;
@@ -56,6 +56,11 @@
   border: $border-solid-border-width $border-solid-border-style $color-gray-500;
   background: $color-white;
   border-radius: $border-solid-border-radius;
+
+  .activeToolbar > :global(.ProseMirror) {
+    border-top-left-radius: 0px;
+    border-top-right-radius: 0px;
+  }
 }
 
 @for $i from 1 through 20 {

--- a/packages/rich-text-editor/src/RichTextEditor/RichTextEditor.tsx
+++ b/packages/rich-text-editor/src/RichTextEditor/RichTextEditor.tsx
@@ -112,8 +112,8 @@ export const RichTextEditor: React.VFC<RichTextEditorProps> = props => {
           className={classnames(
             styles.editor,
             styles[`rows${rows}`],
-            controls && styles.activeToolbar,
-            classNameOverride
+            classNameOverride,
+            { [styles.hasToolbar]: controls != null && controls.length > 0 }
           )}
           {...restProps}
         />

--- a/packages/rich-text-editor/src/RichTextEditor/RichTextEditor.tsx
+++ b/packages/rich-text-editor/src/RichTextEditor/RichTextEditor.tsx
@@ -112,6 +112,7 @@ export const RichTextEditor: React.VFC<RichTextEditorProps> = props => {
           className={classnames(
             styles.editor,
             styles[`rows${rows}`],
+            controls && styles.activeToolbar,
             classNameOverride
           )}
           {...restProps}


### PR DESCRIPTION
## Why
Rte editor state causing clipping while hovering [JIRA](https://cultureamp.atlassian.net/browse/COMP-156)

BEFORE:
<img width="1046" alt="Screenshot 2022-06-07 at 12 06 14 PM" src="https://user-images.githubusercontent.com/46525344/172312281-ae5cc5aa-e29a-4c93-bb06-058a63db0053.png">

AFTER:
<img width="1134" alt="Screenshot 2022-06-07 at 12 04 00 PM" src="https://user-images.githubusercontent.com/46525344/172312482-d34a9232-51cf-46c9-b831-bd072c063743.png">



## What
Adding border radius and removing border radius when toolbar is present
