### PR TITLE
fix: Fixed issue of modal background going full opacity in Chrome 102 by changing animation speed [KDS-523]

### DIFF
--- a/draft-packages/modal/KaizenDraft/Modal/Primitives/GenericModal.scss
+++ b/draft-packages/modal/KaizenDraft/Modal/Primitives/GenericModal.scss
@@ -59,11 +59,12 @@
   transition-duration: $ca-duration-fast;
 
   .backdropLayer {
-    @include ca-animation-fade(
-      $duration: $ca-duration-rapid,
-      $from: 0,
-      $to: 0.5
-    );
+    /*
+      There's a weird bug in Chrome/Blink 102.x that animates the opacity
+      all the way to 1 with 200ms ("rapid" token), but is fine with
+      201ms, see Jira [KDS-523]
+    */
+    @include ca-animation-fade($duration: 201ms, $from: 0, $to: 0.5);
   }
 
   .genericModal {
@@ -78,7 +79,11 @@
   transition-duration: $ca-duration-rapid;
 
   .backdropLayer {
-    @include ca-animation-fade($from: 0.5, $to: 0);
+    @include ca-animation-fade(
+      $duration: $ca-duration-rapid,
+      $from: 0.5,
+      $to: 0
+    );
   }
 
   .genericModal {


### PR DESCRIPTION
## Why
- See issue here: https://cultureamp.atlassian.net/jira/software/projects/KDS/boards/289?selectedIssue=KDS-523
- Modal backdrop would snap to full opacity at the end of the fade-in animation; a window resize would fix it

<img width="300" alt="image" src="https://user-images.githubusercontent.com/763385/172312779-332b7cbc-ef42-4105-b5e6-156ab143d9a0.png">


## What
- Changing the Modal package all the way back to v6.x didn't help, showed same problem, so likely no code regression
- Investigation showed that it is somehow correlated with the latest Blink engine 102.x; MS Edge 95 was fine, once updated to 102 demonstrated the bug; Firefox & Safari also did not exhibit the issue
- After some exploration it showed that changing the animation duration from `rapid` (200ms) to just something slightly off (201ms) made it work; fwiw 300ms also didn't work 🤷