### PR TITLE
feat: Expose onAfterLeave on all modal components

### DIFF
--- a/draft-packages/modal/KaizenDraft/Modal/Presets/ConfirmationModal.tsx
+++ b/draft-packages/modal/KaizenDraft/Modal/Presets/ConfirmationModal.tsx
@@ -41,6 +41,7 @@ export interface ConfirmationModalProps {
   readonly title: string
   readonly onConfirm?: () => void
   readonly onDismiss: () => void
+  readonly onAfterLeave?: () => void
   readonly confirmLabel?: string
   readonly dismissLabel?: string
   readonly confirmWorking?: { label: string; labelHidden?: boolean }
@@ -98,6 +99,7 @@ const ConfirmationModal = ({
   mood,
   title,
   onConfirm,
+  onAfterLeave,
   confirmLabel = "Confirm",
   dismissLabel = "Cancel",
   confirmWorking,
@@ -133,6 +135,7 @@ const ConfirmationModal = ({
       onEscapeKeyup={onDismiss}
       onOutsideModalClick={onDismiss}
       automationId={automationId}
+      onAfterLeave={onAfterLeave}
     >
       <div className={styles.modal}>
         <ModalHeader onDismiss={onDismiss}>

--- a/draft-packages/modal/KaizenDraft/Modal/Presets/ContextModal.tsx
+++ b/draft-packages/modal/KaizenDraft/Modal/Presets/ContextModal.tsx
@@ -26,6 +26,7 @@ export type ContextModalProps = Readonly<
     title: string
     onConfirm?: () => void
     onDismiss: () => void
+    onAfterLeave?: () => void
     confirmLabel?: string
     confirmWorking?: { label: string; labelHidden?: boolean }
     automationId?: string
@@ -48,6 +49,7 @@ const ContextModal = ({
   layout = "portrait",
   title,
   onConfirm,
+  onAfterLeave,
   confirmLabel = "Confirm",
   confirmWorking,
   automationId,
@@ -88,6 +90,7 @@ const ContextModal = ({
       onEscapeKeyup={onDismiss}
       onOutsideModalClick={onDismiss}
       automationId={automationId}
+      onAfterLeave={onAfterLeave}
     >
       <div className={styles.modal}>
         {renderBackground && renderBackground()}

--- a/draft-packages/modal/KaizenDraft/Modal/Presets/InputEditModal.tsx
+++ b/draft-packages/modal/KaizenDraft/Modal/Presets/InputEditModal.tsx
@@ -18,6 +18,7 @@ export interface InputEditModalProps {
   readonly title: string
   readonly onSubmit: () => void
   readonly onDismiss: () => void
+  readonly onAfterLeave?: () => void
   readonly localeDirection?: "rtl" | "ltr"
   readonly submitLabel?: string
   readonly dismissLabel?: string
@@ -37,6 +38,7 @@ const InputEditModal = ({
   mood,
   title,
   onSubmit,
+  onAfterLeave,
   localeDirection = "ltr",
   submitLabel = "Submit",
   dismissLabel = "Cancel",
@@ -66,6 +68,7 @@ const InputEditModal = ({
       isOpen={isOpen}
       onEscapeKeyup={onDismiss}
       automationId={automationId}
+      onAfterLeave={onAfterLeave}
     >
       <div className={styles.modal} dir={localeDirection}>
         <ModalHeader onDismiss={onDismiss}>

--- a/draft-packages/modal/KaizenDraft/Modal/Presets/RoadblockModal.tsx
+++ b/draft-packages/modal/KaizenDraft/Modal/Presets/RoadblockModal.tsx
@@ -18,6 +18,7 @@ export interface RoadblockModalProps {
   readonly isOpen: boolean
   readonly title: string
   readonly onDismiss: () => void
+  readonly onAfterLeave?: () => void
   readonly dismissLabel?: string
   readonly automationId?: string
   readonly children: React.ReactNode
@@ -32,6 +33,7 @@ const RoadblockModal = ({
   isOpen,
   title,
   onDismiss,
+  onAfterLeave,
   dismissLabel = "Back",
   automationId,
   children,
@@ -41,6 +43,7 @@ const RoadblockModal = ({
     onEscapeKeyup={onDismiss}
     onOutsideModalClick={onDismiss}
     automationId={automationId}
+    onAfterLeave={onAfterLeave}
   >
     <div className={styles.modal}>
       <ModalHeader unpadded onDismiss={onDismiss}>

--- a/draft-packages/modal/KaizenDraft/Modal/Primitives/GenericModal.tsx
+++ b/draft-packages/modal/KaizenDraft/Modal/Primitives/GenericModal.tsx
@@ -17,6 +17,7 @@ export interface GenericModalContainerProps {
   readonly focusLockDisabled?: boolean
   readonly onEscapeKeyup?: (event: KeyboardEvent) => void
   readonly onOutsideModalClick?: (event: React.MouseEvent) => void
+  readonly onAfterLeave?: () => void
   readonly automationId?: string
 }
 
@@ -77,6 +78,7 @@ class GenericModal extends React.Component<GenericModalProps> {
     this.removeEventHandlers()
     this.restoreBodyScroll()
     this.removeAriaHider()
+    this.props.onAfterLeave && this.props.onAfterLeave()
   }
 
   addEventHandlers() {


### PR DESCRIPTION
## Why
I need to focus on the RTE after the link modal closes, but I can't do it on submit because the animation still needs to happen first. Our modal puts focus back on the button that opened the modal, but in this case that button has disappeared, and we really want it back in the editor.

I only need this for the Input/Edit Modal, but I figure I may as well expose it on all of our modals while I'm here for future cases.

## What
Adds a new prop to all our modal components called `onAfterLeave`, and passes this callback into the prop of the same name on `Transition` (headlessui component) via `GenericModal'.
