### PR TITLE
ci: update docker release image to node lts stretch

### DIFF
--- a/.buildkite/dockerfiles/release.Dockerfile
+++ b/.buildkite/dockerfiles/release.Dockerfile
@@ -1,13 +1,1 @@
-FROM node:16-alpine
-
-RUN apk update && apk add --no-cache \
-  git \
-  openssh \
-  python2 \
-  py-pip \ 
-  gcc \ 
-  alpine-sdk \ 
-  python2-dev
-
-RUN pip install \
-  awscli
+FROM node:lts-stretch


### PR DESCRIPTION
## Why
release step was breaking on buildkite - [see thread](https://cultureamp.slack.com/archives/C016N8Y1E10/p1654656512683039)


<img width="1115" alt="Screen Shot 2022-06-08 at 4 23 17 pm" src="https://user-images.githubusercontent.com/36558508/172546201-231040ef-39a7-4d33-942e-38cfa3fc1a51.png">


## What
- Removes config Alpine config
- Adds node image stretch
