### PR TITLE
fix: Allow passing both href and onClick to Button from Action component

### DIFF
--- a/draft-packages/tile/KaizenDraft/Tile/components/Action.spec.tsx
+++ b/draft-packages/tile/KaizenDraft/Tile/components/Action.spec.tsx
@@ -1,0 +1,41 @@
+import React from "react"
+import { fireEvent, render } from "@testing-library/react"
+import Action from "./Action"
+
+describe("<Action />", () => {
+  it("renders anchor tag with href and onClick when both is provided", () => {
+    const onClickMock = jest.fn()
+    const { getByRole } = render(
+      <Action
+        action={{
+          label: "I am an anchor",
+          href: "https://example.com",
+          onClick: onClickMock,
+        }}
+      />
+    )
+
+    const anchor = getByRole("link")
+    fireEvent.click(anchor)
+
+    expect(anchor).toHaveAttribute("href", "https://example.com")
+    expect(onClickMock).toHaveBeenCalledTimes(1)
+  })
+
+  it("renders a button when href is not provided", () => {
+    const onClickMock = jest.fn()
+    const { getByRole } = render(
+      <Action
+        action={{
+          label: "I am an anchor",
+          onClick: onClickMock,
+        }}
+      />
+    )
+
+    const button = getByRole("button")
+    fireEvent.click(button)
+
+    expect(onClickMock).toHaveBeenCalledTimes(1)
+  })
+})

--- a/draft-packages/tile/KaizenDraft/Tile/components/Action.tsx
+++ b/draft-packages/tile/KaizenDraft/Tile/components/Action.tsx
@@ -20,21 +20,10 @@ const Action: Action = ({ action, secondary = false, disabled = false }) => {
     newTabAndIUnderstandTheAccessibilityImplications,
   } = action
 
-  return href ? (
+  return (
     <Button
       label={label}
       href={href}
-      secondary={secondary}
-      icon={icon}
-      data-automation-id={automationId}
-      disabled={disabled}
-      newTabAndIUnderstandTheAccessibilityImplications={
-        newTabAndIUnderstandTheAccessibilityImplications
-      }
-    />
-  ) : (
-    <Button
-      label={label}
       onClick={onClick}
       secondary={secondary}
       icon={icon}

--- a/packages/button/src/Button/components/GenericButton.tsx
+++ b/packages/button/src/Button/components/GenericButton.tsx
@@ -199,14 +199,6 @@ const renderLink = (props: Props, ref: Ref<HTMLAnchorElement>) => {
   } = props
   const customProps = getCustomProps(rest)
 
-  const handleOnClick = (event: MouseEvent) => {
-    event.preventDefault()
-    onClick && onClick(event)
-    if (href) {
-      window.location.href = href
-    }
-  }
-
   return (
     <a
       id={id}
@@ -215,7 +207,7 @@ const renderLink = (props: Props, ref: Ref<HTMLAnchorElement>) => {
         newTabAndIUnderstandTheAccessibilityImplications ? "_blank" : "_self"
       }
       className={buttonClass(props)}
-      onClick={handleOnClick}
+      onClick={onClick}
       onFocus={onFocus}
       onBlur={onBlur}
       ref={ref}

--- a/packages/button/src/Button/components/GenericButton.tsx
+++ b/packages/button/src/Button/components/GenericButton.tsx
@@ -199,6 +199,14 @@ const renderLink = (props: Props, ref: Ref<HTMLAnchorElement>) => {
   } = props
   const customProps = getCustomProps(rest)
 
+  const handleOnClick = (event: MouseEvent) => {
+    event.preventDefault()
+    onClick && onClick(event)
+    if (href) {
+      window.location.href = href
+    }
+  }
+
   return (
     <a
       id={id}
@@ -207,7 +215,7 @@ const renderLink = (props: Props, ref: Ref<HTMLAnchorElement>) => {
         newTabAndIUnderstandTheAccessibilityImplications ? "_blank" : "_self"
       }
       className={buttonClass(props)}
-      onClick={onClick}
+      onClick={handleOnClick}
       onFocus={onFocus}
       onBlur={onBlur}
       ref={ref}


### PR DESCRIPTION
## Why
<!-- Why have you created this PR? - Is it a new feature, or a bug fix? Or something else? -->
<!-- Reference any relevant Jira tickets so your reviewer can find more context if needed. -->
<!-- Fixing a GitHub issue? Add "Fixes [issue URL]". -->
In unified-home, we are using `MultiActionTile` for the displaced tiles at the bottom of the page. We are working on [this ticket](https://trello.com/c/nhIwDNmf/427-displaced-tiles-dont-have-analytics) to add missing analytics to track user clicking on these tiles. It turns out that inside `MultiActionTile`, it is using `Action` and it is not passing through `onClick` when `href` is there. Due to that, the `onClick` we pass to `MultiActionTile` would not be called to track user clicks since we are passing through `href` as well.

For more info/discussion, there is slack thread [here](https://cultureamp.slack.com/archives/C0189KBPM4Y/p1654743194761219)


## What
<!-- What do your changes do? How do they change/fix the current behavior? -->
<!-- Add screenshots, GIFs or videos to illustrate the changes.  -->
Allow passing both href and onClick to Button from Action component
