### PR TITLE
feat: Allow aria-labelledby as an alternative to labelText on RTE

### DIFF
--- a/packages/rich-text-editor/docs/RichTextEditor.stories.tsx
+++ b/packages/rich-text-editor/docs/RichTextEditor.stories.tsx
@@ -20,25 +20,28 @@ export default {
   },
 }
 
-export const Default: Story<RichTextEditorProps> = args => {
+export const Default = args => {
   const [rteData, setRTEData] = useState<EditorContentArray>([])
   return (
     <>
       <RichTextEditor
         value={rteData}
         onChange={data => setRTEData(data)}
-        labelText={"Label"}
-        rows={3}
-        controls={[
-          { name: "bold", group: "inline" },
-          { name: "italic", group: "inline" },
-          { name: "underline", group: "inline" },
-          { name: "orderedList", group: "list" },
-          { name: "bulletList", group: "list" },
-        ]}
+        {...args}
       />
     </>
   )
 }
 
 Default.storyName = "Default (Kaizen Demo)"
+Default.args = {
+  labelText: "Label",
+  rows: 3,
+  controls: [
+    { name: "bold", group: "inline" },
+    { name: "italic", group: "inline" },
+    { name: "underline", group: "inline" },
+    { name: "orderedList", group: "list" },
+    { name: "bulletList", group: "list" },
+  ],
+}

--- a/packages/rich-text-editor/docs/RichTextEditor.stories.tsx
+++ b/packages/rich-text-editor/docs/RichTextEditor.stories.tsx
@@ -1,6 +1,8 @@
 import React, { useState } from "react"
-import { RichTextEditor, EditorContentArray } from "@kaizen/rich-text-editor"
+import { Story } from "@storybook/react"
+import { RichTextEditor, EditorContentArray, RichTextEditorProps } from "@kaizen/rich-text-editor"
 import { CATEGORIES } from "../../../storybook/constants"
+import { Label } from "@kaizen/draft-form"
 
 export default {
   title: `${CATEGORIES.components}/Rich Text Editor`,
@@ -14,28 +16,49 @@ export default {
   },
 }
 
-export const Default = args => {
+export const Default: Story<RichTextEditorProps> = args => {
   const [rteData, setRTEData] = useState<EditorContentArray>([])
   return (
     <>
       <RichTextEditor
         value={rteData}
         onChange={data => setRTEData(data)}
-        {...args}
+        labelText={"Label"}
+        rows={3}
+        controls={[
+          { name: "bold", group: "inline" },
+          { name: "italic", group: "inline" },
+          { name: "underline", group: "inline" },
+          { name: "orderedList", group: "list" },
+          { name: "bulletList", group: "list" },
+        ]}
       />
     </>
   )
 }
 
 Default.storyName = "Default (Kaizen Demo)"
-Default.args = {
-  labelText: "Label",
-  rows: 3,
-  controls: [
-    { name: "bold", group: "inline" },
-    { name: "italic", group: "inline" },
-    { name: "underline", group: "inline" },
-    { name: "orderedList", group: "list" },
-    { name: "bulletList", group: "list" },
-  ],
+
+export const WithLabelledBy: Story<RichTextEditorProps> = args => {
+  const [rteData, setRTEData] = useState<EditorContentArray>([])
+  return (
+    <>
+      <Label id="Label-id" labelText="Sample Label" />
+      <RichTextEditor
+        value={rteData}
+        onChange={data => setRTEData(data)}
+        labelledBy={"Label-id"}
+        rows={3}
+        controls={[
+          { name: "bold", group: "inline" },
+          { name: "italic", group: "inline" },
+          { name: "underline", group: "inline" },
+          { name: "orderedList", group: "list" },
+          { name: "bulletList", group: "list" },
+        ]}
+      />
+    </>
+  )
 }
+
+WithLabelledBy.storyName = "Rich Text Editor with LabelledBy Prop"

--- a/packages/rich-text-editor/docs/RichTextEditor.stories.tsx
+++ b/packages/rich-text-editor/docs/RichTextEditor.stories.tsx
@@ -1,8 +1,8 @@
 import React, { useState } from "react"
 import { Story } from "@storybook/react"
 import { RichTextEditor, EditorContentArray, RichTextEditorProps } from "@kaizen/rich-text-editor"
-import { CATEGORIES } from "../../../storybook/constants"
 import { Label } from "@kaizen/draft-form"
+import { CATEGORIES } from "../../../storybook/constants"
 
 export default {
   title: `${CATEGORIES.components}/Rich Text Editor`,

--- a/packages/rich-text-editor/docs/RichTextEditor.stories.tsx
+++ b/packages/rich-text-editor/docs/RichTextEditor.stories.tsx
@@ -1,6 +1,10 @@
 import React, { useState } from "react"
 import { Story } from "@storybook/react"
-import { RichTextEditor, EditorContentArray, RichTextEditorProps } from "@kaizen/rich-text-editor"
+import {
+  RichTextEditor,
+  EditorContentArray,
+  RichTextEditorProps,
+} from "@kaizen/rich-text-editor"
 import { Label } from "@kaizen/draft-form"
 import { CATEGORIES } from "../../../storybook/constants"
 

--- a/packages/rich-text-editor/docs/RichTextEditor.stories.tsx
+++ b/packages/rich-text-editor/docs/RichTextEditor.stories.tsx
@@ -42,27 +42,3 @@ export const Default: Story<RichTextEditorProps> = args => {
 }
 
 Default.storyName = "Default (Kaizen Demo)"
-
-export const WithLabelledBy: Story<RichTextEditorProps> = args => {
-  const [rteData, setRTEData] = useState<EditorContentArray>([])
-  return (
-    <>
-      <Label id="Label-id" labelText="Sample Label" />
-      <RichTextEditor
-        value={rteData}
-        onChange={data => setRTEData(data)}
-        labelledBy={"Label-id"}
-        rows={3}
-        controls={[
-          { name: "bold", group: "inline" },
-          { name: "italic", group: "inline" },
-          { name: "underline", group: "inline" },
-          { name: "orderedList", group: "list" },
-          { name: "bulletList", group: "list" },
-        ]}
-      />
-    </>
-  )
-}
-
-WithLabelledBy.storyName = "Rich Text Editor with LabelledBy Prop"

--- a/packages/rich-text-editor/src/RichTextEditor/RichTextEditor.tsx
+++ b/packages/rich-text-editor/src/RichTextEditor/RichTextEditor.tsx
@@ -51,7 +51,7 @@ interface RTEWithLabelledBy extends BaseRichTextEditorProps {
   labelledBy: string
 }
 
-export type RichTextEditorProps = RTEWithLabelText | RTEWithLabelledBy;
+export type RichTextEditorProps = RTEWithLabelText | RTEWithLabelledBy
 /**
  * {@link https://cultureamp.design/components/rich-text-editor/ Guidance} |
  * {@link https://cultureamp.design/storybook/?path=/docs/components-rich-text-editor--default Storybook}

--- a/packages/rich-text-editor/src/RichTextEditor/RichTextEditor.tsx
+++ b/packages/rich-text-editor/src/RichTextEditor/RichTextEditor.tsx
@@ -43,12 +43,12 @@ interface BaseRichTextEditorProps
 
 interface RTEWithLabelText extends BaseRichTextEditorProps {
   labelText: ReactNode
-  labelledBy?: never
+  ariaLabelledBy?: never
 }
 
 interface RTEWithLabelledBy extends BaseRichTextEditorProps {
   labelText?: never
-  labelledBy: string
+  ariaLabelledBy: string
 }
 
 export type RichTextEditorProps = RTEWithLabelText | RTEWithLabelledBy
@@ -61,14 +61,14 @@ export const RichTextEditor: React.VFC<RichTextEditorProps> = props => {
     onChange,
     value,
     labelText,
-    labelledBy,
+    ariaLabelledBy,
     classNameOverride,
     controls,
     rows = 3,
     ...restProps
   } = props
   const [schema] = useState<Schema>(createSchemaFromControls(controls))
-  const [labelId] = useState<string>(labelledBy || v4())
+  const [labelId] = useState<string>(ariaLabelledBy || v4())
   const [editorId] = useState<string>(v4())
   const [editorRef, editorState, dispatchTransaction] = useRichTextEditor(
     EditorState.create({
@@ -97,7 +97,9 @@ export const RichTextEditor: React.VFC<RichTextEditorProps> = props => {
 
   return (
     <>
-      {!labelledBy && labelText && <Label id={labelId} labelText={labelText} />}
+      {!ariaLabelledBy && labelText && (
+        <Label id={labelId} labelText={labelText} />
+      )}
       {/* TODO: add a bit of margin here once we have a classNameOverride on Label */}
       <div className={styles.editorWrapper}>
         {controls && (

--- a/packages/rich-text-editor/src/RichTextEditor/RichTextEditor.tsx
+++ b/packages/rich-text-editor/src/RichTextEditor/RichTextEditor.tsx
@@ -34,6 +34,7 @@ export interface RichTextEditorProps
   onChange: (content: EditorContentArray) => void
   value: EditorContentArray
   labelText: ReactNode
+  labelledBy: string
   controls?: ToolbarItems[]
   /**
    * Sets a default min-height for the editable area in units of body paragraph line height, similar to the 'rows' attribute on <textarea>.
@@ -51,13 +52,14 @@ export const RichTextEditor: React.VFC<RichTextEditorProps> = props => {
     onChange,
     value,
     labelText,
+    labelledBy,
     classNameOverride,
     controls,
     rows = 3,
     ...restProps
   } = props
   const [schema] = useState<Schema>(createSchemaFromControls(controls))
-  const [labelId] = useState<string>(v4())
+  const [labelId] = useState<string>(labelledBy || v4())
   const [editorId] = useState<string>(v4())
   const [editorRef, editorState, dispatchTransaction] = useRichTextEditor(
     EditorState.create({
@@ -86,7 +88,7 @@ export const RichTextEditor: React.VFC<RichTextEditorProps> = props => {
 
   return (
     <>
-      {labelText && <Label id={labelId} labelText={labelText} />}
+      {!labelledBy && labelText && <Label id={labelId} labelText={labelText} />}
       {/* TODO: add a bit of margin here once we have a classNameOverride on Label */}
       <div className={styles.editorWrapper}>
         {controls && (

--- a/packages/rich-text-editor/src/RichTextEditor/RichTextEditor.tsx
+++ b/packages/rich-text-editor/src/RichTextEditor/RichTextEditor.tsx
@@ -43,12 +43,12 @@ interface BaseRichTextEditorProps
 
 interface RTEWithLabelText extends BaseRichTextEditorProps {
   labelText: ReactNode
-  ariaLabelledBy?: never
+  "aria-labelledby"?: never
 }
 
 interface RTEWithLabelledBy extends BaseRichTextEditorProps {
   labelText?: never
-  ariaLabelledBy: string
+  "aria-labelledby": string
 }
 
 export type RichTextEditorProps = RTEWithLabelText | RTEWithLabelledBy
@@ -61,14 +61,14 @@ export const RichTextEditor: React.VFC<RichTextEditorProps> = props => {
     onChange,
     value,
     labelText,
-    ariaLabelledBy,
+    "aria-labelledby": labelledBy,
     classNameOverride,
     controls,
     rows = 3,
     ...restProps
   } = props
   const [schema] = useState<Schema>(createSchemaFromControls(controls))
-  const [labelId] = useState<string>(ariaLabelledBy || v4())
+  const [labelId] = useState<string>(labelledBy || v4())
   const [editorId] = useState<string>(v4())
   const [editorRef, editorState, dispatchTransaction] = useRichTextEditor(
     EditorState.create({
@@ -97,9 +97,7 @@ export const RichTextEditor: React.VFC<RichTextEditorProps> = props => {
 
   return (
     <>
-      {!ariaLabelledBy && labelText && (
-        <Label id={labelId} labelText={labelText} />
-      )}
+      {!labelledBy && labelText && <Label id={labelId} labelText={labelText} />}
       {/* TODO: add a bit of margin here once we have a classNameOverride on Label */}
       <div className={styles.editorWrapper}>
         {controls && (

--- a/packages/rich-text-editor/src/RichTextEditor/RichTextEditor.tsx
+++ b/packages/rich-text-editor/src/RichTextEditor/RichTextEditor.tsx
@@ -29,12 +29,10 @@ export interface ToolbarItems {
   group?: string
 }
 
-export interface RichTextEditorProps
+interface BaseRichTextEditorProps
   extends OverrideClassName<Omit<HTMLAttributes<HTMLDivElement>, "onChange">> {
   onChange: (content: EditorContentArray) => void
   value: EditorContentArray
-  labelText: ReactNode
-  labelledBy: string
   controls?: ToolbarItems[]
   /**
    * Sets a default min-height for the editable area in units of body paragraph line height, similar to the 'rows' attribute on <textarea>.
@@ -43,6 +41,17 @@ export interface RichTextEditorProps
   rows?: EditorRows
 }
 
+interface RTEWithLabelText extends BaseRichTextEditorProps {
+  labelText: ReactNode
+  labelledBy?: never
+}
+
+interface RTEWithLabelledBy extends BaseRichTextEditorProps {
+  labelText?: never
+  labelledBy: string
+}
+
+export type RichTextEditorProps = RTEWithLabelText | RTEWithLabelledBy;
 /**
  * {@link https://cultureamp.design/components/rich-text-editor/ Guidance} |
  * {@link https://cultureamp.design/storybook/?path=/docs/components-rich-text-editor--default Storybook}


### PR DESCRIPTION
## Why
Using a discriminated union ideally, to make sure consumers are using one of the two. For more details [https://cultureamp.atlassian.net/browse/COMP-161](url)


## What

Added new property `labelledBy` to use it as `aria-labelledby` for Rich Text Editor.

In RTE, label will be created only if `labelledBy` is not passed.