### PR TITLE
feat: open calendar on click and focus on input

### DIFF
--- a/packages/date-picker/docs/DatePicker.stories.tsx
+++ b/packages/date-picker/docs/DatePicker.stories.tsx
@@ -248,7 +248,7 @@ const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({
             isReversed={isReversed}
             status="default"
             validationMessage={undefined}
-            isDisabled
+            disabled
           />
           <DatePicker
             id="datepicker-error"

--- a/packages/date-picker/src/DatePicker/DatePicker.spec.tsx
+++ b/packages/date-picker/src/DatePicker/DatePicker.spec.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react"
-import { act, render, screen, waitFor } from "@testing-library/react"
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { FieldMessageStatus } from "@kaizen/draft-form"
 import format from "date-fns/format"
@@ -9,6 +9,7 @@ import { DatePickerProps } from "."
 const DatePickerWrapper = ({
   status: propsStatus,
   validationMessage: propsValidationMessage,
+  selectedDay,
   ...restProps
 }: Partial<DatePickerProps>) => {
   const [status, setStatus] = useState<FieldMessageStatus>(
@@ -18,7 +19,7 @@ const DatePickerWrapper = ({
     propsValidationMessage
   )
   const [selectedDate, setValueDate] = useState<Date | undefined>(
-    restProps.selectedDay
+    selectedDay
   )
 
   const handleValidation = (validationResponse: ValidationResponse) => {
@@ -26,10 +27,11 @@ const DatePickerWrapper = ({
     validationResponse.validationMessage &&
       setValidationMessage(validationResponse.validationMessage)
   }
+
   return (
     <DatePicker
       id="test__date-picker"
-      labelText="Choose date"
+      labelText="Input label"
       onValidate={handleValidation}
       onDayChange={setValueDate}
       status={status}
@@ -41,264 +43,22 @@ const DatePickerWrapper = ({
 }
 
 describe("<DatePicker />", () => {
-  it("should have an empty input value when a date is not provided", async () => {
+  it("should not show the calendar initially", () => {
     render(<DatePickerWrapper />)
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
+  })
 
+  it("should have an empty input value when a date is not provided", () => {
+    render(<DatePickerWrapper />)
     expect(screen.getByRole("combobox")).toHaveValue("")
   })
 
-  it("should pre-fill the input when an initial date is provided", async () => {
+  it("should pre-fill the input when an initial date is provided", () => {
     render(<DatePickerWrapper selectedDay={new Date("2022-03-1")} />)
-
     expect(screen.getByDisplayValue("Mar 1, 2022")).toBeInTheDocument()
   })
 
-  describe("Selecting a date using the calendar", () => {
-    beforeEach(() => {
-      render(<DatePickerWrapper defaultMonth={new Date("2022-03-01")} />)
-
-      const calendarButton = screen.getByLabelText("Choose date", {
-        selector: "button",
-      })
-
-      userEvent.click(calendarButton)
-
-      waitFor(() => {
-        const dateToSelect =
-          screen.getByText("6th March (Sunday)").parentElement
-        dateToSelect?.focus()
-        userEvent.keyboard("{enter}")
-      })
-    })
-    it("shows the selected date in the input", () => {
-      expect(screen.getByDisplayValue("Mar 6, 2022")).toBeInTheDocument()
-    })
-    it("returns focus to the button once date has been selected", () => {
-      const calendarButton = screen.getByLabelText("Change date, Mar 6, 2022", {
-        selector: "button",
-      })
-      expect(calendarButton).toHaveFocus()
-    })
-  })
-
-  describe("Validation", () => {
-    describe("Custom Validation", () => {
-      it("displays the message when status is error", async () => {
-        render(
-          <DatePickerWrapper status="error" validationMessage="Invalid Date." />
-        )
-        expect(screen.getByText("Invalid Date.")).toBeInTheDocument()
-      })
-    })
-
-    describe("Inbuilt Validation", () => {
-      it("displays error message when selected day is invalid", async () => {
-        render(<DatePickerWrapper selectedDay={new Date("potato")} />)
-
-        expect(screen.getByText("Date is invalid")).toBeInTheDocument()
-      })
-
-      it("displays error message when selected day is disabled", async () => {
-        render(
-          <DatePickerWrapper
-            disabledBefore={new Date("2022-05-15")}
-            selectedDay={new Date("2022-05-05")}
-          />
-        )
-
-        expect(
-          screen.getByText("05/05/2022 is not available, try another date")
-        ).toBeInTheDocument()
-      })
-
-      it("displays error message when input date is invalid", async () => {
-        render(<DatePickerWrapper />)
-
-        const input = screen.getByRole("combobox")
-        userEvent.type(input, "05/05/2022Blah")
-
-        await act(async () => {
-          userEvent.tab()
-        })
-
-        expect(
-          screen.getByText("05/05/2022Blah is an invalid date")
-        ).toBeInTheDocument()
-      })
-
-      it("displays error message when input date is disabled", async () => {
-        render(<DatePickerWrapper disabledBefore={new Date("2022-05-15")} />)
-
-        const input = screen.getByRole("combobox")
-        userEvent.type(input, "05/05/2022")
-
-        await act(async () => {
-          userEvent.tab()
-        })
-
-        expect(
-          screen.getByText("05/05/2022 is not available, try another date")
-        ).toBeInTheDocument()
-      })
-    })
-  })
-
-  describe("Keydown arrow on input", () => {
-    it("shows focus on selected day", async () => {
-      render(<DatePickerWrapper selectedDay={new Date("2022-03-1")} />)
-      const input = screen.getByRole("combobox")
-
-      expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
-
-      await act(async () => {
-        input.focus()
-        userEvent.keyboard("{arrowdown}")
-      })
-      expect(screen.queryByRole("dialog")).toBeInTheDocument()
-
-      const selectedDate = screen.getByText("1st March (Tuesday)")
-
-      expect(selectedDate.parentElement).toHaveFocus()
-    })
-
-    it("shows focus on today when no date is selected", async () => {
-      const today = new Date()
-      const todayFormatted = format(today, "do LLLL (eeee)") // e.g 6th June (Monday)
-
-      render(<DatePickerWrapper selectedDay={undefined} />)
-      const input = screen.getByRole("combobox")
-
-      expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
-
-      await act(async () => {
-        input.focus()
-        userEvent.keyboard("{arrowdown}")
-      })
-      expect(screen.queryByRole("dialog")).toBeInTheDocument()
-
-      const dateToSelect = screen.getByText(todayFormatted).parentElement
-
-      expect(dateToSelect).toHaveFocus()
-    })
-  })
-
-  describe("Click on input", () => {
-    it("shows focus on input", () => {
-      render(<DatePickerWrapper selectedDay={new Date("2022-03-1")} />)
-
-      expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
-
-      const input = screen.getByLabelText("Choose date", { selector: "input" })
-      userEvent.click(input)
-
-      waitFor(() => {
-        expect(screen.queryByRole("dialog")).toBeInTheDocument()
-        expect(input).toHaveFocus()
-      })
-    })
-
-    it("shows focus on the input when a new date is selected from the calendar", async () => {
-      render(<DatePickerWrapper selectedDay={new Date("2022-03-1")} />)
-
-      expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
-
-      const input = screen.getByLabelText("Choose date", { selector: "input" })
-      userEvent.click(input)
-
-      await waitFor(() => {
-        expect(screen.queryByRole("dialog")).toBeInTheDocument()
-      })
-
-      const dateToSelect = screen.getByText("6th March (Sunday)").parentElement
-      dateToSelect && userEvent.click(dateToSelect)
-
-      waitFor(() => {
-        expect(input).toHaveFocus()
-      })
-    })
-  })
-
-  describe("Click on calendar button", () => {
-    it("shows focus on selected day", async () => {
-      render(<DatePickerWrapper selectedDay={new Date("2022-03-1")} />)
-
-      const calendarButton = screen.getByLabelText("Change date, Mar 1, 2022", {
-        selector: "button",
-      })
-
-      expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
-      waitFor(() => {
-        userEvent.click(calendarButton)
-        expect(screen.queryByRole("dialog")).toBeInTheDocument()
-      })
-
-      const selectedDate = screen.getByText("1st March (Tuesday)").parentElement
-
-      expect(selectedDate).toHaveFocus()
-    })
-
-    it("shows focus on today when no date is selected", async () => {
-      const today = new Date()
-      const todayFormatted = format(today, "do LLLL (eeee)") // e.g 6th June (Monday)
-
-      render(<DatePickerWrapper selectedDay={undefined} />)
-
-      const calendarButton = screen.getByLabelText("Choose date", {
-        selector: "button",
-      })
-
-      expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
-      waitFor(() => {
-        userEvent.click(calendarButton)
-        expect(screen.queryByRole("dialog")).toBeInTheDocument()
-      })
-
-      const todayDate = screen.getByText(todayFormatted).parentElement
-
-      expect(todayDate).toHaveFocus()
-    })
-  })
-
-  describe("Keydown enter on calendar button", () => {
-    it("shows focus on selected day", async () => {
-      render(<DatePickerWrapper selectedDay={new Date("2022-03-1")} />)
-      const calendarButton = screen.getByLabelText("Change date, Mar 1, 2022", {
-        selector: "button",
-      })
-      expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
-
-      waitFor(() => {
-        userEvent.click(calendarButton)
-        expect(screen.queryByRole("dialog")).toBeInTheDocument()
-      })
-
-      const selectedDate = screen.getByText("1st March (Tuesday)")
-
-      expect(selectedDate.parentElement).toHaveFocus()
-    })
-
-    it("shows focus on today when no date is selected", async () => {
-      const today = new Date()
-      const todayFormatted = format(today, "do LLLL (eeee)") // e.g 6th June (Monday)
-
-      render(<DatePickerWrapper selectedDay={undefined} />)
-      const calendarButton = screen.getByLabelText("Choose date", {
-        selector: "button",
-      })
-
-      expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
-      waitFor(() => {
-        userEvent.click(calendarButton)
-        expect(screen.queryByRole("dialog")).toBeInTheDocument()
-      })
-
-      const todayDate = screen.getByText(todayFormatted).parentElement
-
-      expect(todayDate).toHaveFocus()
-    })
-  })
-
-  it("allows you to tab through input, button and calendar", async () => {
+  it("allows you to tab through input, button and calendar", () => {
     render(<DatePickerWrapper />)
     const input = screen.getByRole("combobox")
     const calendarButton = screen.getByLabelText("Choose date", {
@@ -310,16 +70,277 @@ describe("<DatePicker />", () => {
       userEvent.keyboard("{arrowDown}")
       expect(screen.queryByRole("dialog")).toBeInTheDocument()
     })
+
     userEvent.tab()
     expect(input).toHaveFocus()
+
     userEvent.tab()
     expect(calendarButton).toHaveFocus()
+
     userEvent.tab()
     waitFor(() => {
       const arrowButton = screen.getByLabelText("Go to previous month", {
         selector: "button",
       })
       expect(arrowButton).toHaveFocus()
+    })
+  })
+})
+
+describe("<DatePicker /> - Input", () => {
+  xit("updates the calendar month as the user types", () => {
+    expect(true).toBe(false)
+  })
+})
+
+describe("<DatePicker /> - Click on input", () => {
+  it("shows focus on input and opens the calendar", () => {
+    render(<DatePickerWrapper selectedDay={new Date("2022-03-1")} />)
+
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
+
+    const input = screen.getByLabelText("Input label", { selector: "input" })
+    userEvent.click(input)
+
+    waitFor(() => {
+      expect(screen.queryByRole("dialog")).toBeInTheDocument()
+      expect(input).toHaveFocus()
+    })
+  })
+
+  it("returns focus to the input when the user clicks a valid day on the calendar", async () => {
+    render(<DatePickerWrapper selectedDay={new Date("2022-03-1")} />)
+
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
+
+    const input = screen.getByLabelText("Input label", { selector: "input" })
+    userEvent.click(input)
+
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog")).toBeInTheDocument()
+    })
+
+    await waitFor(async () => {
+        const dateToSelect = screen.getByText("6th March (Sunday)").parentElement
+        if (dateToSelect) {
+          userEvent.click(dateToSelect)
+        }
+      })
+
+     await waitFor(() => {
+      expect(input).toHaveFocus()
+      expect(input).toHaveValue("03/06/2022")
+      })
+  })
+})
+
+describe("<DatePicker /> - Keydown arrow on input", () => {
+  it("shows focus on selected day", async () => {
+    render(<DatePickerWrapper selectedDay={new Date("2022-03-1")} />)
+    const input = screen.getByRole("combobox")
+
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
+
+    await act(async () => {
+      input.focus()
+      userEvent.keyboard("{arrowdown}")
+    })
+    expect(screen.queryByRole("dialog")).toBeInTheDocument()
+
+    const selectedDate = screen.getByText("1st March (Tuesday)")
+
+    expect(selectedDate.parentElement).toHaveFocus()
+  })
+
+  it("shows focus on today when no date is selected", async () => {
+    const today = new Date()
+    const todayFormatted = format(today, "do LLLL (eeee)") // e.g 6th June (Monday)
+
+    render(<DatePickerWrapper selectedDay={undefined} />)
+    const input = screen.getByRole("combobox")
+
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
+
+    await act(async () => {
+      input.focus()
+      userEvent.keyboard("{arrowdown}")
+    })
+    expect(screen.queryByRole("dialog")).toBeInTheDocument()
+
+    const dateToSelect = screen.getByText(todayFormatted).parentElement
+
+    expect(dateToSelect).toHaveFocus()
+  })
+})
+
+describe("<DatePicker /> - Click on calendar button", () => {
+  it("shows focus on selected day", async () => {
+    render(<DatePickerWrapper selectedDay={new Date("2022-03-1")} />)
+
+    const calendarButton = screen.getByLabelText("Change date, Mar 1, 2022", {
+      selector: "button",
+    })
+
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
+    waitFor(() => {
+      userEvent.click(calendarButton)
+      expect(screen.queryByRole("dialog")).toBeInTheDocument()
+    })
+
+    const selectedDate = screen.getByText("1st March (Tuesday)").parentElement
+
+    expect(selectedDate).toHaveFocus()
+  })
+
+  it("shows focus on today when no date is selected", async () => {
+    const today = new Date()
+    const todayFormatted = format(today, "do LLLL (eeee)") // e.g 6th June (Monday)
+
+    render(<DatePickerWrapper selectedDay={undefined} />)
+
+    const calendarButton = screen.getByLabelText("Choose date", {
+      selector: "button",
+    })
+
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
+    waitFor(() => {
+      userEvent.click(calendarButton)
+      expect(screen.queryByRole("dialog")).toBeInTheDocument()
+    })
+
+    const todayDate = screen.getByText(todayFormatted).parentElement
+
+    expect(todayDate).toHaveFocus()
+  })
+})
+
+describe("<DatePicker /> - Keydown enter on calendar button", () => {
+  it("shows focus on selected day", async () => {
+    render(<DatePickerWrapper selectedDay={new Date("2022-03-1")} />)
+    const calendarButton = screen.getByLabelText("Change date, Mar 1, 2022", {
+      selector: "button",
+    })
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
+
+    waitFor(() => {
+      userEvent.click(calendarButton)
+      expect(screen.queryByRole("dialog")).toBeInTheDocument()
+    })
+
+    const selectedDate = screen.getByText("1st March (Tuesday)")
+
+    expect(selectedDate.parentElement).toHaveFocus()
+  })
+
+  it("shows focus on today when no date is selected", async () => {
+    const today = new Date()
+    const todayFormatted = format(today, "do LLLL (eeee)") // e.g 6th June (Monday)
+
+    render(<DatePickerWrapper selectedDay={undefined} />)
+    const calendarButton = screen.getByLabelText("Choose date", {
+      selector: "button",
+    })
+
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
+    waitFor(() => {
+      userEvent.click(calendarButton)
+      expect(screen.queryByRole("dialog")).toBeInTheDocument()
+    })
+
+    const todayDate = screen.getByText(todayFormatted).parentElement
+
+    expect(todayDate).toHaveFocus()
+  })
+})
+
+describe("<DatePicker /> - Selecting a date using the calendar", () => {
+  beforeEach(async () => {
+    render(<DatePickerWrapper defaultMonth={new Date("2022-03-01")} />)
+
+    const calendarButton = screen.getByLabelText("Choose date", {
+      selector: "button",
+    })
+
+    userEvent.click(calendarButton)
+
+    waitFor(() => {
+      const dateToSelect =
+        screen.getByText("6th March (Sunday)").parentElement
+      dateToSelect?.focus()
+      userEvent.keyboard("{enter}")
+    })
+  })
+
+  it("shows the selected date in the input", () => {
+    expect(screen.getByDisplayValue("Mar 6, 2022")).toBeInTheDocument()
+  })
+
+  it("returns focus to the button once date has been selected", () => {
+    const calendarButton = screen.getByLabelText("Change date, Mar 6, 2022", {
+      selector: "button",
+    })
+    expect(calendarButton).toHaveFocus()
+  })
+})
+
+describe("<DatePicker /> - Validation", () => {
+  describe("Custom Validation", () => {
+    it("displays the message when status is error", async () => {
+      render(
+        <DatePickerWrapper status="error" validationMessage="Invalid Date." />
+      )
+      expect(screen.getByText("Invalid Date.")).toBeInTheDocument()
+    })
+  })
+
+  describe("Inbuilt Validation", () => {
+    it("displays error message when selected day is invalid", async () => {
+      render(<DatePickerWrapper selectedDay={new Date("potato")} />)
+
+      expect(screen.getByText("Date is invalid")).toBeInTheDocument()
+    })
+
+    it("displays error message when selected day is disabled", async () => {
+      render(
+        <DatePickerWrapper
+          disabledBefore={new Date("2022-05-15")}
+          selectedDay={new Date("2022-05-05")}
+        />
+      )
+
+      expect(
+        screen.getByText("05/05/2022 is not available, try another date")
+      ).toBeInTheDocument()
+    })
+
+    it("displays error message when input date is invalid", async () => {
+      render(<DatePickerWrapper />)
+
+      const input = screen.getByRole("combobox")
+      userEvent.type(input, "05/05/2022Blah")
+
+      await act(async () => {
+        userEvent.tab()
+      })
+
+      expect(
+        screen.getByText("05/05/2022Blah is an invalid date")
+      ).toBeInTheDocument()
+    })
+
+    it("displays error message when input date is disabled", async () => {
+      render(<DatePickerWrapper disabledBefore={new Date("2022-05-15")} />)
+
+      const input = screen.getByRole("combobox")
+      userEvent.type(input, "05/05/2022")
+
+      await act(async () => {
+        userEvent.tab()
+      })
+
+      expect(
+        screen.getByText("05/05/2022 is not available, try another date")
+      ).toBeInTheDocument()
     })
   })
 })

--- a/packages/date-picker/src/DatePicker/DatePicker.spec.tsx
+++ b/packages/date-picker/src/DatePicker/DatePicker.spec.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react"
-import { act, render, screen, waitFor } from "@testing-library/react"
+import { render, screen, waitFor } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import format from "date-fns/format"
 import { FieldMessageStatus } from "@kaizen/draft-form"
@@ -343,34 +343,34 @@ describe("<DatePicker /> - Validation", () => {
       ).toBeInTheDocument()
     })
 
-    it("displays error message when input date is invalid", async () => {
+    it("displays error message when input date is invalid", () => {
       render(<DatePickerWrapper />)
 
       const input = screen.getByLabelText("Input label", { selector: "input" })
       userEvent.type(input, "05/05/2022Blah")
 
-      await act(async () => {
-        userEvent.tab()
-      })
+      userEvent.tab()
 
-      expect(
-        screen.getByText("05/05/2022Blah is an invalid date")
-      ).toBeInTheDocument()
+      waitFor(() => {
+        expect(
+          screen.getByText("05/05/2022Blah is an invalid date")
+        ).toBeInTheDocument()
+      })
     })
 
-    it("displays error message when input date is disabled", async () => {
+    it("displays error message when input date is disabled", () => {
       render(<DatePickerWrapper disabledBefore={new Date("2022-05-15")} />)
 
       const input = screen.getByLabelText("Input label", { selector: "input" })
       userEvent.type(input, "05/05/2022")
 
-      await act(async () => {
-        userEvent.tab()
-      })
+      userEvent.tab()
 
-      expect(
-        screen.getByText("05/05/2022 is not available, try another date")
-      ).toBeInTheDocument()
+      waitFor(() => {
+        expect(
+          screen.getByText("05/05/2022 is not available, try another date")
+        ).toBeInTheDocument()
+      })
     })
   })
 })

--- a/packages/date-picker/src/DatePicker/DatePicker.spec.tsx
+++ b/packages/date-picker/src/DatePicker/DatePicker.spec.tsx
@@ -1,8 +1,8 @@
 import React, { useState } from "react"
 import { act, render, screen, waitFor } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
-import { FieldMessageStatus } from "@kaizen/draft-form"
 import format from "date-fns/format"
+import { FieldMessageStatus } from "@kaizen/draft-form"
 import { DatePicker, ValidationResponse } from "./DatePicker"
 import { DatePickerProps } from "."
 
@@ -48,7 +48,8 @@ describe("<DatePicker />", () => {
 
   it("should have an empty input value when a date is not provided", () => {
     render(<DatePickerWrapper />)
-    expect(screen.getByRole("combobox")).toHaveValue("")
+    const input = screen.getByLabelText("Input label", { selector: "input" })
+    expect(input).toHaveValue("")
   })
 
   it("should pre-fill the input when an initial date is provided", () => {
@@ -58,14 +59,13 @@ describe("<DatePicker />", () => {
 
   it("allows you to tab through input, button and calendar", () => {
     render(<DatePickerWrapper />)
-    const input = screen.getByRole("combobox")
-    const calendarButton = screen.getByLabelText("Choose date", {
-      selector: "button",
-    })
+    const input = screen.getByLabelText("Input label", { selector: "input" })
 
     userEvent.tab()
+    expect(input).toHaveFocus()
+
+    userEvent.keyboard("{arrowDown}")
     waitFor(() => {
-      userEvent.keyboard("{arrowDown}")
       expect(screen.queryByRole("dialog")).toBeInTheDocument()
     })
 
@@ -73,199 +73,33 @@ describe("<DatePicker />", () => {
     expect(input).toHaveFocus()
 
     userEvent.tab()
+    const calendarButton = screen.getByRole("button", { name: "Choose date" })
+
     expect(calendarButton).toHaveFocus()
 
     userEvent.tab()
-    waitFor(() => {
-      const arrowButton = screen.getByLabelText("Go to previous month", {
-        selector: "button",
-      })
-      expect(arrowButton).toHaveFocus()
-    })
-  })
-})
-
-describe("<DatePicker /> - Input", () => {
-  xit("updates the calendar month as the user types", () => {
-    expect(true).toBe(false)
-  })
-})
-
-describe("<DatePicker /> - Click on input", () => {
-  it("shows focus on input and opens the calendar", () => {
-    render(<DatePickerWrapper selectedDay={new Date("2022-03-1")} />)
-
-    expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
-
-    const input = screen.getByLabelText("Input label", { selector: "input" })
-    userEvent.click(input)
-
-    waitFor(() => {
-      expect(screen.queryByRole("dialog")).toBeInTheDocument()
-      expect(input).toHaveFocus()
-    })
-  })
-
-  it("returns focus to the input when the user clicks a valid day on the calendar", async () => {
-    render(<DatePickerWrapper selectedDay={new Date("2022-03-1")} />)
-
-    expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
-
-    const input = screen.getByLabelText("Input label", { selector: "input" })
-    userEvent.click(input)
-
-    await waitFor(() => {
-      expect(screen.queryByRole("dialog")).toBeInTheDocument()
-    })
-
-    await waitFor(async () => {
-      const dateToSelect = screen.getByText("6th March (Sunday)").parentElement
-      if (dateToSelect) {
-        userEvent.click(dateToSelect)
-      }
-    })
-
-    await waitFor(() => {
-      expect(input).toHaveFocus()
-      expect(input).toHaveValue("03/06/2022")
-    })
-  })
-})
-
-describe("<DatePicker /> - Keydown arrow on input", () => {
-  it("shows focus on selected day", async () => {
-    render(<DatePickerWrapper selectedDay={new Date("2022-03-1")} />)
-    const input = screen.getByRole("combobox")
-
-    expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
-
-    await act(async () => {
-      input.focus()
-      userEvent.keyboard("{arrowdown}")
-    })
-    expect(screen.queryByRole("dialog")).toBeInTheDocument()
-
-    const selectedDate = screen.getByText("1st March (Tuesday)")
-
-    expect(selectedDate.parentElement).toHaveFocus()
-  })
-
-  it("shows focus on today when no date is selected", async () => {
-    const today = new Date()
-    const todayFormatted = format(today, "do LLLL (eeee)") // e.g 6th June (Monday)
-
-    render(<DatePickerWrapper selectedDay={undefined} />)
-    const input = screen.getByRole("combobox")
-
-    expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
-
-    await act(async () => {
-      input.focus()
-      userEvent.keyboard("{arrowdown}")
-    })
-    expect(screen.queryByRole("dialog")).toBeInTheDocument()
-
-    const dateToSelect = screen.getByText(todayFormatted).parentElement
-
-    expect(dateToSelect).toHaveFocus()
-  })
-})
-
-describe("<DatePicker /> - Click on calendar button", () => {
-  it("shows focus on selected day", async () => {
-    render(<DatePickerWrapper selectedDay={new Date("2022-03-1")} />)
-
-    const calendarButton = screen.getByLabelText("Change date, Mar 1, 2022", {
+    const arrowButton = screen.getByLabelText("Go to previous month", {
       selector: "button",
     })
-
-    expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
-    waitFor(() => {
-      userEvent.click(calendarButton)
-      expect(screen.queryByRole("dialog")).toBeInTheDocument()
-    })
-
-    const selectedDate = screen.getByText("1st March (Tuesday)").parentElement
-
-    expect(selectedDate).toHaveFocus()
-  })
-
-  it("shows focus on today when no date is selected", async () => {
-    const today = new Date()
-    const todayFormatted = format(today, "do LLLL (eeee)") // e.g 6th June (Monday)
-
-    render(<DatePickerWrapper selectedDay={undefined} />)
-
-    const calendarButton = screen.getByLabelText("Choose date", {
-      selector: "button",
-    })
-
-    expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
-    waitFor(() => {
-      userEvent.click(calendarButton)
-      expect(screen.queryByRole("dialog")).toBeInTheDocument()
-    })
-
-    const todayDate = screen.getByText(todayFormatted).parentElement
-
-    expect(todayDate).toHaveFocus()
-  })
-})
-
-describe("<DatePicker /> - Keydown enter on calendar button", () => {
-  it("shows focus on selected day", async () => {
-    render(<DatePickerWrapper selectedDay={new Date("2022-03-1")} />)
-    const calendarButton = screen.getByLabelText("Change date, Mar 1, 2022", {
-      selector: "button",
-    })
-    expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
-
-    waitFor(() => {
-      userEvent.click(calendarButton)
-      expect(screen.queryByRole("dialog")).toBeInTheDocument()
-    })
-
-    const selectedDate = screen.getByText("1st March (Tuesday)")
-
-    expect(selectedDate.parentElement).toHaveFocus()
-  })
-
-  it("shows focus on today when no date is selected", async () => {
-    const today = new Date()
-    const todayFormatted = format(today, "do LLLL (eeee)") // e.g 6th June (Monday)
-
-    render(<DatePickerWrapper selectedDay={undefined} />)
-    const calendarButton = screen.getByLabelText("Choose date", {
-      selector: "button",
-    })
-
-    expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
-    waitFor(() => {
-      userEvent.click(calendarButton)
-      expect(screen.queryByRole("dialog")).toBeInTheDocument()
-    })
-
-    const todayDate = screen.getByText(todayFormatted).parentElement
-
-    expect(todayDate).toHaveFocus()
+    expect(arrowButton).toHaveFocus()
   })
 })
 
 describe("<DatePicker /> - Selecting a date using the calendar", () => {
-  beforeEach(async () => {
+  beforeEach(() => {
     render(<DatePickerWrapper defaultMonth={new Date("2022-03-01")} />)
 
-    const calendarButton = screen.getByLabelText("Choose date", {
-      selector: "button",
-    })
+    const calendarButton = screen.getByRole("button", { name: "Choose date" })
 
     userEvent.click(calendarButton)
 
     waitFor(() => {
-      const dateToSelect = screen.getByText("6th March (Sunday)").parentElement
-      dateToSelect?.focus()
-      userEvent.keyboard("{enter}")
+      expect(screen.queryByRole("dialog")).toBeInTheDocument()
     })
+
+    const dateToSelect = screen.getByText("6th March (Sunday)").parentElement
+    dateToSelect?.focus()
+    userEvent.keyboard("{enter}")
   })
 
   it("shows the selected date in the input", () => {
@@ -273,10 +107,209 @@ describe("<DatePicker /> - Selecting a date using the calendar", () => {
   })
 
   it("returns focus to the button once date has been selected", () => {
-    const calendarButton = screen.getByLabelText("Change date, Mar 6, 2022", {
-      selector: "button",
+    const calendarButton = screen.getByRole("button", {
+      name: "Change date, Mar 6, 2022",
     })
     expect(calendarButton).toHaveFocus()
+  })
+})
+
+// @todo: Move this to be tests for utils/setFocusInCalendar
+describe("<DatePicker /> - Focus within calendar", () => {
+  it("shows focus on today when no date is selected", () => {
+    const today = new Date()
+    const todayFormatted = format(today, "do LLLL (eeee)") // e.g 6th June (Monday)
+
+    render(<DatePickerWrapper />)
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
+
+    const calendarButton = screen.getByRole("button", {
+      name: "Choose date",
+    })
+    userEvent.click(calendarButton)
+    waitFor(() => {
+      expect(screen.queryByRole("dialog")).toBeInTheDocument()
+    })
+
+    const dateToSelect = screen.getByText(todayFormatted).parentElement
+    expect(dateToSelect).toHaveFocus()
+  })
+})
+
+describe("<DatePicker /> - Focus element", () => {
+  describe("Click on input", () => {
+    it("shows focus on input and opens the calendar", () => {
+      render(<DatePickerWrapper selectedDay={new Date("2022-03-1")} />)
+
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
+
+      const input = screen.getByLabelText("Input label", { selector: "input" })
+      userEvent.click(input)
+
+      waitFor(() => {
+        expect(screen.queryByRole("dialog")).toBeInTheDocument()
+        expect(input).toHaveFocus()
+      })
+    })
+
+    it("returns focus to the input when the user clicks a valid day on the calendar", () => {
+      render(<DatePickerWrapper selectedDay={new Date("2022-03-1")} />)
+
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
+
+      const input = screen.getByLabelText("Input label", { selector: "input" })
+      userEvent.click(input)
+
+      waitFor(() => {
+        expect(screen.queryByRole("dialog")).toBeInTheDocument()
+      })
+
+      const dateToSelect = screen.getByText("6th March (Sunday)").parentElement
+      if (dateToSelect) userEvent.click(dateToSelect)
+
+      expect(input).toHaveFocus()
+      expect(input).toHaveValue("03/06/2022")
+    })
+  })
+
+  describe("Keydown arrow on input", () => {
+    beforeEach(async () => {
+      render(<DatePickerWrapper selectedDay={new Date("2022-03-1")} />)
+
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
+
+      const input = screen.getByLabelText("Input label", { selector: "input" })
+      await waitFor(() => {
+        input.focus()
+      })
+      userEvent.keyboard("{ArrowDown}")
+
+      waitFor(() => {
+        expect(screen.queryByRole("dialog")).toBeInTheDocument()
+      })
+    })
+
+    it("shows focus within the calendar", () => {
+      const selectedDate = screen.getByText("1st March (Tuesday)")
+      expect(selectedDate.parentElement).toHaveFocus()
+    })
+
+    it("returns focus to the input when the user escapes from the calendar", () => {
+      const selectedDate = screen.getByText("1st March (Tuesday)")
+      expect(selectedDate.parentElement).toHaveFocus()
+
+      userEvent.keyboard("{Escape}")
+
+      const input = screen.getByLabelText("Input label", { selector: "input" })
+      expect(input).toHaveFocus()
+    })
+  })
+
+  describe("Click on calendar button", () => {
+    beforeEach(() => {
+      render(<DatePickerWrapper selectedDay={new Date("2022-03-1")} />)
+
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
+
+      const calendarButton = screen.getByRole("button", {
+        name: "Change date, Mar 1, 2022",
+      })
+      userEvent.click(calendarButton)
+
+      waitFor(() => {
+        expect(screen.queryByRole("dialog")).toBeInTheDocument()
+      })
+    })
+
+    it("shows focus within the calendar", () => {
+      const selectedDate = screen.getByText("1st March (Tuesday)")
+      expect(selectedDate.parentElement).toHaveFocus()
+    })
+
+    it("returns focus to the input when the user escapes from the calendar", () => {
+      const selectedDate = screen.getByText("1st March (Tuesday)")
+      expect(selectedDate.parentElement).toHaveFocus()
+
+      userEvent.keyboard("{Escape}")
+
+      const calendarButton = screen.getByRole("button", {
+        name: "Change date, Mar 1, 2022",
+      })
+      expect(calendarButton).toHaveFocus()
+    })
+  })
+
+  describe("Keydown enter on calendar button", () => {
+    beforeEach(async () => {
+      render(<DatePickerWrapper selectedDay={new Date("2022-03-1")} />)
+
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
+
+      const calendarButton = screen.getByRole("button", {
+        name: "Change date, Mar 1, 2022",
+      })
+      await waitFor(() => {
+        calendarButton.focus()
+      })
+      expect(calendarButton).toHaveFocus()
+
+      userEvent.keyboard("{Enter}")
+
+      waitFor(() => {
+        expect(screen.queryByRole("dialog")).toBeInTheDocument()
+      })
+    })
+
+    it("shows focus within the calendar", async () => {
+      const selectedDate = screen.getByText("1st March (Tuesday)")
+      expect(selectedDate.parentElement).toHaveFocus()
+    })
+
+    it("returns focus to the input when the user escapes from the calendar", () => {
+      const selectedDate = screen.getByText("1st March (Tuesday)")
+      expect(selectedDate.parentElement).toHaveFocus()
+
+      userEvent.keyboard("{Escape}")
+
+      const calendarButton = screen.getByRole("button", {
+        name: "Change date, Mar 1, 2022",
+      })
+      expect(calendarButton).toHaveFocus()
+    })
+  })
+})
+
+describe("<DatePicker /> - Input format", () => {
+  it("formats values when focus is on the input", async () => {
+    render(<DatePickerWrapper selectedDay={new Date("2022-03-01")} />)
+
+    const input = screen.getByLabelText("Input label", { selector: "input" })
+    expect(input).toHaveValue("Mar 1, 2022")
+
+    await waitFor(() => {
+      input.focus()
+    })
+
+    expect(input).toHaveValue("03/01/2022")
+  })
+
+  it("formats values when the input loses focus - onBlur", async () => {
+    render(<DatePickerWrapper selectedDay={new Date("2022-03-01")} />)
+
+    const input = screen.getByLabelText("Input label", { selector: "input" })
+    expect(input).toHaveValue("Mar 1, 2022")
+
+    await waitFor(() => {
+      input.focus()
+    })
+
+    expect(input).toHaveValue("03/01/2022")
+
+    userEvent.tab()
+
+    waitFor(() => {
+      expect(input).toHaveValue("Mar 1, 2022")
+    })
   })
 })
 
@@ -313,7 +346,7 @@ describe("<DatePicker /> - Validation", () => {
     it("displays error message when input date is invalid", async () => {
       render(<DatePickerWrapper />)
 
-      const input = screen.getByRole("combobox")
+      const input = screen.getByLabelText("Input label", { selector: "input" })
       userEvent.type(input, "05/05/2022Blah")
 
       await act(async () => {
@@ -328,7 +361,7 @@ describe("<DatePicker /> - Validation", () => {
     it("displays error message when input date is disabled", async () => {
       render(<DatePickerWrapper disabledBefore={new Date("2022-05-15")} />)
 
-      const input = screen.getByRole("combobox")
+      const input = screen.getByLabelText("Input label", { selector: "input" })
       userEvent.type(input, "05/05/2022")
 
       await act(async () => {
@@ -339,40 +372,5 @@ describe("<DatePicker /> - Validation", () => {
         screen.getByText("05/05/2022 is not available, try another date")
       ).toBeInTheDocument()
     })
-  })
-})
-
-describe("<DatePicker /> - Formatting", () => {
-  it("formats values when focus is on the input", async () => {
-    render(<DatePickerWrapper selectedDay={new Date("2022-03-01")} />)
-
-    expect(screen.getByDisplayValue("Mar 1, 2022")).toBeInTheDocument()
-
-    const input = screen.getByRole("combobox")
-
-    await act(async () => {
-      input.focus()
-    })
-    expect(screen.getByDisplayValue("03/01/2022")).toBeInTheDocument()
-  })
-
-  it("formats values when the input loses focus - onBlur", async () => {
-    render(<DatePickerWrapper selectedDay={new Date("2022-03-01")} />)
-
-    expect(screen.getByDisplayValue("Mar 1, 2022")).toBeInTheDocument()
-
-    const input = screen.getByRole("combobox")
-
-    await act(async () => {
-      input.focus()
-    })
-    expect(screen.getByDisplayValue("03/01/2022")).toBeInTheDocument()
-
-    // tab to next focusable element
-    await act(async () => {
-      userEvent.tab()
-    })
-
-    expect(screen.getByDisplayValue("Mar 1, 2022")).toBeInTheDocument()
   })
 })

--- a/packages/date-picker/src/DatePicker/DatePicker.spec.tsx
+++ b/packages/date-picker/src/DatePicker/DatePicker.spec.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react"
-import { act, fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { act, render, screen, waitFor } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { FieldMessageStatus } from "@kaizen/draft-form"
 import format from "date-fns/format"
@@ -18,9 +18,7 @@ const DatePickerWrapper = ({
   const [validationMessage, setValidationMessage] = useState<React.ReactNode>(
     propsValidationMessage
   )
-  const [selectedDate, setValueDate] = useState<Date | undefined>(
-    selectedDay
-  )
+  const [selectedDate, setValueDate] = useState<Date | undefined>(selectedDay)
 
   const handleValidation = (validationResponse: ValidationResponse) => {
     validationResponse.status && setStatus(validationResponse.status)
@@ -121,16 +119,16 @@ describe("<DatePicker /> - Click on input", () => {
     })
 
     await waitFor(async () => {
-        const dateToSelect = screen.getByText("6th March (Sunday)").parentElement
-        if (dateToSelect) {
-          userEvent.click(dateToSelect)
-        }
-      })
+      const dateToSelect = screen.getByText("6th March (Sunday)").parentElement
+      if (dateToSelect) {
+        userEvent.click(dateToSelect)
+      }
+    })
 
-     await waitFor(() => {
+    await waitFor(() => {
       expect(input).toHaveFocus()
       expect(input).toHaveValue("03/06/2022")
-      })
+    })
   })
 })
 
@@ -264,8 +262,7 @@ describe("<DatePicker /> - Selecting a date using the calendar", () => {
     userEvent.click(calendarButton)
 
     waitFor(() => {
-      const dateToSelect =
-        screen.getByText("6th March (Sunday)").parentElement
+      const dateToSelect = screen.getByText("6th March (Sunday)").parentElement
       dateToSelect?.focus()
       userEvent.keyboard("{enter}")
     })
@@ -342,5 +339,40 @@ describe("<DatePicker /> - Validation", () => {
         screen.getByText("05/05/2022 is not available, try another date")
       ).toBeInTheDocument()
     })
+  })
+})
+
+describe("<DatePicker /> - Formatting", () => {
+  it("formats values when focus is on the input", async () => {
+    render(<DatePickerWrapper selectedDay={new Date("2022-03-01")} />)
+
+    expect(screen.getByDisplayValue("Mar 1, 2022")).toBeInTheDocument()
+
+    const input = screen.getByRole("combobox")
+
+    await act(async () => {
+      input.focus()
+    })
+    expect(screen.getByDisplayValue("03/01/2022")).toBeInTheDocument()
+  })
+
+  it("formats values when the input loses focus - onBlur", async () => {
+    render(<DatePickerWrapper selectedDay={new Date("2022-03-01")} />)
+
+    expect(screen.getByDisplayValue("Mar 1, 2022")).toBeInTheDocument()
+
+    const input = screen.getByRole("combobox")
+
+    await act(async () => {
+      input.focus()
+    })
+    expect(screen.getByDisplayValue("03/01/2022")).toBeInTheDocument()
+
+    // tab to next focusable element
+    await act(async () => {
+      userEvent.tab()
+    })
+
+    expect(screen.getByDisplayValue("Mar 1, 2022")).toBeInTheDocument()
   })
 })

--- a/packages/date-picker/src/DatePicker/DatePicker.spec.tsx
+++ b/packages/date-picker/src/DatePicker/DatePicker.spec.tsx
@@ -118,7 +118,7 @@ describe("<DatePicker /> - Selecting a date using the calendar", () => {
 describe("<DatePicker /> - Focus within calendar", () => {
   it("shows focus on today when no date is selected", () => {
     const today = new Date()
-    const todayFormatted = format(today, "do LLLL (eeee)") // e.g 6th June (Monday)
+    const todayFormatted = format(today, "do MMMM (eeee)") // e.g 6th June (Monday)
 
     render(<DatePickerWrapper />)
     expect(screen.queryByRole("dialog")).not.toBeInTheDocument()

--- a/packages/date-picker/src/DatePicker/DatePicker.spec.tsx
+++ b/packages/date-picker/src/DatePicker/DatePicker.spec.tsx
@@ -144,7 +144,7 @@ describe("<DatePicker />", () => {
   })
 
   describe("Keydown arrow on input", () => {
-    it("show focus on selected day", async () => {
+    it("shows focus on selected day", async () => {
       render(<DatePickerWrapper selectedDay={new Date("2022-03-1")} />)
       const input = screen.getByRole("combobox")
 
@@ -161,7 +161,7 @@ describe("<DatePicker />", () => {
       expect(selectedDate.parentElement).toHaveFocus()
     })
 
-    it("show focus on today when no date is selected", async () => {
+    it("shows focus on today when no date is selected", async () => {
       const today = new Date()
       const todayFormatted = format(today, "do LLLL (eeee)") // e.g 6th June (Monday)
 
@@ -183,7 +183,7 @@ describe("<DatePicker />", () => {
   })
 
   describe("Click on input", () => {
-    it("show focus on input", () => {
+    it("shows focus on input", () => {
       render(<DatePickerWrapper selectedDay={new Date("2022-03-1")} />)
 
       expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
@@ -197,7 +197,7 @@ describe("<DatePicker />", () => {
       })
     })
 
-    it("show focus on the input when a new date is selected from the calendar", async () => {
+    it("shows focus on the input when a new date is selected from the calendar", async () => {
       render(<DatePickerWrapper selectedDay={new Date("2022-03-1")} />)
 
       expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
@@ -219,7 +219,7 @@ describe("<DatePicker />", () => {
   })
 
   describe("Click on calendar button", () => {
-    it("show focus on selected day", async () => {
+    it("shows focus on selected day", async () => {
       render(<DatePickerWrapper selectedDay={new Date("2022-03-1")} />)
 
       const calendarButton = screen.getByLabelText("Change date, Mar 1, 2022", {
@@ -237,7 +237,7 @@ describe("<DatePicker />", () => {
       expect(selectedDate).toHaveFocus()
     })
 
-    it("show focus on today when no date is selected", async () => {
+    it("shows focus on today when no date is selected", async () => {
       const today = new Date()
       const todayFormatted = format(today, "do LLLL (eeee)") // e.g 6th June (Monday)
 
@@ -260,7 +260,7 @@ describe("<DatePicker />", () => {
   })
 
   describe("Keydown enter on calendar button", () => {
-    it("show focus on selected day", async () => {
+    it("shows focus on selected day", async () => {
       render(<DatePickerWrapper selectedDay={new Date("2022-03-1")} />)
       const calendarButton = screen.getByLabelText("Change date, Mar 1, 2022", {
         selector: "button",
@@ -277,7 +277,7 @@ describe("<DatePicker />", () => {
       expect(selectedDate.parentElement).toHaveFocus()
     })
 
-    it("show focus on today when no date is selected", async () => {
+    it("shows focus on today when no date is selected", async () => {
       const today = new Date()
       const todayFormatted = format(today, "do LLLL (eeee)") // e.g 6th June (Monday)
 

--- a/packages/date-picker/src/DatePicker/DatePicker.spec.tsx
+++ b/packages/date-picker/src/DatePicker/DatePicker.spec.tsx
@@ -197,18 +197,16 @@ describe("<DatePicker />", () => {
       const input = screen.getByRole("combobox")
 
       expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
-      await act(async () => {
-        userEvent.click(input)
-      })
 
       waitFor(() => {
+        userEvent.click(input)
         expect(screen.queryByRole("dialog")).toBeInTheDocument()
         const dateToSelect =
           screen.getByText("6th March (Sunday)").parentElement
 
         dateToSelect && userEvent.click(dateToSelect)
-        expect(input).toHaveFocus()
       })
+      expect(input).toHaveFocus()
     })
   })
 

--- a/packages/date-picker/src/DatePicker/DatePicker.spec.tsx
+++ b/packages/date-picker/src/DatePicker/DatePicker.spec.tsx
@@ -56,12 +56,16 @@ describe("<DatePicker />", () => {
   describe("Selecting a date using the calendar", () => {
     beforeEach(() => {
       render(<DatePickerWrapper defaultMonth={new Date("2022-03-01")} />)
+
       const calendarButton = screen.getByLabelText("Choose date", {
         selector: "button",
       })
+
       userEvent.click(calendarButton)
-      const dateToSelect = screen.getByText("6th March (Sunday)").parentElement
-      act(() => {
+
+      waitFor(() => {
+        const dateToSelect =
+          screen.getByText("6th March (Sunday)").parentElement
         dateToSelect?.focus()
         userEvent.keyboard("{enter}")
       })
@@ -179,34 +183,38 @@ describe("<DatePicker />", () => {
   })
 
   describe("Click on input", () => {
-    it("show focus on input", async () => {
+    it("show focus on input", () => {
       render(<DatePickerWrapper selectedDay={new Date("2022-03-1")} />)
-      const input = screen.getByRole("combobox")
 
       expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
-      waitFor(() => {
-        userEvent.click(input)
-        expect(screen.queryByRole("dialog")).toBeInTheDocument()
-      })
 
-      expect(input).toHaveFocus()
+      const input = screen.getByLabelText("Choose date", { selector: "input" })
+      userEvent.click(input)
+
+      waitFor(() => {
+        expect(screen.queryByRole("dialog")).toBeInTheDocument()
+        expect(input).toHaveFocus()
+      })
     })
 
     it("show focus on the input when a new date is selected from the calendar", async () => {
       render(<DatePickerWrapper selectedDay={new Date("2022-03-1")} />)
-      const input = screen.getByRole("combobox")
 
       expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
 
-      waitFor(() => {
-        userEvent.click(input)
-        expect(screen.queryByRole("dialog")).toBeInTheDocument()
-        const dateToSelect =
-          screen.getByText("6th March (Sunday)").parentElement
+      const input = screen.getByLabelText("Choose date", { selector: "input" })
+      userEvent.click(input)
 
-        dateToSelect && userEvent.click(dateToSelect)
+      await waitFor(() => {
+        expect(screen.queryByRole("dialog")).toBeInTheDocument()
       })
-      expect(input).toHaveFocus()
+
+      const dateToSelect = screen.getByText("6th March (Sunday)").parentElement
+      dateToSelect && userEvent.click(dateToSelect)
+
+      waitFor(() => {
+        expect(input).toHaveFocus()
+      })
     })
   })
 
@@ -245,9 +253,9 @@ describe("<DatePicker />", () => {
         expect(screen.queryByRole("dialog")).toBeInTheDocument()
       })
 
-      const dateToSelect = screen.getByText(todayFormatted).parentElement
+      const todayDate = screen.getByText(todayFormatted).parentElement
 
-      expect(dateToSelect).toHaveFocus()
+      expect(todayDate).toHaveFocus()
     })
   })
 
@@ -284,9 +292,9 @@ describe("<DatePicker />", () => {
         expect(screen.queryByRole("dialog")).toBeInTheDocument()
       })
 
-      const dateToSelect = screen.getByText(todayFormatted).parentElement
+      const todayDate = screen.getByText(todayFormatted).parentElement
 
-      expect(dateToSelect).toHaveFocus()
+      expect(todayDate).toHaveFocus()
     })
   })
 

--- a/packages/date-picker/src/DatePicker/DatePicker.spec.tsx
+++ b/packages/date-picker/src/DatePicker/DatePicker.spec.tsx
@@ -2,6 +2,7 @@ import React, { useState } from "react"
 import { act, render, screen } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { FieldMessageStatus } from "@kaizen/draft-form"
+import format from "date-fns/format"
 import { DatePicker, ValidationResponse } from "./DatePicker"
 import { DatePickerProps } from "."
 
@@ -52,29 +53,56 @@ describe("<DatePicker />", () => {
     expect(screen.getByDisplayValue("Mar 1, 2022")).toBeInTheDocument()
   })
 
-  it("shows/hides calendar on button press", async () => {
-    render(<DatePickerWrapper />)
+  describe("Opening Calendar", () => {
+    it("opens the calendar on input click", async () => {
+      render(<DatePickerWrapper />)
+      const input = screen.getByRole("combobox")
 
-    const button = screen.getByRole("button")
-
-    expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
-
-    await act(async () => button.click())
-    expect(screen.getByRole("dialog")).toBeVisible()
-  })
-
-  it("shows/hides calendar on arrow down keydown", async () => {
-    render(<DatePickerWrapper />)
-
-    const input = screen.getByRole("combobox")
-
-    expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
-
-    await act(async () => {
-      input.focus()
-      userEvent.keyboard("{arrowdown}")
+      await act(async () => {
+        input.click()
+      })
+      expect(screen.getByRole("dialog")).toBeVisible()
     })
-    expect(screen.getByRole("dialog")).toBeVisible()
+
+    it("shows/hides calendar on arrow down keydown within input", async () => {
+      render(<DatePickerWrapper />)
+
+      const input = screen.getByRole("combobox")
+
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
+
+      await act(async () => {
+        input.focus()
+        userEvent.keyboard("{arrowdown}")
+      })
+      expect(screen.getByRole("dialog")).toBeVisible()
+    })
+
+    it("openscalendar on calendar button click", async () => {
+      render(<DatePickerWrapper />)
+
+      const button = screen.getByRole("button")
+
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
+
+      await act(async () => button.click())
+      expect(screen.getByRole("dialog")).toBeVisible()
+    })
+
+    it("opens calendar on calendar button keydown enter", async () => {
+      render(<DatePickerWrapper />)
+
+      const button = screen.getByRole("button")
+
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
+
+      await act(async () => {
+        button.focus()
+        userEvent.keyboard("{enter}")
+      })
+
+      expect(screen.getByRole("dialog")).toBeInTheDocument()
+    })
   })
 
   describe("Selecting a date using the calendar", () => {
@@ -161,5 +189,59 @@ describe("<DatePicker />", () => {
         ).toBeInTheDocument()
       })
     })
+  })
+  describe("Focus", () => {
+    it("show focus on single selected day", async () => {
+      render(<DatePickerWrapper selectedDay={new Date("2022-03-1")} />)
+      const input = screen.getByRole("combobox")
+
+      await act(async () => {
+        input.focus()
+        userEvent.keyboard("{arrowdown}")
+      })
+      const selectedDate = screen.getByText("1st March (Tuesday)")
+
+      expect(selectedDate.parentElement).toHaveFocus()
+    })
+
+    it("show focus on today when no date is selected", async () => {
+      const today = new Date()
+      const todayFormatted = format(today, "do LLLL (eeee)") // e.g 6th June (Monday)
+
+      render(<DatePickerWrapper selectedDay={undefined} />)
+      const input = screen.getByRole("combobox")
+
+      await act(async () => {
+        input.focus()
+        userEvent.keyboard("{arrowdown}")
+      })
+      const dateToSelect = screen.getByText(todayFormatted).parentElement
+
+      expect(dateToSelect).toHaveFocus()
+    })
+
+    it("focuses on the input when a date is selected from the calendar", async () => {
+      // render(<DatePickerWrapper defaultMonth={new Date("2022-03-01")} />)
+      // const input = screen.getByRole("combobox")
+      // await act(async () => {
+      //   input.click()
+      // })
+      // const dateToSelect = screen.getByText("6th March (Sunday)").parentElement
+      // act(() => {
+      //   dateToSelect?.click()
+      // })
+      // expect(input).toHaveFocus()
+    })
+
+    // it("focuses on the input when a date is selected from the calendar", async () => {
+    // })
+
+    // it("focus on the input when it came from the input", async () => {
+    //   //make sure the format is correct
+    // })
+    // it("allows you to tab through input, button and calendar", async () => {
+    // })
+    // it("focus on the button when it came from the button", async () => {
+    // })
   })
 })

--- a/packages/date-picker/src/DatePicker/DatePicker.tsx
+++ b/packages/date-picker/src/DatePicker/DatePicker.tsx
@@ -272,6 +272,9 @@ export const DatePicker: React.VFC<DatePickerProps> = ({
       e.preventDefault()
       setIsOpen(true)
       setLastTrigger("inputKeydown")
+    } else if (e.key === "Tab" && selectedDay) {
+      isOpen && setIsOpen(false)
+      setLastTrigger("calendarButton")
     }
   }
 

--- a/packages/date-picker/src/DatePicker/DatePicker.tsx
+++ b/packages/date-picker/src/DatePicker/DatePicker.tsx
@@ -1,17 +1,17 @@
 import React, { RefObject, useEffect, useRef, useState } from "react"
 import { format } from "date-fns"
 import { DateRange, DateInterval } from "react-day-picker"
-import { FocusOn, InFocusGuard } from "react-focus-on"
+import { FocusOn } from "react-focus-on"
 import { usePopper } from "react-popper"
 import dateStart from "@kaizen/component-library/icons/date-start.icon.svg"
 import { FieldMessageStatus } from "@kaizen/draft-form"
 import { calculateDisabledDays } from "../utils/calculateDisabledDays"
 import { isInvalidDate } from "../utils/isInvalidDate"
 import { isDisabledDate } from "../utils/isDisabledDate"
+import { setFocusInCalendar } from "../utils/setFocusInCalendar"
 import { DateFormat, DayOfWeek } from "./enums"
 import { Calendar, CalendarElement, CalendarProps } from "./components/Calendar"
 import { DateInput, DateInputProps } from "./components/DateInput"
-import calendarStyles from "./components/Calendar/Calendar.scss"
 
 type OmittedDateInputProps =
   | "isOpen"
@@ -117,7 +117,6 @@ export type ValidationResponse = {
  * {@link https://cultureamp.design/storybook/?path=/docs/components-date-picker-date-picker--default-story Storybook}
  */
 export const DatePicker: React.VFC<DatePickerProps> = ({
-  inputRef: propsInputRef,
   id,
   buttonRef = useRef<HTMLButtonElement>(null),
   labelText,
@@ -138,11 +137,7 @@ export const DatePicker: React.VFC<DatePickerProps> = ({
 }) => {
   const wrapperRef = useRef<HTMLDivElement>(null)
   const inputRef = useRef<HTMLInputElement>(null)
-  // const calendarRef = useRef<HTMLDivElement>(null)
-
   const [isOpen, setIsOpen] = useState(false)
-  const [shouldFocusOnCalendar, setShouldFocusOnCalendar] =
-    useState<boolean>(true)
   const [referenceElement, setReferenceElement] =
     useState<HTMLDivElement | null>(null)
   const [popperElement, setPopperElement] = useState<HTMLDivElement | null>(
@@ -280,25 +275,13 @@ export const DatePicker: React.VFC<DatePickerProps> = ({
     }
   }
 
-  const isHTMLElement = (
-    element: Element | undefined
-  ): element is HTMLElement => element instanceof HTMLElement
-
-  const focusInCalendar = (calendarElement: CalendarElement): void => {
-    const dayToFocus = calendarElement.getElementsByClassName(
-      selectedDay ? calendarStyles.daySelected : calendarStyles.dayToday
-    )[0]
-
-    if (isHTMLElement(dayToFocus)) dayToFocus.focus()
-  }
-
   const handleCalendarMount = (calendarElement: CalendarElement): void => {
     switch (lastTrigger) {
       case "inputClick":
       case "inputFocus":
         return
       default:
-        focusInCalendar(calendarElement)
+        setFocusInCalendar(calendarElement, selectedDay)
     }
   }
 

--- a/packages/date-picker/src/DatePicker/DatePicker.tsx
+++ b/packages/date-picker/src/DatePicker/DatePicker.tsx
@@ -25,7 +25,6 @@ type OmittedDateInputProps =
   | "onButtonClick"
   | "calendarId"
   | "value"
-  | "disabledDays"
 
 export interface DatePickerProps
   extends Omit<DateInputProps, OmittedDateInputProps> {
@@ -365,7 +364,6 @@ export const DatePicker: React.VFC<DatePickerProps> = ({
             onButtonClick={handleButtonClick}
             icon={dateStart}
             value={inputValue}
-            disabledDays={disabledDays}
             {...restDateInputProps}
           />
         </div>

--- a/packages/date-picker/src/DatePicker/DatePicker.tsx
+++ b/packages/date-picker/src/DatePicker/DatePicker.tsx
@@ -145,7 +145,7 @@ export const DatePicker: React.VFC<DatePickerProps> = ({
   )
 
   const [lastTrigger, setLastTrigger] = useState<
-    "inputFocus" | "inputClick" | "inputKeydown" | "calendarButton"
+    "inputFocus" | "inputKeydown" | "calendarButton"
   >()
 
   const { styles, attributes } = usePopper(referenceElement, popperElement, {
@@ -232,12 +232,10 @@ export const DatePicker: React.VFC<DatePickerProps> = ({
     handleDayChange(date, inputValue)
   }
 
-  const handleInputFocus = () => {
-    setLastTrigger("inputFocus")
-  }
+  const handleInputFocus = () => setLastTrigger("inputFocus")
 
   const handleReturnFocus = (): void => {
-    if (lastTrigger === "inputKeydown") {
+    if (lastTrigger === "inputKeydown" || lastTrigger === "inputFocus") {
       return inputRef.current?.focus()
     }
 
@@ -260,20 +258,21 @@ export const DatePicker: React.VFC<DatePickerProps> = ({
   const handleKeyDown = (
     e: React.KeyboardEvent<HTMLInputElement> | React.KeyboardEvent<Element>
   ): void => {
-    // check whether event key is arrow down or alt + arrow down, open calendar if so.
     if (e.key === "ArrowDown" || (e.key === "ArrowDown" && e.altKey === true)) {
       e.preventDefault()
       setIsOpen(true)
       setLastTrigger("inputKeydown")
     } else if (e.key === "Tab" && selectedDay) {
       isOpen && setIsOpen(false)
+      // @todo what's this? check with Nat
+      // calendar remains open, but since focus shifted to calendarButton instead of input
+      // the lastTrigger wouldn't be accurate
       setLastTrigger("calendarButton")
     }
   }
 
   const handleCalendarMount = (calendarElement: CalendarElement): void => {
     switch (lastTrigger) {
-      case "inputClick":
       case "inputFocus":
         return
       default:

--- a/packages/date-picker/src/DatePicker/DatePicker.tsx
+++ b/packages/date-picker/src/DatePicker/DatePicker.tsx
@@ -9,8 +9,9 @@ import { calculateDisabledDays } from "../utils/calculateDisabledDays"
 import { isInvalidDate } from "../utils/isInvalidDate"
 import { isDisabledDate } from "../utils/isDisabledDate"
 import { DateFormat, DayOfWeek } from "./enums"
-import { Calendar, CalendarProps } from "./components/Calendar"
+import { Calendar, CalendarElement, CalendarProps } from "./components/Calendar"
 import { DateInput, DateInputProps } from "./components/DateInput"
+import calendarStyles from "./components/Calendar/Calendar.scss"
 
 type OmittedDateInputProps =
   | "isOpen"
@@ -134,8 +135,9 @@ export const DatePicker: React.VFC<DatePickerProps> = ({
   onClick,
   ...restDateInputProps
 }) => {
+  const wrapperRef = useRef<HTMLDivElement>(null)
   const inputRef = useRef<HTMLInputElement>(null)
-  const calendarRef = useRef<HTMLDivElement>(null)
+  // const calendarRef = useRef<HTMLDivElement>(null)
 
   const [isOpen, setIsOpen] = useState(false)
   const [shouldFocusOnCalendar, setShouldFocusOnCalendar] =
@@ -145,7 +147,8 @@ export const DatePicker: React.VFC<DatePickerProps> = ({
   const [popperElement, setPopperElement] = useState<HTMLDivElement | null>(
     null
   )
-  const wrapperRef = useRef<HTMLDivElement>(null)
+
+  const [lastTrigger, setLastTrigger] = useState<"inputClick" | "inputKeydown" | "calendarButton">()
 
   const { styles, attributes } = usePopper(referenceElement, popperElement, {
     modifiers: [
@@ -237,13 +240,15 @@ export const DatePicker: React.VFC<DatePickerProps> = ({
 
   const handleButtonClick = (): void => {
     setIsOpen(!isOpen)
-    setShouldFocusOnCalendar(true)
+    // setShouldFocusOnCalendar(true)
+    setLastTrigger("calendarButton")
     onButtonClick && onButtonClick()
   }
 
   const handleInputClick: React.MouseEventHandler<HTMLInputElement> = e => {
     setIsOpen(true)
-    setShouldFocusOnCalendar(false)
+    // setShouldFocusOnCalendar(false)
+    setLastTrigger("inputClick")
     onClick && onClick(e)
   }
 
@@ -254,7 +259,29 @@ export const DatePicker: React.VFC<DatePickerProps> = ({
     if (e.key === "ArrowDown" || (e.key === "ArrowDown" && e.altKey === true)) {
       e.preventDefault()
       setIsOpen(true)
-      setShouldFocusOnCalendar(true)
+      setLastTrigger("inputKeydown")
+      // setShouldFocusOnCalendar(true)
+    }
+  }
+
+const isHTMLElement = (element: Element | undefined): element is HTMLElement => element instanceof HTMLElement
+
+  const focusInCalendar = (calendarElement: CalendarElement): void => {
+    const dayToFocus = calendarElement.getElementsByClassName(
+      selectedDay ? calendarStyles.daySelected : calendarStyles.dayToday)[0]
+
+    if (isHTMLElement(dayToFocus)) dayToFocus.focus()
+  }
+
+  const handleCalendarMount = (calendarElement: CalendarElement): void => {
+    console.log("onMount called",calendarElement)
+    switch (lastTrigger) {
+      case "inputClick":
+        console.log("last trigger inputClick", lastTrigger)
+        return
+      default:
+        console.log("onMount default", lastTrigger)
+        focusInCalendar(calendarElement)
     }
   }
 
@@ -326,7 +353,8 @@ export const DatePicker: React.VFC<DatePickerProps> = ({
             weekStartsOn={weekStartsOn}
             disabledDays={disabledDays}
             onDayChange={handleOnCalendarDayChange}
-            shouldFocusOnCalendar={shouldFocusOnCalendar}
+            // shouldFocusOnCalendar={shouldFocusOnCalendar}
+            onMount={handleCalendarMount}
           />
         </FocusOn>
       )}

--- a/packages/date-picker/src/DatePicker/DatePicker.tsx
+++ b/packages/date-picker/src/DatePicker/DatePicker.tsx
@@ -145,11 +145,7 @@ export const DatePicker: React.VFC<DatePickerProps> = ({
   )
 
   const [lastTrigger, setLastTrigger] = useState<
-    | "inputFocus"
-    | "inputClick"
-    | "inputKeydown"
-    | "calendarButton"
-    | "calendarSelectDay"
+    "inputFocus" | "inputClick" | "inputKeydown" | "calendarButton"
   >()
 
   const { styles, attributes } = usePopper(referenceElement, popperElement, {
@@ -223,7 +219,6 @@ export const DatePicker: React.VFC<DatePickerProps> = ({
   }
 
   const handleCalendarDayChange = (date: Date): void => {
-    setLastTrigger("calendarSelectDay")
     if (!isDisabledDate(date, disabledDays)) {
       handleDayChange(date)
       setIsOpen(false)
@@ -234,9 +229,7 @@ export const DatePicker: React.VFC<DatePickerProps> = ({
     date: Date | undefined,
     inputValue: string
   ): void => {
-    if (lastTrigger !== "calendarSelectDay") {
-      handleDayChange(date, inputValue)
-    }
+    handleDayChange(date, inputValue)
   }
 
   const handleInputFocus = () => {

--- a/packages/date-picker/src/DatePicker/DatePicker.tsx
+++ b/packages/date-picker/src/DatePicker/DatePicker.tsx
@@ -8,6 +8,7 @@ import { FieldMessageStatus } from "@kaizen/draft-form"
 import { calculateDisabledDays } from "../utils/calculateDisabledDays"
 import { isInvalidDate } from "../utils/isInvalidDate"
 import { isDisabledDate } from "../utils/isDisabledDate"
+import calendarStyles from "./components/Calendar/Calendar.scss"
 import { DateFormat, DayOfWeek } from "./enums"
 import { Calendar, CalendarProps } from "./components/Calendar"
 import { DateInput, DateInputProps } from "./components/DateInput"
@@ -28,6 +29,7 @@ export interface DatePickerProps
   isDisabled?: boolean
   buttonRef?: RefObject<HTMLButtonElement>
   onButtonClick?: DateInputProps["onButtonClick"]
+  onClick?: DateInputProps["onClick"]
   /**
    * Accepts a DayOfWeek value to start the week on that day. By default,
    * it's set to Monday.
@@ -132,10 +134,15 @@ export const DatePicker: React.VFC<DatePickerProps> = ({
   onButtonClick,
   onDayChange,
   onValidate,
+  onClick,
   ...restDateInputProps
 }) => {
   const inputRef = useRef<HTMLInputElement>(null)
+  const calendarRef = useRef<HTMLDivElement>(null)
+
   const [isOpen, setIsOpen] = useState(false)
+  const [shouldFocusOnCalendar, setShouldFocusOnCalendar] =
+    useState<boolean>(true)
   const [referenceElement, setReferenceElement] =
     useState<HTMLDivElement | null>(null)
   const [popperElement, setPopperElement] = useState<HTMLDivElement | null>(
@@ -233,7 +240,14 @@ export const DatePicker: React.VFC<DatePickerProps> = ({
 
   const handleButtonClick = (): void => {
     setIsOpen(true)
+    setShouldFocusOnCalendar(true)
     onButtonClick && onButtonClick()
+  }
+
+  const handleInputClick: React.MouseEventHandler<HTMLInputElement> = e => {
+    setIsOpen(true)
+    setShouldFocusOnCalendar(false)
+    onClick && onClick(e)
   }
 
   const handleKeyDown = (
@@ -243,6 +257,7 @@ export const DatePicker: React.VFC<DatePickerProps> = ({
     if (e.key === "ArrowDown" || (e.key === "ArrowDown" && e.altKey === true)) {
       e.preventDefault()
       setIsOpen(true)
+      setShouldFocusOnCalendar(true)
     }
   }
 
@@ -292,6 +307,7 @@ export const DatePicker: React.VFC<DatePickerProps> = ({
           onKeyDown={handleKeyDown}
           valueDate={selectedDay}
           disabledDays={disabledDays}
+          onClick={handleInputClick}
           {...restDateInputProps}
         />
       </div>
@@ -301,6 +317,7 @@ export const DatePicker: React.VFC<DatePickerProps> = ({
           onDeactivation={handleReturnFocus}
           onClickOutside={() => setIsOpen(false)}
           onEscapeKey={() => setIsOpen(false)}
+          shards={[inputRef, buttonRef]}
         >
           <Calendar
             mode="single"
@@ -313,6 +330,7 @@ export const DatePicker: React.VFC<DatePickerProps> = ({
             weekStartsOn={weekStartsOn}
             disabledDays={disabledDays}
             onDayChange={handleOnCalendarDayChange}
+            shouldFocusOnCalendar={shouldFocusOnCalendar}
           />
         </FocusOn>
       )}

--- a/packages/date-picker/src/DatePicker/DatePicker.tsx
+++ b/packages/date-picker/src/DatePicker/DatePicker.tsx
@@ -8,7 +8,6 @@ import { FieldMessageStatus } from "@kaizen/draft-form"
 import { calculateDisabledDays } from "../utils/calculateDisabledDays"
 import { isInvalidDate } from "../utils/isInvalidDate"
 import { isDisabledDate } from "../utils/isDisabledDate"
-import calendarStyles from "./components/Calendar/Calendar.scss"
 import { DateFormat, DayOfWeek } from "./enums"
 import { Calendar, CalendarProps } from "./components/Calendar"
 import { DateInput, DateInputProps } from "./components/DateInput"
@@ -237,7 +236,7 @@ export const DatePicker: React.VFC<DatePickerProps> = ({
   }
 
   const handleButtonClick = (): void => {
-    setIsOpen(true)
+    setIsOpen(!isOpen)
     setShouldFocusOnCalendar(true)
     onButtonClick && onButtonClick()
   }

--- a/packages/date-picker/src/DatePicker/DatePicker.tsx
+++ b/packages/date-picker/src/DatePicker/DatePicker.tsx
@@ -26,7 +26,6 @@ export interface DatePickerProps
   extends Omit<DateInputProps, OmittedDateInputProps> {
   id: string
   labelText: string
-  isDisabled?: boolean
   buttonRef?: RefObject<HTMLButtonElement>
   onButtonClick?: DateInputProps["onButtonClick"]
   onClick?: DateInputProps["onClick"]
@@ -121,7 +120,6 @@ export const DatePicker: React.VFC<DatePickerProps> = ({
   id,
   buttonRef = useRef<HTMLButtonElement>(null),
   labelText,
-  isDisabled = false,
   disabledDates,
   disabledDaysOfWeek,
   disabledRange,
@@ -298,7 +296,6 @@ export const DatePicker: React.VFC<DatePickerProps> = ({
           inputRef={inputRef}
           buttonRef={buttonRef}
           isOpen={isOpen}
-          disabled={isDisabled}
           onBlur={handleInputChange}
           labelText={labelText}
           icon={dateStart}

--- a/packages/date-picker/src/DatePicker/DateRangePicker.spec.tsx
+++ b/packages/date-picker/src/DatePicker/DateRangePicker.spec.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { act, render, screen } from "@testing-library/react"
+import { act, render, screen, waitFor } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { DateRange } from "react-day-picker"
 import { DateRangePicker } from "./DateRangePicker"
@@ -25,26 +25,23 @@ describe("<DateRangePicker />", () => {
   })
 
   it("is able to select date range and shows in button", async () => {
-    jest.setTimeout(10000)
     render(<DateRangePicker {...defaultProps} />)
 
     const element = screen.getByRole("button")
 
-    await act(async () => element.click())
-
-    const selectedFromDate = screen.getByText("6th March (Sunday)")
-
-    await act(async () => {
+    waitFor(() => {
+      element.click()
+      const selectedFromDate = screen.getByText("6th March (Sunday)")
       selectedFromDate.parentElement && selectedFromDate.parentElement.focus()
       userEvent.keyboard("{enter}")
     })
 
-    const selectedToDate = screen.getByText("16th March (Wednesday)")
-
-    await act(async () => {
+    waitFor(() => {
+      const selectedToDate = screen.getByText("16th March (Wednesday)")
       selectedToDate.parentElement && selectedToDate.parentElement.focus()
       userEvent.keyboard("{enter}")
     })
+
     expect(element.innerText === "Mar 6 – Mar 16, 2022")
   })
 

--- a/packages/date-picker/src/DatePicker/components/Calendar/Calendar.spec.tsx
+++ b/packages/date-picker/src/DatePicker/components/Calendar/Calendar.spec.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from "@testing-library/react"
 import React from "react"
+import format from "date-fns/format"
 import { DayOfWeek } from "../../enums"
 import { Calendar, CalendarProps } from "./Calendar"
 import "@testing-library/jest-dom"
@@ -7,19 +8,53 @@ import "@testing-library/jest-dom"
 const defaultProps: CalendarProps = {
   mode: "single",
   id: "calendar-dialog",
-  value: new Date("2022-03-01"),
   defaultMonth: new Date("2022-03-01"),
+  value: new Date("2022-03-01"),
   onDayChange: jest.fn<void, [Date]>(),
   weekStartsOn: DayOfWeek.Mon,
   setPopperElement: jest.fn(),
+  shouldFocusOnCalendar: true,
 }
 
+const CalendarWrapper = ({ ...restProps }: Partial<CalendarProps>) => (
+  <Calendar {...defaultProps} {...restProps} />
+)
+
 describe("<Calendar />", () => {
-  it("show focus on selected day", async () => {
-    render(<Calendar {...defaultProps} />)
+  it("show focus on single selected day", async () => {
+    render(<CalendarWrapper />)
 
     const selectedDate = screen.getByText("1st March (Tuesday)")
 
     expect(selectedDate.parentElement).toHaveFocus()
+  })
+
+  it("show focus on range from selected date", async () => {
+    const selectedDateRange = {
+      from: new Date("2022-03-01"),
+      to: new Date("2022-03-15"),
+    }
+    render(<CalendarWrapper mode="range" selectedRange={selectedDateRange} />)
+
+    const selectedDate = screen.getByText("1st March (Tuesday)")
+
+    expect(selectedDate.parentElement).toHaveFocus()
+  })
+
+  it("show focus on today when no date is selected", () => {
+    const today = new Date()
+    const todayFormatted = format(today, "do LLLL (eeee)") // e.g 6th June (Monday)
+
+    render(<CalendarWrapper defaultMonth={today} value={undefined} />)
+
+    const dateToSelect = screen.getByText(todayFormatted).parentElement
+
+    expect(dateToSelect).toHaveFocus()
+  })
+
+  it("does not focus within the calendar when shouldFocusOnCalendar is false", () => {
+    render(<CalendarWrapper shouldFocusOnCalendar={false} />)
+
+    expect(document.body).toHaveFocus()
   })
 })

--- a/packages/date-picker/src/DatePicker/components/Calendar/Calendar.spec.tsx
+++ b/packages/date-picker/src/DatePicker/components/Calendar/Calendar.spec.tsx
@@ -1,5 +1,6 @@
-import { render, screen } from "@testing-library/react"
 import React from "react"
+import { render, screen } from "@testing-library/react"
+import { format } from "date-fns"
 import { DayOfWeek } from "../../enums"
 import { Calendar, CalendarProps } from "./Calendar"
 import "@testing-library/jest-dom"
@@ -12,25 +13,27 @@ const defaultProps: CalendarProps = {
   setPopperElement: jest.fn(),
 }
 
-const CalendarWrapper = ({ ...restProps }: Partial<CalendarProps>) => (
-  <Calendar {...defaultProps} {...restProps} />
+const CalendarWrapper = (props: Partial<CalendarProps>) => (
+  <Calendar {...defaultProps} {...props} />
 )
 
 describe("<Calendar />", () => {
-  it("displays default month when provided", async () => {
+  it("displays default month when provided", () => {
     render(<CalendarWrapper defaultMonth={new Date("2022-03-01")} />)
 
     expect(screen.getByText("March 2022")).toBeInTheDocument()
   })
-  it("displays default month as value's month when provided", async () => {
+  it("displays default month as value's month when provided", () => {
     render(<CalendarWrapper value={new Date("2022-03-01")} />)
 
     expect(screen.getByText("March 2022")).toBeInTheDocument()
   })
 
-  it("displays default month as todays current month when provided", async () => {
+  it("displays default month as todays current month when provided", () => {
     render(<CalendarWrapper />)
 
-    expect(screen.getByText("June 2022")).toBeInTheDocument()
+    const today = new Date()
+    const todayFormatted = format(today, "MMMM yyyy") // e.g June 2022
+    expect(screen.getByText(todayFormatted)).toBeInTheDocument()
   })
 })

--- a/packages/date-picker/src/DatePicker/components/Calendar/Calendar.spec.tsx
+++ b/packages/date-picker/src/DatePicker/components/Calendar/Calendar.spec.tsx
@@ -1,6 +1,5 @@
 import { render, screen } from "@testing-library/react"
 import React from "react"
-import format from "date-fns/format"
 import { DayOfWeek } from "../../enums"
 import { Calendar, CalendarProps } from "./Calendar"
 import "@testing-library/jest-dom"
@@ -8,12 +7,9 @@ import "@testing-library/jest-dom"
 const defaultProps: CalendarProps = {
   mode: "single",
   id: "calendar-dialog",
-  defaultMonth: new Date("2022-03-01"),
-  value: new Date("2022-03-01"),
   onDayChange: jest.fn<void, [Date]>(),
   weekStartsOn: DayOfWeek.Mon,
   setPopperElement: jest.fn(),
-  shouldFocusOnCalendar: true,
 }
 
 const CalendarWrapper = ({ ...restProps }: Partial<CalendarProps>) => (
@@ -21,40 +17,20 @@ const CalendarWrapper = ({ ...restProps }: Partial<CalendarProps>) => (
 )
 
 describe("<Calendar />", () => {
-  it("show focus on single selected day", async () => {
+  it("displays default month when provided", async () => {
+    render(<CalendarWrapper defaultMonth={new Date("2022-03-01")} />)
+
+    expect(screen.getByText("March 2022")).toBeInTheDocument()
+  })
+  it("displays default month as value's month when provided", async () => {
+    render(<CalendarWrapper value={new Date("2022-03-01")} />)
+
+    expect(screen.getByText("March 2022")).toBeInTheDocument()
+  })
+
+  it("displays default month as todays current month when provided", async () => {
     render(<CalendarWrapper />)
 
-    const selectedDate = screen.getByText("1st March (Tuesday)")
-
-    expect(selectedDate.parentElement).toHaveFocus()
-  })
-
-  it("show focus on range from selected date", async () => {
-    const selectedDateRange = {
-      from: new Date("2022-03-01"),
-      to: new Date("2022-03-15"),
-    }
-    render(<CalendarWrapper mode="range" selectedRange={selectedDateRange} />)
-
-    const selectedDate = screen.getByText("1st March (Tuesday)")
-
-    expect(selectedDate.parentElement).toHaveFocus()
-  })
-
-  it("show focus on today when no date is selected", () => {
-    const today = new Date()
-    const todayFormatted = format(today, "do LLLL (eeee)") // e.g 6th June (Monday)
-
-    render(<CalendarWrapper defaultMonth={today} value={undefined} />)
-
-    const dateToSelect = screen.getByText(todayFormatted).parentElement
-
-    expect(dateToSelect).toHaveFocus()
-  })
-
-  it("does not focus within the calendar when shouldFocusOnCalendar is false", () => {
-    render(<CalendarWrapper shouldFocusOnCalendar={false} />)
-
-    expect(document.body).toHaveFocus()
+    expect(screen.getByText("June 2022")).toBeInTheDocument()
   })
 })

--- a/packages/date-picker/src/DatePicker/components/Calendar/Calendar.tsx
+++ b/packages/date-picker/src/DatePicker/components/Calendar/Calendar.tsx
@@ -11,6 +11,8 @@ import { DayOfWeek } from "../../enums"
 import { defaultCalendarClasses } from "./CalendarClasses"
 import calendarStyles from "./Calendar.scss"
 
+export type CalendarElement = HTMLDivElement
+
 export type CalendarProps = {
   id: string
   setPopperElement: Dispatch<SetStateAction<HTMLDivElement | null>>
@@ -31,10 +33,8 @@ export type CalendarProps = {
   selectedRange?: DateRange
   mode: "single" | "range"
   modifiers?: DateRange
-  onMount?: (calendarElement: HTMLDivElement) => void
+  onMount?: (calendarElement: CalendarElement) => void
 }
-
-export type CalendarElement = HTMLDivElement
 
 const isValidWeekStartsOn = (
   day: DayOfWeek | undefined

--- a/packages/date-picker/src/DatePicker/components/Calendar/Calendar.tsx
+++ b/packages/date-picker/src/DatePicker/components/Calendar/Calendar.tsx
@@ -59,12 +59,11 @@ export const Calendar: React.VFC<CalendarProps> = ({
   modifiers,
   mode,
   // shouldFocusOnCalendar = false,
-  onMount
+  onMount,
 }) => {
   const calendarRef = useRef<CalendarElement>(null)
 
   useEffect(() => {
-    console.log("calendarRef",calendarRef)
     if (calendarRef.current) onMount && onMount(calendarRef.current)
   }, [calendarRef])
 

--- a/packages/date-picker/src/DatePicker/components/Calendar/Calendar.tsx
+++ b/packages/date-picker/src/DatePicker/components/Calendar/Calendar.tsx
@@ -31,6 +31,7 @@ export type CalendarProps = {
   selectedRange?: DateRange
   mode: "single" | "range"
   modifiers?: DateRange
+  shouldFocusOnCalendar?: boolean
 }
 
 const isValidWeekStartsOn = (
@@ -52,27 +53,28 @@ export const Calendar: React.VFC<CalendarProps> = ({
   selectedRange,
   modifiers,
   mode,
+  shouldFocusOnCalendar = false,
 }) => {
   const calendarRef = useRef<HTMLDivElement>(null)
 
   // Initial focus when opening the calendar
   useEffect(() => {
-    if (!calendarRef.current) return
+    if (shouldFocusOnCalendar && calendarRef.current) {
+      if (value || selectedRange?.from) {
+        const selectedDay = calendarRef.current.getElementsByClassName(
+          calendarStyles.daySelected
+        )[0] as HTMLElement
 
-    if (value || selectedRange?.from) {
-      const selectedDay = calendarRef.current.getElementsByClassName(
-        calendarStyles.daySelected
-      )[0] as HTMLElement
-      selectedDay?.focus()
-      return
-    } else {
+        return selectedDay?.focus()
+      }
+
       const today = calendarRef.current.getElementsByClassName(
         calendarStyles.dayToday
       )[0] as HTMLElement
+
       today?.focus()
-      return
     }
-  }, [])
+  }, [shouldFocusOnCalendar, calendarRef.current])
 
   const getdefaultMonth = () => selectedRange?.from || value || defaultMonth
 
@@ -138,5 +140,3 @@ export const Calendar: React.VFC<CalendarProps> = ({
     </div>
   )
 }
-
-Calendar.displayName = "Calendar"

--- a/packages/date-picker/src/DatePicker/components/Calendar/Calendar.tsx
+++ b/packages/date-picker/src/DatePicker/components/Calendar/Calendar.tsx
@@ -31,15 +31,18 @@ export type CalendarProps = {
   selectedRange?: DateRange
   mode: "single" | "range"
   modifiers?: DateRange
-  shouldFocusOnCalendar?: boolean
+  // shouldFocusOnCalendar?: boolean
+  onMount?: (calendarElement: HTMLDivElement) => void
 }
+
+export type CalendarElement = HTMLDivElement
 
 const isValidWeekStartsOn = (
   day: DayOfWeek | undefined
 ): day is 0 | 1 | 2 | 3 | 4 | 5 | 6 | undefined =>
   [0, 1, 2, 3, 4, 5, 6, undefined].includes(day)
 
-const isHTMLElement = (element: Element | undefined): element is HTMLElement => element instanceof HTMLElement
+// const isHTMLElement = (element: Element | undefined): element is HTMLElement => element instanceof HTMLElement
 
 export const Calendar: React.VFC<CalendarProps> = ({
   id,
@@ -55,28 +58,15 @@ export const Calendar: React.VFC<CalendarProps> = ({
   selectedRange,
   modifiers,
   mode,
-  shouldFocusOnCalendar = false,
+  // shouldFocusOnCalendar = false,
+  onMount
 }) => {
-  const calendarRef = useRef<HTMLDivElement>(null)
+  const calendarRef = useRef<CalendarElement>(null)
 
   useEffect(() => {
-    if (shouldFocusOnCalendar && calendarRef.current) {
-      if (value || selectedRange?.from) {
-        const selectedDay = calendarRef.current.getElementsByClassName(
-          calendarStyles.daySelected
-        )[0]
-
-        if (isHTMLElement(selectedDay)) selectedDay.focus()
-        return
-      }
-
-      const today = calendarRef.current.getElementsByClassName(
-        calendarStyles.dayToday
-      )[0]
-
-      if (isHTMLElement(today)) today.focus()
-    }
-  }, [shouldFocusOnCalendar, calendarRef])
+    console.log("calendarRef",calendarRef)
+    if (calendarRef.current) onMount && onMount(calendarRef.current)
+  }, [calendarRef])
 
   const selectedMonth = selectedRange?.from || value || defaultMonth
 

--- a/packages/date-picker/src/DatePicker/components/Calendar/Calendar.tsx
+++ b/packages/date-picker/src/DatePicker/components/Calendar/Calendar.tsx
@@ -127,3 +127,5 @@ export const Calendar: React.VFC<CalendarProps> = ({
     </div>
   )
 }
+
+Calendar.displayName = "Calendar"

--- a/packages/date-picker/src/DatePicker/components/Calendar/Calendar.tsx
+++ b/packages/date-picker/src/DatePicker/components/Calendar/Calendar.tsx
@@ -31,7 +31,6 @@ export type CalendarProps = {
   selectedRange?: DateRange
   mode: "single" | "range"
   modifiers?: DateRange
-  // shouldFocusOnCalendar?: boolean
   onMount?: (calendarElement: HTMLDivElement) => void
 }
 
@@ -41,8 +40,6 @@ const isValidWeekStartsOn = (
   day: DayOfWeek | undefined
 ): day is 0 | 1 | 2 | 3 | 4 | 5 | 6 | undefined =>
   [0, 1, 2, 3, 4, 5, 6, undefined].includes(day)
-
-// const isHTMLElement = (element: Element | undefined): element is HTMLElement => element instanceof HTMLElement
 
 export const Calendar: React.VFC<CalendarProps> = ({
   id,
@@ -58,7 +55,6 @@ export const Calendar: React.VFC<CalendarProps> = ({
   selectedRange,
   modifiers,
   mode,
-  // shouldFocusOnCalendar = false,
   onMount,
 }) => {
   const calendarRef = useRef<CalendarElement>(null)

--- a/packages/date-picker/src/DatePicker/components/Calendar/Calendar.tsx
+++ b/packages/date-picker/src/DatePicker/components/Calendar/Calendar.tsx
@@ -39,6 +39,8 @@ const isValidWeekStartsOn = (
 ): day is 0 | 1 | 2 | 3 | 4 | 5 | 6 | undefined =>
   [0, 1, 2, 3, 4, 5, 6, undefined].includes(day)
 
+const isHTMLElement = (element: Element | undefined): element is HTMLElement => element instanceof HTMLElement
+
 export const Calendar: React.VFC<CalendarProps> = ({
   id,
   setPopperElement,
@@ -57,26 +59,26 @@ export const Calendar: React.VFC<CalendarProps> = ({
 }) => {
   const calendarRef = useRef<HTMLDivElement>(null)
 
-  // Initial focus when opening the calendar
   useEffect(() => {
     if (shouldFocusOnCalendar && calendarRef.current) {
       if (value || selectedRange?.from) {
         const selectedDay = calendarRef.current.getElementsByClassName(
           calendarStyles.daySelected
-        )[0] as HTMLElement
+        )[0]
 
-        return selectedDay?.focus()
+        if (isHTMLElement(selectedDay)) selectedDay.focus()
+        return
       }
 
       const today = calendarRef.current.getElementsByClassName(
         calendarStyles.dayToday
-      )[0] as HTMLElement
+      )[0]
 
-      today?.focus()
+      if (isHTMLElement(today)) today.focus()
     }
-  }, [shouldFocusOnCalendar, calendarRef.current])
+  }, [shouldFocusOnCalendar, calendarRef])
 
-  const getdefaultMonth = () => selectedRange?.from || value || defaultMonth
+  const selectedMonth = selectedRange?.from || value || defaultMonth
 
   const IconRight: React.VFC = () => (
     <Icon icon={arrowRight} role="presentation" />
@@ -100,7 +102,7 @@ export const Calendar: React.VFC<CalendarProps> = ({
           <DayPicker
             mode="single"
             selected={value}
-            defaultMonth={getdefaultMonth()}
+            defaultMonth={selectedMonth}
             weekStartsOn={
               isValidWeekStartsOn(weekStartsOn) ? weekStartsOn : undefined
             }
@@ -117,7 +119,7 @@ export const Calendar: React.VFC<CalendarProps> = ({
           <DayPicker
             mode="range"
             selected={selectedRange}
-            defaultMonth={getdefaultMonth()}
+            defaultMonth={selectedMonth}
             weekStartsOn={
               isValidWeekStartsOn(weekStartsOn) ? weekStartsOn : undefined
             }

--- a/packages/date-picker/src/DatePicker/components/DateInput/DateInput.scss
+++ b/packages/date-picker/src/DatePicker/components/DateInput/DateInput.scss
@@ -4,11 +4,6 @@
 @import "~@kaizen/component-library/styles/animation";
 @import "../../mixins";
 
-// -----------------------------------------------
-// Date Input
-// -----------------------------------------------
-
-// Vars
 $input-disabled-opacity: 0.3;
 
 .iconButton {
@@ -36,10 +31,6 @@ $input-disabled-opacity: 0.3;
     outline: none;
   }
 
-  .disabled {
-    opacity: $input-disabled-opacity;
-  }
-
   &.calendarActive {
     color: $color-blue-500;
     background-color: $color-blue-100;
@@ -59,8 +50,6 @@ $input-disabled-opacity: 0.3;
   @include ca-animation-fade(in);
 }
 
-.message {
-  &.disabled {
-    opacity: $input-disabled-opacity;
-  }
+.disabled {
+  opacity: $input-disabled-opacity;
 }

--- a/packages/date-picker/src/DatePicker/components/DateInput/DateInput.spec.tsx
+++ b/packages/date-picker/src/DatePicker/components/DateInput/DateInput.spec.tsx
@@ -8,16 +8,19 @@ const defaultProps = {
   labelText: "Label",
   description: "Description text",
   icon: dateStart,
-  isOpen: false,
+  isCalendarOpen: false,
   onButtonClick: jest.fn<void, []>(),
   onKeyDown: jest.fn<void, [React.KeyboardEvent<HTMLInputElement>]>(),
-  onBlur: jest.fn,
-  onChange: jest.fn,
   calendarId: "calendar-dialog",
   value: undefined,
 }
 
 describe("<DateInput />", () => {
+  it("has the role of combobox", () => {
+    render(<DateInput {...defaultProps} />)
+    expect(screen.getByRole("combobox", { name: "Label" })).toBeInTheDocument()
+  })
+
   it("renders a description and aria-describeBy when provided", () => {
     const ariaDescribedBy = "text-field-test-field-message"
 
@@ -32,7 +35,13 @@ describe("<DateInput />", () => {
   })
 
   it("updates calendar button aria-label with selected day", async () => {
-    render(<DateInput {...defaultProps} value={"Mar 1, 2022"} />)
+    render(
+      <DateInput
+        {...defaultProps}
+        value="Mar 1, 2022"
+        onChange={() => undefined}
+      />
+    )
 
     expect(
       screen.getByLabelText("Change date, Mar 1, 2022")

--- a/packages/date-picker/src/DatePicker/components/DateInput/DateInput.spec.tsx
+++ b/packages/date-picker/src/DatePicker/components/DateInput/DateInput.spec.tsx
@@ -1,12 +1,11 @@
 import React from "react"
 import { render, screen } from "@testing-library/react"
 import dateStart from "@kaizen/component-library/icons/date-start.icon.svg"
-import { DateInput } from "./DateInput"
+import { DateInput, DateInputProps } from "./DateInput"
 
 const defaultProps = {
   id: "text-field-test",
   labelText: "Label",
-  description: "Description text",
   icon: dateStart,
   isCalendarOpen: false,
   onButtonClick: jest.fn<void, []>(),
@@ -15,46 +14,77 @@ const defaultProps = {
   value: undefined,
 }
 
+const DateInputWrapper = (props: Partial<DateInputProps>) => (
+  <DateInput {...defaultProps} {...props} />
+)
+
 describe("<DateInput />", () => {
-  it("has the role of combobox", () => {
-    render(<DateInput {...defaultProps} />)
-    expect(screen.getByRole("combobox", { name: "Label" })).toBeInTheDocument()
+  describe("Input", () => {
+    it("has the role of combobox", () => {
+      render(<DateInputWrapper />)
+      expect(
+        screen.getByRole("combobox", { name: "Label" })
+      ).toBeInTheDocument()
+    })
+
+    it("associates the description with the input", () => {
+      render(<DateInputWrapper />)
+      expect(
+        screen.getByRole("combobox", { description: "Format: mm/dd/yyyy" })
+      ).toBeInTheDocument()
+    })
   })
 
-  it("renders a description and aria-describeBy when provided", () => {
-    const ariaDescribedBy = "text-field-test-field-message"
+  describe("Icon button", () => {
+    it("has helpful label", () => {
+      render(<DateInputWrapper />)
+      expect(
+        screen.getByRole("button", { name: "Choose date" })
+      ).toBeInTheDocument()
+    })
 
-    const { container } = render(<DateInput {...defaultProps} />)
-    expect(
-      container.querySelector(`[aria-describedby="${ariaDescribedBy}"]`)
-    ).toBeInTheDocument()
-
-    expect(
-      screen.getByText("Description text (Format: mm/dd/yyyy)")
-    ).toBeInTheDocument()
+    it("has helpful label showing the current date when one is selected", () => {
+      render(
+        <DateInputWrapper value="Mar 1, 2022" onChange={() => undefined} />
+      )
+      expect(
+        screen.getByRole("button", { name: "Change date, Mar 1, 2022" })
+      ).toBeInTheDocument()
+    })
   })
 
-  it("updates calendar button aria-label with selected day", async () => {
-    render(
-      <DateInput
-        {...defaultProps}
-        value="Mar 1, 2022"
-        onChange={() => undefined}
-      />
-    )
-
-    expect(
-      screen.getByLabelText("Change date, Mar 1, 2022")
-    ).toBeInTheDocument()
+  describe("States", () => {
+    it("disables both input and icon button", () => {
+      render(<DateInputWrapper disabled />)
+      const input = screen.getByRole("combobox", { name: "Label" })
+      const calendarButton = screen.getByRole("button", { name: "Choose date" })
+      expect(input).toBeDisabled()
+      expect(calendarButton).toBeDisabled()
+    })
   })
 
-  it("updates calendar button to be disabled when input is disabled", async () => {
-    render(<DateInput {...defaultProps} disabled />)
+  describe("Validation", () => {
+    it("shows validation message", () => {
+      render(
+        <DateInputWrapper
+          status="error"
+          validationMessage="There is an error"
+        />
+      )
+      const errorMessage = screen.getByText("There is an error")
+      expect(errorMessage).toBeInTheDocument()
+    })
 
-    const calendarButton = screen
-      .getByLabelText("Choose date")
-      .closest("button")
-
-    expect(calendarButton).toBeDisabled()
+    it("does not show validation message when field is disabled", () => {
+      render(
+        <DateInputWrapper
+          status="error"
+          validationMessage="There is an error"
+          disabled
+        />
+      )
+      const errorMessage = screen.queryByText("There is an error")
+      expect(errorMessage).not.toBeInTheDocument()
+    })
   })
 })

--- a/packages/date-picker/src/DatePicker/components/DateInput/DateInput.spec.tsx
+++ b/packages/date-picker/src/DatePicker/components/DateInput/DateInput.spec.tsx
@@ -1,6 +1,5 @@
 import React from "react"
-import { act, render, screen } from "@testing-library/react"
-import userEvent from "@testing-library/user-event"
+import { render, screen } from "@testing-library/react"
 import dateStart from "@kaizen/component-library/icons/date-start.icon.svg"
 import { DateInput } from "./DateInput"
 
@@ -12,9 +11,10 @@ const defaultProps = {
   isOpen: false,
   onButtonClick: jest.fn<void, []>(),
   onKeyDown: jest.fn<void, [React.KeyboardEvent<HTMLInputElement>]>(),
-  onBlur: jest.fn<void, [Date | undefined, string]>(),
+  onBlur: jest.fn,
+  onChange: jest.fn,
   calendarId: "calendar-dialog",
-  valueDate: undefined,
+  value: undefined,
 }
 
 describe("<DateInput />", () => {
@@ -31,41 +31,8 @@ describe("<DateInput />", () => {
     ).toBeInTheDocument()
   })
 
-  it("formats values when focus is on the input", async () => {
-    render(<DateInput {...defaultProps} valueDate={new Date("2022-03-01")} />)
-
-    expect(screen.getByDisplayValue("Mar 1, 2022")).toBeInTheDocument()
-
-    const input = screen.getByRole("combobox")
-
-    await act(async () => {
-      input.focus()
-    })
-    expect(screen.getByDisplayValue("03/01/2022")).toBeInTheDocument()
-  })
-
-  it("formats values when the input loses focus - onBlur", async () => {
-    render(<DateInput {...defaultProps} valueDate={new Date("2022-03-01")} />)
-
-    expect(screen.getByDisplayValue("Mar 1, 2022")).toBeInTheDocument()
-
-    const input = screen.getByRole("combobox")
-
-    await act(async () => {
-      input.focus()
-    })
-    expect(screen.getByDisplayValue("03/01/2022")).toBeInTheDocument()
-
-    // tab to next focusable element
-    await act(async () => {
-      userEvent.tab()
-    })
-
-    expect(screen.getByDisplayValue("Mar 1, 2022")).toBeInTheDocument()
-  })
-
   it("updates calendar button aria-label with selected day", async () => {
-    render(<DateInput {...defaultProps} valueDate={new Date("2022-03-01")} />)
+    render(<DateInput {...defaultProps} value={"Mar 1, 2022"} />)
 
     expect(
       screen.getByLabelText("Change date, Mar 1, 2022")

--- a/packages/date-picker/src/DatePicker/components/DateInput/DateInput.tsx
+++ b/packages/date-picker/src/DatePicker/components/DateInput/DateInput.tsx
@@ -113,6 +113,7 @@ export const DateInput: React.VFC<DateInputProps> = ({
         disabled={disabled}
         reversed={isReversed}
         endIconAdornment={IconButton}
+        status={status}
         {...inputProps}
       />
       {shouldShowValidationMessage && (

--- a/packages/date-picker/src/DatePicker/components/DateInput/DateInput.tsx
+++ b/packages/date-picker/src/DatePicker/components/DateInput/DateInput.tsx
@@ -27,37 +27,29 @@ type OmittedInputProps =
   | "automationId"
 
 export interface DateInputProps extends Omit<InputProps, OmittedInputProps> {
+  buttonRef?: React.RefObject<HTMLButtonElement>
   id: string
   calendarId: string
-  buttonRef?: React.RefObject<HTMLButtonElement>
+  isCalendarOpen: boolean
   labelText: React.ReactNode
-  icon: React.SVGAttributes<SVGSymbolElement>
   /**
    * A description that provides context for the text field
    */
   description?: React.ReactNode
-  isCalendarOpen: boolean
+  icon: React.SVGAttributes<SVGSymbolElement>
   /**
-   * Event for the onClick of the icon button
+   * Icon button onClick handler
    */
   onButtonClick: React.MouseEventHandler<HTMLButtonElement>
   isReversed?: boolean
   /**
-   * The input value as a Date
+   * Updates the styling of the validation FieldMessage
    */
-  value: string | undefined
-  /**
-   * The callback for then onBlur is triggered on the input
-   */
-  disabledDays?: Matcher[] | undefined
+  status?: FieldMessageStatus
   /**
    * A descriptive message for `status` states
    */
   validationMessage?: string | React.ReactNode
-  /**
-   * Updates the styling of the validation FieldMessage
-   */
-  status?: FieldMessageStatus
 }
 
 export const DateInput: React.VFC<DateInputProps> = ({
@@ -65,17 +57,16 @@ export const DateInput: React.VFC<DateInputProps> = ({
   buttonRef,
   id,
   calendarId,
+  isCalendarOpen,
   labelText,
   description,
   icon,
   onButtonClick,
-  isCalendarOpen,
   disabled,
   isReversed = false,
-  value,
-  disabledDays,
-  validationMessage,
   status,
+  validationMessage,
+  value,
   ...inputProps
 }) => {
   // Focus behaviour breaks when this is a function component.
@@ -97,6 +88,8 @@ export const DateInput: React.VFC<DateInputProps> = ({
     </button>
   )
 
+  const descriptionId = `${id}-field-message`
+
   const shouldShowValidationMessage = !disabled && validationMessage
 
   return (
@@ -114,7 +107,7 @@ export const DateInput: React.VFC<DateInputProps> = ({
         aria-expanded={isCalendarOpen}
         aria-haspopup="dialog"
         aria-controls={calendarId}
-        aria-describedby={description ? `${id}-field-message` : undefined}
+        aria-describedby={descriptionId}
         autoComplete="off"
         value={value}
         disabled={disabled}
@@ -133,7 +126,7 @@ export const DateInput: React.VFC<DateInputProps> = ({
         className={classnames([styles.message, disabled && styles.disabled])}
       >
         <FieldMessage
-          id={`${id}-field-message`}
+          id={descriptionId}
           message={getDescription(description)}
           reversed={isReversed}
         />

--- a/packages/date-picker/src/DatePicker/components/DateInput/DateInput.tsx
+++ b/packages/date-picker/src/DatePicker/components/DateInput/DateInput.tsx
@@ -109,6 +109,7 @@ export const DateInput: React.VFC<DateInputProps> = ({
   useEffect(() => {
     if (
       inputRef?.current !== document.activeElement &&
+      // This check should belong to the parent
       !document.activeElement?.classList.contains(calendarStyles.day)
     ) {
       valueDate && formatDateAsText(valueDate, disabledDays, setValueString)
@@ -120,12 +121,16 @@ export const DateInput: React.VFC<DateInputProps> = ({
   ) => {
     if (valueString !== "") {
       const parsedDate = parse(valueString, DateFormat.Numeral, new Date())
+
       if (isInvalidDate(parsedDate)) {
         return onBlur(parsedDate, valueString)
       }
+
+      // This check should belong to the parent
       if (e.relatedTarget?.classList.contains(calendarStyles.day)) {
         return onBlur(parsedDate, valueString)
       }
+
       formatDateAsText(parsedDate, disabledDays, setValueString)
       return onBlur(parsedDate, valueString)
     }

--- a/packages/date-picker/src/DatePicker/components/DateInput/DateInput.tsx
+++ b/packages/date-picker/src/DatePicker/components/DateInput/DateInput.tsx
@@ -33,6 +33,7 @@ type OmittedInputProps =
   | "automationId"
 
 export interface DateInputProps extends Omit<InputProps, OmittedInputProps> {
+  inputRef: React.RefObject<HTMLInputElement>
   id: string
   calendarId: string
   buttonRef?: React.RefObject<HTMLButtonElement>
@@ -84,6 +85,7 @@ const formatDateAsText = (
 export const DateInput: React.VFC<DateInputProps> = ({
   id,
   disabled = false,
+  inputRef,
   buttonRef,
   labelText,
   description,
@@ -94,6 +96,8 @@ export const DateInput: React.VFC<DateInputProps> = ({
   isOpen,
   valueDate,
   onBlur,
+  onFocus,
+  onChange,
   disabledDays,
   validationMessage,
   status,
@@ -102,10 +106,12 @@ export const DateInput: React.VFC<DateInputProps> = ({
   const [valueString, setValueString] = useState<string>("")
 
   useEffect(() => {
-    valueDate && formatDateAsText(valueDate, disabledDays, setValueString)
-  }, [valueDate])
+    if (inputRef?.current !== document.activeElement) {
+      valueDate && formatDateAsText(valueDate, disabledDays, setValueString)
+    }
+  }, [valueDate, inputRef])
 
-  const handleBlur: React.FocusEventHandler<HTMLInputElement> = (): void => {
+  const handleBlur: React.FocusEventHandler<HTMLInputElement> = () => {
     if (valueString !== "") {
       const parsedDate = parse(valueString, DateFormat.Numeral, new Date())
       if (isInvalidDate(parsedDate)) {
@@ -117,13 +123,16 @@ export const DateInput: React.VFC<DateInputProps> = ({
     }
     onBlur(undefined, valueString)
   }
-  const handleFocus = (): void => {
+
+  const handleFocus: React.FocusEventHandler<HTMLInputElement> = e => {
     valueDate && setValueString(format(valueDate, DateFormat.Numeral))
+    onFocus && onFocus(e)
   }
 
-  const handleChange: React.ChangeEventHandler<HTMLInputElement> = ({
-    target,
-  }): void => setValueString(target.value)
+  const handleChange: React.ChangeEventHandler<HTMLInputElement> = e => {
+    setValueString(e.target.value)
+    onChange && onChange(e)
+  }
 
   const getDescription = (): React.ReactNode => {
     switch (typeof description) {
@@ -147,6 +156,7 @@ export const DateInput: React.VFC<DateInputProps> = ({
         disabled={disabled}
       />
       <Input
+        inputRef={inputRef}
         id={id}
         role="combobox"
         aria-expanded={isOpen}

--- a/packages/date-picker/src/DatePicker/components/DateInput/DateInput.tsx
+++ b/packages/date-picker/src/DatePicker/components/DateInput/DateInput.tsx
@@ -33,7 +33,6 @@ type OmittedInputProps =
   | "automationId"
 
 export interface DateInputProps extends Omit<InputProps, OmittedInputProps> {
-  inputRef: React.RefObject<HTMLInputElement>
   id: string
   calendarId: string
   buttonRef?: React.RefObject<HTMLButtonElement>

--- a/packages/date-picker/src/DatePicker/components/DateInput/DateInput.tsx
+++ b/packages/date-picker/src/DatePicker/components/DateInput/DateInput.tsx
@@ -15,6 +15,7 @@ import { Matcher } from "react-day-picker/src/types/Matchers"
 import { DateFormat } from "../../enums"
 import { isInvalidDate } from "../../../utils/isInvalidDate"
 import { isDisabledDate } from "../../../utils/isDisabledDate"
+import calendarStyles from "../Calendar/Calendar.scss"
 import styles from "./DateInput.scss"
 
 type OmittedInputProps =
@@ -70,6 +71,7 @@ export interface DateInputProps extends Omit<InputProps, OmittedInputProps> {
 const formatDateAsText = (
   date: Date,
   disabledDays: Matcher[] | undefined,
+
   onFormat: (newFormattedDate: string) => void
 ): void => {
   if (isDisabledDate(date, disabledDays)) {
@@ -105,18 +107,25 @@ export const DateInput: React.VFC<DateInputProps> = ({
   const [valueString, setValueString] = useState<string>("")
 
   useEffect(() => {
-    if (inputRef?.current !== document.activeElement) {
+    if (
+      inputRef?.current !== document.activeElement &&
+      !document.activeElement?.classList.contains(calendarStyles.day)
+    ) {
       valueDate && formatDateAsText(valueDate, disabledDays, setValueString)
     }
   }, [valueDate, inputRef])
 
-  const handleBlur: React.FocusEventHandler<HTMLInputElement> = () => {
+  const handleBlur: React.FocusEventHandler<HTMLInputElement> = (
+    e: React.FocusEvent<HTMLInputElement>
+  ) => {
     if (valueString !== "") {
       const parsedDate = parse(valueString, DateFormat.Numeral, new Date())
       if (isInvalidDate(parsedDate)) {
         return onBlur(parsedDate, valueString)
       }
-
+      if (e.relatedTarget?.classList.contains(calendarStyles.day)) {
+        return onBlur(parsedDate, valueString)
+      }
       formatDateAsText(parsedDate, disabledDays, setValueString)
       return onBlur(parsedDate, valueString)
     }

--- a/packages/date-picker/src/DatePicker/components/DateInput/DateInput.tsx
+++ b/packages/date-picker/src/DatePicker/components/DateInput/DateInput.tsx
@@ -123,12 +123,16 @@ export const DateInput: React.VFC<DateInputProps> = ({
     onBlur(undefined, valueString)
   }
 
-  const handleFocus: React.FocusEventHandler<HTMLInputElement> = e => {
+  const handleFocus: React.FocusEventHandler<HTMLInputElement> = (
+    e: React.FocusEvent<HTMLInputElement>
+  ) => {
     valueDate && setValueString(format(valueDate, DateFormat.Numeral))
     onFocus && onFocus(e)
   }
 
-  const handleChange: React.ChangeEventHandler<HTMLInputElement> = e => {
+  const handleChange: React.ChangeEventHandler<HTMLInputElement> = (
+    e: React.ChangeEvent<HTMLInputElement>
+  ) => {
     setValueString(e.target.value)
     onChange && onChange(e)
   }

--- a/packages/date-picker/src/DatePicker/components/DateInput/DateInput.tsx
+++ b/packages/date-picker/src/DatePicker/components/DateInput/DateInput.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react"
+import React from "react"
 import { Icon } from "@kaizen/component-library"
 import classnames from "classnames"
 import {
@@ -9,13 +9,7 @@ import {
   InputProps,
   Label,
 } from "@kaizen/draft-form"
-import { format, parse } from "date-fns"
 import { Matcher } from "react-day-picker/src/types/Matchers"
-
-import { DateFormat } from "../../enums"
-import { isInvalidDate } from "../../../utils/isInvalidDate"
-import { isDisabledDate } from "../../../utils/isDisabledDate"
-import calendarStyles from "../Calendar/Calendar.scss"
 import styles from "./DateInput.scss"
 
 type OmittedInputProps =
@@ -25,8 +19,6 @@ type OmittedInputProps =
   | "status"
   | "inputValue"
   | "reversed"
-  | "onBlur"
-  | "value"
   | "type"
   | "ariaLabel"
   | "ariaDescribedBy"
@@ -52,11 +44,11 @@ export interface DateInputProps extends Omit<InputProps, OmittedInputProps> {
   /**
    * The input value as a Date
    */
-  valueDate: Date | undefined
+  value: string | undefined
   /**
    * The callback for then onBlur is triggered on the input
    */
-  onBlur: (date: Date | undefined, inputValue: string) => void
+  // onBlur: (date: Date | undefined, inputValue: string) => void
   disabledDays?: Matcher[] | undefined
   /**
    * A descriptive message for `status` states
@@ -66,21 +58,6 @@ export interface DateInputProps extends Omit<InputProps, OmittedInputProps> {
    * Updates the styling of the validation FieldMessage
    */
   status?: FieldMessageStatus
-}
-
-const formatDateAsText = (
-  date: Date,
-  disabledDays: Matcher[] | undefined,
-
-  onFormat: (newFormattedDate: string) => void
-): void => {
-  if (isDisabledDate(date, disabledDays)) {
-    return onFormat(format(date, DateFormat.Numeral))
-  }
-  if (isInvalidDate(date)) {
-    return onFormat("Invalid Date")
-  }
-  onFormat(format(date, DateFormat.Text))
 }
 
 export const DateInput: React.VFC<DateInputProps> = ({
@@ -95,7 +72,7 @@ export const DateInput: React.VFC<DateInputProps> = ({
   onButtonClick,
   calendarId,
   isOpen,
-  valueDate,
+  value,
   onBlur,
   onFocus,
   onChange,
@@ -104,53 +81,6 @@ export const DateInput: React.VFC<DateInputProps> = ({
   status,
   ...inputProps
 }) => {
-  const [valueString, setValueString] = useState<string>("")
-
-  useEffect(() => {
-    if (
-      inputRef?.current !== document.activeElement &&
-      // This check should belong to the parent
-      !document.activeElement?.classList.contains(calendarStyles.day)
-    ) {
-      valueDate && formatDateAsText(valueDate, disabledDays, setValueString)
-    }
-  }, [valueDate, inputRef])
-
-  const handleBlur: React.FocusEventHandler<HTMLInputElement> = (
-    e: React.FocusEvent<HTMLInputElement>
-  ) => {
-    if (valueString !== "") {
-      const parsedDate = parse(valueString, DateFormat.Numeral, new Date())
-
-      if (isInvalidDate(parsedDate)) {
-        return onBlur(parsedDate, valueString)
-      }
-
-      // This check should belong to the parent
-      if (e.relatedTarget?.classList.contains(calendarStyles.day)) {
-        return onBlur(parsedDate, valueString)
-      }
-
-      formatDateAsText(parsedDate, disabledDays, setValueString)
-      return onBlur(parsedDate, valueString)
-    }
-    onBlur(undefined, valueString)
-  }
-
-  const handleFocus: React.FocusEventHandler<HTMLInputElement> = (
-    e: React.FocusEvent<HTMLInputElement>
-  ) => {
-    valueDate && setValueString(format(valueDate, DateFormat.Numeral))
-    onFocus && onFocus(e)
-  }
-
-  const handleChange: React.ChangeEventHandler<HTMLInputElement> = (
-    e: React.ChangeEvent<HTMLInputElement>
-  ) => {
-    setValueString(e.target.value)
-    onChange && onChange(e)
-  }
-
   const getDescription = (): React.ReactNode => {
     switch (typeof description) {
       case "string":
@@ -181,7 +111,7 @@ export const DateInput: React.VFC<DateInputProps> = ({
         aria-controls={calendarId}
         aria-describedby={description ? `${id}-field-message` : undefined}
         autoComplete="off"
-        value={valueString}
+        value={value}
         disabled={disabled}
         reversed={isReversed}
         endIconAdornment={
@@ -194,9 +124,7 @@ export const DateInput: React.VFC<DateInputProps> = ({
             className={classnames(styles.iconButton, {
               [styles.calendarActive]: isOpen,
             })}
-            aria-label={
-              valueString ? `Change date, ${valueString}` : "Choose date"
-            }
+            aria-label={value ? `Change date, ${value}` : "Choose date"}
           >
             <div
               className={classnames({
@@ -207,9 +135,9 @@ export const DateInput: React.VFC<DateInputProps> = ({
             </div>
           </button>
         }
-        onChange={handleChange}
-        onBlur={handleBlur}
-        onFocus={handleFocus}
+        onChange={onChange}
+        onBlur={onBlur}
+        onFocus={onFocus}
         {...inputProps}
       />
       {shouldShowValidationMessage && (

--- a/packages/date-picker/src/DatePicker/components/DateInput/utils/getDescription.spec.tsx
+++ b/packages/date-picker/src/DatePicker/components/DateInput/utils/getDescription.spec.tsx
@@ -1,0 +1,28 @@
+import React from "react"
+import { getDescription } from "./getDescription"
+
+describe("getDescription", () => {
+  it("returns template string when description is undefined", () => {
+    const description = getDescription(undefined)
+    expect(description).toBe("Format: mm/dd/yyyy")
+  })
+
+  it("returns template string when description is empty string", () => {
+    const description = getDescription("")
+    expect(description).toBe("Format: mm/dd/yyyy")
+  })
+
+  it("returns template string when description is a string", () => {
+    const description = getDescription("Description here")
+    expect(description).toBe("Description here (Format: mm/dd/yyyy)")
+  })
+
+  it("returns template string when description is an element", () => {
+    const description = getDescription(<span>Description span</span>)
+    expect(description).toEqual(
+      <>
+        <span>Description span</span> (Format: mm/dd/yyyy)
+      </>
+    )
+  })
+})

--- a/packages/date-picker/src/DatePicker/components/DateInput/utils/getDescription.tsx
+++ b/packages/date-picker/src/DatePicker/components/DateInput/utils/getDescription.tsx
@@ -3,13 +3,13 @@ import React from "react"
 export const getDescription = (
   description: React.ReactNode
 ): React.ReactNode => {
-  switch (typeof description) {
-    case "string":
-      if (description === "") return "Format: mm/dd/yyyy"
-      return `${description} (Format: mm/dd/yyyy)`
-    case "object":
-      return <>{description} (Format: mm/dd/yyyy)</>
-    default:
-      return "Format: mm/dd/yyyy"
+  if (React.isValidElement(description)) {
+    return <>{description} (Format: mm/dd/yyyy)</>
   }
+
+  if (typeof description === "string" && description !== "") {
+    return `${description} (Format: mm/dd/yyyy)`
+  }
+
+  return "Format: mm/dd/yyyy"
 }

--- a/packages/date-picker/src/DatePicker/components/DateInput/utils/getDescription.tsx
+++ b/packages/date-picker/src/DatePicker/components/DateInput/utils/getDescription.tsx
@@ -1,0 +1,15 @@
+import React from "react"
+
+export const getDescription = (
+  description: React.ReactNode
+): React.ReactNode => {
+  switch (typeof description) {
+    case "string":
+      if (description === "") return "Format: mm/dd/yyyy"
+      return `${description} (Format: mm/dd/yyyy)`
+    case "object":
+      return <>{description} (Format: mm/dd/yyyy)</>
+    default:
+      return "Format: mm/dd/yyyy"
+  }
+}

--- a/packages/date-picker/src/utils/formatDateAsText.spec.ts
+++ b/packages/date-picker/src/utils/formatDateAsText.spec.ts
@@ -1,0 +1,21 @@
+import { formatDateAsText } from "./formatDateAsText"
+
+const onFormat = jest.fn<void, [string]>()
+
+describe("formatDateAsText", () => {
+  it("formats valid date in text format", () => {
+    formatDateAsText(new Date("2022-01-16"), undefined, onFormat)
+    expect(onFormat).toHaveBeenCalledWith("Jan 16, 2022")
+  })
+
+  it("formats disabled date in numeral format", () => {
+    const disabledDays = [{ before: new Date("2022-02-16") }]
+    formatDateAsText(new Date("2022-01-16"), disabledDays, onFormat)
+    expect(onFormat).toHaveBeenCalledWith("Jan 16, 2022")
+  })
+
+  it("formats invalid date as error message", () => {
+    formatDateAsText(new Date("potato"), undefined, onFormat)
+    expect(onFormat).toHaveBeenCalledWith("Invalid Date")
+  })
+})

--- a/packages/date-picker/src/utils/formatDateAsText.spec.ts
+++ b/packages/date-picker/src/utils/formatDateAsText.spec.ts
@@ -11,7 +11,7 @@ describe("formatDateAsText", () => {
   it("formats disabled date in numeral format", () => {
     const disabledDays = [{ before: new Date("2022-02-16") }]
     formatDateAsText(new Date("2022-01-16"), disabledDays, onFormat)
-    expect(onFormat).toHaveBeenCalledWith("Jan 16, 2022")
+    expect(onFormat).toHaveBeenCalledWith("01/16/2022")
   })
 
   it("formats invalid date as error message", () => {

--- a/packages/date-picker/src/utils/formatDateAsText.ts
+++ b/packages/date-picker/src/utils/formatDateAsText.ts
@@ -1,0 +1,19 @@
+import { format } from "date-fns"
+import { Matcher } from "react-day-picker"
+import { DateFormat } from "../DatePicker/enums"
+import { isDisabledDate } from "./isDisabledDate"
+import { isInvalidDate } from "./isInvalidDate"
+
+export const formatDateAsText = (
+  date: Date,
+  disabledDays: Matcher[] | undefined,
+  onFormat: (newFormattedDate: string) => void
+): void => {
+  if (isDisabledDate(date, disabledDays)) {
+    return onFormat(format(date, DateFormat.Numeral))
+  }
+  if (isInvalidDate(date)) {
+    return onFormat("Invalid Date")
+  }
+  onFormat(format(date, DateFormat.Text))
+}

--- a/packages/date-picker/src/utils/setFocusInCalendar.ts
+++ b/packages/date-picker/src/utils/setFocusInCalendar.ts
@@ -1,0 +1,16 @@
+import calendarStyles from "../DatePicker/components/Calendar/Calendar.scss"
+import { CalendarElement } from "../DatePicker/components/Calendar/Calendar"
+
+const isHTMLElement = (element: Element | undefined): element is HTMLElement =>
+  element instanceof HTMLElement
+
+export const setFocusInCalendar = (
+  calendarElement: CalendarElement,
+  selectedDay: Date | undefined
+): void => {
+  const dayToFocus = calendarElement.getElementsByClassName(
+    selectedDay ? calendarStyles.daySelected : calendarStyles.dayToday
+  )[0]
+
+  if (isHTMLElement(dayToFocus)) dayToFocus.focus()
+}


### PR DESCRIPTION
## Why
<!-- Why have you created this PR? - Is it a new feature, or a bug fix? Or something else? -->
<!-- Reference any relevant Jira tickets so your reviewer can find more context if needed. -->
<!-- Fixing a GitHub issue? Add "Fixes [issue URL]". -->

Fixes [card](https://cultureamp.atlassian.net/jira/software/projects/KDS/boards/289?selectedIssue=KDS-480)
- Add onClick to input to open the calendar dialog.
- Remain focus within the input if the input is clicked.

## What
<!-- What do your changes do? How do they change/fix the current behavior? -->
<!-- Add screenshots, GIFs or videos to illustrate the changes.  -->

UI:
- Returns focus to input when a date is selected through the calendar and:
  -  it was opened via input click
  -  it was opened via input keydown down arrow

- Returns focus to the calendar button when a date is selected through the calendar and:
  - it was opened via calendar button click
  - it was opened via calendar button keydown enter
- Closes the calendar when user is within the input and a date is selected and keydown on Tab.

Technical:
- Add `onClick` to input to open calendar dialog
- Created a check for when the focus should go to the calendar once opened or remain within the input.
- Update `handleInputBlur` and `handleReturnFocus` to conditionally call depending on the `lastTrigger` element.
- Move `FocusOn` wrapper to be around both the `DateInput` and the `Calendar` to allow tabbing across.
- Add new `DatePicker` tests for each scenario of opening the calendar Dialog. 


**NOT IN**

- Allow user to press {enter} when focused within Input to confirm input 
- The calendar to change month as we type