### PR TITLE
chore(deps): address vulnerabilities

### DIFF
--- a/js-audit-allow-list.json
+++ b/js-audit-allow-list.json
@@ -3,46 +3,9 @@
     {
       "title": "Regex DOS",
       "cve": "CVE-2021-33623",
-      "reason": "Regex DOS attacks aren't relevant in our devDependencies",
-      "reviewer": "christianklammer",
-      "whenSubDependencyOf": ["lerna", "node-sass"]
-    }
-  ],
-  "node-fetch": [
-    {
-      "title": "Does not honor the size option after following a redirect, which means that when a content size is over the limit, a FetchError will never get thrown and the process will end without failure.",
-      "cve": "CVE-2020-15168",
-      "reason": "Dev dependency",
-      "reviewer": "christianklammer",
-      "whenSubDependencyOf": ["eslint-plugin-graphql"]
-    }
-  ],
-  "is-svg": [
-    {
-      "title": "ReDoS",
-      "cve": "CVE-2021-28092",
-      "reason": "Dev dependency",
-      "reviewer": "christianklammer",
-      "whenSubDependencyOf": ["optimize-css-assets-webpack-plugin"]
-    },
-    {
-      "title": "ReDoS",
-      "cve": "CVE-2021-29059",
-      "reason": "Dev dependency",
-      "reviewer": "christianklammer",
-      "whenSubDependencyOf": ["optimize-css-assets-webpack-plugin"]
-    }
-  ],
-  "ansi-html": [
-    {
-      "title": "If an attacker provides a malicious string, it will get stuck processing the input for an extremely long time.",
-      "cve": "CVE-2021-23424",
-      "reason": "Dev dependency",
-      "reviewer": "christianklammer",
-      "whenSubDependencyOf": [
-        "@storybook/react",
-        "@pmmmwh/react-refresh-webpack-plugin"
-      ]
+      "reason": "Regex DOS attacks aren't relevant to dev tools",
+      "reviewer": "christianklammer, cassandra.tam",
+      "whenSubDependencyOf": ["lerna", "@storybook/react"]
     }
   ],
   "ansi-regex": [
@@ -50,29 +13,17 @@
       "title": "Inefficient Regular Expression Complexity",
       "cve": "CVE-2021-3807",
       "reason": "Dev dependency",
-      "reviewer": "christianklammer",
-      "whenSubDependencyOf": [
-        "@storybook/node-logger",
-        "strip-ansi",
-        "pretty-format"
-      ]
+      "reviewer": "cassandra.tam",
+      "whenSubDependencyOf": ["@storybook/node-logger", "commitizen"]
     }
   ],
-  "follow-redirects": [
+  "minimist": [
     {
-      "title": "Still under investigation",
-      "cve": "CVE-2022-0155",
-      "reason": "Dev dependency",
-      "reviewer": "christianklammer",
-      "whenSubDependencyOf": ["axios", "http-proxy"]
-    }
-  ],
-  "node-sass": [
-    {
-      "title": "Certificate validation in node-sass 2.0.0 to 4.14.1 is disabled when requesting binaries even if the user is not specifying an alternative download path.",
-      "cve": "CVE-2020-24025",
-      "reason": "Our builds fail",
-      "reviewer": "cassandra.tam"
+      "title": "Minimist <=1.2.5 is vulnerable to Prototype Pollution via file index.js, function setKey() (lines 69-95).",
+      "cve": "CVE-2021-44906",
+      "reason": "Dev dependency; Note: Commitizen has been updated, but there hasn't been a release yet",
+      "reviewer": "cassandra.tam",
+      "whenSubDependencyOf": ["commitizen"]
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -114,8 +114,7 @@
     "webpack": "^5.68.0"
   },
   "resolutions": {
-    "@types/react": "^18.0.9",
-    "axios": "0.21.2"
+    "@types/react": "^18.0.9"
   },
   "config": {
     "commitizen": {

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "jest-canvas-mock": "^2.3.1",
     "jest-circus": "^27.4.2",
     "jest-static-stubs": "^0.0.1",
-    "lerna": "^3.22.1",
+    "lerna": "3.22.1",
     "node-fetch": "^2.6.7",
     "postcss-loader": "^3.0.0",
     "postcss-preset-env": "^6.7.1",

--- a/package.json
+++ b/package.json
@@ -26,14 +26,12 @@
     "commit": "cz"
   },
   "dependencies": {
-    "@storybook/addon-essentials": "^6.5.6",
-    "@storybook/addon-links": "^6.5.6",
-    "@storybook/addons": "^6.5.6",
-    "@storybook/api": "^6.5.6",
-    "@storybook/components": "^6.5.6",
-    "@storybook/core-events": "^6.5.6",
-    "@storybook/react": "^6.5.6",
-    "@storybook/theming": "^6.5.6",
+    "@storybook/addons": "^6.5.9",
+    "@storybook/api": "^6.5.9",
+    "@storybook/components": "^6.5.9",
+    "@storybook/core-events": "^6.5.9",
+    "@storybook/react": "^6.5.9",
+    "@storybook/theming": "^6.5.9",
     "chalk": "^2.4.2",
     "classnames": "^2.3.1",
     "focus-visible": "^5.2.0",
@@ -59,6 +57,8 @@
     "@babel/preset-react": "^7.16.7",
     "@babel/preset-typescript": "^7.16.7",
     "@storybook/addon-a11y": "^6.5.6",
+    "@storybook/addon-essentials": "^6.5.9",
+    "@storybook/addon-links": "^6.5.9",
     "@storybook/builder-webpack5": "^6.5.6",
     "@storybook/manager-webpack5": "^6.5.6",
     "@storybook/node-logger": "^6.5.6",
@@ -114,8 +114,8 @@
     "webpack": "^5.68.0"
   },
   "resolutions": {
-    "axios": "0.21.2",
-    "@types/react": "^18.0.9"
+    "@types/react": "^18.0.9",
+    "axios": "0.21.2"
   },
   "config": {
     "commitizen": {

--- a/package.json
+++ b/package.json
@@ -116,6 +116,9 @@
   "resolutions": {
     "@types/react": "^18.0.9"
   },
+  "resolutionsComments": {
+    "@types/react": "@testing-library/react-12 has an incorrect dep (instead of peerDep) of @types/react@^17 which we don't want"
+  },
   "config": {
     "commitizen": {
       "path": "./node_modules/cz-conventional-changelog"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2231,6 +2231,20 @@
     classnames "^2.3.1"
     motion-ui cultureamp/motion-ui
 
+"@kaizen/component-library@^14.3.4":
+  version "14.3.6"
+  resolved "https://registry.yarnpkg.com/@kaizen/component-library/-/component-library-14.3.6.tgz#bbc8beb7af1bd619de0e3e8c4c292050683bcd28"
+  integrity sha512-7fXTOOLuGIgsE+SmsfCCyWQfFlkhsgv0i5Va3FwSPBdO5RSkCmnxOHxNRFGydkQ0vAiBYTJmGKlXl8aGdC43dg==
+  dependencies:
+    "@kaizen/component-base" "^1.1.0"
+    "@kaizen/deprecated-component-library-helpers" "^2.5.6"
+    "@kaizen/hosted-assets" "^2.0.0"
+    "@types/classnames" "^2.3.0"
+    "@types/lodash" "^4.14.182"
+    "@types/uuid" "^3.4.10"
+    classnames "^2.3.1"
+    motion-ui cultureamp/motion-ui
+
 "@kaizen/draft-button@^5.4.1", "@kaizen/draft-button@^5.6.25":
   version "5.6.25"
   resolved "https://registry.yarnpkg.com/@kaizen/draft-button/-/draft-button-5.6.25.tgz#041db38c4d99a1f1c2fb7dd9578ea3f75de708bd"
@@ -5907,13 +5921,6 @@ axe-core@^4.2.0, axe-core@^4.3.5:
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.3.5.tgz#78d6911ba317a8262bfee292aeafcc1e04b49cc5"
   integrity sha512-WKTW1+xAzhMS5dJsxWkliixlO/PqC4VhmO9T4juNYcaTg9jzWiJsou6m5pxWYGfigWbwzJWeFY6z47a+4neRXA==
 
-axios@0.21.2:
-  version "0.21.2"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.2.tgz#21297d5084b2aeeb422f5d38e7be4fbb82239017"
-  integrity sha512-87otirqUw3e8CzHTMO+/9kh/FSgXt/eVDvipijwDtEuwbkySWZ9SBm6VEubmJ/kLKEoLQV/POhxXFb66bfekfg==
-  dependencies:
-    follow-redirects "^1.14.0"
-
 axobject-query@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/axobject-query/-/axobject-query-2.2.0.tgz#943d47e10c0b704aa42275e20edf3722648989be"
@@ -9242,11 +9249,6 @@ focus-visible@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/focus-visible/-/focus-visible-5.2.0.tgz#3a9e41fccf587bd25dcc2ef045508284f0a4d6b3"
   integrity sha512-Rwix9pBtC1Nuy5wysTmKy+UjbDJpIfg8eHjw0rjZ1mX4GNLz1Bmd16uDpI3Gk1i70Fgcs8Csg2lPm8HULFg9DQ==
-
-follow-redirects@^1.14.0:
-  version "1.14.7"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.7.tgz#2004c02eb9436eee9a21446a6477debf17e81685"
-  integrity sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ==
 
 for-in@^1.0.2:
   version "1.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3368,7 +3368,7 @@
     ts-dedent "^2.0.0"
     util-deprecate "^1.0.2"
 
-"@storybook/addon-essentials@^6.5.6":
+"@storybook/addon-essentials@^6.5.9":
   version "6.5.9"
   resolved "https://registry.yarnpkg.com/@storybook/addon-essentials/-/addon-essentials-6.5.9.tgz#32ba63acba4d153f4cf6ac33cbbf14b87d260788"
   integrity sha512-V9ThjKQsde4A2Es20pLFBsn0MWx2KCJuoTcTsANP4JDcbvEmj8UjbDWbs8jAU+yzJT5r+CI6NoWmQudv12ZOgw==
@@ -3389,7 +3389,7 @@
     regenerator-runtime "^0.13.7"
     ts-dedent "^2.0.0"
 
-"@storybook/addon-links@^6.5.6":
+"@storybook/addon-links@^6.5.9":
   version "6.5.9"
   resolved "https://registry.yarnpkg.com/@storybook/addon-links/-/addon-links-6.5.9.tgz#91cbca0c044796badf2498723fdd10dacea5748b"
   integrity sha512-4BYC7pkxL3NLRnEgTA9jpIkObQKril+XFj1WtmY/lngF90vvK0Kc/TtvTA2/5tSgrHfxEuPevIdxMIyLJ4ejWQ==
@@ -3467,7 +3467,7 @@
     prop-types "^15.7.2"
     regenerator-runtime "^0.13.7"
 
-"@storybook/addons@6.5.9", "@storybook/addons@^6.5.6":
+"@storybook/addons@6.5.9", "@storybook/addons@^6.5.9":
   version "6.5.9"
   resolved "https://registry.yarnpkg.com/@storybook/addons/-/addons-6.5.9.tgz#5a9d7395c579a9cbc44dfc122362fb3c95dfb9d5"
   integrity sha512-adwdiXg+mntfPocLc1KXjZXyLgGk7Aac699Fwe+OUYPEC5tW347Rm/kFatcE556d42o5czcRiq3ZSIGWnm9ieQ==
@@ -3484,7 +3484,7 @@
     global "^4.4.0"
     regenerator-runtime "^0.13.7"
 
-"@storybook/api@6.5.9", "@storybook/api@^6.5.6":
+"@storybook/api@6.5.9", "@storybook/api@^6.5.9":
   version "6.5.9"
   resolved "https://registry.yarnpkg.com/@storybook/api/-/api-6.5.9.tgz#303733214c9de0422d162f7c54ae05d088b89bf9"
   integrity sha512-9ylztnty4Y+ALU/ehW3BML9czjCAFsWvrwuCi6UgcwNjswwjSX3VRLhfD1KT3pl16ho//95LgZ0LnSwROCcPOA==
@@ -3671,7 +3671,7 @@
     core-js "^3.8.2"
     global "^4.4.0"
 
-"@storybook/components@6.5.9", "@storybook/components@^6.5.6":
+"@storybook/components@6.5.9", "@storybook/components@^6.5.9":
   version "6.5.9"
   resolved "https://registry.yarnpkg.com/@storybook/components/-/components-6.5.9.tgz#97e07ffe11ab76c01ccee380888991bd161f75b2"
   integrity sha512-BhfX980O9zn/1J4FNMeDo8ZvL1m5Ml3T4HRpfYmEBnf8oW5b5BeF6S2K2cwFStZRjWqm1feUcwNpZxCBVMkQnQ==
@@ -3769,7 +3769,7 @@
     util-deprecate "^1.0.2"
     webpack "4"
 
-"@storybook/core-events@6.5.9", "@storybook/core-events@^6.5.6":
+"@storybook/core-events@6.5.9", "@storybook/core-events@^6.5.9":
   version "6.5.9"
   resolved "https://registry.yarnpkg.com/@storybook/core-events/-/core-events-6.5.9.tgz#5b0783c7d22a586c0f5e927a61fe1b1223e19637"
   integrity sha512-tXt7a3ZvJOCeEKpNa/B5rQM5VI7UJLlOh3IHOImWn4HqoBRrZvbourmac+PRZAtXpos0h3c6554Hjapj/Sny5Q==
@@ -4031,7 +4031,7 @@
     react-docgen-typescript "^2.1.1"
     tslib "^2.0.0"
 
-"@storybook/react@^6.5.6":
+"@storybook/react@^6.5.9":
   version "6.5.9"
   resolved "https://registry.yarnpkg.com/@storybook/react/-/react-6.5.9.tgz#687ec1f6b785822a392b7ac115b61800f69fb7cd"
   integrity sha512-Rp+QaTQAzxJhwuzJXVd49mnIBLQRlF8llTxPT2YoGHdrGkku/zl/HblQ6H2yzEf15367VyzaAv/BpLsO9Jlfxg==
@@ -4146,7 +4146,7 @@
     read-pkg-up "^7.0.1"
     regenerator-runtime "^0.13.7"
 
-"@storybook/theming@6.5.9", "@storybook/theming@^6.5.6":
+"@storybook/theming@6.5.9", "@storybook/theming@^6.5.9":
   version "6.5.9"
   resolved "https://registry.yarnpkg.com/@storybook/theming/-/theming-6.5.9.tgz#13f60a3a3cd73ceb5caf9f188e1627e79f1891aa"
   integrity sha512-KM0AMP5jMQPAdaO8tlbFCYqx9uYM/hZXGSVUhznhLYu7bhNAIK7ZVmXxyE/z/khM++8eUHzRoZGiO/cwCkg9Xw==
@@ -13188,12 +13188,12 @@ minimist-options@^3.0.1:
     arrify "^1.0.1"
     is-plain-obj "^1.1.0"
 
-minimist@1.2.5, minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0:
+minimist@1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
   integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
 
-minimist@^1.2.5:
+minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0, minimist@^1.2.5:
   version "1.2.6"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.6.tgz#8637a5b759ea0d6e98702cfb3a9283323c93af44"
   integrity sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==

--- a/yarn.lock
+++ b/yarn.lock
@@ -12226,7 +12226,7 @@ lazy-universal-dotenv@^3.0.1:
     dotenv "^8.0.0"
     dotenv-expand "^5.1.0"
 
-lerna@^3.22.1:
+lerna@3.22.1:
   version "3.22.1"
   resolved "https://registry.yarnpkg.com/lerna/-/lerna-3.22.1.tgz#82027ac3da9c627fd8bf02ccfeff806a98e65b62"
   integrity sha512-vk1lfVRFm+UuEFA7wkLKeSF7Iz13W+N/vFd48aW2yuS7Kv0RbNm2/qcDPV863056LMfkRlsEe+QYOw3palj5Lg==


### PR DESCRIPTION
## What

Address vulnerability warnings and update js audit allow list.

- Upgraded Storybook packages to ^6.5.9
- Reviewed and updated js audit allow list
- Removed `axios` resolution
- Added comment for why we have a resolution for `@types/react`

## Why

We're vulnerable :(

## Notes

We still have quite a long list of warnings (which are in the allow list) which are caused by:
- `lerna` 
	- we couldn't upgrade it simply, and since we're looking to change to `changesets` later, no point investing too much time into it
- `commitizen` 
	- the package itself seems to have updated its dependencies automatically, but there hasn't been a release done. Since it's a dev tool, not too fussed
- `@storybook/*` 
	- the main vulnerability seems to be `ansi-regex` in `node-logger`, which is quite embedded.
	- `trim-newlines` is a regex DOS which is not relevant (checked with Foundations)
- `svgo` 
	- seems that this requires extra config changes to get working, but there are new versions (same with `svgo-loader`)