### PR TITLE
refactor: remove deprecated styles and helpers from EmptyState

### DIFF
--- a/draft-packages/empty-state/KaizenDraft/EmptyState/EmptyState.tsx
+++ b/draft-packages/empty-state/KaizenDraft/EmptyState/EmptyState.tsx
@@ -9,6 +9,7 @@ import {
   EmptyStatesPositive,
   AnimatedSceneProps,
 } from "@kaizen/draft-illustration"
+import { Paragraph, Heading } from "@kaizen/typography"
 import styles from "./styles.scss"
 
 const ILLUSTRATIONS: { [k: string]: React.VFC<AnimatedSceneProps> } = {
@@ -94,8 +95,16 @@ export const EmptyState: React.VFC<EmptyStateProps> = ({
       </div>
       <div className={styles.textSide}>
         <div className={styles.textSideInner}>
-          <div className={styles.heading}>{headingText}</div>
-          <div className={styles.description}>{bodyText}</div>
+          <Heading
+            variant="heading-3"
+            classNameOverride={styles.heading}
+            tag="div"
+          >
+            {headingText}
+          </Heading>
+          <Paragraph variant="body" classNameOverride={styles.description}>
+            {bodyText}
+          </Paragraph>
           {children}
         </div>
       </div>

--- a/draft-packages/empty-state/KaizenDraft/EmptyState/responsive.scss
+++ b/draft-packages/empty-state/KaizenDraft/EmptyState/responsive.scss
@@ -1,34 +1,44 @@
-@import "~@kaizen/deprecated-component-library-helpers/styles/layout";
 @import "~@kaizen/design-tokens/sass/layout";
 
 $small: 300px;
 $medium: $layout-breakpoints-medium;
 $large: $layout-breakpoints-large;
 
+// comes from ca-layout-padding x2 which is no longer used
+$side-padding: 48px;
 $sidebarWidth: 240px;
-$sidebarWithPadding: $sidebarWidth + (2 * $ca-layout-side-padding);
-$contentPadding: 2 * $ca-layout-side-padding;
+$sidebarWithPadding: $sidebarWidth + $side-padding;
+
+$typography-heading-3-font-size-small: 1.25rem;
+$typography-heading-3-font-weight-small: 700;
+$typography-heading-3-line-height-small: 1.5rem;
 
 @mixin large-sidebar-and-content {
-  @media (min-width: $large + $sidebarWithPadding + $contentPadding) {
+  @media (min-width: ($large + $sidebarWithPadding + $side-padding)) {
     @content;
   }
 }
 
 @mixin large-content-only {
-  @media (min-width: $large + $contentPadding) {
+  @media (min-width: ($large + $side-padding)) {
     @content;
   }
 }
 
 @mixin medium {
-  @media (min-width: $medium + $contentPadding) {
+  @media (min-width: ($medium + $side-padding)) {
     @content;
   }
 }
 
 @mixin small {
-  @media (max-width: $medium + $contentPadding - 1px) {
+  @media (max-width: ($medium + $side-padding - 1px)) {
     @content;
   }
+}
+
+@mixin typography-heading-3-sm {
+  font-size: $typography-heading-3-font-size-small;
+  line-height: $typography-heading-3-line-height-small;
+  font-weight: $typography-heading-3-font-weight-small;
 }

--- a/draft-packages/empty-state/KaizenDraft/EmptyState/styles.scss
+++ b/draft-packages/empty-state/KaizenDraft/EmptyState/styles.scss
@@ -1,8 +1,6 @@
 @import "~@kaizen/design-tokens/sass/spacing";
 @import "~@kaizen/design-tokens/sass/color";
 @import "~@kaizen/design-tokens/sass/border";
-@import "~@kaizen/component-library/styles/border";
-@import "~@kaizen/deprecated-component-library-helpers/styles/type";
 @import "./responsive";
 
 .container {
@@ -86,7 +84,7 @@
     max-width: 50%;
     flex-grow: 1;
     box-sizing: border-box;
-    padding-right: $spacing-md;
+    padding-inline-end: $spacing-md;
   }
 
   .sidebarAndContent & {
@@ -146,35 +144,13 @@
 }
 
 .heading {
-  @include ca-type-inter-display;
   margin-bottom: $spacing-md;
 
-  .sidebarAndContent & {
-    @include large-sidebar-and-content {
-      @include ca-type-inter-title;
-    }
-  }
-
-  .contentOnly & {
-    @include large-content-only {
-      @include ca-type-inter-title;
-    }
+  @media (max-width: (375px)) {
+    @include typography-heading-3-sm;
   }
 }
 
 .description {
-  @include kz-typography-paragraph-body;
   margin-bottom: $spacing-md;
-
-  .sidebarAndContent & {
-    @include small {
-      @include kz-typography-paragraph-body;
-    }
-  }
-
-  .contentOnly & {
-    @include small {
-      @include kz-typography-paragraph-body;
-    }
-  }
 }

--- a/draft-packages/empty-state/package.json
+++ b/draft-packages/empty-state/package.json
@@ -35,7 +35,7 @@
     "@kaizen/component-base": "^1.1.0",
     "@kaizen/component-library": "^15.0.3",
     "@kaizen/draft-illustration": "^5.1.15",
-    "@types/classnames": "^2.3.0",
+    "@kaizen/typography": "^2.2.3",
     "classnames": "^2.3.1"
   },
   "devDependencies": {


### PR DESCRIPTION
## Why
Empty state was relying on deprecated-component-library-helpers and using kz- typography styles,
which was importing old sizes, weights and line-heights. This has been removed and the Paragraph and
Heading components have used to align to the UI toolkit


## What
- replaces divs with `Paragraph` and `Heading` components
- replaces deprecates typographic styles with design tokens
- aligns sizes and responsiveness to ui toolkit
