### PR TITLE
chore: Remove legacy-packages folder

### DIFF
--- a/.github/workflows/chromatic.yaml
+++ b/.github/workflows/chromatic.yaml
@@ -11,7 +11,6 @@ on:
     paths:
       - packages/**
       - draft-packages/**
-      - legacy-packages/**
 
 jobs:
   visual-testing:

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "version": "independent",
   "npmClient": "yarn",
-  "packages": ["packages/*", "draft-packages/*", "legacy-packages/*"],
+  "packages": ["packages/*", "draft-packages/*"],
   "useWorkspaces": true
 }

--- a/package.json
+++ b/package.json
@@ -2,8 +2,7 @@
   "private": true,
   "workspaces": [
     "packages/*",
-    "draft-packages/*",
-    "legacy-packages/*"
+    "draft-packages/*"
   ],
   "engines": {
     "node": ">=14.18.0"

--- a/storybook/main.ts
+++ b/storybook/main.ts
@@ -24,7 +24,6 @@ const defaultStoryPaths = [
   "../packages/**/*.stories.tsx",
   "../packages/**/*.stories.mdx",
   "../draft-packages/**/!(deprecated.)*.stories.tsx",
-  "../legacy-packages/**/*.stories.tsx",
 ]
 
 module.exports = {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,11 +12,6 @@
     "noEmit": true
   },
   "files": ["./types.d.ts"],
-  "include": [
-    "./packages/**/*",
-    "./draft-packages/**/*",
-    "./legacy-packages/**/*",
-    "./storybook/**/*"
-  ],
+  "include": ["./packages/**/*", "./draft-packages/**/*", "./storybook/**/*"],
   "exclude": ["**/node_modules"]
 }


### PR DESCRIPTION
## What
Delete the legacy-packages folder and any config related to it.

## Why
There are no packages remaining in the `legacy-packages` folder, so this can be removed



