### PR TITLE
fix: Remove tab on scene illustrations [KDS-564]

### DIFF
--- a/draft-packages/illustration/KaizenDraft/Illustration/Players/VideoPlayer.spec.tsx
+++ b/draft-packages/illustration/KaizenDraft/Illustration/Players/VideoPlayer.spec.tsx
@@ -76,6 +76,7 @@ describe("<VideoPlayer />", () => {
           playsinline=""
           poster="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/heart/spot/moods-cautionary.svg.png"
           preload="metadata"
+          tabindex="-1"
           width="100%"
         >
           <source
@@ -109,6 +110,7 @@ describe("<VideoPlayer />", () => {
           playsinline=""
           poster="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/heart/spot/moods-cautionary.svg.png"
           preload="metadata"
+          tabindex="-1"
           width="100%"
         >
           <source

--- a/draft-packages/illustration/KaizenDraft/Illustration/Players/VideoPlayer.tsx
+++ b/draft-packages/illustration/KaizenDraft/Illustration/Players/VideoPlayer.tsx
@@ -76,6 +76,7 @@ export const VideoPlayer = ({
 
   useEffect(() => {
     if (!window) return
+
     const reducedMotionQuery = window.matchMedia(
       "(prefers-reduced-motion: reduce)"
     )
@@ -96,6 +97,7 @@ export const VideoPlayer = ({
   useEffect(() => {
     const { current: videoElement } = videoRef
     if (!videoElement) return
+
     if (prefersReducedMotion) {
       videoElement.pause()
     } else if (autoplay && !prefersReducedMotion) {
@@ -120,6 +122,7 @@ export const VideoPlayer = ({
     // Add event listeners for the video element
     const { current: videoElement } = videoRef
     if (!videoElement || !onEnded) return
+
     videoElement.addEventListener("ended", onEnded)
 
     return function cleanup() {
@@ -127,62 +130,40 @@ export const VideoPlayer = ({
     }
   }, [videoRef])
 
-  const aspectClassName =
-    (aspectRatio ? styles[aspectRatio] : "") + " " + styles.aspectRatioWrapper
-
-  return (
-    <>
-      {aspectRatio ? (
-        <figure className={aspectClassName}>
-          <video
-            muted={true}
-            aria-hidden={true}
-            preload="metadata"
-            ref={videoRef}
-            width="100%"
-            data-testid="kz-video-player"
-            className={styles.wrapper}
-            loop={loop}
-            poster={assetUrl(`${fallback}.png`)}
-            autoPlay={prefersReducedMotion ? false : autoplay}
-            playsInline={true}
-          >
-            {/**
-             * This seems counter-intuitive, but webm support is codec specific.
-             * Only offer webm if we are positive the browser supports it.
-             * Reference: https://bugs.webkit.org/show_bug.cgi?id=216652#c1
-             */}
-            {canPlayWebm() && (
-              <source src={assetUrl(`${source}.webm`)} type="video/webm" />
-            )}
-            <source src={assetUrl(`${source}.mp4`)} type="video/mp4" />
-          </video>
-        </figure>
-      ) : (
-        <video
-          muted={true}
-          aria-hidden={true}
-          preload="metadata"
-          ref={videoRef}
-          width="100%"
-          data-testid="kz-video-player"
-          className={styles.wrapper}
-          loop={loop}
-          poster={assetUrl(`${fallback}.png`)}
-          autoPlay={prefersReducedMotion ? false : autoplay}
-          playsInline={true}
-        >
-          {/**
-           * This seems counter-intuitive, but webm support is codec specific.
-           * Only offer webm if we are positive the browser supports it.
-           * Reference: https://bugs.webkit.org/show_bug.cgi?id=216652#c1
-           */}
-          {canPlayWebm() && (
-            <source src={assetUrl(`${source}.webm`)} type="video/webm" />
-          )}
-          <source src={assetUrl(`${source}.mp4`)} type="video/mp4" />
-        </video>
+  const videoPlayer = (
+    <video
+      muted={true}
+      aria-hidden={true}
+      preload="metadata"
+      ref={videoRef}
+      width="100%"
+      data-testid="kz-video-player"
+      className={styles.wrapper}
+      loop={loop}
+      poster={assetUrl(`${fallback}.png`)}
+      autoPlay={prefersReducedMotion ? false : autoplay}
+      playsInline={true}
+      tabIndex={-1}
+    >
+      {/**
+       * This seems counter-intuitive, but webm support is codec specific.
+       * Only offer webm if we are positive the browser supports it.
+       * Reference: https://bugs.webkit.org/show_bug.cgi?id=216652#c1
+       */}
+      {canPlayWebm() && (
+        <source src={assetUrl(`${source}.webm`)} type="video/webm" />
       )}
-    </>
+      <source src={assetUrl(`${source}.mp4`)} type="video/mp4" />
+    </video>
   )
+
+  if (aspectRatio) {
+    return (
+      <figure className={styles[aspectRatio] + " " + styles.aspectRatioWrapper}>
+        {videoPlayer}
+      </figure>
+    )
+  }
+
+  return videoPlayer
 }

--- a/draft-packages/illustration/KaizenDraft/Illustration/Players/VideoPlayer.tsx
+++ b/draft-packages/illustration/KaizenDraft/Illustration/Players/VideoPlayer.tsx
@@ -159,7 +159,7 @@ export const VideoPlayer = ({
 
   if (aspectRatio) {
     return (
-      <figure className={styles[aspectRatio] + " " + styles.aspectRatioWrapper}>
+      <figure className={`${styles[aspectRatio]} ${styles.aspectRatioWrapper}`}>
         {videoPlayer}
       </figure>
     )

--- a/packages/brand-moment/src/__snapshots__/BrandMoment.spec.tsx.snap
+++ b/packages/brand-moment/src/__snapshots__/BrandMoment.spec.tsx.snap
@@ -33,6 +33,7 @@ exports[`<BrandMoment /> matches the snapshot 1`] = `
                 playsinline=""
                 poster="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/heart/scene/brand-moments-error.png"
                 preload="metadata"
+                tabindex="-1"
                 width="100%"
               >
                 <source

--- a/yarn.lock
+++ b/yarn.lock
@@ -15373,7 +15373,7 @@ promzard@^0.3.0:
   dependencies:
     read "1"
 
-prop-types@^15.0.0, prop-types@^15.5.10, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.2:
+prop-types@^15.0.0, prop-types@^15.5.10, prop-types@^15.6.0, prop-types@^15.6.2, prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==


### PR DESCRIPTION
## Why
- See: [KDS-564](https://cultureamp.atlassian.net/jira/software/projects/KDS/boards/289?selectedIssue=KDS-564)
- Scene illustrations get tab focus (at least in Firefox), probably because they're `video` elements
<img width="300" alt="image" src="https://user-images.githubusercontent.com/763385/175456011-fe1f88d3-7d2c-4174-8c13-5f0ac1729a2b.png">


## What
- Added `tabindex="-1"` to the `video` tag
- Refactor: Removed some duplication in the current component
