### PR TITLE
test: improve DatePicker tests

### DIFF
--- a/packages/date-picker/src/DatePicker/DatePicker.spec.tsx
+++ b/packages/date-picker/src/DatePicker/DatePicker.spec.tsx
@@ -165,7 +165,6 @@ describe("<DatePicker /> - Focus element", () => {
       const dateToSelect = screen.getByRole("button", {
         name: "6th March (Sunday)",
       })
-      expect(dateToSelect).toBeInstanceOf(HTMLElement)
       userEvent.click(dateToSelect)
 
       expect(input).toHaveFocus()

--- a/packages/date-picker/src/DatePicker/DatePicker.spec.tsx
+++ b/packages/date-picker/src/DatePicker/DatePicker.spec.tsx
@@ -1,7 +1,6 @@
 import React, { useState } from "react"
 import { render, screen, waitFor } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
-import format from "date-fns/format"
 import { FieldMessageStatus } from "@kaizen/draft-form"
 import { DatePicker, ValidationResponse } from "./DatePicker"
 import { DatePickerProps } from "."
@@ -83,27 +82,6 @@ describe("<DatePicker />", () => {
       name: "Go to previous month",
     })
     expect(arrowButton).toHaveFocus()
-  })
-})
-
-// @todo: Move this to be tests for utils/setFocusInCalendar
-describe("<DatePicker /> - Focus within calendar", () => {
-  it("shows focus on today when no date is selected", () => {
-    const today = new Date()
-    const todayFormatted = format(today, "do MMMM (eeee)") // e.g 6th June (Monday)
-
-    render(<DatePickerWrapper />)
-
-    const calendarButton = screen.getByRole("button", {
-      name: "Choose date",
-    })
-    userEvent.click(calendarButton)
-    waitFor(() => {
-      expect(screen.queryByRole("dialog")).toBeVisible()
-    })
-
-    const dateToSelect = screen.getByRole("button", { name: todayFormatted })
-    expect(dateToSelect).toHaveFocus()
   })
 })
 

--- a/packages/date-picker/src/DatePicker/DatePicker.spec.tsx
+++ b/packages/date-picker/src/DatePicker/DatePicker.spec.tsx
@@ -49,7 +49,7 @@ describe("<DatePicker />", () => {
 
   it("should have an empty input value when a date is not provided", () => {
     render(<DatePickerWrapper />)
-    const input = screen.getByRole("combobox", { name: "Input label" })
+    const input = screen.getByLabelText("Input label")
     expect(input).toHaveValue("")
   })
 
@@ -58,9 +58,9 @@ describe("<DatePicker />", () => {
     expect(screen.getByDisplayValue("Mar 1, 2022")).toBeInTheDocument()
   })
 
-  it("allows you to tab through input, button and calendar", async () => {
+  it("allows you to tab through input, button and calendar", () => {
     render(<DatePickerWrapper />)
-    const input = screen.getByRole("combobox", { name: "Input label" })
+    const input = screen.getByLabelText("Input label")
 
     userEvent.tab()
     expect(input).toHaveFocus()
@@ -143,7 +143,7 @@ describe("<DatePicker /> - Focus element", () => {
     it("shows focus on input and opens the calendar", () => {
       render(<DatePickerWrapper selectedDay={new Date("2022-03-1")} />)
 
-      const input = screen.getByRole("combobox", { name: "Input label" })
+      const input = screen.getByLabelText("Input label")
       userEvent.click(input)
 
       waitFor(() => {
@@ -155,14 +155,16 @@ describe("<DatePicker /> - Focus element", () => {
     it("returns focus to the input when the user clicks a valid day on the calendar", () => {
       render(<DatePickerWrapper selectedDay={new Date("2022-03-1")} />)
 
-      const input = screen.getByRole("combobox", { name: "Input label" })
+      const input = screen.getByLabelText("Input label")
       userEvent.click(input)
 
       waitFor(() => {
         expect(screen.queryByRole("dialog")).toBeVisible()
       })
 
-      const dateToSelect = screen.getByText("6th March (Sunday)").parentElement!
+      const dateToSelect = screen.getByRole("button", {
+        name: "6th March (Sunday)",
+      })
       expect(dateToSelect).toBeInstanceOf(HTMLElement)
       userEvent.click(dateToSelect)
 
@@ -175,7 +177,7 @@ describe("<DatePicker /> - Focus element", () => {
     beforeEach(async () => {
       render(<DatePickerWrapper selectedDay={new Date("2022-03-1")} />)
 
-      const input = screen.getByRole("combobox", { name: "Input label" })
+      const input = screen.getByLabelText("Input label")
       await waitFor(() => {
         input.focus()
       })
@@ -187,17 +189,21 @@ describe("<DatePicker /> - Focus element", () => {
     })
 
     it("shows focus within the calendar", () => {
-      const selectedDate = screen.getByText("1st March (Tuesday)")
-      expect(selectedDate.parentElement).toHaveFocus()
+      const selectedDate = screen.getByRole("button", {
+        name: "1st March (Tuesday)",
+      })
+      expect(selectedDate).toHaveFocus()
     })
 
     it("returns focus to the input when the user escapes from the calendar", () => {
-      const selectedDate = screen.getByText("1st March (Tuesday)")
-      expect(selectedDate.parentElement).toHaveFocus()
+      const selectedDate = screen.getByRole("button", {
+        name: "1st March (Tuesday)",
+      })
+      expect(selectedDate).toHaveFocus()
 
       userEvent.keyboard("{Escape}")
 
-      const input = screen.getByRole("combobox", { name: "Input label" })
+      const input = screen.getByLabelText("Input label")
       expect(input).toHaveFocus()
     })
   })
@@ -217,8 +223,10 @@ describe("<DatePicker /> - Focus element", () => {
     })
 
     it("shows focus within the calendar", () => {
-      const selectedDate = screen.getByText("1st March (Tuesday)")
-      expect(selectedDate.parentElement).toHaveFocus()
+      const selectedDate = screen.getByRole("button", {
+        name: "1st March (Tuesday)",
+      })
+      expect(selectedDate).toHaveFocus()
     })
 
     it("returns focus to the input when the user escapes from the calendar", () => {
@@ -277,7 +285,7 @@ describe("<DatePicker /> - Input format", () => {
   it("formats values when focus is on the input", async () => {
     render(<DatePickerWrapper selectedDay={new Date("2022-03-01")} />)
 
-    const input = screen.getByRole("combobox", { name: "Input label" })
+    const input = screen.getByLabelText("Input label")
     expect(input).toHaveValue("Mar 1, 2022")
 
     userEvent.tab()
@@ -288,7 +296,7 @@ describe("<DatePicker /> - Input format", () => {
   it("formats values when the input loses focus - onBlur", async () => {
     render(<DatePickerWrapper selectedDay={new Date("2022-03-01")} />)
 
-    const input = screen.getByRole("combobox", { name: "Input label" })
+    const input = screen.getByLabelText("Input label")
     expect(input).toHaveValue("Mar 1, 2022")
 
     userEvent.tab()
@@ -336,7 +344,7 @@ describe("<DatePicker /> - Validation", () => {
     it("displays error message when input date is invalid", () => {
       render(<DatePickerWrapper />)
 
-      const input = screen.getByRole("combobox", { name: "Input label" })
+      const input = screen.getByLabelText("Input label")
       userEvent.type(input, "05/05/2022Blah")
 
       userEvent.tab()
@@ -351,7 +359,7 @@ describe("<DatePicker /> - Validation", () => {
     it("displays error message when input date is disabled", () => {
       render(<DatePickerWrapper disabledBefore={new Date("2022-05-15")} />)
 
-      const input = screen.getByRole("combobox", { name: "Input label" })
+      const input = screen.getByLabelText("Input label")
       userEvent.type(input, "05/05/2022")
 
       userEvent.tab()

--- a/packages/date-picker/src/DatePicker/DatePicker.spec.tsx
+++ b/packages/date-picker/src/DatePicker/DatePicker.spec.tsx
@@ -49,7 +49,7 @@ describe("<DatePicker />", () => {
 
   it("should have an empty input value when a date is not provided", () => {
     render(<DatePickerWrapper />)
-    const input = screen.getByLabelText("Input label", { selector: "input" })
+    const input = screen.getByRole("combobox", { name: "Input label" })
     expect(input).toHaveValue("")
   })
 
@@ -58,16 +58,17 @@ describe("<DatePicker />", () => {
     expect(screen.getByDisplayValue("Mar 1, 2022")).toBeInTheDocument()
   })
 
-  it("allows you to tab through input, button and calendar", () => {
+  it("allows you to tab through input, button and calendar", async () => {
     render(<DatePickerWrapper />)
-    const input = screen.getByLabelText("Input label", { selector: "input" })
+    const input = screen.getByRole("combobox", { name: "Input label" })
 
     userEvent.tab()
     expect(input).toHaveFocus()
 
     userEvent.keyboard("{arrowDown}")
+
     waitFor(() => {
-      expect(screen.queryByRole("dialog")).toBeInTheDocument()
+      expect(screen.getByRole("dialog")).toBeVisible()
     })
 
     userEvent.tab()
@@ -75,12 +76,11 @@ describe("<DatePicker />", () => {
 
     userEvent.tab()
     const calendarButton = screen.getByRole("button", { name: "Choose date" })
-
     expect(calendarButton).toHaveFocus()
 
     userEvent.tab()
-    const arrowButton = screen.getByLabelText("Go to previous month", {
-      selector: "button",
+    const arrowButton = screen.getByRole("button", {
+      name: "Go to previous month",
     })
     expect(arrowButton).toHaveFocus()
   })
@@ -95,11 +95,13 @@ describe("<DatePicker /> - Selecting a date using the calendar", () => {
     userEvent.click(calendarButton)
 
     waitFor(() => {
-      expect(screen.queryByRole("dialog")).toBeInTheDocument()
+      expect(screen.getByRole("dialog")).toBeVisible()
     })
 
-    const dateToSelect = screen.getByText("6th March (Sunday)").parentElement
-    dateToSelect?.focus()
+    const dateToSelect = screen.getByRole("button", {
+      name: "6th March (Sunday)",
+    })
+    dateToSelect.focus()
     userEvent.keyboard("{enter}")
   })
 
@@ -122,17 +124,16 @@ describe("<DatePicker /> - Focus within calendar", () => {
     const todayFormatted = format(today, "do MMMM (eeee)") // e.g 6th June (Monday)
 
     render(<DatePickerWrapper />)
-    expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
 
     const calendarButton = screen.getByRole("button", {
       name: "Choose date",
     })
     userEvent.click(calendarButton)
     waitFor(() => {
-      expect(screen.queryByRole("dialog")).toBeInTheDocument()
+      expect(screen.queryByRole("dialog")).toBeVisible()
     })
 
-    const dateToSelect = screen.getByText(todayFormatted).parentElement
+    const dateToSelect = screen.getByRole("button", { name: todayFormatted })
     expect(dateToSelect).toHaveFocus()
   })
 })
@@ -142,13 +143,11 @@ describe("<DatePicker /> - Focus element", () => {
     it("shows focus on input and opens the calendar", () => {
       render(<DatePickerWrapper selectedDay={new Date("2022-03-1")} />)
 
-      expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
-
-      const input = screen.getByLabelText("Input label", { selector: "input" })
+      const input = screen.getByRole("combobox", { name: "Input label" })
       userEvent.click(input)
 
       waitFor(() => {
-        expect(screen.queryByRole("dialog")).toBeInTheDocument()
+        expect(screen.queryByRole("dialog")).toBeVisible()
         expect(input).toHaveFocus()
       })
     })
@@ -156,17 +155,16 @@ describe("<DatePicker /> - Focus element", () => {
     it("returns focus to the input when the user clicks a valid day on the calendar", () => {
       render(<DatePickerWrapper selectedDay={new Date("2022-03-1")} />)
 
-      expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
-
-      const input = screen.getByLabelText("Input label", { selector: "input" })
+      const input = screen.getByRole("combobox", { name: "Input label" })
       userEvent.click(input)
 
       waitFor(() => {
-        expect(screen.queryByRole("dialog")).toBeInTheDocument()
+        expect(screen.queryByRole("dialog")).toBeVisible()
       })
 
-      const dateToSelect = screen.getByText("6th March (Sunday)").parentElement
-      if (dateToSelect) userEvent.click(dateToSelect)
+      const dateToSelect = screen.getByText("6th March (Sunday)").parentElement!
+      expect(dateToSelect).toBeInstanceOf(HTMLElement)
+      userEvent.click(dateToSelect)
 
       expect(input).toHaveFocus()
       expect(input).toHaveValue("03/06/2022")
@@ -177,16 +175,14 @@ describe("<DatePicker /> - Focus element", () => {
     beforeEach(async () => {
       render(<DatePickerWrapper selectedDay={new Date("2022-03-1")} />)
 
-      expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
-
-      const input = screen.getByLabelText("Input label", { selector: "input" })
+      const input = screen.getByRole("combobox", { name: "Input label" })
       await waitFor(() => {
         input.focus()
       })
       userEvent.keyboard("{ArrowDown}")
 
       waitFor(() => {
-        expect(screen.queryByRole("dialog")).toBeInTheDocument()
+        expect(screen.queryByRole("dialog")).toBeVisible()
       })
     })
 
@@ -201,7 +197,7 @@ describe("<DatePicker /> - Focus element", () => {
 
       userEvent.keyboard("{Escape}")
 
-      const input = screen.getByLabelText("Input label", { selector: "input" })
+      const input = screen.getByRole("combobox", { name: "Input label" })
       expect(input).toHaveFocus()
     })
   })
@@ -210,15 +206,13 @@ describe("<DatePicker /> - Focus element", () => {
     beforeEach(() => {
       render(<DatePickerWrapper selectedDay={new Date("2022-03-1")} />)
 
-      expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
-
       const calendarButton = screen.getByRole("button", {
         name: "Change date, Mar 1, 2022",
       })
       userEvent.click(calendarButton)
 
       waitFor(() => {
-        expect(screen.queryByRole("dialog")).toBeInTheDocument()
+        expect(screen.getByRole("dialog")).toBeVisible()
       })
     })
 
@@ -228,8 +222,10 @@ describe("<DatePicker /> - Focus element", () => {
     })
 
     it("returns focus to the input when the user escapes from the calendar", () => {
-      const selectedDate = screen.getByText("1st March (Tuesday)")
-      expect(selectedDate.parentElement).toHaveFocus()
+      const selectedDate = screen.getByRole("button", {
+        name: "1st March (Tuesday)",
+      })
+      expect(selectedDate).toHaveFocus()
 
       userEvent.keyboard("{Escape}")
 
@@ -244,8 +240,6 @@ describe("<DatePicker /> - Focus element", () => {
     beforeEach(async () => {
       render(<DatePickerWrapper selectedDay={new Date("2022-03-1")} />)
 
-      expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
-
       const calendarButton = screen.getByRole("button", {
         name: "Change date, Mar 1, 2022",
       })
@@ -257,19 +251,18 @@ describe("<DatePicker /> - Focus element", () => {
       userEvent.keyboard("{Enter}")
 
       waitFor(() => {
-        expect(screen.queryByRole("dialog")).toBeInTheDocument()
+        expect(screen.getByRole("dialog")).toBeVisible()
       })
     })
 
     it("shows focus within the calendar", async () => {
-      const selectedDate = screen.getByText("1st March (Tuesday)")
-      expect(selectedDate.parentElement).toHaveFocus()
+      const selectedDate = screen.getByRole("button", {
+        name: "1st March (Tuesday)",
+      })
+      expect(selectedDate).toHaveFocus()
     })
 
     it("returns focus to the input when the user escapes from the calendar", () => {
-      const selectedDate = screen.getByText("1st March (Tuesday)")
-      expect(selectedDate.parentElement).toHaveFocus()
-
       userEvent.keyboard("{Escape}")
 
       const calendarButton = screen.getByRole("button", {
@@ -284,12 +277,10 @@ describe("<DatePicker /> - Input format", () => {
   it("formats values when focus is on the input", async () => {
     render(<DatePickerWrapper selectedDay={new Date("2022-03-01")} />)
 
-    const input = screen.getByLabelText("Input label", { selector: "input" })
+    const input = screen.getByRole("combobox", { name: "Input label" })
     expect(input).toHaveValue("Mar 1, 2022")
 
-    await waitFor(() => {
-      input.focus()
-    })
+    userEvent.tab()
 
     expect(input).toHaveValue("03/01/2022")
   })
@@ -297,12 +288,10 @@ describe("<DatePicker /> - Input format", () => {
   it("formats values when the input loses focus - onBlur", async () => {
     render(<DatePickerWrapper selectedDay={new Date("2022-03-01")} />)
 
-    const input = screen.getByLabelText("Input label", { selector: "input" })
+    const input = screen.getByRole("combobox", { name: "Input label" })
     expect(input).toHaveValue("Mar 1, 2022")
 
-    await waitFor(() => {
-      input.focus()
-    })
+    userEvent.tab()
 
     expect(input).toHaveValue("03/01/2022")
 
@@ -320,7 +309,7 @@ describe("<DatePicker /> - Validation", () => {
       render(
         <DatePickerWrapper status="error" validationMessage="Invalid Date." />
       )
-      expect(screen.getByText("Invalid Date.")).toBeInTheDocument()
+      expect(screen.getByText("Invalid Date.")).toBeVisible()
     })
   })
 
@@ -328,7 +317,7 @@ describe("<DatePicker /> - Validation", () => {
     it("displays error message when selected day is invalid", async () => {
       render(<DatePickerWrapper selectedDay={new Date("potato")} />)
 
-      expect(screen.getByText("Date is invalid")).toBeInTheDocument()
+      expect(screen.getByText("Date is invalid")).toBeVisible()
     })
 
     it("displays error message when selected day is disabled", async () => {
@@ -341,13 +330,13 @@ describe("<DatePicker /> - Validation", () => {
 
       expect(
         screen.getByText("05/05/2022 is not available, try another date")
-      ).toBeInTheDocument()
+      ).toBeVisible()
     })
 
     it("displays error message when input date is invalid", () => {
       render(<DatePickerWrapper />)
 
-      const input = screen.getByLabelText("Input label", { selector: "input" })
+      const input = screen.getByRole("combobox", { name: "Input label" })
       userEvent.type(input, "05/05/2022Blah")
 
       userEvent.tab()
@@ -355,14 +344,14 @@ describe("<DatePicker /> - Validation", () => {
       waitFor(() => {
         expect(
           screen.getByText("05/05/2022Blah is an invalid date")
-        ).toBeInTheDocument()
+        ).toBeVisible()
       })
     })
 
     it("displays error message when input date is disabled", () => {
       render(<DatePickerWrapper disabledBefore={new Date("2022-05-15")} />)
 
-      const input = screen.getByLabelText("Input label", { selector: "input" })
+      const input = screen.getByRole("combobox", { name: "Input label" })
       userEvent.type(input, "05/05/2022")
 
       userEvent.tab()
@@ -370,7 +359,7 @@ describe("<DatePicker /> - Validation", () => {
       waitFor(() => {
         expect(
           screen.getByText("05/05/2022 is not available, try another date")
-        ).toBeInTheDocument()
+        ).toBeVisible()
       })
     })
   })

--- a/packages/date-picker/src/utils/setFocusInCalendar.spec.tsx
+++ b/packages/date-picker/src/utils/setFocusInCalendar.spec.tsx
@@ -1,0 +1,48 @@
+import React from "react"
+import { render, screen } from "@testing-library/react"
+import { format } from "date-fns"
+import { enUS } from "date-fns/locale"
+import { Calendar, CalendarProps } from "../DatePicker/components/Calendar"
+import { setFocusInCalendar } from "./setFocusInCalendar"
+
+const CalendarWrapper = (props: Partial<CalendarProps>): JSX.Element => (
+  <Calendar
+    mode="single"
+    id="calendar-dialog"
+    onDayChange={jest.fn<void, [Date]>()}
+    setPopperElement={jest.fn()}
+    locale={enUS}
+    onMount={calendarElement =>
+      setFocusInCalendar(calendarElement, props.value)
+    }
+    {...props}
+  />
+)
+
+const today = new Date()
+const todayFormatted = format(today, "do MMMM (eeee)") // e.g 6th June (Monday)
+
+describe("setFocusInCalendar", () => {
+  it("should focus on today when no date is selected", () => {
+    render(<CalendarWrapper />)
+
+    const dayToFocus = screen.getByRole("button", { name: todayFormatted })
+    expect(dayToFocus).toHaveFocus()
+  })
+
+  it("should focus on the selected day", () => {
+    render(<CalendarWrapper value={new Date("2022-08-15")} />)
+
+    const dayToFocus = screen.getByRole("button", {
+      name: "15th August (Monday)",
+    })
+    expect(dayToFocus).toHaveFocus()
+  })
+
+  it("should focus on today when selected date is invalid", () => {
+    render(<CalendarWrapper value={new Date("potato")} />)
+
+    const dayToFocus = screen.getByRole("button", { name: todayFormatted })
+    expect(dayToFocus).toHaveFocus()
+  })
+})


### PR DESCRIPTION
## Why

[KDS-584](https://cultureamp.atlassian.net/browse/KDS-584?atlOrigin=eyJpIjoiYzE2NTIwODc4OWI5NDliNzk1N2IyNWZkNzZhOTM4ZmIiLCJwIjoiaiJ9)
There’s some minor niceties we can use to make our tests more reflect the intended behaviour.

## What
- Use `getByRole` instead of using `selector` argument, or traversing DOM element’s parent
- Skip some assertions that have been done in previous tests
- Use `toBeVisible` instead of `toBeInTheDocument`, which makes sure the element is in the document _and_ the accessibility tree.
- Use tabbing instead of focusing on specific elements.

@HeartSquared changes:
- Remove unnecessary usages of `async`
- Clean up tests to use consistent patterns
- Add tests for `setFocusInCalendar`