### PR TITLE
refactor: update RTE nested list styles

### DIFF
--- a/packages/rich-text-editor/src/RichTextEditor/RichTextEditor.scss
+++ b/packages/rich-text-editor/src/RichTextEditor/RichTextEditor.scss
@@ -35,6 +35,7 @@
   line-height: $typography-paragraph-body-line-height;
   letter-spacing: $typography-paragraph-body-letter-spacing;
   padding: $spacing-sm calc(#{$spacing-xs} * 3);
+  position: relative;
   transition: background-color $animation-duration-immediate,
     border-color $animation-duration-immediate;
   white-space: pre-wrap;
@@ -63,7 +64,8 @@
     pointer-events: none;
     position: absolute;
     background: transparent;
-    border-radius: $border-focus-ring-border-radius;
+    border-radius: 2px 2px $border-focus-ring-border-radius
+      $border-focus-ring-border-radius;
     border-width: $border-focus-ring-border-width;
     border-style: $border-focus-ring-border-style;
     border-color: $color-blue-500;

--- a/packages/rich-text-editor/src/RichTextEditor/RichTextEditor.scss
+++ b/packages/rich-text-editor/src/RichTextEditor/RichTextEditor.scss
@@ -4,6 +4,29 @@
 @import "@kaizen/design-tokens/sass/spacing";
 @import "@kaizen/design-tokens/sass/typography";
 
+@mixin nestedListStyles {
+  ol {
+    list-style-type: decimal;
+    ol {
+      list-style-type: lower-alpha;
+      ol {
+        list-style-type: lower-roman;
+        @content;
+      }
+    }
+  }
+  ul {
+    list-style-type: disc;
+    ul {
+      list-style-type: circle;
+      ul {
+        list-style-type: square;
+        @content;
+      }
+    }
+  }
+}
+
 .editor > :global(.ProseMirror) {
   border-radius: $border-solid-border-radius;
   font-family: $typography-paragraph-body-font-family;
@@ -48,6 +71,10 @@
     left: calc(-1 * #{$focus-ring-offset});
     right: calc(-1 * #{$focus-ring-offset});
     bottom: calc(-1 * #{$focus-ring-offset});
+  }
+
+  @include nestedListStyles {
+    @include nestedListStyles;
   }
 }
 


### PR DESCRIPTION
## Why
The default lists in the rte did not have any nested styles.


## What
- adds recurring nested list styles for `ul` and `ol` tags up to a dept of 6
- I also used this PR to update the focus ring to match design since this is a very small scss change we wanted to fix

| Prev lists | Updated lists |
|---|---|
| ![old_list_styles](https://user-images.githubusercontent.com/36558508/175846893-1497f536-8cbf-4bd3-a5a9-59150bd9a096.png) | ![new_list_styles](https://user-images.githubusercontent.com/36558508/175846909-6f3c960e-bd71-46dc-b3b3-5641f1a9df44.png) | 


| Prev border | Updated border |
|---|---|
|  ![old_focus](https://user-images.githubusercontent.com/36558508/175847211-c768f71f-e856-4e65-bc8a-d1cc37802aa3.png)   |   ![new_focus](https://user-images.githubusercontent.com/36558508/175847196-a6ca6468-4f19-4009-a906-66af91fedd4b.png)  | 
