### PR TITLE
fix: update calendar to check for Invalid Date type Date

### DIFF
--- a/packages/date-picker/docs/DatePicker.stories.tsx
+++ b/packages/date-picker/docs/DatePicker.stories.tsx
@@ -56,7 +56,7 @@ DefaultStory.parameters = {
 
 export const ValidationStory = props => {
   const [selectedDate, setValueDate] = useState<Date | undefined>(
-    new Date("potato")
+    new Date(2022, 4, 5)
   )
   const [status, setStatus] = useState<FieldMessageStatus | undefined>()
   const [response, setResponse] = useState<ValidationResponse | undefined>()

--- a/packages/date-picker/docs/DatePicker.stories.tsx
+++ b/packages/date-picker/docs/DatePicker.stories.tsx
@@ -56,7 +56,7 @@ DefaultStory.parameters = {
 
 export const ValidationStory = props => {
   const [selectedDate, setValueDate] = useState<Date | undefined>(
-    new Date(2022, 4, 5)
+    new Date("potato")
   )
   const [status, setStatus] = useState<FieldMessageStatus | undefined>()
   const [response, setResponse] = useState<ValidationResponse | undefined>()
@@ -229,6 +229,7 @@ const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({
             description={
               <>
                 <Paragraph
+                  tag="span"
                   variant="small"
                   color={isReversed ? "white" : "dark"}
                 >

--- a/packages/date-picker/src/DatePicker/DatePicker.tsx
+++ b/packages/date-picker/src/DatePicker/DatePicker.tsx
@@ -246,7 +246,12 @@ export const DatePicker: React.VFC<DatePickerProps> = ({
 
   const handleInputFocus: React.FocusEventHandler<HTMLInputElement> = e => {
     setLastTrigger("inputFocus")
-    selectedDay && setInputValue(format(selectedDay, DateFormat.Numeral))
+    if (selectedDay) {
+      const newInputValue = isInvalidDate(selectedDay)
+        ? ""
+        : format(selectedDay, DateFormat.Numeral)
+      setInputValue(newInputValue)
+    }
     onInputFocus && onInputFocus(e)
   }
 

--- a/packages/date-picker/src/DatePicker/components/Calendar/Calendar.tsx
+++ b/packages/date-picker/src/DatePicker/components/Calendar/Calendar.tsx
@@ -86,8 +86,16 @@ export const Calendar: React.VFC<CalendarProps> = ({
         {mode === "single" && (
           <DayPicker
             mode="single"
-            selected={value}
-            defaultMonth={selectedMonth}
+            selected={
+              value && value.toDateString() === "Invalid Date"
+                ? undefined
+                : value
+            }
+            defaultMonth={
+              selectedMonth && selectedMonth.toDateString() === "Invalid Date"
+                ? new Date()
+                : selectedMonth
+            }
             weekStartsOn={
               isValidWeekStartsOn(weekStartsOn) ? weekStartsOn : undefined
             }

--- a/packages/date-picker/src/DatePicker/components/Calendar/Calendar.tsx
+++ b/packages/date-picker/src/DatePicker/components/Calendar/Calendar.tsx
@@ -8,6 +8,7 @@ import { Icon } from "@kaizen/component-library"
 import arrowRight from "@kaizen/component-library/icons/arrow-right.icon.svg"
 import arrowLeft from "@kaizen/component-library/icons/arrow-left.icon.svg"
 import { DayOfWeek } from "../../enums"
+import { isInvalidDate } from "../../../utils/isInvalidDate"
 import { defaultCalendarClasses } from "./CalendarClasses"
 import calendarStyles from "./Calendar.scss"
 
@@ -86,13 +87,9 @@ export const Calendar: React.VFC<CalendarProps> = ({
         {mode === "single" && (
           <DayPicker
             mode="single"
-            selected={
-              value && value.toDateString() === "Invalid Date"
-                ? undefined
-                : value
-            }
+            selected={value && isInvalidDate(value) ? undefined : value}
             defaultMonth={
-              selectedMonth && selectedMonth.toDateString() === "Invalid Date"
+              selectedMonth && isInvalidDate(selectedMonth)
                 ? new Date()
                 : selectedMonth
             }

--- a/packages/date-picker/src/DatePicker/components/Calendar/Calendar.tsx
+++ b/packages/date-picker/src/DatePicker/components/Calendar/Calendar.tsx
@@ -64,7 +64,9 @@ export const Calendar: React.VFC<CalendarProps> = ({
     if (calendarRef.current) onMount && onMount(calendarRef.current)
   }, [calendarRef])
 
-  const selectedMonth = selectedRange?.from || value || defaultMonth
+  const monthToShow = selectedRange?.from || value || defaultMonth
+  const selectedMonth =
+    monthToShow && isInvalidDate(monthToShow) ? undefined : monthToShow
 
   const IconRight: React.VFC = () => (
     <Icon icon={arrowRight} role="presentation" />
@@ -88,11 +90,7 @@ export const Calendar: React.VFC<CalendarProps> = ({
           <DayPicker
             mode="single"
             selected={value && isInvalidDate(value) ? undefined : value}
-            defaultMonth={
-              selectedMonth && isInvalidDate(selectedMonth)
-                ? new Date()
-                : selectedMonth
-            }
+            defaultMonth={selectedMonth}
             weekStartsOn={
               isValidWeekStartsOn(weekStartsOn) ? weekStartsOn : undefined
             }

--- a/packages/date-picker/src/utils/setFocusInCalendar.ts
+++ b/packages/date-picker/src/utils/setFocusInCalendar.ts
@@ -10,7 +10,7 @@ export const setFocusInCalendar = (
   selectedDay: Date | undefined
 ): void => {
   const dayToFocus = calendarElement.getElementsByClassName(
-    selectedDay && isInvalidDate(selectedDay)
+    selectedDay && !isInvalidDate(selectedDay)
       ? calendarStyles.daySelected
       : calendarStyles.dayToday
   )[0]

--- a/packages/date-picker/src/utils/setFocusInCalendar.ts
+++ b/packages/date-picker/src/utils/setFocusInCalendar.ts
@@ -1,5 +1,6 @@
 import calendarStyles from "../DatePicker/components/Calendar/Calendar.scss"
 import { CalendarElement } from "../DatePicker/components/Calendar/Calendar"
+import { isInvalidDate } from "./isInvalidDate"
 
 const isHTMLElement = (element: Element | undefined): element is HTMLElement =>
   element instanceof HTMLElement
@@ -9,7 +10,7 @@ export const setFocusInCalendar = (
   selectedDay: Date | undefined
 ): void => {
   const dayToFocus = calendarElement.getElementsByClassName(
-    selectedDay && selectedDay.toDateString() !== "Invalid Date"
+    selectedDay && isInvalidDate(selectedDay)
       ? calendarStyles.daySelected
       : calendarStyles.dayToday
   )[0]

--- a/packages/date-picker/src/utils/setFocusInCalendar.ts
+++ b/packages/date-picker/src/utils/setFocusInCalendar.ts
@@ -9,7 +9,9 @@ export const setFocusInCalendar = (
   selectedDay: Date | undefined
 ): void => {
   const dayToFocus = calendarElement.getElementsByClassName(
-    selectedDay ? calendarStyles.daySelected : calendarStyles.dayToday
+    selectedDay && selectedDay.toDateString() !== "Invalid Date"
+      ? calendarStyles.daySelected
+      : calendarStyles.dayToday
   )[0]
 
   if (isHTMLElement(dayToFocus)) dayToFocus.focus()


### PR DESCRIPTION
## Why
<!-- Why have you created this PR? - Is it a new feature, or a bug fix? Or something else? -->
<!-- Reference any relevant Jira tickets so your reviewer can find more context if needed. -->
<!-- Fixing a GitHub issue? Add "Fixes [issue URL]". -->
Calendar could not open when an invalid date was initially set.

## What
<!-- What do your changes do? How do they change/fix the current behavior? -->
<!-- Add screenshots, GIFs or videos to illustrate the changes.  -->

- Check for invalid date which is type of Date but check as a string for both `selected` and `defautMonth`
