### PR TITLE
fix: Update styles to use import instead of require

### DIFF
--- a/draft-packages/likert-scale-legacy/KaizenDraft/LikertScaleLegacy/LikertScaleLegacy.tsx
+++ b/draft-packages/likert-scale-legacy/KaizenDraft/LikertScaleLegacy/LikertScaleLegacy.tsx
@@ -5,7 +5,7 @@ import { Paragraph } from "@kaizen/typography"
 import determineSelectionFromKeyPress from "./helpers/determineSelectionFromKeyPress"
 import { Scale, ScaleItem, ScaleValue } from "./types"
 
-const styles = require("./styles.module.scss")
+import styles from "./styles.module.scss"
 
 type ItemRefs = Array<{
   value: ScaleValue

--- a/packages/notification/src/ToastNotificationsList.tsx
+++ b/packages/notification/src/ToastNotificationsList.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from "react"
 import GenericNotification from "./components/GenericNotification"
 import { RemoveToastNotification, ToastNotification } from "./types"
-const styles = require("./ToastNotificationsList.module.scss")
+import styles from "./ToastNotificationsList.module.scss"
 
 export const ToastNotificationsList = ({
   notifications,


### PR DESCRIPTION
## Why
<!-- Why have you created this PR? - Is it a new feature, or a bug fix? Or something else? -->
<!-- Reference any relevant Jira tickets so your reviewer can find more context if needed. -->
<!-- Fixing a GitHub issue? Add "Fixes [issue URL]". -->
- when upgrading performance-ui to @cultureamp/frontend-build v2, we discovered style modules referenced using require were not being applied
  - see this slack thread for more context: https://cultureamp.slack.com/archives/C016N8Y1E10/p1656464394609989
- the suggested solution from FE foundations was to update kaizen packages to use import instead of require
- it looks like this change was made for a bunch of packages a while ago, but these couple components got missed: https://github.com/cultureamp/kaizen-design-system/pull/782

## What
<!-- What do your changes do? How do they change/fix the current behavior? -->
<!-- Add screenshots, GIFs or videos to illustrate the changes.  -->
- no functional change, using `import` should result in the same behaviour
