### PR TITLE
Exclude branches created to resolve Snyk findings

### DIFF
--- a/.github/workflows/chromatic.yaml
+++ b/.github/workflows/chromatic.yaml
@@ -11,6 +11,8 @@ on:
     paths:
       - packages/**
       - draft-packages/**
+    branches-ignore:
+      - 'snyk-fix*'
 
 jobs:
   visual-testing:


### PR DESCRIPTION
## Why
Ignore branches, created by Snyk, to reduce the cost of running Chromatic
