### PR TITLE
feat: Create RichTextContent and EditableRichTextContent components

### DIFF
--- a/packages/rich-text-editor/docs/EditableRichTextContent.stories.tsx
+++ b/packages/rich-text-editor/docs/EditableRichTextContent.stories.tsx
@@ -1,0 +1,73 @@
+import React, { useState } from "react"
+import {
+  EditableRichTextContent,
+  RichTextEditor,
+  EditorContentArray,
+} from "@kaizen/rich-text-editor"
+import { Button } from "@kaizen/button"
+import { Box } from "@kaizen/component-library"
+import { CATEGORIES, SUB_CATEGORIES } from "../../../storybook/constants"
+import dummyContent from "./dummyContent.json"
+
+export default {
+  title: `${CATEGORIES.components}/${SUB_CATEGORIES.richTextEditor}/Editable Rich Text Content`,
+  component: EditableRichTextContent,
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'import { EditableRichTextContent } from "@kaizen/rich-text-editor"',
+      },
+    },
+  },
+}
+
+export const EditableRichTextContentStory = args => <InlineEditor {...args} />
+EditableRichTextContentStory.storyName = "Default"
+EditableRichTextContentStory.args = {
+  content: dummyContent,
+  labelText: "Shared notes",
+  isLabelHidden: false,
+}
+
+function InlineEditor(props: {
+  content: EditorContentArray
+  labelText: string
+}) {
+  const [editMode, setEditMode] = useState<boolean>(false)
+  const [rteData, setRTEData] = useState<EditorContentArray>(dummyContent)
+  const handleContentClick = () => setEditMode(true)
+  const handleCancel = () => setEditMode(false)
+
+  if (editMode) {
+    return (
+      <>
+        <RichTextEditor
+          labelText={props.labelText}
+          controls={[
+            { name: "bold", group: "inline" },
+            { name: "italic", group: "inline" },
+            { name: "underline", group: "inline" },
+            { name: "orderedList", group: "list" },
+            { name: "bulletList", group: "list" },
+            { name: "link", group: "link" },
+          ]}
+          value={rteData}
+          onChange={data => setRTEData(data)}
+        />
+        <Box mt={0.5} style={{ display: "flex", justifyContent: "end" }}>
+          <Button label="Cancel" secondary onClick={handleCancel} />
+          <Button label="Save" primary onClick={handleCancel} />
+        </Box>
+      </>
+    )
+  }
+
+  return (
+    <EditableRichTextContent
+      onClick={handleContentClick}
+      content={rteData}
+      labelText={props.labelText}
+    />
+  )
+}

--- a/packages/rich-text-editor/docs/RichTextContent.stories.tsx
+++ b/packages/rich-text-editor/docs/RichTextContent.stories.tsx
@@ -1,0 +1,23 @@
+import React from "react"
+import { RichTextContent } from "@kaizen/rich-text-editor"
+import { CATEGORIES, SUB_CATEGORIES } from "../../../storybook/constants"
+import dummyContent from "./dummyContent.json"
+
+export default {
+  title: `${CATEGORIES.components}/${SUB_CATEGORIES.richTextEditor}/Rich Text Content`,
+  component: RichTextContent,
+  parameters: {
+    docs: {
+      description: {
+        component: 'import { RichTextContent } from "@kaizen/rich-text-editor"',
+      },
+    },
+  },
+}
+
+export const RichTextContentStory = args => <RichTextContent {...args} />
+
+RichTextContentStory.storyName = "Default"
+RichTextContentStory.args = {
+  content: dummyContent,
+}

--- a/packages/rich-text-editor/docs/RichTextEditor.stories.tsx
+++ b/packages/rich-text-editor/docs/RichTextEditor.stories.tsx
@@ -1,9 +1,10 @@
 import React, { useState } from "react"
 import { RichTextEditor, EditorContentArray } from "@kaizen/rich-text-editor"
-import { CATEGORIES } from "../../../storybook/constants"
+import { CATEGORIES, SUB_CATEGORIES } from "../../../storybook/constants"
+import dummyContent from "./dummyContent.json"
 
 export default {
-  title: `${CATEGORIES.components}/Rich Text Editor`,
+  title: `${CATEGORIES.components}/${SUB_CATEGORIES.richTextEditor}/Rich Text Editor`,
   component: RichTextEditor,
   parameters: {
     docs: {
@@ -15,15 +16,13 @@ export default {
 }
 
 export const Default = args => {
-  const [rteData, setRTEData] = useState<EditorContentArray>([])
+  const [rteData, setRTEData] = useState<EditorContentArray>(dummyContent)
   return (
-    <>
-      <RichTextEditor
-        value={rteData}
-        onChange={data => setRTEData(data)}
-        {...args}
-      />
-    </>
+    <RichTextEditor
+      value={rteData}
+      onChange={data => setRTEData(data)}
+      {...args}
+    />
   )
 }
 

--- a/packages/rich-text-editor/docs/ToggleIconButton.stories.tsx
+++ b/packages/rich-text-editor/docs/ToggleIconButton.stories.tsx
@@ -2,13 +2,17 @@ import React, { Children } from "react"
 import { Story } from "@storybook/react"
 import { withDesign } from "storybook-addon-designs"
 import boldIcon from "@kaizen/component-library/icons/bold.icon.svg"
-import { CATEGORIES, SUB_CATEGORIES } from "../../../storybook/constants"
+import {
+  CATEGORIES,
+  SUB_CATEGORIES,
+  SUB_COMPONENTS_FOLDER_NAME,
+} from "../../../storybook/constants"
 import { figmaEmbed } from "../../../storybook/helpers"
 import { ToggleIconButton, ToggleIconButtonProps } from "../"
 import { StoryWrapper } from "../../../storybook/components/StoryWrapper"
 
 export default {
-  title: `${CATEGORIES.components}/${SUB_CATEGORIES.richTextEditor}/Toggle Icon Button`,
+  title: `${CATEGORIES.components}/${SUB_CATEGORIES.richTextEditor}/${SUB_COMPONENTS_FOLDER_NAME}/Toggle Icon Button`,
   component: ToggleIconButton,
   parameters: {
     actions: {

--- a/packages/rich-text-editor/docs/Toolbar.stories.tsx
+++ b/packages/rich-text-editor/docs/Toolbar.stories.tsx
@@ -7,12 +7,16 @@ import bulletListIcon from "@kaizen/component-library/icons/bulletted-list.icon.
 import numberListIcon from "@kaizen/component-library/icons/numbered-list.icon.svg"
 import underlineIcon from "@kaizen/component-library/icons/underline.icon.svg"
 import linkIcon from "@kaizen/component-library/icons/add-link.icon.svg"
-import { CATEGORIES, SUB_CATEGORIES } from "../../../storybook/constants"
+import {
+  CATEGORIES,
+  SUB_CATEGORIES,
+  SUB_COMPONENTS_FOLDER_NAME,
+} from "../../../storybook/constants"
 import { figmaEmbed } from "../../../storybook/helpers"
 import { ToggleIconButton, Toolbar, ToolbarProps, ToolbarSection } from "../"
 
 export default {
-  title: `${CATEGORIES.components}/${SUB_CATEGORIES.richTextEditor}/Toolbar`,
+  title: `${CATEGORIES.components}/${SUB_CATEGORIES.richTextEditor}/${SUB_COMPONENTS_FOLDER_NAME}/Toolbar`,
   component: Toolbar,
   parameters: {
     actions: {

--- a/packages/rich-text-editor/docs/dummyContent.json
+++ b/packages/rich-text-editor/docs/dummyContent.json
@@ -1,0 +1,158 @@
+[
+  {
+    "type": "paragraph",
+    "content": [
+      {
+        "type": "text",
+        "marks": [{ "type": "strong" }],
+        "text": "Some notes I'd like to share in bold text:"
+      }
+    ]
+  },
+  {
+    "type": "bulletList",
+    "content": [
+      {
+        "type": "listItem",
+        "content": [
+          {
+            "type": "paragraph",
+            "content": [
+              { "type": "text", "text": "Note 1 " },
+              {
+                "type": "text",
+                "marks": [
+                  {
+                    "type": "link",
+                    "attrs": {
+                      "href": "https://cultureamp.design",
+                      "_metadata": null,
+                      "target": "_blank",
+                      "rel": "noreferrer"
+                    }
+                  }
+                ],
+                "text": "with link"
+              }
+            ]
+          },
+          {
+            "type": "bulletList",
+            "content": [
+              {
+                "type": "listItem",
+                "content": [
+                  {
+                    "type": "paragraph",
+                    "content": [{ "type": "text", "text": "Sub list item" }]
+                  },
+                  {
+                    "type": "bulletList",
+                    "content": [
+                      {
+                        "type": "listItem",
+                        "content": [
+                          {
+                            "type": "paragraph",
+                            "content": [
+                              { "type": "text", "text": "Sub-sub item" }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "type": "listItem",
+        "content": [
+          {
+            "type": "paragraph",
+            "content": [
+              { "type": "text", "text": "Another really " },
+              {
+                "type": "text",
+                "marks": [{ "type": "underline" }],
+                "text": "important note"
+              },
+              { "type": "text", "text": " " },
+              {
+                "type": "text",
+                "marks": [{ "type": "em" }],
+                "text": "(that I'd like to emphasise)"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "paragraph",
+    "content": [{ "type": "text", "text": "Additionally:" }]
+  },
+  {
+    "type": "orderedList",
+    "attrs": { "order": 1 },
+    "content": [
+      {
+        "type": "listItem",
+        "content": [
+          {
+            "type": "paragraph",
+            "content": [{ "type": "text", "text": "Point one" }]
+          },
+          {
+            "type": "orderedList",
+            "attrs": { "order": 1 },
+            "content": [
+              {
+                "type": "listItem",
+                "content": [
+                  {
+                    "type": "paragraph",
+                    "content": [{ "type": "text", "text": "Numbered sub item" }]
+                  },
+                  {
+                    "type": "orderedList",
+                    "attrs": { "order": 1 },
+                    "content": [
+                      {
+                        "type": "listItem",
+                        "content": [
+                          {
+                            "type": "paragraph",
+                            "content": [
+                              {
+                                "type": "text",
+                                "text": "Numbered sub-sub item"
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "type": "listItem",
+        "content": [
+          {
+            "type": "paragraph",
+            "content": [{ "type": "text", "text": "Point two" }]
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/packages/rich-text-editor/index.ts
+++ b/packages/rich-text-editor/index.ts
@@ -1,1 +1,5 @@
 export * from "./src/RichTextEditor"
+export * from "./src/RichTextContent"
+export * from "./src/EditableRichTextContent"
+export * from "./src/constants"
+export * from "./src/types"

--- a/packages/rich-text-editor/package.json
+++ b/packages/rich-text-editor/package.json
@@ -32,7 +32,8 @@
   "private": false,
   "license": "MIT",
   "dependencies": {
-    "@cultureamp/rich-text-toolkit": "^1.8.2",
+    "@cultureamp/rich-text-toolkit": "^1.8.3",
+    "@kaizen/a11y": "^1.4.11",
     "@kaizen/component-base": "^1.1.0",
     "@kaizen/component-library": "^15.0.3",
     "@kaizen/draft-form": "^7.2.14",

--- a/packages/rich-text-editor/src/EditableRichTextContent/EditableRichTextContent.scss
+++ b/packages/rich-text-editor/src/EditableRichTextContent/EditableRichTextContent.scss
@@ -1,0 +1,27 @@
+@import "@kaizen/design-tokens/sass/animation";
+@import "@kaizen/design-tokens/sass/border";
+@import "@kaizen/design-tokens/sass/color";
+@import "@kaizen/design-tokens/sass/spacing";
+
+.editableContainer :global(.ProseMirror) {
+  padding: $spacing-sm;
+  position: relative;
+  border-radius: $border-solid-border-radius;
+  border: $border-focus-ring-border-width $border-focus-ring-border-style
+    transparent;
+  transition: background-color $animation-duration-immediate,
+    border-color $animation-duration-immediate;
+}
+
+.editableContainer:hover :global(.ProseMirror) {
+  background-color: $color-gray-200;
+  border-color: $color-blue-500;
+}
+
+// Temporary solution for focus styling the content area
+// (the problem with this is that it shows this styling when focusing a link within the content
+.editableContainer:focus-within :global(.ProseMirror) {
+  background-color: $color-gray-200;
+  border: $border-focus-ring-border-width $border-focus-ring-border-style
+    $color-blue-500;
+}

--- a/packages/rich-text-editor/src/EditableRichTextContent/EditableRichTextContent.scss
+++ b/packages/rich-text-editor/src/EditableRichTextContent/EditableRichTextContent.scss
@@ -11,6 +11,7 @@
     transparent;
   transition: background-color $animation-duration-immediate,
     border-color $animation-duration-immediate;
+  background-color: $color-gray-200;
 }
 
 .editableContainer:hover :global(.ProseMirror) {

--- a/packages/rich-text-editor/src/EditableRichTextContent/EditableRichTextContent.tsx
+++ b/packages/rich-text-editor/src/EditableRichTextContent/EditableRichTextContent.tsx
@@ -1,0 +1,52 @@
+import React, { SyntheticEvent, HTMLAttributes } from "react"
+import classnames from "classnames"
+import { VisuallyHidden } from "@kaizen/a11y"
+import { OverrideClassName } from "@kaizen/component-base"
+import { Label } from "@kaizen/draft-form"
+import { EditorContentArray, RichTextContent } from "../../"
+import styles from "./EditableRichTextContent.scss"
+
+export interface EditableRichTextContentProps
+  extends OverrideClassName<Omit<HTMLAttributes<HTMLDivElement>, "onClick">> {
+  onClick: (event: SyntheticEvent<HTMLElement>) => void
+  content: EditorContentArray
+  labelText: string
+  isLabelHidden?: boolean
+}
+
+export const EditableRichTextContent: React.VFC<
+  EditableRichTextContentProps
+> = props => {
+  const {
+    onClick,
+    content,
+    classNameOverride,
+    labelText,
+    isLabelHidden = false,
+    ...restProps
+  } = props
+
+  return (
+    <>
+      {!isLabelHidden && <Label labelText={labelText} />}
+      {/* Disabling these a11y linting errors because there is a <button> that mitigates these concerns. The onClick here is just an additional layer. */}
+      {/* eslint-disable-next-line jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events */}
+      <div
+        onClick={onClick}
+        className={classnames(styles.editableContainer, classNameOverride)}
+        {...restProps}
+      >
+        <VisuallyHidden>
+          <button
+            type="button"
+            onClick={onClick}
+            aria-label={`Edit ${labelText}`}
+          />
+        </VisuallyHidden>
+        <RichTextContent content={content} />
+      </div>
+    </>
+  )
+}
+
+EditableRichTextContent.displayName = "EditableRichTextContent"

--- a/packages/rich-text-editor/src/EditableRichTextContent/EditableRichTextContent.tsx
+++ b/packages/rich-text-editor/src/EditableRichTextContent/EditableRichTextContent.tsx
@@ -1,4 +1,4 @@
-import React, { SyntheticEvent, HTMLAttributes } from "react"
+import React, { MouseEvent, HTMLAttributes } from "react"
 import classnames from "classnames"
 import { VisuallyHidden } from "@kaizen/a11y"
 import { OverrideClassName } from "@kaizen/component-base"
@@ -8,7 +8,7 @@ import styles from "./EditableRichTextContent.scss"
 
 export interface EditableRichTextContentProps
   extends OverrideClassName<Omit<HTMLAttributes<HTMLDivElement>, "onClick">> {
-  onClick: (event: SyntheticEvent<HTMLElement>) => void
+  onClick: (event: MouseEvent<HTMLElement>) => void
   content: EditorContentArray
   labelText: string
   isLabelHidden?: boolean

--- a/packages/rich-text-editor/src/EditableRichTextContent/index.ts
+++ b/packages/rich-text-editor/src/EditableRichTextContent/index.ts
@@ -1,0 +1,1 @@
+export * from "./EditableRichTextContent"

--- a/packages/rich-text-editor/src/RichTextContent/RichTextContent.scss
+++ b/packages/rich-text-editor/src/RichTextContent/RichTextContent.scss
@@ -1,0 +1,5 @@
+@import "../mixins";
+
+.content > :global(.ProseMirror) {
+  @include contentStyles;
+}

--- a/packages/rich-text-editor/src/RichTextContent/RichTextContent.tsx
+++ b/packages/rich-text-editor/src/RichTextContent/RichTextContent.tsx
@@ -1,0 +1,43 @@
+import React, { useState, HTMLAttributes } from "react"
+import classnames from "classnames"
+import { EditorState } from "prosemirror-state"
+import { useRichTextEditor } from "@cultureamp/rich-text-toolkit"
+import { OverrideClassName } from "@kaizen/component-base"
+import { Node, Schema } from "prosemirror-model"
+import { EditorContentArray } from "../types"
+import { createSchemaWithAll } from "../RichTextEditor/schema"
+import styles from "./RichTextContent.scss"
+
+interface RichTextContentProps
+  extends OverrideClassName<HTMLAttributes<HTMLDivElement>> {
+  content: EditorContentArray
+}
+
+export const RichTextContent = (props: RichTextContentProps) => {
+  const { content, classNameOverride, ...restProps } = props
+  const [schema] = useState<Schema>(createSchemaWithAll())
+
+  const [editorRef] = useRichTextEditor(
+    EditorState.create({
+      doc: Node.fromJSON(schema, {
+        type: "doc",
+        content,
+      }),
+      schema,
+    }),
+    undefined,
+    {
+      editable: false,
+    }
+  )
+
+  return (
+    <div
+      ref={editorRef}
+      className={classnames(styles.content, classNameOverride)}
+      {...restProps}
+    />
+  )
+}
+
+RichTextContent.displayName = "RichTextContent"

--- a/packages/rich-text-editor/src/RichTextContent/index.ts
+++ b/packages/rich-text-editor/src/RichTextContent/index.ts
@@ -1,0 +1,1 @@
+export * from "./RichTextContent"

--- a/packages/rich-text-editor/src/RichTextEditor/RichTextEditor.scss
+++ b/packages/rich-text-editor/src/RichTextEditor/RichTextEditor.scss
@@ -3,50 +3,15 @@
 @import "@kaizen/design-tokens/sass/color";
 @import "@kaizen/design-tokens/sass/spacing";
 @import "@kaizen/design-tokens/sass/typography";
-
-@mixin nestedListStyles {
-  ol {
-    list-style-type: decimal;
-    ol {
-      list-style-type: lower-alpha;
-      ol {
-        list-style-type: lower-roman;
-        @content;
-      }
-    }
-  }
-  ul {
-    list-style-type: disc;
-    ul {
-      list-style-type: circle;
-      ul {
-        list-style-type: square;
-        @content;
-      }
-    }
-  }
-}
+@import "../mixins";
 
 .editor > :global(.ProseMirror) {
+  @include contentStyles;
   border-radius: $border-solid-border-radius;
-  font-family: $typography-paragraph-body-font-family;
-  font-weight: $typography-paragraph-body-font-weight;
-  font-size: $typography-paragraph-body-font-size;
-  line-height: $typography-paragraph-body-line-height;
-  letter-spacing: $typography-paragraph-body-letter-spacing;
   padding: $spacing-sm calc(#{$spacing-xs} * 3);
   position: relative;
   transition: background-color $animation-duration-immediate,
     border-color $animation-duration-immediate;
-  white-space: pre-wrap;
-
-  > p {
-    margin: 0 0 $spacing-sm;
-  }
-
-  > p:last-child {
-    margin-bottom: 0;
-  }
 
   &:hover,
   &:focus {
@@ -73,10 +38,6 @@
     left: calc(-1 * #{$focus-ring-offset});
     right: calc(-1 * #{$focus-ring-offset});
     bottom: calc(-1 * #{$focus-ring-offset});
-  }
-
-  @include nestedListStyles {
-    @include nestedListStyles;
   }
 }
 

--- a/packages/rich-text-editor/src/RichTextEditor/RichTextEditor.spec.tsx
+++ b/packages/rich-text-editor/src/RichTextEditor/RichTextEditor.spec.tsx
@@ -2,7 +2,8 @@ import React, { useState } from "react"
 import { render, screen, fireEvent, waitFor } from "@testing-library/react"
 import "@testing-library/jest-dom"
 import userEvent from "@testing-library/user-event"
-import { RichTextEditor, EditorContentArray } from "./"
+import { EditorContentArray } from "../types"
+import { RichTextEditor } from "./"
 
 // This helper is needed to simulate selection of a component since we
 // cannot userEvent.type with contenteditable

--- a/packages/rich-text-editor/src/RichTextEditor/RichTextEditor.tsx
+++ b/packages/rich-text-editor/src/RichTextEditor/RichTextEditor.tsx
@@ -12,7 +12,7 @@ import {
   createLinkManager,
 } from "@cultureamp/rich-text-toolkit"
 import { OverrideClassName } from "@kaizen/component-base"
-import { EditorContentArray, EditorRows } from "./types"
+import { ToolbarItems, EditorContentArray, EditorRows } from "../types"
 import { createSchemaFromControls } from "./schema"
 import { buildKeymap } from "./keymap"
 import { buildControlMap } from "./controlmap"
@@ -20,20 +20,7 @@ import { buildInputRules } from "./inputrules"
 import styles from "./RichTextEditor.scss"
 import { Toolbar, ToolbarSection, ToggleIconButton } from "./"
 
-export type ToolbarControlTypes =
-  | "bold"
-  | "italic"
-  | "underline"
-  | "orderedList"
-  | "bulletList"
-  | "link"
-
-export interface ToolbarItems {
-  name: ToolbarControlTypes
-  group?: string
-}
-
-interface BaseRichTextEditorProps
+export interface BaseRichTextEditorProps
   extends OverrideClassName<Omit<HTMLAttributes<HTMLDivElement>, "onChange">> {
   onChange: (content: EditorContentArray) => void
   value: EditorContentArray

--- a/packages/rich-text-editor/src/RichTextEditor/controlmap.ts
+++ b/packages/rich-text-editor/src/RichTextEditor/controlmap.ts
@@ -12,7 +12,7 @@ import { Schema, NodeType, MarkType } from "prosemirror-model"
 import { Command, toggleMark } from "prosemirror-commands"
 import { wrapInList, liftListItem, sinkListItem } from "prosemirror-schema-list"
 import { markIsActive } from "@cultureamp/rich-text-toolkit"
-import { ToolbarItems, ToolbarControlTypes } from "./RichTextEditor"
+import { ToolbarItems, ToolbarControlTypes } from "../types"
 
 type ToolbarControl = {
   icon: React.SVGAttributes<SVGSymbolElement>

--- a/packages/rich-text-editor/src/RichTextEditor/index.ts
+++ b/packages/rich-text-editor/src/RichTextEditor/index.ts
@@ -1,5 +1,4 @@
 export * from "./RichTextEditor"
-export * from "./types"
 export * from "./components/ToggleIconButton"
 export * from "./components/Toolbar"
 export * from "./components/ToolbarSection"

--- a/packages/rich-text-editor/src/RichTextEditor/schema.ts
+++ b/packages/rich-text-editor/src/RichTextEditor/schema.ts
@@ -3,7 +3,8 @@ import {
   nodes as coreNodes,
   marks as coreMarks,
 } from "@cultureamp/rich-text-toolkit"
-import { ToolbarItems } from "./RichTextEditor"
+import { TOOLBAR_CONTROLS } from "../constants"
+import { ToolbarItems, ToolbarControlTypes } from "../types"
 
 export const defaultNodes: NodeSpec = {
   doc: coreNodes.doc,
@@ -12,45 +13,52 @@ export const defaultNodes: NodeSpec = {
   hardBreak: coreNodes.hardBreak,
 }
 
-export const createSchemaFromControls = (
-  controls: ToolbarItems[] | undefined
-) => {
+export const createSchemaFromControls = (controls?: ToolbarItems[]) => {
+  if (!controls) {
+    return createSchema()
+  }
+
+  const namesFromControls = controls.reduce(
+    (acc: string[], c: ToolbarItems) => [...acc, c.name],
+    []
+  ) as ToolbarControlTypes[]
+  return createSchema(namesFromControls)
+}
+export const createSchemaWithAll = () => createSchema(TOOLBAR_CONTROLS)
+
+function createSchema(controls?: ToolbarControlTypes[]) {
   if (!controls) {
     return new Schema({
       nodes: defaultNodes,
     })
   }
 
-  const allControlNames: string[] = controls.reduce(
-    (acc: string[], c: ToolbarItems) => [...acc, c.name],
-    []
-  )
   const newNodes = { ...defaultNodes }
   const newMarks = {}
 
-  if (allControlNames.includes("bold")) {
+  if (controls.includes("bold")) {
     newMarks["strong"] = coreMarks.strong
   }
 
-  if (allControlNames.includes("italic")) {
+  if (controls.includes("italic")) {
     newMarks["em"] = coreMarks.em
   }
 
-  if (allControlNames.includes("underline")) {
+  if (controls.includes("underline")) {
     newMarks["underline"] = coreMarks.underline
   }
 
-  if (allControlNames.includes("bulletList")) {
+  if (controls.includes("bulletList")) {
     newNodes["bulletList"] = coreNodes.bulletList
     newNodes["listItem"] = coreNodes.listItem
   }
 
-  if (allControlNames.includes("orderedList")) {
+  if (controls.includes("orderedList")) {
     newNodes["orderedList"] = coreNodes.orderedList
     newNodes["listItem"] = coreNodes.listItem
   }
 
-  if (allControlNames.includes("link")) {
+  if (controls.includes("link")) {
     newMarks["link"] = coreMarks.link
   }
 

--- a/packages/rich-text-editor/src/_mixins.scss
+++ b/packages/rich-text-editor/src/_mixins.scss
@@ -18,6 +18,12 @@
     margin-bottom: 0;
   }
 
+  @include nestedListStyles {
+    @include nestedListStyles;
+  }
+}
+
+@mixin nestedListStyles {
   ol {
     list-style-type: decimal;
     ol {

--- a/packages/rich-text-editor/src/_mixins.scss
+++ b/packages/rich-text-editor/src/_mixins.scss
@@ -1,0 +1,41 @@
+@import "@kaizen/design-tokens/sass/spacing";
+@import "@kaizen/design-tokens/sass/typography";
+
+@mixin contentStyles {
+  font-family: $typography-paragraph-body-font-family;
+  font-weight: $typography-paragraph-body-font-weight;
+  font-size: $typography-paragraph-body-font-size;
+  line-height: $typography-paragraph-body-line-height;
+  letter-spacing: $typography-paragraph-body-letter-spacing;
+  position: relative;
+  white-space: pre-wrap;
+
+  > p {
+    margin: 0 0 $spacing-sm;
+  }
+
+  > p:last-child {
+    margin-bottom: 0;
+  }
+
+  ol {
+    list-style-type: decimal;
+    ol {
+      list-style-type: lower-alpha;
+      ol {
+        list-style-type: lower-roman;
+        @content;
+      }
+    }
+  }
+  ul {
+    list-style-type: disc;
+    ul {
+      list-style-type: circle;
+      ul {
+        list-style-type: square;
+        @content;
+      }
+    }
+  }
+}

--- a/packages/rich-text-editor/src/constants.ts
+++ b/packages/rich-text-editor/src/constants.ts
@@ -1,0 +1,10 @@
+import { ToolbarControlTypes } from "./types"
+
+export const TOOLBAR_CONTROLS: ToolbarControlTypes[] = [
+  "bold",
+  "italic",
+  "underline",
+  "orderedList",
+  "bulletList",
+  "link",
+]

--- a/packages/rich-text-editor/src/types.ts
+++ b/packages/rich-text-editor/src/types.ts
@@ -1,3 +1,16 @@
+export type ToolbarControlTypes =
+  | "bold"
+  | "italic"
+  | "underline"
+  | "orderedList"
+  | "bulletList"
+  | "link"
+
+export interface ToolbarItems {
+  name: ToolbarControlTypes
+  group?: string
+}
+
 export type EditorContentArray = Array<{ [key: string]: any }>
 
 export type EditorRows =

--- a/storybook/constants.ts
+++ b/storybook/constants.ts
@@ -17,3 +17,5 @@ export const SUB_CATEGORIES = {
   loadingSkeleton: "Loading Skeleton",
   datePicker: "Date Picker",
 }
+
+export const SUB_COMPONENTS_FOLDER_NAME = "Subcomponents"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1681,10 +1681,10 @@
   resolved "https://registry.yarnpkg.com/@csstools/selector-specificity/-/selector-specificity-2.0.1.tgz#b6b8d81780b9a9f6459f4bfe9226ac6aefaefe87"
   integrity sha512-aG20vknL4/YjQF9BSV7ts4EWm/yrjagAN7OWBNmlbEOUiu0llj4OGrFoOKK3g2vey4/p2omKCoHrWtPxSwV3HA==
 
-"@cultureamp/rich-text-toolkit@^1.8.2":
-  version "1.8.2"
-  resolved "https://npm.pkg.github.com/download/@cultureamp/rich-text-toolkit/1.8.2/f82bad10aceff2115e62d0da613d707edb9e45f24a5bfd80d47abd398c61b98f#1e8ea5432171d7af853f590ca1689843a9eb050f"
-  integrity sha512-3kS36xrF/UNdpJ4ZXZ8S5nb63J/dt3lj6m/p87GwQTdG2o0PNiieRKhPkLRG+ZoB13MBt4cN0Vv1OA1fbC9Vig==
+"@cultureamp/rich-text-toolkit@^1.8.3":
+  version "1.8.3"
+  resolved "https://npm.pkg.github.com/download/@cultureamp/rich-text-toolkit/1.8.3/dc78190eb66878f8360bb54ef8e4b88919256f2b8ce477605337d246acccb0da#6b5e98f7024cc62f544d82c371ac894307da90c9"
+  integrity sha512-yg27FWkLppCBzCANDn1wDwcH9lS2+fPhbErlMs0mAY3BB42gEpZwpjwepXWEuakwrf5Z1lXTbFABtWMqr/Bm0A==
   dependencies:
     "@kaizen/button" "^1.2.8"
     "@kaizen/component-library" "^14.3.4"


### PR DESCRIPTION
## What
Creates two new components in the `@kaizen/rich-text-editor` package.

**`RichTextContent`**
Renders content created from the `RichTextEditor`. Creates a schema that includes all of our possible features/controls.

**`EditableRichTextContent`**
Renders the content with some styling and accessibility built in. Adds hover and focus styling, and a visually hidden button.

Smaller changes:
* Created some demo rich text data for our stories
* Moved `Toolbar` and `ToggleIconButton` into a `Subcomponents` subfolder on Storybook
* Moved all of the common styling rules for our content (things like typography and list styling) into a single mixin that is applied to both the editor and content.
* Created a constant array with our possible control names, to make it easy to generate a schema with *everything* for the content component.
* Moved some stuff out of the `RichTextEditor` folder into the `src` folder so that it can used across multiple components.

### Known issues
* I have done a temporary solution for the focus styling of the editable content area. Currently, when you're focused on a link inside the content area, you will see the focus indicator for the content area as well. I'll be following up with an adjustment for this.
* When clicking a link inside of the editable content wrapper, the event bubbles up and the onClick of the editable wrapper is triggered.

Both of these things will be fixed in a follow up.

## Why
Our teams need a way of rendering the content that's created with our RTE component, and this gives them an easy way to do that.

We've also seen the requirement for the pattern built here where the content is a clickable area, which will allow a user to switch to editing the content.
