### PR TITLE
feat: update secondary select styles

### DIFF
--- a/draft-packages/select/KaizenDraft/Select/Select.tsx
+++ b/draft-packages/select/KaizenDraft/Select/Select.tsx
@@ -98,7 +98,7 @@ export const Select = React.forwardRef<any, SelectProps>((props, ref) => {
   })
   return (
     <>
-      {label ? <Label>{label}</Label> : null}
+      {label ? <Label reversed={reversed}>{label}</Label> : null}
       <ReactSelect
         {...props}
         ref={ref}
@@ -170,7 +170,7 @@ const Control: typeof components.Control = props => (
 )
 
 const Placeholder: typeof components.Placeholder = props => (
-  <components.Placeholder {...props}>
+  <components.Placeholder {...props} className={styles.placeholderOverrides}>
     <span className={styles.placeholder}>{props.children}</span>
   </components.Placeholder>
 )

--- a/draft-packages/select/KaizenDraft/Select/styles.react.scss
+++ b/draft-packages/select/KaizenDraft/Select/styles.react.scss
@@ -207,6 +207,10 @@ $focus-border-color: $color-blue-500;
           border-color: $secondary-reversed-focus-color;
         }
       }
+
+      .placeholder {
+        color: $color-white;
+      }
     }
   }
 
@@ -305,7 +309,9 @@ $focus-border-color: $color-blue-500;
       max-width: 100%;
       padding-right: 30px;
     }
-
+    .placeholderOverrides {
+      padding-right: 30px;
+    }
     .singleValue {
       max-width: 100%;
     }


### PR DESCRIPTION
## Why
<!-- Why have you created this PR? - Is it a new feature, or a bug fix? Or something else? -->
<!-- Reference any relevant Jira tickets so your reviewer can find more context if needed. -->
<!-- Fixing a GitHub issue? Add "Fixes [issue URL]". -->
Secondary placeholder was missing padding and reversed styles.

## What
<!-- What do your changes do? How do they change/fix the current behavior? -->
<!-- Add screenshots, GIFs or videos to illustrate the changes.  -->
- Add padding to placeholder
- Add reversed colour to placeholder and label when reversed.
