### PR TITLE
chore: upgrade toolkit to latest version

### DIFF
--- a/packages/rich-text-editor/package.json
+++ b/packages/rich-text-editor/package.json
@@ -32,7 +32,7 @@
   "private": false,
   "license": "MIT",
   "dependencies": {
-    "@cultureamp/rich-text-toolkit": "^1.8.3",
+    "@cultureamp/rich-text-toolkit": "^1.9.0",
     "@kaizen/a11y": "^1.4.11",
     "@kaizen/component-base": "^1.1.0",
     "@kaizen/component-library": "^15.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1681,10 +1681,10 @@
   resolved "https://registry.yarnpkg.com/@csstools/selector-specificity/-/selector-specificity-2.0.1.tgz#b6b8d81780b9a9f6459f4bfe9226ac6aefaefe87"
   integrity sha512-aG20vknL4/YjQF9BSV7ts4EWm/yrjagAN7OWBNmlbEOUiu0llj4OGrFoOKK3g2vey4/p2omKCoHrWtPxSwV3HA==
 
-"@cultureamp/rich-text-toolkit@^1.8.3":
-  version "1.8.3"
-  resolved "https://npm.pkg.github.com/download/@cultureamp/rich-text-toolkit/1.8.3/dc78190eb66878f8360bb54ef8e4b88919256f2b8ce477605337d246acccb0da#6b5e98f7024cc62f544d82c371ac894307da90c9"
-  integrity sha512-yg27FWkLppCBzCANDn1wDwcH9lS2+fPhbErlMs0mAY3BB42gEpZwpjwepXWEuakwrf5Z1lXTbFABtWMqr/Bm0A==
+"@cultureamp/rich-text-toolkit@^1.9.0":
+  version "1.9.0"
+  resolved "https://npm.pkg.github.com/download/@cultureamp/rich-text-toolkit/1.9.0/51e486832fcc2802940e694e022dc83401d7e4bca1713f144f83877b420b7036#7fbbc4312a304e974d3e4610e9b3855acfa40f4f"
+  integrity sha512-novOW/V8WvZgjL2u97PLvhMFhNh+U2gwJY2xjv9/Y8Yz4FQQAGQ6a6fBbAVYfa1CUo1oIV1clIMMhAguh6mpmA==
   dependencies:
     "@kaizen/button" "^1.2.8"
     "@kaizen/component-library" "^14.3.4"


### PR DESCRIPTION
## Why
- latest version updates link validation


## What
- updates `@cultureamp/rich-text-toolkit` v1.8 to v1.9
