### PR TITLE
fix: export RichTextContentProps to fix compiler breaking

### DIFF
--- a/packages/rich-text-editor/src/RichTextContent/RichTextContent.tsx
+++ b/packages/rich-text-editor/src/RichTextContent/RichTextContent.tsx
@@ -8,7 +8,7 @@ import { EditorContentArray } from "../types"
 import { createSchemaWithAll } from "../RichTextEditor/schema"
 import styles from "./RichTextContent.scss"
 
-interface RichTextContentProps
+export interface RichTextContentProps
   extends OverrideClassName<HTMLAttributes<HTMLDivElement>> {
   content: EditorContentArray
 }


### PR DESCRIPTION
## Why
To resolve a broken build, [see thread](https://cultureamp.slack.com/archives/C02NUQ27G56/p1658287850617659) for the full context.

<img width="875" alt="image (6)" src="https://user-images.githubusercontent.com/36558508/180104801-3d9d5a4d-f71e-46fe-b8b9-ab0e432b73da.png">

## What
- export RichTextContentProps interface from RichTextContent component