### PR TITLE
chore(plopjs): update stories template default story name

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -222,3 +222,15 @@ Remember to always check the CHANGELOG (e.g. [`/packages/component-library/CHANG
 ## Contributing components
 
 To learn more about contributing components, see the [Kaizen Site: components overview](https://cultureamp.design/components/overview).
+
+### Patterns
+
+Refer to the [docs folder](docs) for code guidelines and patterns.
+
+### Component generator
+
+To generate a new component and package, new component within an existing package, or a subcomponent,
+run the following command and follow the prompts:
+```
+yarn plop
+```

--- a/README.md
+++ b/README.md
@@ -69,9 +69,11 @@ Command | Summary
 :- | :-
 `yarn storybook` | Develop components locally using Storybook
 `STORIES=path/to/package yarn storybook` | Develop just one package at a time using Storybook (builds faster!)
+`yarn commit` | Use commitizen to help you write your conventional commits
 `yarn compile` | Run all typechecks
 `yarn lint` | Run all linters
 `yarn lint:fix` | Run all linters, fixing violations
+`yarn plop` | Add a new component/subcomponent
 `yarn test` | Run all tests (using [Jest](https://jestjs.io/))
 `yarn reset` | Reinstall all dependencies
 

--- a/plop-templates/basic-component/docs/{{pascalCase componentName}}.stories.tsx.hbs
+++ b/plop-templates/basic-component/docs/{{pascalCase componentName}}.stories.tsx.hbs
@@ -21,8 +21,8 @@ export default {
   decorators: [withDesign],
 } as ComponentMeta<typeof {{pascalCase componentName}}>
 
-export const DefaultKaizenSiteDemo: ComponentStory<typeof {{pascalCase componentName}}> = args => <{{pascalCase componentName}} {...args} />
-DefaultKaizenSiteDemo.storyName = "{{pascalCase componentName}}"
+export const DefaultStory: ComponentStory<typeof {{pascalCase componentName}}> = args => <{{pascalCase componentName}} {...args} />
+DefaultStory.storyName = "{{pascalCase componentName}}"
 
 const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({
   isReversed,


### PR DESCRIPTION
## What

- Update plop template for stories to change `DefaultKaizenSiteDemo` to `DefaultStory`
- Update README `Package Scripts` to include `yarn commit` and `yarn plop`
- Update contributing docs to mention component generator and recipe docs

## Why

Kevin mentioned that it would be worth documenting about the existence of the component generator in more places to be more discoverable.