### PR TITLE
refactor: remove deprecated styles from Tag component

### DIFF
--- a/draft-packages/tag/KaizenDraft/Tag/Tag.scss
+++ b/draft-packages/tag/KaizenDraft/Tag/Tag.scss
@@ -57,6 +57,11 @@ $small: $spacing-md;
 
 .textContent {
   margin-top: -1px;
+  font-family: $typography-paragraph-small-font-family;
+  font-weight: $typography-paragraph-small-font-weight;
+  font-size: $typography-paragraph-small-font-size;
+  line-height: $typography-paragraph-small-line-height;
+  letter-spacing: $typography-paragraph-small-letter-spacing;
   white-space: nowrap;
 }
 
@@ -67,14 +72,10 @@ $small: $spacing-md;
   height: 100%;
   align-items: center;
   padding: 0 $spacing-xs;
-  margin-right: -0.6625rem;
-  margin-left: -0.225rem;
+  margin-inline-end: -0.6625rem;
+  margin-inline-start: -0.225rem;
   color: rgba($color-purple-800-rgb, 0.7);
   cursor: pointer;
-  [dir="rtl"] & {
-    margin-left: -0.6625rem;
-    margin-right: -0.225rem;
-  }
 
   &:hover {
     color: $color-purple-800;

--- a/draft-packages/tag/KaizenDraft/Tag/Tag.scss
+++ b/draft-packages/tag/KaizenDraft/Tag/Tag.scss
@@ -2,7 +2,6 @@
 @import "~@kaizen/design-tokens/sass/color";
 @import "~@kaizen/design-tokens/sass/typography";
 @import "~@kaizen/design-tokens/sass/spacing";
-@import "~@kaizen/deprecated-component-library-helpers/styles/layout";
 
 $medium: calc(#{$spacing-md} * 1.25);
 $small: $spacing-md;
@@ -15,11 +14,11 @@ $small: $spacing-md;
   font: inherit;
   margin: 0;
   padding: 0;
-  transition: none; // override Murmur global styles :(
+  transition: none;
 }
 
 .root {
-  @include ca-margin($end: calc(#{$spacing-md} * 0.5));
+  margin-inline-end: calc(#{$spacing-md} * 0.5);
   font-size: $typography-paragraph-small-font-size;
   font-weight: $typography-paragraph-small-font-weight;
   letter-spacing: $typography-paragraph-small-letter-spacing;
@@ -43,20 +42,20 @@ $small: $spacing-md;
 }
 
 .validationIcon {
-  @include ca-margin($start: calc(#{$spacing-md} * -0.15), $end: $spacing-xs);
-  display: flex;
   align-items: center;
+  display: flex;
+  margin-inline-start: calc(#{$spacing-md} * -0.15);
+  margin-inline-end: $spacing-xs;
 }
 
 .profile {
-  @include ca-margin($start: calc(#{$spacing-md} * -0.15), $end: $spacing-xs);
+  margin-inline-start: calc(#{$spacing-md} * -0.15);
+  margin-inline-end: $spacing-xs;
   display: flex;
   align-items: center;
 }
 
 .textContent {
-  @include kz-typography-paragraph-small;
-  @include ca-inherit-baseline;
   margin-top: -1px;
   white-space: nowrap;
 }
@@ -232,10 +231,8 @@ $pulse-ring-position: calc(
 );
 
 .pulse {
-  @include ca-margin(
-    $start: calc(#{$spacing-md} * 0.35),
-    $end: calc(#{$spacing-md} * 0.15)
-  );
+  margin-inline-start: calc(#{$spacing-md} * 0.35);
+  margin-inline-end: calc(#{$spacing-md} * 0.15);
   width: $pulse-size-initial;
   height: $pulse-size-initial;
   border-radius: 50%;

--- a/draft-packages/tag/KaizenDraft/Tag/Tag.tsx
+++ b/draft-packages/tag/KaizenDraft/Tag/Tag.tsx
@@ -1,6 +1,5 @@
 import { Icon } from "@kaizen/component-library"
 import { Avatar, AvatarProps } from "@kaizen/draft-avatar"
-import { Paragraph } from "@kaizen/typography"
 import classNames from "classnames"
 import * as React from "react"
 import clearIcon from "@kaizen/component-library/icons/clear-white.icon.svg"
@@ -134,10 +133,8 @@ const Tag = (props: TagProps) => {
                 return
             }
           })()}
-        <Paragraph
-          variant="small"
-          tag="span"
-          classNameOverride={classNames(styles.textContent, {
+        <span
+          className={classNames(styles.textContent, {
             [styles.truncate]: isTruncated,
           })}
           style={{
@@ -145,7 +142,7 @@ const Tag = (props: TagProps) => {
           }}
         >
           {children}
-        </Paragraph>
+        </span>
         {dismissible && (
           <>
             <button

--- a/draft-packages/tag/KaizenDraft/Tag/Tag.tsx
+++ b/draft-packages/tag/KaizenDraft/Tag/Tag.tsx
@@ -1,5 +1,6 @@
 import { Icon } from "@kaizen/component-library"
 import { Avatar, AvatarProps } from "@kaizen/draft-avatar"
+import { Paragraph } from "@kaizen/typography"
 import classNames from "classnames"
 import * as React from "react"
 import clearIcon from "@kaizen/component-library/icons/clear-white.icon.svg"
@@ -133,8 +134,10 @@ const Tag = (props: TagProps) => {
                 return
             }
           })()}
-        <span
-          className={classNames(styles.textContent, {
+        <Paragraph
+          variant="small"
+          tag="span"
+          classNameOverride={classNames(styles.textContent, {
             [styles.truncate]: isTruncated,
           })}
           style={{
@@ -142,7 +145,7 @@ const Tag = (props: TagProps) => {
           }}
         >
           {children}
-        </span>
+        </Paragraph>
         {dismissible && (
           <>
             <button

--- a/draft-packages/tag/package.json
+++ b/draft-packages/tag/package.json
@@ -33,9 +33,8 @@
   "license": "MIT",
   "dependencies": {
     "@kaizen/component-library": "^15.0.4",
-    "@kaizen/deprecated-component-library-helpers": "^2.5.6",
+    "@kaizen/typography": "^2.2.3",
     "@kaizen/draft-avatar": "^2.7.12",
-    "@types/classnames": "^2.3.0",
     "classnames": "^2.3.1"
   },
   "devDependencies": {

--- a/draft-packages/tag/package.json
+++ b/draft-packages/tag/package.json
@@ -33,7 +33,6 @@
   "license": "MIT",
   "dependencies": {
     "@kaizen/component-library": "^15.0.4",
-    "@kaizen/typography": "^2.2.3",
     "@kaizen/draft-avatar": "^2.7.12",
     "classnames": "^2.3.1"
   },


### PR DESCRIPTION
## Why
To remove dependency on old deprecate library helpers - [see ticket ](https://cultureamp.atlassian.net/browse/KDS-570) and [original discovery](https://cultureamp.atlassian.net/browse/KDS-548)

## What
- replaces style dependent on `deprecated-component-library-helpers` with design tokens and modern CSS
- remove redundant @types/classname from package.json dependency 
