### PR TITLE
refactor: add flex wrap to toolbar section

### DIFF
--- a/packages/rich-text-editor/src/RichTextEditor/components/ToolbarSection/ToolbarSection.scss
+++ b/packages/rich-text-editor/src/RichTextEditor/components/ToolbarSection/ToolbarSection.scss
@@ -7,6 +7,7 @@
   gap: $spacing-xs;
   margin: $spacing-xs 0;
   padding: 0 $spacing-xs;
+  flex-wrap: wrap;
 }
 
 .toolbarSection + .toolbarSection {


### PR DESCRIPTION
## Why
There is an overlap of the buttons on smaller screens. Since this will still be wrapping within each Section each individual button won't be bump each other but will break across multiple lines (see video for reference). After time boxing an alternative solution to remove section wrapper and try to use a divider or lastItem class between the sections, I opted to push this change up first to deal with the bug. The alternatives solutions will likely take more (though worthwhile investigating in the future).

https://user-images.githubusercontent.com/36558508/180934363-c9dcee07-53c0-4243-adac-21f6d58a40a4.mp4

## What
- this adds a simple flex wrap on the sections

## Additional note
There is currently an additional section wrapper that is being created in the controlMap but I will address this in a different PR