### PR TITLE
fix(rte): fix bug where long strings overflow editor

### DIFF
--- a/packages/rich-text-editor/src/RichTextEditor/RichTextEditor.scss
+++ b/packages/rich-text-editor/src/RichTextEditor/RichTextEditor.scss
@@ -51,6 +51,7 @@
   border: $border-solid-border-width $border-solid-border-style $color-gray-500;
   background: $color-white;
   border-radius: $border-solid-border-radius;
+  word-wrap: break-word;
 }
 
 @for $i from 1 through 20 {


### PR DESCRIPTION
Fixes an issue where a long, unbroken string will overflow the editor. This fix makes it wrap to a new line.