### PR TITLE
feat(likert-scale-legacy): add validation message support

### DIFF
--- a/draft-packages/likert-scale-legacy/KaizenDraft/LikertScaleLegacy/LikertScaleLegacy.spec.tsx
+++ b/draft-packages/likert-scale-legacy/KaizenDraft/LikertScaleLegacy/LikertScaleLegacy.spec.tsx
@@ -1,0 +1,76 @@
+import React from "react"
+import { render, screen } from "@testing-library/react"
+import "@testing-library/jest-dom"
+
+import { LikertScaleLegacy, LikertScaleProps } from "./LikertScaleLegacy"
+import { Scale } from "./types"
+
+const scale: Scale = [
+  {
+    value: -1,
+    label: "Not rated",
+  },
+  {
+    value: 1,
+    label: "Strong Disagree",
+  },
+  {
+    value: 2,
+    label: "Disagree",
+  },
+  {
+    value: 3,
+    label: "Neither agree or disagree",
+  },
+  {
+    value: 4,
+    label: "Agree",
+  },
+  {
+    value: 5,
+    label: "Strongly agree",
+  },
+]
+
+const LikertScaleLegacyWrapper = (props: Partial<LikertScaleProps>) => (
+  <LikertScaleLegacy
+    scale={scale}
+    labelId="test__likert-scale"
+    selectedItem={null}
+    onSelect={() => undefined}
+    {...props}
+  />
+)
+
+describe("<TextField />", () => {
+  it("shows a validation message when provided and status is error", () => {
+    render(
+      <LikertScaleLegacyWrapper
+        validationMessage="This is an error"
+        status="error"
+      />
+    )
+
+    expect(screen.getByText("This is an error")).toBeVisible
+
+    expect(
+      screen.getByRole("radiogroup", {
+        description: "Error message This is an error",
+      })
+    ).toBeInTheDocument
+  })
+
+  it("does not show a validation message when provided and status is default", () => {
+    render(
+      <LikertScaleLegacyWrapper
+        validationMessage="This is an error"
+        status="default"
+      />
+    )
+    expect(
+      screen.getByRole("radiogroup", {
+        description: undefined,
+      })
+    ).toBeInTheDocument
+  })
+})

--- a/draft-packages/likert-scale-legacy/KaizenDraft/LikertScaleLegacy/LikertScaleLegacy.tsx
+++ b/draft-packages/likert-scale-legacy/KaizenDraft/LikertScaleLegacy/LikertScaleLegacy.tsx
@@ -1,6 +1,7 @@
 import React, { useState, createRef } from "react"
 import classnames from "classnames"
 import { Paragraph } from "@kaizen/typography"
+import { FieldMessage } from "@kaizen/draft-form"
 import determineSelectionFromKeyPress from "./helpers/determineSelectionFromKeyPress"
 import { Scale, ScaleItem, ScaleValue } from "./types"
 import styles from "./LikertScaleLegacy.module.scss"
@@ -16,8 +17,8 @@ export interface LikertScaleProps {
   selectedItem: ScaleItem | null
   automationId?: string
   reversed?: boolean
-  validationError?: boolean
-  validationErrorId?: string
+  validationMessage?: string
+  status?: "default" | "error"
   onSelect: (value: ScaleItem | null) => void
 }
 
@@ -31,8 +32,8 @@ export const LikertScaleLegacy = ({
   reversed,
   automationId,
   onSelect,
-  validationError,
-  validationErrorId,
+  validationMessage,
+  status,
   labelId,
 }: LikertScaleProps) => {
   const [hoveredItem, setHoveredItem] = useState<ScaleItem | null>(null)
@@ -96,6 +97,13 @@ export const LikertScaleLegacy = ({
     legend = selectedItem.label
   }
 
+  const shouldDisplayValidationMessage =
+    status !== "default" && validationMessage !== undefined
+
+  const validationMessageId = shouldDisplayValidationMessage
+    ? `${labelId}-field-validation-message`
+    : undefined
+
   return (
     <div
       className={classnames(styles.container, {
@@ -105,7 +113,7 @@ export const LikertScaleLegacy = ({
       aria-labelledby={labelId}
       role="radiogroup"
       tabIndex={-1}
-      aria-describedby={(validationError && validationErrorId) || undefined}
+      aria-describedby={validationMessageId}
       data-automation-id={automationId}
     >
       <div
@@ -182,6 +190,14 @@ export const LikertScaleLegacy = ({
           )
         })}
       </div>
+      {shouldDisplayValidationMessage && (
+        <FieldMessage
+          id={validationMessageId}
+          message={validationMessage}
+          status={status}
+          reversed={reversed}
+        />
+      )}
     </div>
   )
 }

--- a/draft-packages/likert-scale-legacy/docs/LikertScaleLegacy.stories.tsx
+++ b/draft-packages/likert-scale-legacy/docs/LikertScaleLegacy.stories.tsx
@@ -5,7 +5,6 @@ import {
   Scale,
   ScaleItem,
 } from "@kaizen/draft-likert-scale-legacy"
-import { Box } from "@kaizen/component-library"
 import { Heading } from "@kaizen/typography"
 import { figmaEmbed } from "../../../storybook/helpers"
 import { CATEGORIES } from "../../../storybook/constants"
@@ -84,13 +83,19 @@ DefaultStory.parameters = {
 
 const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({
   isReversed,
-}) => (
-  <Box mt={2}>
+}) => {
+  const SectionHeading: React.VFC<{ heading: string }> = ({ heading }) => (
+    <Heading variant="heading-3" tag="h1" color={isReversed ? "white" : "dark"}>
+      {heading}
+    </Heading>
+  )
+
+  return (
     <StoryWrapper isReversed={isReversed}>
+      <SectionHeading heading="Likert Scale" />
       <StoryWrapper.Row rowTitle="Not rated">
         <LikertScaleLegacy
           scale={scale}
-          automationId="123"
           labelId="1"
           selectedItem={scale[0]}
           onSelect={() => undefined}
@@ -100,7 +105,6 @@ const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({
       <StoryWrapper.Row rowTitle="Strongly disagree">
         <LikertScaleLegacy
           scale={scale}
-          automationId="123"
           labelId="1"
           selectedItem={scale[1]}
           onSelect={() => undefined}
@@ -110,7 +114,6 @@ const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({
       <StoryWrapper.Row rowTitle="Disagree">
         <LikertScaleLegacy
           scale={scale}
-          automationId="123"
           labelId="2"
           selectedItem={scale[2]}
           onSelect={() => undefined}
@@ -120,7 +123,6 @@ const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({
       <StoryWrapper.Row rowTitle="Neither agree or disagree">
         <LikertScaleLegacy
           scale={scale}
-          automationId="123"
           labelId="3"
           selectedItem={scale[3]}
           onSelect={() => undefined}
@@ -130,7 +132,6 @@ const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({
       <StoryWrapper.Row rowTitle="Agree">
         <LikertScaleLegacy
           scale={scale}
-          automationId="123"
           labelId="4"
           selectedItem={scale[4]}
           onSelect={() => undefined}
@@ -140,24 +141,41 @@ const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({
       <StoryWrapper.Row rowTitle="Strongly agree">
         <LikertScaleLegacy
           scale={scale}
-          automationId="123"
           labelId="5"
           selectedItem={scale[5]}
           onSelect={() => undefined}
           reversed={isReversed}
         />
       </StoryWrapper.Row>
+
+      <SectionHeading heading="Validation" />
+      <StoryWrapper.Row rowTitle="Error">
+        <LikertScaleLegacy
+          scale={scale}
+          labelId="Error state"
+          selectedItem={scale[0]}
+          onSelect={() => undefined}
+          reversed={isReversed}
+          validationMessage="Error message here"
+          status="error"
+        />
+      </StoryWrapper.Row>
     </StoryWrapper>
-  </Box>
-)
+  )
+}
 
 export const StickerSheetDefault = StickerSheetTemplate.bind({})
 StickerSheetDefault.storyName = "Sticker Sheet (Default)"
-StickerSheetDefault.parameters = { chromatic: { disable: false } }
+StickerSheetDefault.parameters = {
+  chromatic: { disable: false },
+  controls: { disable: true },
+}
+
 export const StickerSheetReversed = StickerSheetTemplate.bind({})
 StickerSheetReversed.storyName = "Sticker Sheet (Reversed)"
 StickerSheetReversed.args = { isReversed: true }
 StickerSheetReversed.parameters = {
   backgrounds: { default: "Purple 700" },
   chromatic: { disable: false },
+  controls: { disable: true },
 }

--- a/draft-packages/likert-scale-legacy/package.json
+++ b/draft-packages/likert-scale-legacy/package.json
@@ -33,6 +33,7 @@
   "license": "MIT",
   "dependencies": {
     "@kaizen/component-library": "^15.1.2",
+    "@kaizen/draft-form": "^7.2.16",
     "@kaizen/typography": "^2.2.4",
     "classnames": "^2.3.1"
   },


### PR DESCRIPTION
- add new dependency @kaizen/draft-form

BREAKING CHANGE: replace props validationError & validationErrorId with validationMessage & status

## Why
The motivation for this change is to allow the LikertScale to produce an error message when input is not valid.


## What
The LikertScale will now produce an error message when is passed a validationMessage and set to a status of "error"
