### PR TITLE
feat: Add custom component render prop to navigation tab of title block

### DIFF
--- a/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/NavigationTabs.module.scss
+++ b/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/NavigationTabs.module.scss
@@ -1,9 +1,7 @@
 @import "~@kaizen/design-tokens/sass/border";
+@import "~@kaizen/design-tokens/sass/spacing";
 @import "~@kaizen/design-tokens/sass/typography";
 @import "~@kaizen/design-tokens/sass/color";
-@import "~@kaizen/deprecated-component-library-helpers/styles/type";
-@import "~@kaizen/component-library/styles/fonts";
-@import "~@kaizen/deprecated-component-library-helpers/styles/layout";
 @import "./mixins";
 
 .container {
@@ -14,44 +12,29 @@
 
 .linkAnchor {
   display: flex;
-  padding: 0 calc(#{$ca-grid} / 2);
-  @include ca-margin($end: $ca-grid);
-  color: rgba($color-white-rgb, 0.7);
-  text-decoration: none;
-
-  @include title-block-under-1440 {
-    @include ca-margin($end: $ca-grid * 0.25);
-  }
-
-  @media (max-width: 1189px) {
-    margin: 0;
-  }
-
-  &.lightBackground {
-    color: rgba($color-purple-800-rgb, 0.75);
-
-    &:hover {
-      color: $color-blue-500;
-    }
-  }
-
-  &:hover {
-    color: $color-white;
-    text-decoration: none;
-  }
-}
-
-.linkLabel {
-  position: relative;
-  display: flex;
   align-items: center;
-  white-space: nowrap;
-
+  padding: 0 $spacing-sm;
+  position: relative;
+  color: rgba($color-white-rgb, 0.7);
   font-family: $typography-heading-4-font-family;
   font-weight: $typography-heading-4-font-weight;
   font-size: $typography-heading-4-font-size;
   line-height: $typography-heading-4-line-height;
   letter-spacing: $typography-heading-4-letter-spacing;
+  text-decoration: none;
+  white-space: nowrap;
+  margin-right: $spacing-md;
+
+    &[dir="rtl"],
+    [dir="rtl"] & {
+      margin-left: $spacing-md;
+      margin-right: 0;
+    }
+
+  &:hover {
+    color: $color-white;
+    text-decoration: none;
+  }
 
   @include title-block-under-1366 {
     font-family: $typography-heading-5-font-family;
@@ -59,6 +42,20 @@
     font-size: $typography-heading-5-font-size;
     line-height: $typography-heading-5-line-height;
     letter-spacing: $typography-heading-5-letter-spacing;
+  }
+
+  @include title-block-under-1440 {
+    margin-right: $spacing-xs;
+
+    &[dir="rtl"],
+    [dir="rtl"] & {
+      margin-left: $spacing-xs;
+      margin-right: 0;
+    }
+  }
+
+  @media (max-width: 1189px) {
+    margin: 0;
   }
 
   &.active {
@@ -70,8 +67,8 @@
       height: 5px;
       position: absolute;
       top: 0;
-      left: calc(-1 * calc(#{$ca-grid} / 2));
-      right: calc(-1 * calc(#{$ca-grid} / 2));
+      left: 0;
+      right: 0;
       background-color: $color-white;
       transition: transform cubic-bezier(0.55, 0.085, 0.68, 0.53) 150ms;
       border-radius: 0 0 $border-solid-border-radius $border-solid-border-radius;
@@ -83,9 +80,18 @@
           0;
       }
     }
+  }
+}
 
-    .lightBackground & {
-      color: $color-blue-500;
+.linkAnchor.lightBackground {
+  color: rgba($color-purple-800-rgb, 0.75);
+
+  &:hover {
+    color: $color-blue-500;
+  }
+
+  &.active {
+    color: $color-blue-500;
 
       &::before {
         background-color: $color-blue-500;
@@ -98,10 +104,5 @@
             0 0;
         }
       }
-    }
-  }
-
-  &.active:hover {
-    text-decoration: none;
   }
 }

--- a/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/NavigationTabs.module.scss
+++ b/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/NavigationTabs.module.scss
@@ -25,11 +25,11 @@
   white-space: nowrap;
   margin-right: $spacing-md;
 
-    &[dir="rtl"],
-    [dir="rtl"] & {
-      margin-left: $spacing-md;
-      margin-right: 0;
-    }
+  &[dir="rtl"],
+  [dir="rtl"] & {
+    margin-left: $spacing-md;
+    margin-right: 0;
+  }
 
   &:hover {
     color: $color-white;
@@ -93,16 +93,16 @@
   &.active {
     color: $color-blue-500;
 
-      &::before {
-        background-color: $color-blue-500;
-        top: 3px;
+    &::before {
+      background-color: $color-blue-500;
+      top: 3px;
 
-        @include title-block-medium-and-small {
-          top: auto;
-          bottom: 0;
-          border-radius: $border-solid-border-radius $border-solid-border-radius
-            0 0;
-        }
+      @include title-block-medium-and-small {
+        top: auto;
+        bottom: 0;
+        border-radius: $border-solid-border-radius $border-solid-border-radius 0
+          0;
       }
+    }
   }
 }

--- a/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/NavigationTabs.spec.tsx
+++ b/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/NavigationTabs.spec.tsx
@@ -1,22 +1,12 @@
 import React from "react"
 import { render, screen } from "@testing-library/react"
 import { fireEvent } from "@storybook/testing-library"
-import NavigationTab, { NavigationTabProps } from "./NavigationTabs"
+import NavigationTab, { CustomNavigationTabProps } from "./NavigationTabs"
 
-/**
- *   text: string
-  href: string
-  active?: boolean
-  handleClick?: (event: React.MouseEvent) => void
-  variant?: Variant
-  id?: string
-  automationId?: string
-  component?: (props: Omit<NavigationTabProps, "component">) => JSX.Element
- */
-
-const CustomComponent = (props: Omit<NavigationTabProps, "component">) => (
+const CustomComponent = (props: CustomNavigationTabProps) => (
   <button
     onClick={props.handleClick}
+    className={props.className}
   >{`${props.href} - ${props.text} - ${props.active}`}</button>
 )
 
@@ -37,6 +27,7 @@ describe("NavigationTabs", () => {
       })
     ).toHaveAttribute("href", href)
   })
+
   describe("with a component prop", () => {
     it("renders the component passed with the navigation tab props", () => {
       const handleClick = jest.fn()
@@ -49,12 +40,15 @@ describe("NavigationTabs", () => {
           handleClick={handleClick}
           active
           component={CustomComponent}
+          variant="education"
         />
       )
 
       const button = screen.getByRole("button", {
         name: `${href} - ${text} - true`,
       })
+      expect(button).toHaveClass("linkAnchor", "active", "lightBackground")
+
       fireEvent.click(button)
       expect(handleClick).toBeCalledTimes(1)
     })

--- a/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/NavigationTabs.spec.tsx
+++ b/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/NavigationTabs.spec.tsx
@@ -1,0 +1,62 @@
+import React from "react"
+import { render, screen } from "@testing-library/react"
+import { fireEvent } from "@storybook/testing-library"
+import NavigationTab, { NavigationTabProps } from "./NavigationTabs"
+
+/**
+ *   text: string
+  href: string
+  active?: boolean
+  handleClick?: (event: React.MouseEvent) => void
+  variant?: Variant
+  id?: string
+  automationId?: string
+  component?: (props: Omit<NavigationTabProps, "component">) => JSX.Element
+ */
+
+const CustomComponent = (props: Omit<NavigationTabProps, "component">) => (
+  <button
+    onClick={props.handleClick}
+  >{`${props.href} - ${props.text} - ${props.active}`}</button>
+)
+
+describe("NavigationTabs", () => {
+  it("renders a link", () => {
+    const text = "I am navigation tabs"
+    const href = "www.cultureamp.com"
+    render(<NavigationTab text={text} href={href} />)
+
+    expect(
+      screen.getByRole("link", {
+        name: text,
+      })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole("link", {
+        name: text,
+      })
+    ).toHaveAttribute("href", href)
+  })
+  describe("with a component prop", () => {
+    it("renders the component passed with the navigation tab props", () => {
+      const handleClick = jest.fn()
+      const text = "I am also navigation tabs"
+      const href = "www.cultureamp.com"
+      render(
+        <NavigationTab
+          text={text}
+          href={href}
+          handleClick={handleClick}
+          active
+          component={CustomComponent}
+        />
+      )
+
+      const button = screen.getByRole("button", {
+        name: `${href} - ${text} - true`,
+      })
+      fireEvent.click(button)
+      expect(handleClick).toBeCalledTimes(1)
+    })
+  })
+})

--- a/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/NavigationTabs.spec.tsx
+++ b/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/NavigationTabs.spec.tsx
@@ -28,7 +28,7 @@ describe("NavigationTabs", () => {
     ).toHaveAttribute("href", href)
   })
 
-  describe("with a component prop", () => {
+  describe("with a render prop", () => {
     it("renders the component passed with the navigation tab props", () => {
       const handleClick = jest.fn()
       const text = "I am also navigation tabs"
@@ -39,7 +39,7 @@ describe("NavigationTabs", () => {
           href={href}
           handleClick={handleClick}
           active
-          component={CustomComponent}
+          renderTab={CustomComponent}
           variant="education"
         />
       )

--- a/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/NavigationTabs.tsx
+++ b/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/NavigationTabs.tsx
@@ -18,7 +18,12 @@ export type NavigationTabProps = {
   variant?: Variant
   id?: string
   automationId?: string
-  component?: (props: CustomNavigationTabProps) => JSX.Element
+  /**
+   * Custom render for the tab. Commonly used to replace the link with a router link component.
+   * Props given to the NavigationTab component will be passed back, along with a decorated className.
+   * It is up to you to reapply them to your custom component.
+   */
+  renderTab?: (props: CustomNavigationTabProps) => JSX.Element
 }
 
 const isLight = (variant: Variant | undefined): boolean =>
@@ -30,8 +35,8 @@ const NavigationTab = (props: NavigationTabProps) => {
     [styles.active]: props.active,
   })
 
-  if (props.component) {
-    const { component: Component, ...otherProps } = props
+  if (props.renderTab) {
+    const { renderTab: Component, ...otherProps } = props
     return <Component {...otherProps} className={className} />
   }
 

--- a/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/NavigationTabs.tsx
+++ b/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/NavigationTabs.tsx
@@ -11,29 +11,37 @@ export type NavigationTabProps = {
   variant?: Variant
   id?: string
   automationId?: string
+  component?: (props: Omit<NavigationTabProps, "component">) => JSX.Element
 }
 
 const isLight = (variant: Variant | undefined): boolean =>
   variant !== undefined && NON_REVERSED_VARIANTS.includes(variant)
 
-const NavigationTab = (props: NavigationTabProps) => (
-  <a
-    className={classnames(styles.linkAnchor, {
-      [styles.lightBackground]: isLight(props.variant),
-    })}
-    href={props.href}
-    onClick={props.handleClick}
-    id={props.id}
-    data-automation-id={props.automationId}
-  >
-    <div
-      className={classnames(styles.linkLabel, {
-        [styles.active]: props.active,
+const NavigationTab = (props: NavigationTabProps) => {
+  if (props.component) {
+    const { component: Component, ...otherProps } = props
+    return <Component {...otherProps} />
+  }
+
+  return (
+    <a
+      className={classnames(styles.linkAnchor, {
+        [styles.lightBackground]: isLight(props.variant),
       })}
+      href={props.href}
+      onClick={props.handleClick}
+      id={props.id}
+      data-automation-id={props.automationId}
     >
-      {props.text}
-    </div>
-  </a>
-)
+      <div
+        className={classnames(styles.linkLabel, {
+          [styles.active]: props.active,
+        })}
+      >
+        {props.text}
+      </div>
+    </a>
+  )
+}
 
 export default NavigationTab

--- a/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/NavigationTabs.tsx
+++ b/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/NavigationTabs.tsx
@@ -27,19 +27,14 @@ const NavigationTab = (props: NavigationTabProps) => {
     <a
       className={classnames(styles.linkAnchor, {
         [styles.lightBackground]: isLight(props.variant),
+        [styles.active]: props.active,
       })}
       href={props.href}
       onClick={props.handleClick}
       id={props.id}
       data-automation-id={props.automationId}
     >
-      <div
-        className={classnames(styles.linkLabel, {
-          [styles.active]: props.active,
-        })}
-      >
-        {props.text}
-      </div>
+      {props.text}
     </a>
   )
 }

--- a/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/NavigationTabs.tsx
+++ b/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/NavigationTabs.tsx
@@ -3,6 +3,13 @@ import classnames from "classnames"
 import { NON_REVERSED_VARIANTS, Variant } from "./TitleBlockZen"
 import styles from "./NavigationTabs.module.scss"
 
+export type CustomNavigationTabProps = Omit<
+  NavigationTabProps,
+  "component" | "variant"
+> & {
+  className: string
+}
+
 export type NavigationTabProps = {
   text: string
   href: string
@@ -11,24 +18,26 @@ export type NavigationTabProps = {
   variant?: Variant
   id?: string
   automationId?: string
-  component?: (props: Omit<NavigationTabProps, "component">) => JSX.Element
+  component?: (props: CustomNavigationTabProps) => JSX.Element
 }
 
 const isLight = (variant: Variant | undefined): boolean =>
   variant !== undefined && NON_REVERSED_VARIANTS.includes(variant)
 
 const NavigationTab = (props: NavigationTabProps) => {
+  const className = classnames(styles.linkAnchor, {
+    [styles.lightBackground]: isLight(props.variant),
+    [styles.active]: props.active,
+  })
+
   if (props.component) {
     const { component: Component, ...otherProps } = props
-    return <Component {...otherProps} />
+    return <Component {...otherProps} className={className} />
   }
 
   return (
     <a
-      className={classnames(styles.linkAnchor, {
-        [styles.lightBackground]: isLight(props.variant),
-        [styles.active]: props.active,
-      })}
+      className={className}
       href={props.href}
       onClick={props.handleClick}
       id={props.id}


### PR DESCRIPTION
## Why
We want to render `Link` components from our routing library for tabs.

## What

Similar to the GenericButton `component` prop, we've added a custom render prop to the  TitleBlock.NavigationTab. Most props are forwarded through the render prop, however, className is calculated by the internals and then forwarded through.

## Notes

We removed the inner div of the navigation tab link. This allowed the classNames to be passed as one string to the resulting custom component. All styles of the div could be safely moved to the anchor tag.

Unlike the GenericButton, the NavigationTab was not a forwardRef component. We did not add that functionality here, but it may be useful to add in the future.
