### PR TITLE
refactor: add override and change target of css focus

### DIFF
--- a/packages/rich-text-editor/src/EditableRichTextContent/EditableRichTextContent.module.scss
+++ b/packages/rich-text-editor/src/EditableRichTextContent/EditableRichTextContent.module.scss
@@ -19,10 +19,7 @@
   border-color: $color-blue-500;
 }
 
-// Temporary solution for focus styling the content area
-// (the problem with this is that it shows this styling when focusing a link within the content
-.editableContainer:focus-within :global(.ProseMirror) {
-  background-color: $color-gray-200;
+.editableContainer .hiddenButton:focus-within + * > :global(.ProseMirror) {
   border: $border-focus-ring-border-width $border-focus-ring-border-style
     $color-blue-500;
 }

--- a/packages/rich-text-editor/src/EditableRichTextContent/EditableRichTextContent.tsx
+++ b/packages/rich-text-editor/src/EditableRichTextContent/EditableRichTextContent.tsx
@@ -46,7 +46,7 @@ export const EditableRichTextContent: React.VFC<
         className={classnames(styles.editableContainer, classNameOverride)}
         {...restProps}
       >
-        <VisuallyHidden>
+        <VisuallyHidden classNameOverride={styles.hiddenButton}>
           <button
             type="button"
             onClick={onClick}


### PR DESCRIPTION
## Why
There is a double focus ring on the editable rich text content for keyboard navigation when tabing to inner anchor tags in the rte content.

## What
- useses the  visually hidden classNameOverride to target the sibling element for focus

## Side by side

https://user-images.githubusercontent.com/36558508/181419532-1413da79-86e4-4c2c-820c-2f9a892408b3.mp4


