### PR TITLE
feat: add classNameOverride to hidden wrapper

### DIFF
--- a/packages/a11y/package.json
+++ b/packages/a11y/package.json
@@ -36,6 +36,7 @@
     "react": "^16.9.0 || ^17.0.0 || ^18.0.0"
   },
   "dependencies": {
-    "@kaizen/component-library": "^15.1.2"
+    "@kaizen/component-library": "^15.1.2",
+    "@kaizen/component-base": "^1.0.0"
   }
 }

--- a/packages/a11y/src/VisuallyHidden/VisuallyHidden.tsx
+++ b/packages/a11y/src/VisuallyHidden/VisuallyHidden.tsx
@@ -1,11 +1,12 @@
 import { ReactNode, createElement, HTMLAttributes } from "react"
+import { OverrideClassName } from "@kaizen/component-base"
 
 import styles from "./VisuallyHidden.module.scss"
 
 export type AllowedTags = "div" | "span"
 
 export interface VisuallyHiddenProps
-  extends Omit<HTMLAttributes<HTMLElement>, "className"> {
+  extends OverrideClassName<HTMLAttributes<HTMLElement>> {
   children: ReactNode
   /**
    * The HTML tag rendered by this component
@@ -15,9 +16,10 @@ export interface VisuallyHiddenProps
 
 export const VisuallyHidden: React.VFC<VisuallyHiddenProps> = ({
   children,
+  classNameOverride,
   tag = "span",
   ...otherProps
 }) => {
-  const className = styles.srOnly
+  const className = `${styles.srOnly} ${classNameOverride}`
   return createElement(tag, { ...otherProps, className }, children)
 }


### PR DESCRIPTION
## Why
This aligns to our pattern of extending classNameOverride for handling additional classes in our component. This would be used for target purposes within CSS and was created off the back of the comments in [this PR](https://github.com/cultureamp/kaizen-design-system/pull/2882/files#r931765082)

## What
- extends classNameOverride prop on VisuallyHidden component
