### PR TITLE
feat: add maximize and minimize icons to comp lib

### DIFF
--- a/packages/component-library/icons/maximize.icon.svg
+++ b/packages/component-library/icons/maximize.icon.svg
@@ -1,0 +1,1 @@
+<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M2 18v-7.018h1.965v3.697L14.679 3.965h-3.697V2H18v7.018h-1.965V5.32L5.321 16.035h3.697V18H2Z" fill="#000000" /></svg>

--- a/packages/component-library/icons/minimize.icon.svg
+++ b/packages/component-library/icons/minimize.icon.svg
@@ -1,3 +1,1 @@
-<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M19 2.269L14.239 7.03L17.2 10H10V2.8L12.961 5.761L17.731 1L19 2.269ZM2.269 19L7.03 14.239L10 17.2V10H2.8L5.761 12.961L1 17.731L2.269 19Z" fill="#000000"/>
-</svg>
+<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M2.354 19 1 17.646l5.74-5.74H3.136V10H10v6.864H8.095V13.26L2.355 19ZM10 10V3.136h1.905V6.74L17.645 1 19 2.354l-5.74 5.74h3.604V10H10Z" fill="#000000"/></svg>


### PR DESCRIPTION
## Why
There’s a need by designer Aru in team Apollo for a Maximize icon, as currently there is only a Minimize icon.  This will be used to expand and contract a data table they’re working on, with the impetus to go fullscreen if the user needs.


## What
- adds max and minimize icons