### PR TITLE
fix(date-picker): remove unnecessary :not(.outside) selectors in Calendar styles

### DIFF
--- a/packages/date-picker/docs/Calendar.stories.tsx
+++ b/packages/date-picker/docs/Calendar.stories.tsx
@@ -97,6 +97,12 @@ const StickerSheetCalendarTemplate: Story<{ isReversed: boolean }> = ({
           id="today-selected"
           value={new Date("2022-05-01")}
         />
+        <CalendarExample
+          defaultMonth={new Date("2022-05-01")}
+          id="today-disabled"
+          value={new Date("2022-05-01")}
+          disabledDays={[new Date("2022-05-01")]}
+        />
       </StoryWrapper.Row>
 
       <StoryWrapper.RowHeader headings={["Hover", "Focus"]} gridColumns={3} />
@@ -125,7 +131,7 @@ StickerSheetCalendar.play = ({ canvasElement }) => {
     })
   }
 
-  const todayCalendarIds = ["today-default", "today-selected"]
+  const todayCalendarIds = ["today-default", "today-selected", "today-disabled"]
 
   todayCalendarIds.forEach(id => {
     getElementWithinCalendar(id, "1st May (Sunday)").classList.add(

--- a/packages/date-picker/docs/DatePicker.stories.tsx
+++ b/packages/date-picker/docs/DatePicker.stories.tsx
@@ -95,16 +95,18 @@ export default {
       control: "text",
     },
     disabledDates: {
-      options: ["None", "May2022"],
+      options: ["None", "Today", "May2022"],
       control: {
         type: "select",
         labels: {
           None: "undefined",
+          Today: "[new Date()]",
           May2022: '[new Date("2022-05-01"), new Date("2022-05-22")]',
         },
       },
       mapping: {
         None: undefined,
+        Today: [new Date()],
         May2022: [new Date("2022-05-01"), new Date("2022-05-22")],
       },
     },

--- a/packages/date-picker/src/_primitives/Calendar/Calendar.module.scss
+++ b/packages/date-picker/src/_primitives/Calendar/Calendar.module.scss
@@ -202,20 +202,18 @@ $rdp-cell-size: 40px;
   }
 
   &:not([aria-disabled="true"]) {
-    &:not(.outside) {
+    &:hover,
+    &:global(.story__datepicker__calendar--hover) {
+      background-color: $color-blue-200;
+      color: $color-blue-500;
+    }
+
+    &:not(.daySelected) {
       &:hover,
       &:global(.story__datepicker__calendar--hover) {
-        background-color: $color-blue-200;
+        border-radius: $cell-border-radius;
+        background-color: $color-blue-100;
         color: $color-blue-500;
-      }
-
-      &:not(.daySelected) {
-        &:hover,
-        &:global(.story__datepicker__calendar--hover) {
-          border-radius: $cell-border-radius;
-          background-color: $color-blue-100;
-          color: $color-blue-500;
-        }
       }
     }
   }
@@ -223,34 +221,32 @@ $rdp-cell-size: 40px;
 
 .daySelected {
   &:not([aria-disabled="true"]) {
-    &:not(.outside) {
-      border-radius: $cell-border-radius;
-      background-color: $color-blue-500;
-      color: $color-white;
+    border-radius: $cell-border-radius;
+    background-color: $color-blue-500;
+    color: $color-white;
 
-      &:hover,
-      &:global(.story__datepicker__calendar--hover) {
-        background-color: $color-blue-400;
-        color: $color-white;
-      }
+    &:hover,
+    &:global(.story__datepicker__calendar--hover) {
+      background-color: $color-blue-400;
+      color: $color-white;
     }
   }
 }
 
-.dayToday:not(.outside),
+.dayToday,
 :global(.story__datepicker__calendar--day-today) {
   color: $color-blue-500;
   font-weight: bold;
 }
 
-.dayRangeStart:not(.outside),
-.dayRangeEnd:not(.outside) {
+.dayRangeStart,
+.dayRangeEnd {
   border-radius: $cell-border-radius;
   background-color: $color-blue-500;
   color: $color-white;
 }
 
-.dayRangeMiddle:not([aria-disabled="true"]):not(.outside):not(.from):not(.to):not(:hover) {
+.dayRangeMiddle:not([aria-disabled="true"]):not(.from):not(.to):not(:hover) {
   background-color: $color-blue-100;
   color: $color-blue-500;
 }


### PR DESCRIPTION
## Why

When "today" is disabled in the Calendar, the disabled styles (grey font) were not coming through; although they did when the date was focused.

|OLD|NEW|
|---|---|
|![image](https://user-images.githubusercontent.com/25891850/182273936-425b507a-5d9f-47fc-86a2-b242d0bd8be2.png)|<img width="292" alt="image" src="https://user-images.githubusercontent.com/25891850/182275005-f267735e-23ef-49e5-a269-cb54b3ab1115.png">|

## What

Removed the `:not(.outside)` selectors which don't appear to do anything except make things overspecific.
