### PR TITLE
fix: Styling tweaks to Select component

### DIFF
--- a/draft-packages/select/KaizenDraft/Select/Select.module.scss
+++ b/draft-packages/select/KaizenDraft/Select/Select.module.scss
@@ -141,7 +141,8 @@ $focus-border-color: $color-blue-500;
 
   .input {
     color: $color-purple-800;
-    padding-right: 20px;
+    padding: 0 20px 0 0;
+    margin: 0;
   }
 
   &.secondarySmall {
@@ -338,10 +339,10 @@ $focus-border-color: $color-blue-500;
       top: 0px;
       transform: none;
       max-width: 100%;
-      padding-right: 10px;
+      padding-right: 14px;
     }
     .placeholderOverrides {
-      padding-right: 10px;
+      padding-right: 14px;
     }
     .singleValue {
       max-width: 100%;

--- a/draft-packages/select/KaizenDraft/Select/Select.module.scss
+++ b/draft-packages/select/KaizenDraft/Select/Select.module.scss
@@ -339,13 +339,22 @@ $focus-border-color: $color-blue-500;
       top: 0px;
       transform: none;
       max-width: 100%;
+      padding-right: 30px;
+    }
+    .placeholderOverrides {
+      padding-right: 30px;
+    }
+    .singleValue {
+      max-width: 100%;
+    }
+  }
+
+  &.searchable {
+    .singleValueOverrides {
       padding-right: 14px;
     }
     .placeholderOverrides {
       padding-right: 14px;
-    }
-    .singleValue {
-      max-width: 100%;
     }
   }
 }

--- a/draft-packages/select/KaizenDraft/Select/Select.module.scss
+++ b/draft-packages/select/KaizenDraft/Select/Select.module.scss
@@ -320,13 +320,32 @@ $focus-border-color: $color-blue-500;
       top: 0px;
       transform: none;
       max-width: 100%;
-      padding-right: 30px;
+      padding-right: 10px;
     }
     .placeholderOverrides {
-      padding-right: 30px;
+      padding-right: 10px;
     }
     .singleValue {
       max-width: 100%;
+    }
+  }
+
+  .input {
+    color: $color-purple-800;
+    padding-right: 20px;
+  }
+  &.reversed {
+    .input {
+      color: $color-white;
+    }
+  }
+  &.secondarySmall {
+    .input {
+      font-family: $typography-paragraph-extra-small-font-family;
+      font-weight: $typography-paragraph-extra-small-font-weight;
+      font-size: $typography-paragraph-extra-small-font-size;
+      line-height: $typography-paragraph-extra-small-line-height;
+      letter-spacing: $typography-paragraph-extra-small-letter-spacing;
     }
   }
 }

--- a/draft-packages/select/KaizenDraft/Select/Select.module.scss
+++ b/draft-packages/select/KaizenDraft/Select/Select.module.scss
@@ -139,11 +139,29 @@ $focus-border-color: $color-blue-500;
     @include base-font-style();
   }
 
+  .input {
+    color: $color-purple-800;
+    padding-right: 20px;
+  }
+
+  &.secondarySmall {
+    .input {
+      font-family: $typography-paragraph-extra-small-font-family;
+      font-weight: $typography-paragraph-extra-small-font-weight;
+      font-size: $typography-paragraph-extra-small-font-size;
+      line-height: $typography-paragraph-extra-small-line-height;
+      letter-spacing: $typography-paragraph-extra-small-letter-spacing;
+    }
+  }
+
   &.reversed {
     .singleValue {
       color: $color-white;
     }
     .singleValueOverrides {
+      color: $color-white;
+    }
+    .input {
       color: $color-white;
     }
   }
@@ -327,25 +345,6 @@ $focus-border-color: $color-blue-500;
     }
     .singleValue {
       max-width: 100%;
-    }
-  }
-
-  .input {
-    color: $color-purple-800;
-    padding-right: 20px;
-  }
-  &.reversed {
-    .input {
-      color: $color-white;
-    }
-  }
-  &.secondarySmall {
-    .input {
-      font-family: $typography-paragraph-extra-small-font-family;
-      font-weight: $typography-paragraph-extra-small-font-weight;
-      font-size: $typography-paragraph-extra-small-font-size;
-      line-height: $typography-paragraph-extra-small-line-height;
-      letter-spacing: $typography-paragraph-extra-small-letter-spacing;
     }
   }
 }

--- a/draft-packages/select/KaizenDraft/Select/Select.tsx
+++ b/draft-packages/select/KaizenDraft/Select/Select.tsx
@@ -71,6 +71,7 @@ export const Select = React.forwardRef<any, SelectProps>((props, ref) => {
     label,
     validationMessage,
     description,
+    isSearchable,
   } = props
 
   // the default for fullWidth depends on the variant
@@ -95,6 +96,7 @@ export const Select = React.forwardRef<any, SelectProps>((props, ref) => {
     [styles.notFullWidth]: !fullWidth,
     [styles.disabled]: props.isDisabled,
     [styles.error]: status === "error",
+    [styles.searchable]: isSearchable !== false,
   })
   return (
     <>

--- a/draft-packages/select/KaizenDraft/Select/Select.tsx
+++ b/draft-packages/select/KaizenDraft/Select/Select.tsx
@@ -115,6 +115,7 @@ export const Select = React.forwardRef<any, SelectProps>((props, ref) => {
           ValueContainer,
           ClearIndicator,
           IndicatorSeparator: null,
+          Input,
         }}
         className={classes}
       />
@@ -239,8 +240,13 @@ const IndicatorsContainer: typeof components.IndicatorsContainer = props => (
 const ValueContainer: typeof components.ValueContainer = props => (
   <components.ValueContainer {...props} className={styles.valueContainer} />
 )
+
 const ClearIndicator: typeof components.ClearIndicator = props => (
   <components.ClearIndicator {...props}>
     <Icon icon={clearIcon} role="presentation" />
   </components.ClearIndicator>
+)
+
+const Input: typeof components.Input = props => (
+  <components.Input {...props} className={styles.input} />
 )

--- a/draft-packages/select/docs/Select.stories.tsx
+++ b/draft-packages/select/docs/Select.stories.tsx
@@ -122,6 +122,24 @@ const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({
               isDisabled
             />
           </StoryWrapper.Row>
+          <StoryWrapper.Row rowTitle="Non Searchable">
+            <Select
+              options={OPTIONS}
+              defaultValue={OPTIONS[9]}
+              placeholder="Edit survey"
+              isSearchable={false}
+            />
+            <Heading variant="heading-4" color="dark">
+              N/A
+            </Heading>
+            <Select
+              options={OPTIONS}
+              defaultValue={OPTIONS[9]}
+              placeholder="Edit survey"
+              isDisabled
+              isSearchable={false}
+            />
+          </StoryWrapper.Row>
         </StoryWrapper>
 
         <StoryWrapper>
@@ -178,6 +196,23 @@ const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({
           options={OPTIONS}
           defaultValue={OPTIONS[0]}
           isDisabled
+        />
+      </StoryWrapper.Row>
+      <StoryWrapper.Row rowTitle="Secondary Small - non searchable">
+        <Select
+          reversed={isReversed}
+          variant="secondary-small"
+          options={OPTIONS}
+          defaultValue={OPTIONS[0]}
+          isSearchable={false}
+        />
+        <Select
+          reversed={isReversed}
+          variant="secondary-small"
+          options={OPTIONS}
+          defaultValue={OPTIONS[0]}
+          isDisabled
+          isSearchable={false}
         />
       </StoryWrapper.Row>
     </StoryWrapper>


### PR DESCRIPTION
## Why
I noticed some styling issues with our Select component, see tweaks below.

## What

### 1) Reversed mode: input text is wrong color & caret clashes with text

Before:

<img width="254" alt="image" src="https://user-images.githubusercontent.com/763385/182507261-b0b8a9ed-57d9-43ab-a6e1-23ae6eac8a3a.png">

<img width="274" alt="image" src="https://user-images.githubusercontent.com/763385/182508101-79900c87-95fb-41ea-861a-d70c86e6e44c.png">

After:

<img width="250" alt="image" src="https://user-images.githubusercontent.com/763385/182507655-2e74c77a-4a0b-4654-b95a-25f9bd7e11b8.png">

<img width="264" alt="image" src="https://user-images.githubusercontent.com/763385/182508132-ad5235c2-26db-47f0-b217-b959f5d3442e.png">


### 2) Input text in secondary small is too big

Before:

<img width="244" alt="image" src="https://user-images.githubusercontent.com/763385/182507789-e9d1d968-f3ba-4bf9-a03f-634a60f6b61c.png">

After:

<img width="257" alt="image" src="https://user-images.githubusercontent.com/763385/182508022-3fb2318c-9fb6-4e69-8667-afd6b1dd1fdb.png">



