### PR TITLE
feat: Add secondary action prop

### DIFF
--- a/draft-packages/modal/KaizenDraft/Modal/Presets/InputEditModal.spec.tsx
+++ b/draft-packages/modal/KaizenDraft/Modal/Presets/InputEditModal.spec.tsx
@@ -85,7 +85,7 @@ describe("<InputEditModal />", () => {
         onSubmit={handleSubmit}
         onDismiss={handleDismiss}
         onSecondaryAction={handleSecondaryAction}
-        dismissLabel="Secondary button"
+        secondaryLabel="Secondary button"
       >
         Example modal body
       </InputEditModalWrapper>

--- a/draft-packages/modal/KaizenDraft/Modal/Presets/InputEditModal.spec.tsx
+++ b/draft-packages/modal/KaizenDraft/Modal/Presets/InputEditModal.spec.tsx
@@ -75,7 +75,7 @@ describe("<InputEditModal />", () => {
     expect(handleDismiss).toHaveBeenCalledTimes(0)
   })
 
-  it("supports a secondary action when secondary button is pressed", () => {
+  it("supports a secondary action when secondary-action and secondary-label both props are provided", () => {
     const handleSubmit = jest.fn()
     const handleDismiss = jest.fn()
     const handleSecondaryAction = jest.fn()
@@ -94,5 +94,25 @@ describe("<InputEditModal />", () => {
     expect(handleSubmit).toHaveBeenCalledTimes(0)
     expect(handleDismiss).toHaveBeenCalledTimes(0)
     expect(handleSecondaryAction).toHaveBeenCalledTimes(1)
+  })
+
+  it("dismiss works as usual when only one of the prop (secondary-action / secondary-label) is provided", () => {
+    const handleSubmit = jest.fn()
+    const handleDismiss = jest.fn()
+    const handleSecondaryAction = jest.fn()
+
+    const { getByText } = render(
+      <InputEditModalWrapper
+        onSubmit={handleSubmit}
+        onDismiss={handleDismiss}
+        onSecondaryAction={handleSecondaryAction}
+      >
+        Example modal body
+      </InputEditModalWrapper>
+    )
+    fireEvent.click(getByText(/Cancel/i))
+    expect(handleSubmit).toHaveBeenCalledTimes(0)
+    expect(handleDismiss).toHaveBeenCalledTimes(1)
+    expect(handleSecondaryAction).toHaveBeenCalledTimes(0)
   })
 })

--- a/draft-packages/modal/KaizenDraft/Modal/Presets/InputEditModal.spec.tsx
+++ b/draft-packages/modal/KaizenDraft/Modal/Presets/InputEditModal.spec.tsx
@@ -74,4 +74,25 @@ describe("<InputEditModal />", () => {
     expect(handleSubmit).toHaveBeenCalledTimes(1)
     expect(handleDismiss).toHaveBeenCalledTimes(0)
   })
+
+  it("supports a secondary action when secondary button is pressed", () => {
+    const handleSubmit = jest.fn()
+    const handleDismiss = jest.fn()
+    const handleSecondaryAction = jest.fn()
+
+    const { getByText } = render(
+      <InputEditModalWrapper
+        onSubmit={handleSubmit}
+        onDismiss={handleDismiss}
+        onSecondaryAction={handleSecondaryAction}
+        dismissLabel="Secondary button"
+      >
+        Example modal body
+      </InputEditModalWrapper>
+    )
+    fireEvent.click(getByText(/Secondary button/i))
+    expect(handleSubmit).toHaveBeenCalledTimes(0)
+    expect(handleDismiss).toHaveBeenCalledTimes(0)
+    expect(handleSecondaryAction).toHaveBeenCalledTimes(1)
+  })
 })

--- a/draft-packages/modal/KaizenDraft/Modal/Presets/InputEditModal.tsx
+++ b/draft-packages/modal/KaizenDraft/Modal/Presets/InputEditModal.tsx
@@ -17,6 +17,7 @@ export interface InputEditModalProps {
   readonly mood: "positive" | "destructive"
   readonly title: string
   readonly onSubmit: () => void
+  readonly onConfirm?: () => void
   readonly onDismiss: () => void
   readonly onAfterLeave?: () => void
   readonly localeDirection?: "rtl" | "ltr"
@@ -38,6 +39,7 @@ const InputEditModal = ({
   mood,
   title,
   onSubmit,
+  onConfirm,
   onAfterLeave,
   localeDirection = "ltr",
   submitLabel = "Submit",
@@ -60,7 +62,11 @@ const InputEditModal = ({
 
   const footerActions: ButtonProps[] = [
     { ...submitAction, ...workingProps },
-    { label: dismissLabel, onClick: onDismiss, disabled: !!submitWorking },
+    {
+      label: dismissLabel,
+      onClick: onConfirm || onDismiss,
+      disabled: !!submitWorking,
+    },
   ]
 
   return (

--- a/draft-packages/modal/KaizenDraft/Modal/Presets/InputEditModal.tsx
+++ b/draft-packages/modal/KaizenDraft/Modal/Presets/InputEditModal.tsx
@@ -17,7 +17,7 @@ export interface InputEditModalProps {
   readonly mood: "positive" | "destructive"
   readonly title: string
   readonly onSubmit: () => void
-  readonly onConfirm?: () => void
+  readonly onSecondaryAction?: () => void
   readonly onDismiss: () => void
   readonly onAfterLeave?: () => void
   readonly localeDirection?: "rtl" | "ltr"
@@ -39,7 +39,7 @@ const InputEditModal = ({
   mood,
   title,
   onSubmit,
-  onConfirm,
+  onSecondaryAction,
   onAfterLeave,
   localeDirection = "ltr",
   submitLabel = "Submit",
@@ -64,7 +64,7 @@ const InputEditModal = ({
     { ...submitAction, ...workingProps },
     {
       label: dismissLabel,
-      onClick: onConfirm || onDismiss,
+      onClick: onSecondaryAction || onDismiss,
       disabled: !!submitWorking,
     },
   ]

--- a/draft-packages/modal/KaizenDraft/Modal/Presets/InputEditModal.tsx
+++ b/draft-packages/modal/KaizenDraft/Modal/Presets/InputEditModal.tsx
@@ -62,11 +62,13 @@ const InputEditModal = ({
       }
     : {}
 
+  const showSecondary = onSecondaryAction && secondaryLabel
+
   const footerActions: ButtonProps[] = [
     { ...submitAction, ...workingProps },
     {
-      label: secondaryLabel || dismissLabel,
-      onClick: onSecondaryAction || onDismiss,
+      label: showSecondary ? secondaryLabel : dismissLabel,
+      onClick: showSecondary ? onSecondaryAction : onDismiss,
       disabled: !!submitWorking,
     },
   ]

--- a/draft-packages/modal/KaizenDraft/Modal/Presets/InputEditModal.tsx
+++ b/draft-packages/modal/KaizenDraft/Modal/Presets/InputEditModal.tsx
@@ -23,6 +23,7 @@ export interface InputEditModalProps {
   readonly localeDirection?: "rtl" | "ltr"
   readonly submitLabel?: string
   readonly dismissLabel?: string
+  readonly secondaryLabel?: string
   readonly automationId?: string
   readonly children: React.ReactNode
   readonly submitWorking?: { label: string; labelHidden?: boolean }
@@ -44,6 +45,7 @@ const InputEditModal = ({
   localeDirection = "ltr",
   submitLabel = "Submit",
   dismissLabel = "Cancel",
+  secondaryLabel,
   submitWorking,
   automationId,
   children,
@@ -63,7 +65,7 @@ const InputEditModal = ({
   const footerActions: ButtonProps[] = [
     { ...submitAction, ...workingProps },
     {
-      label: dismissLabel,
+      label: secondaryLabel || dismissLabel,
       onClick: onSecondaryAction || onDismiss,
       disabled: !!submitWorking,
     },

--- a/draft-packages/modal/docs/InputEditModal.stories.tsx
+++ b/draft-packages/modal/docs/InputEditModal.stories.tsx
@@ -109,7 +109,7 @@ InputEditModalExample.args = {
   mood: "positive",
   title: "Input-edit modal title",
   submitLabel: "Primary label",
-  dismissLabel: "Secondary label",
+  secondaryLabel: "Secondary label",
 }
 InputEditModalExample.parameters = {
   docs: { source: { type: "code" } },

--- a/draft-packages/modal/docs/InputEditModal.stories.tsx
+++ b/draft-packages/modal/docs/InputEditModal.stories.tsx
@@ -51,15 +51,6 @@ const InputEditModalTemplate: ComponentStory<typeof InputEditModal> = args => {
 
   const handleOpen = () => setIsOpen(true)
   const handleClose = () => setIsOpen(false)
-  const handlePrimaryAction = () => {
-    alert("Sorry to interrupt. This is a primary action.")
-  }
-  const handleSecondaryAction = () => {
-    alert("Sorry to interrupt. This is a secondary action.")
-  }
-  const handleDismiss = () => {
-    handleClose()
-  }
 
   const SELECT_OPTIONS = [
     { value: "Mindy", label: "Mindy" },
@@ -80,9 +71,8 @@ const InputEditModalTemplate: ComponentStory<typeof InputEditModal> = args => {
       <InputEditModal
         {...args}
         isOpen={args.isOpen === undefined ? isOpen : args.isOpen}
-        onSubmit={handlePrimaryAction}
-        onSecondaryAction={handleSecondaryAction}
-        onDismiss={handleDismiss}
+        onSubmit={handleClose}
+        onDismiss={handleClose}
       >
         <Box mb={1}>
           <ModalAccessibleDescription>
@@ -108,8 +98,7 @@ InputEditModalExample.storyName = "Input Edit Modal"
 InputEditModalExample.args = {
   mood: "positive",
   title: "Input-edit modal title",
-  submitLabel: "Primary label",
-  secondaryLabel: "Secondary label",
+  submitLabel: "Submit label",
 }
 InputEditModalExample.parameters = {
   docs: { source: { type: "code" } },

--- a/draft-packages/modal/docs/InputEditModal.stories.tsx
+++ b/draft-packages/modal/docs/InputEditModal.stories.tsx
@@ -81,7 +81,7 @@ const InputEditModalTemplate: ComponentStory<typeof InputEditModal> = args => {
         {...args}
         isOpen={args.isOpen === undefined ? isOpen : args.isOpen}
         onSubmit={handlePrimaryAction}
-        onConfirm={handleSecondaryAction}
+        onSecondaryAction={handleSecondaryAction}
         onDismiss={handleDismiss}
       >
         <Box mb={1}>

--- a/draft-packages/modal/docs/InputEditModal.stories.tsx
+++ b/draft-packages/modal/docs/InputEditModal.stories.tsx
@@ -51,6 +51,15 @@ const InputEditModalTemplate: ComponentStory<typeof InputEditModal> = args => {
 
   const handleOpen = () => setIsOpen(true)
   const handleClose = () => setIsOpen(false)
+  const handlePrimaryAction = () => {
+    alert("Sorry to interrupt. This is a primary action.")
+  }
+  const handleSecondaryAction = () => {
+    alert("Sorry to interrupt. This is a secondary action.")
+  }
+  const handleDismiss = () => {
+    handleClose()
+  }
 
   const SELECT_OPTIONS = [
     { value: "Mindy", label: "Mindy" },
@@ -71,8 +80,9 @@ const InputEditModalTemplate: ComponentStory<typeof InputEditModal> = args => {
       <InputEditModal
         {...args}
         isOpen={args.isOpen === undefined ? isOpen : args.isOpen}
-        onSubmit={handleClose}
-        onDismiss={handleClose}
+        onSubmit={handlePrimaryAction}
+        onConfirm={handleSecondaryAction}
+        onDismiss={handleDismiss}
       >
         <Box mb={1}>
           <ModalAccessibleDescription>
@@ -98,7 +108,8 @@ InputEditModalExample.storyName = "Input Edit Modal"
 InputEditModalExample.args = {
   mood: "positive",
   title: "Input-edit modal title",
-  submitLabel: "Submit label",
+  submitLabel: "Primary label",
+  dismissLabel: "Secondary label",
 }
 InputEditModalExample.parameters = {
   docs: { source: { type: "code" } },


### PR DESCRIPTION
## Why
In `InputEditModal` modal - we currently have 3 buttons.
1) A primary button to Submit action.
2) A secondary button that is attached to Dismiss action.
3) A close button that is attached to Dismiss action.

We in Polaris have a product need to separate these 3 buttons with 3 distinct actions. 

## What
* When two props `onSecondaryAction` and `secondaryLabel` are supplied, secondary action feature is available in the secondary button.
* Otherwise, the modal works as usual.

## Image of the modal with Secondary and Primary buttons
<img width="641" alt="Screen Shot 2022-08-04 at 3 33 47 pm" src="https://user-images.githubusercontent.com/26585669/182770541-abbf4d69-9ee4-4a78-9a0f-a0c061c717ef.png">


## Notes
* Gearing towards minimal change and only `minor` version upgrade.
* So, not touching other prop names.
* I'd like to avoid major package upgrade.
* Have done design review with designer in #community_amplify_1on1