### PR TITLE
feat(date-picker): add fallback date to focus on for calendar

### DIFF
--- a/packages/date-picker/src/utils/setFocusInCalendar.spec.tsx
+++ b/packages/date-picker/src/utils/setFocusInCalendar.spec.tsx
@@ -44,4 +44,13 @@ describe("setFocusInCalendar", () => {
     const dayToFocus = screen.getByRole("button", { name: todayFormatted })
     expect(dayToFocus).toHaveFocus()
   })
+
+  it("should focus on the first of the month when there is no selected day nor in the current month", () => {
+    render(<CalendarWrapper defaultMonth={new Date("2022-05-01")} />)
+
+    const dayToFocus = screen.getByRole("button", {
+      name: "1st May (Sunday)",
+    })
+    expect(dayToFocus).toHaveFocus()
+  })
 })

--- a/packages/date-picker/src/utils/setFocusInCalendar.ts
+++ b/packages/date-picker/src/utils/setFocusInCalendar.ts
@@ -9,11 +9,15 @@ export const setFocusInCalendar = (
   calendarElement: CalendarElement,
   selectedDay: Date | undefined
 ): void => {
-  const dayToFocus = calendarElement.getElementsByClassName(
+  const daySelectedOrToday = calendarElement.getElementsByClassName(
     selectedDay && !isInvalidDate(selectedDay)
       ? calendarStyles.daySelected
       : calendarStyles.dayToday
   )[0]
+
+  const dayToFocus =
+    daySelectedOrToday ??
+    calendarElement.getElementsByClassName(calendarStyles.day)[0]
 
   if (isHTMLElement(dayToFocus)) dayToFocus.focus()
 }


### PR DESCRIPTION
## What

Add focus fallback to the first day of the displayed month.

## Why

To cater for cases such as "the default month is set to a different month than the current month, and there is no selected day". Fallback to focusing on the first of the month.