### PR TITLE
test(date-picker): fix Date(Range)Picker tests with overlapping act calls

### DIFF
--- a/packages/date-picker/src/DatePicker/DatePicker.spec.tsx
+++ b/packages/date-picker/src/DatePicker/DatePicker.spec.tsx
@@ -58,7 +58,7 @@ describe("<DatePicker />", () => {
     expect(screen.getByDisplayValue("Mar 1, 2022")).toBeInTheDocument()
   })
 
-  it("allows you to tab through input, button and calendar", () => {
+  it("allows you to tab through input, button and calendar", async () => {
     render(<DatePickerWrapper />)
     const input = screen.getByLabelText("Input label")
 
@@ -67,7 +67,7 @@ describe("<DatePicker />", () => {
 
     userEvent.keyboard("{arrowDown}")
 
-    waitFor(() => {
+    await waitFor(() => {
       expect(screen.getByRole("dialog")).toBeVisible()
     })
 
@@ -102,7 +102,7 @@ describe("<DatePicker />", () => {
     userEvent.type(input, "05/01/2022")
     userEvent.keyboard("{Enter}")
 
-    waitFor(() => {
+    await waitFor(() => {
       expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
     })
     expect(input).toHaveFocus()
@@ -114,13 +114,13 @@ describe("<DatePicker />", () => {
 
 describe("<DatePicker /> - Focus element", () => {
   describe("Click on input", () => {
-    beforeEach(() => {
+    beforeEach(async () => {
       render(<DatePickerWrapper selectedDay={new Date("2022-03-01")} />)
 
       const input = screen.getByLabelText("Input label")
       userEvent.click(input)
 
-      waitFor(() => {
+      await waitFor(() => {
         expect(screen.queryByRole("dialog")).toBeVisible()
       })
     })
@@ -149,7 +149,7 @@ describe("<DatePicker /> - Focus element", () => {
   })
 
   describe("Keydown arrow on input", () => {
-    beforeEach(() => {
+    beforeEach(async () => {
       render(<DatePickerWrapper selectedDay={new Date("2022-03-01")} />)
 
       const input = screen.getByLabelText("Input label")
@@ -158,7 +158,7 @@ describe("<DatePicker /> - Focus element", () => {
 
       userEvent.keyboard("{ArrowDown}")
 
-      waitFor(() => {
+      await waitFor(() => {
         expect(screen.queryByRole("dialog")).toBeVisible()
       })
     })
@@ -179,7 +179,7 @@ describe("<DatePicker /> - Focus element", () => {
   })
 
   describe("Click on calendar button", () => {
-    beforeEach(() => {
+    beforeEach(async () => {
       render(<DatePickerWrapper selectedDay={new Date("2022-03-01")} />)
 
       const calendarButton = screen.getByRole("button", {
@@ -187,7 +187,7 @@ describe("<DatePicker /> - Focus element", () => {
       })
       userEvent.click(calendarButton)
 
-      waitFor(() => {
+      await waitFor(() => {
         expect(screen.getByRole("dialog")).toBeVisible()
       })
     })
@@ -210,7 +210,7 @@ describe("<DatePicker /> - Focus element", () => {
   })
 
   describe("Keydown enter on calendar button", () => {
-    beforeEach(() => {
+    beforeEach(async () => {
       render(<DatePickerWrapper selectedDay={new Date("2022-03-01")} />)
 
       const calendarButton = screen.getByRole("button", {
@@ -224,7 +224,7 @@ describe("<DatePicker /> - Focus element", () => {
 
       userEvent.keyboard("{Enter}")
 
-      waitFor(() => {
+      await waitFor(() => {
         expect(screen.getByRole("dialog")).toBeVisible()
       })
     })
@@ -256,7 +256,7 @@ describe("<DatePicker /> - Input format", () => {
 
     userEvent.click(input)
 
-    waitFor(() => {
+    await waitFor(() => {
       expect(input).toHaveValue("03/01/2022")
     })
   })
@@ -269,13 +269,13 @@ describe("<DatePicker /> - Input format", () => {
 
     userEvent.click(input)
 
-    waitFor(() => {
+    await waitFor(() => {
       expect(input).toHaveValue("03/01/2022")
     })
 
     userEvent.tab()
 
-    waitFor(() => {
+    await waitFor(() => {
       expect(input).toHaveValue("Mar 1, 2022")
     })
   })
@@ -313,7 +313,7 @@ describe("<DatePicker /> - Validation", () => {
       ).toBeVisible()
     })
 
-    it("displays error message when input date is invalid", () => {
+    it("displays error message when input date is invalid", async () => {
       render(<DatePickerWrapper />)
 
       const input = screen.getByLabelText("Input label")
@@ -321,14 +321,14 @@ describe("<DatePicker /> - Validation", () => {
 
       userEvent.tab()
 
-      waitFor(() => {
+      await waitFor(() => {
         expect(
           screen.getByText("05/05/2022Blah is an invalid date")
         ).toBeVisible()
       })
     })
 
-    it("displays error message when input date is disabled", () => {
+    it("displays error message when input date is disabled", async () => {
       render(<DatePickerWrapper disabledBefore={new Date("2022-05-15")} />)
 
       const input = screen.getByLabelText("Input label")
@@ -336,7 +336,7 @@ describe("<DatePicker /> - Validation", () => {
 
       userEvent.tab()
 
-      waitFor(() => {
+      await waitFor(() => {
         expect(
           screen.getByText("05/05/2022 is not available, try another date")
         ).toBeVisible()

--- a/packages/date-picker/src/DateRangePicker/DateRangePicker.spec.tsx
+++ b/packages/date-picker/src/DateRangePicker/DateRangePicker.spec.tsx
@@ -36,26 +36,26 @@ const DateRangePickerWrapper = ({
 }
 
 describe("<DateRangePicker />", () => {
-  it("renders DateRangePicker and shows/hides on button press", () => {
+  it("renders DateRangePicker and shows/hides on button press", async () => {
     render(<DateRangePickerWrapper />)
-
-    const button = screen.getByRole("button")
 
     expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
 
+    const button = screen.getByRole("button")
     userEvent.click(button)
-    waitFor(() => {
+
+    await waitFor(() => {
       expect(screen.queryByRole("dialog")).toBeInTheDocument()
     })
   })
 
-  it("shows/hides on button focus and keydown enter", () => {
+  it("shows/hides on button focus and keydown enter", async () => {
     render(<DateRangePickerWrapper />)
 
     expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
 
     const button = screen.getByRole("button")
-    waitFor(() => {
+    await waitFor(() => {
       button.focus()
       userEvent.keyboard("{enter}")
     })
@@ -63,20 +63,20 @@ describe("<DateRangePicker />", () => {
     expect(screen.queryByRole("dialog")).toBeInTheDocument()
   })
 
-  it("is able to select date range and shows in button", () => {
+  it("is able to select date range and shows in button", async () => {
     render(<DateRangePickerWrapper />)
 
     const button = screen.getByRole("button")
 
     userEvent.click(button)
 
-    waitFor(() => {
+    await waitFor(() => {
       const selectedFromDate = screen.getByText("6th March (Sunday)")
       selectedFromDate.parentElement && selectedFromDate.parentElement.focus()
       userEvent.keyboard("{enter}")
     })
 
-    waitFor(() => {
+    await waitFor(() => {
       const selectedToDate = screen.getByText("16th March (Wednesday)")
       selectedToDate.parentElement && selectedToDate.parentElement.focus()
       userEvent.keyboard("{enter}")
@@ -85,7 +85,7 @@ describe("<DateRangePicker />", () => {
     expect(button.innerText === "Mar 6 – Mar 16, 2022")
   })
 
-  it("updates the selected range when the user selects a new range", () => {
+  it("updates the selected range when the user selects a new range", async () => {
     const selectedDateRange = {
       from: new Date(2022, 2, 1),
       to: new Date(2022, 2, 16),
@@ -97,13 +97,13 @@ describe("<DateRangePicker />", () => {
 
     userEvent.click(button)
 
-    waitFor(() => {
+    await waitFor(() => {
       const selectedFromDate = screen.getByText("6th March (Sunday)")
       selectedFromDate.parentElement && selectedFromDate.parentElement.focus()
       userEvent.keyboard("{enter}")
     })
 
-    waitFor(() => {
+    await waitFor(() => {
       const selectedToDate = screen.getByText("16th March (Wednesday)")
       selectedToDate.parentElement && selectedToDate.parentElement.focus()
       userEvent.keyboard("{enter}")
@@ -111,19 +111,20 @@ describe("<DateRangePicker />", () => {
 
     expect(button.innerText === "Mar 6 – Mar 16, 2022")
   })
-  it("resets the selected from date when the user attempts to select a to date that is before the from date", () => {
+
+  it("resets the selected from date when the user attempts to select a to date that is before the from date", async () => {
     render(<DateRangePickerWrapper />)
 
     const button = screen.getByRole("button")
     userEvent.click(button)
 
-    waitFor(() => {
+    await waitFor(() => {
       const selectedFromDate = screen.getByText("6th March (Sunday)")
       selectedFromDate.parentElement && selectedFromDate.parentElement.focus()
       userEvent.keyboard("{enter}")
     })
 
-    waitFor(() => {
+    await waitFor(() => {
       const selectedToDate = screen.getByText("1st March (Tuesday)")
       selectedToDate.parentElement && selectedToDate.parentElement.focus()
       userEvent.keyboard("{enter}")


### PR DESCRIPTION
## Why

[KDS-698](https://cultureamp.atlassian.net/jira/software/projects/KDS/boards/289?selectedIssue=KDS-698)
Discovered we had jest `overlapping act calls` errors in https://github.com/cultureamp/kaizen-design-system/runs/7717010748?check_suite_focus=true when looking at other errors.

## What

Made DatePicker tests async where needed