### PR TITLE
feat(date-picker): render inbuilt validation when props not set

### DIFF
--- a/packages/date-picker/docs/DatePicker.stories.tsx
+++ b/packages/date-picker/docs/DatePicker.stories.tsx
@@ -193,23 +193,11 @@ export default {
 
 export const DefaultStory: ComponentStory<typeof DatePicker> = props => {
   const [selectedDate, setValueDate] = useState<Date | undefined>()
-  const [status, setStatus] = useState<FieldMessageStatus | undefined>()
-  const [validationMessage, setValidationMessage] = useState<
-    string | undefined
-  >()
-
-  const handleValidation = (validationResponse: ValidationResponse): void => {
-    setStatus(validationResponse.status)
-    setValidationMessage(validationResponse.validationMessage)
-  }
 
   return (
     <DatePicker
       {...props}
       onDayChange={setValueDate}
-      onValidate={handleValidation}
-      status={props.status || status}
-      validationMessage={props.validationMessage || validationMessage}
       selectedDay={props.selectedDay || selectedDate}
     />
   )
@@ -357,10 +345,7 @@ const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({
             labelText="Label"
             selectedDay={selectedDate}
             onDayChange={setValueDate}
-            onValidate={() => undefined}
             isReversed={isReversed}
-            status="default"
-            validationMessage={undefined}
             locale="en-AU"
           />
           <DatePicker
@@ -368,10 +353,7 @@ const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({
             labelText="Label"
             selectedDay={new Date(2022, 1, 5)}
             onDayChange={() => undefined}
-            onValidate={() => undefined}
             isReversed={isReversed}
-            status="default"
-            validationMessage={undefined}
             locale="en-AU"
           />
           <DatePicker
@@ -379,7 +361,6 @@ const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({
             labelText="Label"
             selectedDay={undefined}
             onDayChange={() => undefined}
-            onValidate={() => undefined}
             isReversed={isReversed}
             description={
               <>
@@ -392,8 +373,6 @@ const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({
                 </Paragraph>
               </>
             }
-            status="default"
-            validationMessage={undefined}
             locale="en-AU"
           />
           <DatePicker
@@ -401,10 +380,7 @@ const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({
             labelText="Label"
             selectedDay={undefined}
             onDayChange={() => undefined}
-            onValidate={() => undefined}
             isReversed={isReversed}
-            status="default"
-            validationMessage={undefined}
             locale="en-AU"
             disabled
           />
@@ -413,10 +389,7 @@ const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({
             labelText="Label"
             selectedDay={new Date("potato")}
             onDayChange={() => undefined}
-            onValidate={() => undefined}
             isReversed={isReversed}
-            status="error"
-            validationMessage="Invalid Date"
             locale="en-AU"
           />
         </StoryWrapper.Row>
@@ -429,10 +402,7 @@ const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({
             labelText="Label"
             selectedDay={new Date("2022, 1, 5")}
             onDayChange={() => undefined}
-            onValidate={() => undefined}
             isReversed={isReversed}
-            status="default"
-            validationMessage={undefined}
             locale="en-AU"
           />
           <DatePicker
@@ -440,10 +410,7 @@ const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({
             labelText="Label"
             selectedDay={new Date("2022, 1, 5")}
             onDayChange={() => undefined}
-            onValidate={() => undefined}
             isReversed={isReversed}
-            status="default"
-            validationMessage={undefined}
             locale="en-US"
           />
         </StoryWrapper.Row>

--- a/packages/date-picker/src/DatePicker/DatePicker.spec.tsx
+++ b/packages/date-picker/src/DatePicker/DatePicker.spec.tsx
@@ -264,18 +264,18 @@ describe("<DatePicker /> - Input format", () => {
 })
 
 describe("<DatePicker /> - Validation", () => {
-  it("displays the message when status is error", () => {
-    render(
-      <DatePickerWrapper
-        status="error"
-        validationMessage="Custom validation message"
-      />
-    )
-    expect(screen.getByTitle("Error message")).toBeInTheDocument()
-    expect(screen.getByText("Custom validation message")).toBeVisible()
-  })
-
   describe("Custom Validation", () => {
+    it("displays custom validation message when provided (overrides inbuilt validation)", () => {
+      render(
+        <DatePickerWrapper
+          status="error"
+          validationMessage="Custom validation message"
+        />
+      )
+      expect(screen.getByTitle("Error message")).toBeInTheDocument()
+      expect(screen.getByText("Custom validation message")).toBeVisible()
+    })
+
     it("does not show inbuilt validation message when onValidate is set", () => {
       const onValidate = jest.fn<void, [ValidationResponse]>()
       render(<DatePickerWrapper onValidate={onValidate} />)

--- a/packages/date-picker/src/DatePicker/DatePicker.spec.tsx
+++ b/packages/date-picker/src/DatePicker/DatePicker.spec.tsx
@@ -270,10 +270,12 @@ describe("<DatePicker /> - Validation", () => {
         <DatePickerWrapper
           status="error"
           validationMessage="Custom validation message"
+          selectedDay={new Date("potato")}
         />
       )
       expect(screen.getByTitle("Error message")).toBeInTheDocument()
       expect(screen.getByText("Custom validation message")).toBeVisible()
+      expect(screen.queryByText("Date is invalid")).not.toBeInTheDocument()
     })
 
     it("does not show inbuilt validation message when onValidate is set", () => {


### PR DESCRIPTION
## Why
<!-- Why have you created this PR? - Is it a new feature, or a bug fix? Or something else? -->
<!-- Reference any relevant Jira tickets so your reviewer can find more context if needed. -->
<!-- Fixing a GitHub issue? Add "Fixes [issue URL]". -->

- Improve developer experience

## What
<!-- What do your changes do? How do they change/fix the current behavior? -->
<!-- Add screenshots, GIFs or videos to illustrate the changes.  -->

- Allow `status`, `validationMessage`, and `onValidate` to be optional and use inbuilt validation.
