### PR TITLE
chore: Fixed typos in Avatar sticker sheet headings

### DIFF
--- a/draft-packages/avatar/docs/Avatar.stories.tsx
+++ b/draft-packages/avatar/docs/Avatar.stories.tsx
@@ -95,8 +95,8 @@ const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({
         <StoryWrapper.RowHeader
           headings={[
             "Photo Personal",
-            "Intials Personal",
-            "Initals Generic",
+            "Initials Personal",
+            "Initials Generic",
             "Default User",
           ]}
         />
@@ -112,7 +112,7 @@ const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({
 
       <StoryWrapper isReversed={isReversed}>
         <StoryWrapper.RowHeader
-          headings={["Initals Unicode", "Initals Long", "Company Avatar"]}
+          headings={["Initials Unicode", "Initials Long", "Company Avatar"]}
         />
         {ROWS.map(({ title, size }) => (
           <StoryWrapper.Row key={title} rowTitle={title}>


### PR DESCRIPTION
## Why
- I always use this sticker sheet during the Kaizen onboarding and keep stumbling on the typos

<img width="1102" alt="image" src="https://user-images.githubusercontent.com/763385/183789701-16afb356-0338-48e0-a50d-8859ae21217e.png">


## What
<img width="1227" alt="image" src="https://user-images.githubusercontent.com/763385/183789722-c70308ca-4657-4231-98ed-7035b885b6b5.png">
