### PR TITLE
fix: use max-width on label

### DIFF
--- a/draft-packages/form/KaizenDraft/Form/RadioGroup/RadioGroup.module.scss
+++ b/draft-packages/form/KaizenDraft/Form/RadioGroup/RadioGroup.module.scss
@@ -22,6 +22,6 @@
   }
 
   label {
-    width: 400px;
+    max-width: 400px;
   }
 }


### PR DESCRIPTION
## Why
https://cultureamp.atlassian.net/browse/KDS-716

The `label` inside a `RadioGroup` is given a width of 400px, which could cause problems on small screens and increased font-size.

## What
As suggested by @christian314159 using a `max-width` instead of `width` is the best solution to prevent any scenarios that do require the width 