### PR TITLE
feat: Use `listIsActive` to highlight list buttons when active

### DIFF
--- a/packages/rich-text-editor/package.json
+++ b/packages/rich-text-editor/package.json
@@ -32,7 +32,7 @@
   "private": false,
   "license": "MIT",
   "dependencies": {
-    "@cultureamp/rich-text-toolkit": "^1.10.0",
+    "@cultureamp/rich-text-toolkit": "^1.11.0",
     "@kaizen/a11y": "^1.5.1",
     "@kaizen/component-base": "^1.1.0",
     "@kaizen/component-library": "^15.2.0",

--- a/packages/rich-text-editor/src/RichTextEditor/controlmap.ts
+++ b/packages/rich-text-editor/src/RichTextEditor/controlmap.ts
@@ -11,7 +11,7 @@ import { EditorState, Transaction } from "prosemirror-state"
 import { Schema, NodeType, MarkType } from "prosemirror-model"
 import { Command, toggleMark } from "prosemirror-commands"
 import { wrapInList, liftListItem, sinkListItem } from "prosemirror-schema-list"
-import { markIsActive } from "@cultureamp/rich-text-toolkit"
+import { markIsActive, listIsActive } from "@cultureamp/rich-text-toolkit"
 import { ToolbarItems, ToolbarControlTypes } from "../types"
 
 /** Configuration for individual controls */
@@ -209,6 +209,7 @@ export function buildControlMap(
   const controlGroupIndex: ControlGroupTypes = createControlGroupIndex(controls)
   const toolbarControls: GroupedToolbarControls =
     createInitialControls(controlGroupIndex)
+  const listNodes = [schema.nodes.bulletList, schema.nodes.orderedList]
 
   if (schema.marks.strong) {
     const type = schema.marks.strong
@@ -248,7 +249,7 @@ export function buildControlMap(
     const groupIndex = getGroupIndex(controlGroupIndex, "bulletList")
     toolbarControls[groupIndex].push({
       action: createToggleListCommand(type),
-      isActive: false,
+      isActive: listIsActive(editorState, type, listNodes),
       label: "Bullet List",
       icon: bulletListIcon,
     })
@@ -259,7 +260,7 @@ export function buildControlMap(
     const groupIndex = getGroupIndex(controlGroupIndex, "orderedList")
     toolbarControls[groupIndex].push({
       action: createToggleListCommand(type),
-      isActive: false,
+      isActive: listIsActive(editorState, type, listNodes),
       label: "Numbered List",
       icon: numberedListIcon,
     })

--- a/yarn.lock
+++ b/yarn.lock
@@ -1843,10 +1843,10 @@
   resolved "https://registry.yarnpkg.com/@csstools/selector-specificity/-/selector-specificity-2.0.1.tgz#b6b8d81780b9a9f6459f4bfe9226ac6aefaefe87"
   integrity sha512-aG20vknL4/YjQF9BSV7ts4EWm/yrjagAN7OWBNmlbEOUiu0llj4OGrFoOKK3g2vey4/p2omKCoHrWtPxSwV3HA==
 
-"@cultureamp/rich-text-toolkit@^1.10.0":
-  version "1.10.0"
-  resolved "https://npm.pkg.github.com/download/@cultureamp/rich-text-toolkit/1.10.0/449bf3cac959c66a1822b018e6fbd7b3cd1ad3c7afab833f19a2b14702ed5c95#b50a7ee0f98272d0c62b1bc905093a32a6db6e6c"
-  integrity sha512-mAofhOoZVdDztmafaa1u54SO6DZaiTL7B/QMtC28pHgZ6B7kccDy/0sdgiq3U30MC0h6P2nB+WZjRwVHTpYJ2g==
+"@cultureamp/rich-text-toolkit@^1.11.0":
+  version "1.11.0"
+  resolved "https://npm.pkg.github.com/download/@cultureamp/rich-text-toolkit/1.11.0/2cdbe00397f6b54f3e5f775018fd9973abc176c1531711d443a63eb9c5e4642b#92441bde6927abc124331addbf32efe06cb7cb9a"
+  integrity sha512-rJUOGKrLLhBa++s2bmG+LaQvoJUTvX9m+/Big4z9NLS5SzWsYhsAvlTGUv7MJBtBFN7+bFxQDET/8N8JgD0gLQ==
   dependencies:
     "@kaizen/button" "^1.2.8"
     "@kaizen/component-library" "^14.3.4"


### PR DESCRIPTION
## Why
To highlight the list buttons in the toolbar when it is active in the RTE component
[COMP-262](https://cultureamp.atlassian.net/browse/COMP-262)


## What
- Update dependency version for `rich-text-toolkit`
- Use `listIsActive` method from `rich-text-toolkit` to highlight list buttons

## Screenshots

- Bullet list
![Bullet list](https://user-images.githubusercontent.com/25001871/184060968-bdc6b0c5-f493-4aef-9ac6-4ce4f6d566d3.png)

- Numbered list
![Numbered list](https://user-images.githubusercontent.com/25001871/184060970-e76c1ce7-26bc-4d67-b45e-7782ac9b5ccd.png)

