### PR TITLE
fix(filter-multi-select): use spacing-xs between children and chevron

### DIFF
--- a/packages/select/src/FilterMultiSelect/components/Trigger/TriggerButtonBase/TriggerButtonBase.scss
+++ b/packages/select/src/FilterMultiSelect/components/Trigger/TriggerButtonBase/TriggerButtonBase.scss
@@ -1,4 +1,5 @@
 @import "~@kaizen/design-tokens/sass/border";
+@import "~@kaizen/design-tokens/sass/spacing";
 @import "../mixins";
 
 .button {
@@ -6,4 +7,8 @@
   border-radius: $border-solid-border-radius;
 
   width: max-content;
+}
+
+.icon {
+  margin-left: $spacing-xs;
 }

--- a/packages/select/src/FilterMultiSelect/components/Trigger/TriggerButtonBase/TriggerButtonBase.tsx
+++ b/packages/select/src/FilterMultiSelect/components/Trigger/TriggerButtonBase/TriggerButtonBase.tsx
@@ -24,10 +24,12 @@ export const TriggerButtonBase: React.VFC<TriggerButtonBaseProps> = ({
       ref={buttonRef}
       className={classNames(styles.button, classNameOverride)}
     >
-      <span>{children}</span>
+      {children}
+
       <Icon
         icon={menuTriggerState.isOpen ? chevronUp : chevronDown}
         role="presentation"
+        classNameOverride={styles.icon}
       />
     </button>
   )

--- a/packages/select/src/FilterMultiSelect/components/Trigger/_mixins.scss
+++ b/packages/select/src/FilterMultiSelect/components/Trigger/_mixins.scss
@@ -40,7 +40,6 @@
   }
 
   display: inline-flex;
-  gap: $spacing-sm;
   align-items: center;
 
   .iconWrapper {


### PR DESCRIPTION
## What
On the FilterMultiSelect's trigger button, changes spacing between children and the chevron from 12px to $spacing-xs

## Why
Spacing was previously 12px, which is a larger value than the figma design

### Before
<img width="221" alt="image" src="https://user-images.githubusercontent.com/34709943/184581348-5ea3c23f-1ff1-4292-9dd7-b83854721313.png">

### After
<img width="210" alt="image" src="https://user-images.githubusercontent.com/34709943/184581301-ca14e918-f446-40b3-92da-2b6ad9b9ac8a.png">
