### PR TITLE
fix: FilterMultiSelect stories - FilterBar 

### DIFF
--- a/packages/select/docs/FilterBarExample/DemographicValueSelect.tsx
+++ b/packages/select/docs/FilterBarExample/DemographicValueSelect.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react"
+import React, { Key, useEffect, useState } from "react"
 import { Selection } from "@react-types/shared"
 import {
   FilterMultiSelect,
@@ -16,6 +16,7 @@ export interface DemograhicValueSelectProps {
   onRemove: () => void
   onSelectionChange: (selectedKeys: React.Key[]) => void
   id: string
+  selectedKeys: Set<Key>
 }
 
 export const DemographicValueSelect = ({
@@ -23,9 +24,8 @@ export const DemographicValueSelect = ({
   label,
   onRemove,
   onSelectionChange,
+  selectedKeys,
 }: DemograhicValueSelectProps) => {
-  const [selectedKeys, setSelectedKeys] = useState<Selection>(new Set())
-
   // Mock data
   const demographicValues =
     id === "id-department"
@@ -47,7 +47,6 @@ export const DemographicValueSelect = ({
   }, [])
 
   const handleSelectionChange = (keys: Selection) => {
-    setSelectedKeys(keys)
     onSelectionChange(getSelectedOptionKeys(keys, demographicValueItems))
   }
 

--- a/packages/select/docs/FilterMultiSelect.stories.tsx
+++ b/packages/select/docs/FilterMultiSelect.stories.tsx
@@ -1,4 +1,4 @@
-import React, { Key, useState } from "react"
+import React, { useState } from "react"
 import { ComponentMeta } from "@storybook/react"
 import { withDesign } from "storybook-addon-designs"
 import { Selection } from "@react-types/shared"

--- a/packages/select/docs/FilterMultiSelect.stories.tsx
+++ b/packages/select/docs/FilterMultiSelect.stories.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react"
+import React, { Key, useState } from "react"
 import { ComponentMeta } from "@storybook/react"
 import { withDesign } from "storybook-addon-designs"
 import { Selection } from "@react-types/shared"
@@ -98,6 +98,7 @@ export const FilterBarDemo = args => {
           {selectedGroups.map(({ name, id }) => (
             <DemographicValueSelect
               label={name}
+              selectedKeys={new Set(selectedDemographicValues[id])}
               id={id}
               onRemove={() => {
                 focusAddFilter()

--- a/packages/select/src/FilterMultiSelect/provider/SelectionProvider/SelectionProvider.spec.tsx
+++ b/packages/select/src/FilterMultiSelect/provider/SelectionProvider/SelectionProvider.spec.tsx
@@ -72,19 +72,19 @@ describe("<SelectionProviderWrapper /> - Visual content", () => {
           name: "option-1-label-mock",
           selected: false,
         })
-      )
+      ).toBeVisible()
       expect(
         screen.getByRole("option", {
           name: "option-2-label-mock",
           selected: false,
         })
-      )
+      ).toBeVisible()
       expect(
         screen.getByRole("option", {
           name: "option-3-label-mock",
           selected: false,
         })
-      )
+      ).toBeVisible()
     })
 
     test("The listbox is labelled by the provided label", () => {
@@ -108,19 +108,19 @@ describe("<SelectionProviderWrapper /> - Visual content", () => {
           name: "option-1-label-mock",
           selected: false,
         })
-      )
+      ).toBeVisible()
       expect(
         screen.getByRole("option", {
           name: "option-2-label-mock",
           selected: true,
         })
-      )
+      ).toBeVisible()
       expect(
         screen.getByRole("option", {
           name: "option-3-label-mock",
           selected: false,
         })
-      )
+      ).toBeVisible()
     })
   })
 
@@ -132,19 +132,19 @@ describe("<SelectionProviderWrapper /> - Visual content", () => {
           name: "option-1-label-mock",
           selected: true,
         })
-      )
+      ).toBeVisible()
       expect(
         screen.getByRole("option", {
           name: "option-2-label-mock",
           selected: true,
         })
-      )
+      ).toBeVisible()
       expect(
         screen.getByRole("option", {
           name: "option-3-label-mock",
           selected: true,
         })
-      )
+      ).toBeVisible()
     })
   })
 })
@@ -235,19 +235,19 @@ describe("<SelectionProviderWrapper /> - Mouse interaction", () => {
         name: "option-1-label-mock",
         selected: false,
       })
-    )
+    ).toBeVisible()
     expect(
       screen.getByRole("option", {
         name: "option-2-label-mock",
         selected: false,
       })
-    )
+    ).toBeVisible()
     expect(
       screen.getByRole("option", {
         name: "option-3-label-mock",
         selected: false,
       })
-    )
+    ).toBeVisible()
   })
 
   it("fires onSelectionChange when clicks on Clear all button", () => {
@@ -285,7 +285,7 @@ describe("<SelectionProviderWrapper /> - Mouse interaction", () => {
         name: "option-2-label-mock",
         selected: false,
       })
-    )
+    ).toBeVisible()
   })
 })
 
@@ -293,7 +293,6 @@ describe("<SelectionProviderWrapper /> - Keyboard interaction", () => {
   describe("Given no selectedKeys", () => {
     it("focuses on the frist option when tabs onto the list", () => {
       render(<SelectionProviderWrapper />)
-      const listBox = screen.getByRole("listbox")
       userEvent.tab()
 
       expect(
@@ -367,9 +366,6 @@ describe("<SelectionProviderWrapper /> - Keyboard interaction", () => {
 
   it("selects the option when hits enter on a non-selected option", () => {
     render(<SelectionProviderWrapper />)
-    const option1 = screen.getByRole("option", {
-      name: "option-1-label-mock",
-    })
 
     userEvent.tab()
     userEvent.keyboard("{Enter}")
@@ -397,7 +393,7 @@ describe("<SelectionProviderWrapper /> - Keyboard interaction", () => {
         name: "option-2-label-mock",
         selected: false,
       })
-    )
+    ).toBeVisible()
   })
 
   it("fires onSelectionChange when hits enter on a option", () => {

--- a/packages/select/src/FilterMultiSelect/provider/SelectionProvider/SelectionProvider.spec.tsx
+++ b/packages/select/src/FilterMultiSelect/provider/SelectionProvider/SelectionProvider.spec.tsx
@@ -1,6 +1,7 @@
-import React from "react"
-import { render, screen, waitFor } from "@testing-library/react"
+import React, { useState } from "react"
+import { render, screen } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
+import { Selection } from "@react-types/shared"
 import { SearchInput } from "../../components/SearchInput"
 import { ListBox } from "../../components/ListBox"
 import { MultiSelectOption } from "../../components/MultiSelectOption"
@@ -33,23 +34,34 @@ const itemsMock: ItemType[] = [
 
 const SelectionProviderWrapper = ({
   items = itemsMock,
+  selectedKeys,
+  onSelectionChange,
   ...props
-}: Partial<SelectionProviderProps>) => (
-  <SelectionProvider
-    selectionMode="multiple"
-    items={items}
-    label="selection-label-mock"
-    {...props}
-  >
-    <ListBox>
-      {item => <MultiSelectOption key={item.key} item={item} />}
-    </ListBox>
+}: Partial<SelectionProviderProps>) => {
+  const [selected, setSelected] = useState<Selection>(selectedKeys ?? new Set())
 
-    <SearchInput label="search-input-label-mock" />
-    <SelectAllButton />
-    <ClearButton />
-  </SelectionProvider>
-)
+  return (
+    <SelectionProvider
+      selectionMode="multiple"
+      items={items}
+      label="selection-label-mock"
+      selectedKeys={selected}
+      onSelectionChange={selection => {
+        setSelected(selection)
+        onSelectionChange && onSelectionChange(selection)
+      }}
+      {...props}
+    >
+      <ListBox>
+        {item => <MultiSelectOption key={item.key} item={item} />}
+      </ListBox>
+
+      <SearchInput label="search-input-label-mock" />
+      <SelectAllButton />
+      <ClearButton />
+    </SelectionProvider>
+  )
+}
 
 describe("<SelectionProviderWrapper /> - Visual content", () => {
   describe("Given no selectedKeys", () => {
@@ -218,38 +230,41 @@ describe("<SelectionProviderWrapper /> - Mouse interaction", () => {
 
     userEvent.click(clear)
 
-    waitFor(() => {
-      expect(
-        screen.getByRole("option", {
-          name: "option-1-label-mock",
-          selected: false,
-        })
-      )
-      expect(
-        screen.getByRole("option", {
-          name: "option-2-label-mock",
-          selected: false,
-        })
-      )
-      expect(
-        screen.getByRole("option", {
-          name: "option-3-label-mock",
-          selected: false,
-        })
-      )
-    })
+    expect(
+      screen.getByRole("option", {
+        name: "option-1-label-mock",
+        selected: false,
+      })
+    )
+    expect(
+      screen.getByRole("option", {
+        name: "option-2-label-mock",
+        selected: false,
+      })
+    )
+    expect(
+      screen.getByRole("option", {
+        name: "option-3-label-mock",
+        selected: false,
+      })
+    )
   })
 
-  it("fires onSelectionChange when clicks on Clear all button", async () => {
+  it("fires onSelectionChange when clicks on Clear all button", () => {
     const spy = jest.fn()
-    render(<SelectionProviderWrapper onSelectionChange={spy} />)
+    render(
+      <SelectionProviderWrapper
+        onSelectionChange={spy}
+        selectedKeys={new Set(["option-2-value-mock"])}
+      />
+    )
     const clear = screen.getByRole("button", {
       name: "Clear",
     })
 
     userEvent.click(clear)
 
-    waitFor(() => expect(spy).toHaveBeenCalledTimes(1))
+    expect(spy).toHaveBeenCalledTimes(1)
   })
 
   it("de-selects the option when clicks on a selected option", () => {
@@ -265,13 +280,11 @@ describe("<SelectionProviderWrapper /> - Mouse interaction", () => {
 
     userEvent.click(option2)
 
-    waitFor(() =>
-      expect(
-        screen.getByRole("option", {
-          name: "option-2-label-mock",
-          selected: false,
-        })
-      )
+    expect(
+      screen.getByRole("option", {
+        name: "option-2-label-mock",
+        selected: false,
+      })
     )
   })
 })
@@ -379,13 +392,11 @@ describe("<SelectionProviderWrapper /> - Keyboard interaction", () => {
     userEvent.tab()
     userEvent.keyboard("{Enter}")
 
-    waitFor(() =>
-      expect(
-        screen.getByRole("option", {
-          name: "option-2-label-mock",
-          selected: false,
-        })
-      )
+    expect(
+      screen.getByRole("option", {
+        name: "option-2-label-mock",
+        selected: false,
+      })
     )
   })
 


### PR DESCRIPTION
## Why
A bug was raised that when having multiple filter category selected, removing the first category will clear the second one as well.


## What
The proposed solution:

- remove the internal state within the [DemographicValueSelect.tsx](https://github.com/cultureamp/kaizen-design-system/compare/ll/fix-filter-multi-select-stories?expand=1#diff-fb7011fd06c523f4db5afb33622454f35bbb27efdd224b70c16c68b94f9a800d) 
- allow its value to be controlled externally

## Result

https://user-images.githubusercontent.com/8596435/184593993-f5d23529-06d2-455b-9312-f3dad54b8fef.mov
