### PR TITLE
feat: Preload fonts in ThemeProvider & handle default theme

### DIFF
--- a/packages/design-tokens/react/ThemeProvider.tsx
+++ b/packages/design-tokens/react/ThemeProvider.tsx
@@ -68,13 +68,6 @@ export const ThemeProvider = ({
       />
       <link
         rel="preload"
-        href="https://d1e7r7b0lb8p4d.cloudfront.net/fonts/inter/inter-light.woff2"
-        as="font"
-        type="font/woff2"
-        crossOrigin="crossorigin"
-      />
-      <link
-        rel="preload"
         href="https://d1e7r7b0lb8p4d.cloudfront.net/fonts/tiempos/tiempos-headline-bold.woff2"
         as="font"
         type="font/woff2"


### PR DESCRIPTION
## Why
In `unified-home` and `unified-navigation` we preload the font resources and create a Theme Manager using the default theme. This is repeated across both these repos. This PR takes in these commonalities and incorporates it within Kaizen `ThemeProvider`

Thread: https://cultureamp.slack.com/archives/C0189KBPM4Y/p1660535756937689

