### PR TITLE
fix: Splitbutton flaky test on chromatic

### DIFF
--- a/packages/split-button/docs/SplitButton.stories.tsx
+++ b/packages/split-button/docs/SplitButton.stories.tsx
@@ -28,25 +28,17 @@ const WrapperChromaticIgnore: React.VFC<{ children: React.ReactNode }> = ({
 }) => <div data-chromatic="ignore">{children}</div>
 
 const DROPDOWN_CONTENT__ENABLED = (
-  <WrapperChromaticIgnore>
-    <MenuList>
-      <MenuItem
-        icon={editIcon}
-        label="Menu Item 1"
-        onClick={action("clicked")}
-      />
-      <MenuItem icon={duplicateIcon} label="Menu Item 2" />
-    </MenuList>
-  </WrapperChromaticIgnore>
+  <MenuList>
+    <MenuItem icon={editIcon} label="Menu Item 1" onClick={action("clicked")} />
+    <MenuItem icon={duplicateIcon} label="Menu Item 2" />
+  </MenuList>
 )
 
 const DROPDOWN_CONTENT__ONE_DISABLED = (
-  <WrapperChromaticIgnore>
-    <MenuList>
-      <MenuItem icon={editIcon} label="Menu Item 1" disabled />
-      <MenuItem icon={duplicateIcon} label="Menu Item 2" />
-    </MenuList>
-  </WrapperChromaticIgnore>
+  <MenuList>
+    <MenuItem icon={editIcon} label="Menu Item 1" disabled />
+    <MenuItem icon={duplicateIcon} label="Menu Item 2" />
+  </MenuList>
 )
 
 export default {
@@ -193,24 +185,26 @@ const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({
       </StoryWrapper>
 
       {IS_CHROMATIC && (
-        <StoryWrapper isReversed={isReversed}>
-          <StoryWrapper.RowHeader headings={["LTR", "RTL"]} />
-          <StoryWrapper.Row rowTitle="Dropdown open">
-            <SplitButton
-              isReversed={isReversed}
-              actionButtonProps={ACTION_BUTTON_PROPS__BUTTON}
-              dropdownContent={DROPDOWN_CONTENT__ENABLED}
-              isDropdownInitOpen
-            />
-            <SplitButton
-              isReversed={isReversed}
-              actionButtonProps={ACTION_BUTTON_PROPS__BUTTON}
-              dropdownContent={DROPDOWN_CONTENT__ENABLED}
-              dir="rtl"
-              isDropdownInitOpen
-            />
-          </StoryWrapper.Row>
-        </StoryWrapper>
+        <WrapperChromaticIgnore>
+          <StoryWrapper isReversed={isReversed}>
+            <StoryWrapper.RowHeader headings={["LTR", "RTL"]} />
+            <StoryWrapper.Row rowTitle="Dropdown open">
+              <SplitButton
+                isReversed={isReversed}
+                actionButtonProps={ACTION_BUTTON_PROPS__BUTTON}
+                dropdownContent={DROPDOWN_CONTENT__ENABLED}
+                isDropdownInitOpen
+              />
+              <SplitButton
+                isReversed={isReversed}
+                actionButtonProps={ACTION_BUTTON_PROPS__BUTTON}
+                dropdownContent={DROPDOWN_CONTENT__ENABLED}
+                dir="rtl"
+                isDropdownInitOpen
+              />
+            </StoryWrapper.Row>
+          </StoryWrapper>
+        </WrapperChromaticIgnore>
       )}
     </>
   )

--- a/packages/split-button/docs/SplitButton.stories.tsx
+++ b/packages/split-button/docs/SplitButton.stories.tsx
@@ -131,7 +131,7 @@ const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({
       </StoryWrapper>
 
       <StoryWrapper isReversed={isReversed}>
-        <StoryWrapper.RowHeader headings={["Hoover", "Active", "Focus"]} />
+        <StoryWrapper.RowHeader headings={["Hover", "Active", "Focus"]} />
         <StoryWrapper.Row rowTitle="Action button">
           <SplitButton
             isReversed={isReversed}

--- a/packages/split-button/docs/SplitButton.stories.tsx
+++ b/packages/split-button/docs/SplitButton.stories.tsx
@@ -131,7 +131,7 @@ const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({
       </StoryWrapper>
 
       <StoryWrapper isReversed={isReversed}>
-        <StoryWrapper.RowHeader headings={["Hover", "Active", "Focus"]} />
+        <StoryWrapper.RowHeader headings={["Hoover", "Active", "Focus"]} />
         <StoryWrapper.Row rowTitle="Action button">
           <SplitButton
             isReversed={isReversed}

--- a/packages/split-button/docs/SplitButton.stories.tsx
+++ b/packages/split-button/docs/SplitButton.stories.tsx
@@ -23,10 +23,6 @@ const ACTION_BUTTON_PROPS__ANCHOR = {
   href: "//example.com",
 }
 
-const WrapperChromaticIgnore: React.VFC<{ children: React.ReactNode }> = ({
-  children,
-}) => <div data-chromatic="ignore">{children}</div>
-
 const DROPDOWN_CONTENT__ENABLED = (
   <MenuList>
     <MenuItem icon={editIcon} label="Menu Item 1" onClick={action("clicked")} />
@@ -185,26 +181,24 @@ const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({
       </StoryWrapper>
 
       {IS_CHROMATIC && (
-        <WrapperChromaticIgnore>
-          <StoryWrapper isReversed={isReversed}>
-            <StoryWrapper.RowHeader headings={["LTR", "RTL"]} />
-            <StoryWrapper.Row rowTitle="Dropdown open">
-              <SplitButton
-                isReversed={isReversed}
-                actionButtonProps={ACTION_BUTTON_PROPS__BUTTON}
-                dropdownContent={DROPDOWN_CONTENT__ENABLED}
-                isDropdownInitOpen
-              />
-              <SplitButton
-                isReversed={isReversed}
-                actionButtonProps={ACTION_BUTTON_PROPS__BUTTON}
-                dropdownContent={DROPDOWN_CONTENT__ENABLED}
-                dir="rtl"
-                isDropdownInitOpen
-              />
-            </StoryWrapper.Row>
-          </StoryWrapper>
-        </WrapperChromaticIgnore>
+        <StoryWrapper isReversed={isReversed} data-chromatic="ignore">
+          <StoryWrapper.RowHeader headings={["LTR", "RTL"]} />
+          <StoryWrapper.Row rowTitle="Dropdown open">
+            <SplitButton
+              isReversed={isReversed}
+              actionButtonProps={ACTION_BUTTON_PROPS__BUTTON}
+              dropdownContent={DROPDOWN_CONTENT__ENABLED}
+              isDropdownInitOpen
+            />
+            <SplitButton
+              isReversed={isReversed}
+              actionButtonProps={ACTION_BUTTON_PROPS__BUTTON}
+              dropdownContent={DROPDOWN_CONTENT__ENABLED}
+              dir="rtl"
+              isDropdownInitOpen
+            />
+          </StoryWrapper.Row>
+        </StoryWrapper>
       )}
     </>
   )

--- a/packages/split-button/docs/SplitButton.stories.tsx
+++ b/packages/split-button/docs/SplitButton.stories.tsx
@@ -3,7 +3,6 @@ import { ComponentMeta, Story } from "@storybook/react"
 import { action } from "@storybook/addon-actions"
 import { MenuItem, MenuList } from "@kaizen/draft-menu"
 import { withDesign } from "storybook-addon-designs"
-import isChromatic from "chromatic"
 import duplicateIcon from "@kaizen/component-library/icons/duplicate.icon.svg"
 import editIcon from "@kaizen/component-library/icons/edit.icon.svg"
 import { StoryWrapper } from "../../../storybook/components/StoryWrapper"
@@ -11,8 +10,6 @@ import { figmaEmbed } from "../../../storybook/helpers"
 import { CATEGORIES } from "../../../storybook/constants"
 import { SplitButton, SplitButtonProps } from "../"
 import { ActionButton, DropdownButton } from "../src/SplitButton/components"
-
-const IS_CHROMATIC = isChromatic()
 
 const ACTION_BUTTON_PROPS__BUTTON = {
   label: "Edit Survey",
@@ -179,27 +176,6 @@ const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({
           />
         </StoryWrapper.Row>
       </StoryWrapper>
-
-      {IS_CHROMATIC && (
-        <StoryWrapper isReversed={isReversed} data-chromatic="ignore">
-          <StoryWrapper.RowHeader headings={["LTR", "RTL"]} />
-          <StoryWrapper.Row rowTitle="Dropdown open">
-            <SplitButton
-              isReversed={isReversed}
-              actionButtonProps={ACTION_BUTTON_PROPS__BUTTON}
-              dropdownContent={DROPDOWN_CONTENT__ENABLED}
-              isDropdownInitOpen
-            />
-            <SplitButton
-              isReversed={isReversed}
-              actionButtonProps={ACTION_BUTTON_PROPS__BUTTON}
-              dropdownContent={DROPDOWN_CONTENT__ENABLED}
-              dir="rtl"
-              isDropdownInitOpen
-            />
-          </StoryWrapper.Row>
-        </StoryWrapper>
-      )}
     </>
   )
 }


### PR DESCRIPTION
## Why
<!-- Why have you created this PR? - Is it a new feature, or a bug fix? Or something else? -->
<!-- Reference any relevant Jira tickets so your reviewer can find more context if needed. -->
<!-- Fixing a GitHub issue? Add "Fixes [issue URL]". -->
The split button's menu causes flaky chromatic tests when the position is a few pixels off.

## What
<!-- What do your changes do? How do they change/fix the current behavior? -->
<!-- Add screenshots, GIFs or videos to illustrate the changes.  -->
- Wrap the chromatic rows in a chromatic ignore