### PR TITLE
refactor(date-picker): update DateInput to use forwardRef

### DIFF
--- a/packages/date-picker/src/DatePicker/DatePicker.tsx
+++ b/packages/date-picker/src/DatePicker/DatePicker.tsx
@@ -122,7 +122,7 @@ export interface DatePickerProps
  */
 export const DatePicker: React.VFC<DatePickerProps> = ({
   id,
-  buttonRef = useRef<HTMLButtonElement>(null),
+  buttonRef: propsButtonRef = useRef<HTMLButtonElement>(null),
   locale: propsLocale,
   disabledDates,
   disabledDaysOfWeek,
@@ -146,6 +146,11 @@ export const DatePicker: React.VFC<DatePickerProps> = ({
 }) => {
   const containerRef = useRef<HTMLInputElement>(null)
   const inputRef = useRef<HTMLInputElement>(null)
+  const buttonRef = useRef<HTMLButtonElement>(propsButtonRef?.current || null)
+  const dateInputRefs = useRef({
+    inputRef,
+    buttonRef,
+  })
   const [inputValue, setInputValue] = useState<string>("")
   const [isOpen, setIsOpen] = useState(false)
   const [lastTrigger, setLastTrigger] = useState<
@@ -308,8 +313,7 @@ export const DatePicker: React.VFC<DatePickerProps> = ({
     >
       <div ref={containerRef}>
         <DateInput
-          inputRef={inputRef}
-          buttonRef={buttonRef}
+          ref={dateInputRefs}
           id={id}
           calendarId={`${id}-calendar-dialog`}
           value={inputValue}

--- a/packages/date-picker/src/DatePicker/components/DateInput/DateInput.spec.tsx
+++ b/packages/date-picker/src/DatePicker/components/DateInput/DateInput.spec.tsx
@@ -1,8 +1,9 @@
-import React from "react"
+import React, { useRef } from "react"
 import { render, screen } from "@testing-library/react"
 import "@testing-library/jest-dom"
 import { enUS } from "date-fns/locale"
 import dateStart from "@kaizen/component-library/icons/date-start.icon.svg"
+import userEvent from "@testing-library/user-event"
 import { DateInput, DateInputProps } from "./DateInput"
 
 const defaultProps = {
@@ -88,6 +89,43 @@ describe("<DateInput />", () => {
       )
       const errorMessage = screen.queryByText("There is an error")
       expect(errorMessage).not.toBeInTheDocument()
+    })
+  })
+
+  describe("Refs", () => {
+    it("uses consumer buttonRef", () => {
+      const fn = jest.fn<void, [string | null | undefined]>()
+
+      const Wrapper = () => {
+        const buttonRef = useRef<HTMLButtonElement>(null)
+        const ref = useRef({ buttonRef })
+
+        const handleClick = () => {
+          fn(buttonRef.current?.getAttribute("aria-label"))
+        }
+
+        return (
+          <>
+            <DateInput
+              id="date-input-ref"
+              calendarId="cal-id"
+              isCalendarOpen={false}
+              labelText="label"
+              icon={dateStart}
+              onButtonClick={handleClick}
+              locale={enUS}
+              ref={ref}
+            />
+            <button onClick={handleClick}>Click me</button>
+          </>
+        )
+      }
+
+      render(<Wrapper />)
+
+      userEvent.click(screen.getByText("Click me"))
+
+      expect(fn).toBeCalledWith("Choose date")
     })
   })
 })

--- a/packages/date-picker/src/DatePicker/components/DateInput/DateInput.spec.tsx
+++ b/packages/date-picker/src/DatePicker/components/DateInput/DateInput.spec.tsx
@@ -94,14 +94,14 @@ describe("<DateInput />", () => {
 
   describe("Refs", () => {
     it("uses consumer buttonRef", () => {
-      const fn = jest.fn<void, [string | null | undefined]>()
+      const onButtonClick = jest.fn<void, [string | null | undefined]>()
 
       const Wrapper = () => {
         const buttonRef = useRef<HTMLButtonElement>(null)
         const ref = useRef({ buttonRef })
 
         const handleClick = () => {
-          fn(buttonRef.current?.getAttribute("aria-label"))
+          onButtonClick(buttonRef.current?.getAttribute("aria-label"))
         }
 
         return (
@@ -125,7 +125,7 @@ describe("<DateInput />", () => {
 
       userEvent.click(screen.getByText("Click me"))
 
-      expect(fn).toBeCalledWith("Choose date")
+      expect(onButtonClick).toBeCalledWith("Choose date")
     })
   })
 })

--- a/packages/date-picker/src/utils/isRefObject.ts
+++ b/packages/date-picker/src/utils/isRefObject.ts
@@ -1,0 +1,3 @@
+export const isRefObject = (
+  ref: React.ForwardedRef<any>
+): ref is React.MutableRefObject<any> => ref !== null && "current" in ref


### PR DESCRIPTION
## Why
<!-- Why have you created this PR? - Is it a new feature, or a bug fix? Or something else? -->
<!-- Reference any relevant Jira tickets so your reviewer can find more context if needed. -->
<!-- Fixing a GitHub issue? Add "Fixes [issue URL]". -->
- To refactor Date Input to use forward Ref

## What
<!-- What do your changes do? How do they change/fix the current behavior? -->
<!-- Add screenshots, GIFs or videos to illustrate the changes.  -->
- use forwardRef within DateInput
- pass buttonRef and InputRef as a ref Object to DateInput