### PR TITLE
fix: KDS-737 Only apply 'select all' and 'clear' to filtered items when using the search

### DIFF
--- a/packages/select/src/FilterMultiSelect/components/SelectionControlButton/ClearButton/ClearButton.spec.tsx
+++ b/packages/select/src/FilterMultiSelect/components/SelectionControlButton/ClearButton/ClearButton.spec.tsx
@@ -10,13 +10,22 @@ jest.mock("../../../provider", () => ({
 
 describe("<ClearButton /> - interaction", () => {
   describe("Given selection is not empty", () => {
-    it("triggesrs selectionManager.clearSelection() when clicks on the button", () => {
+    it("triggers selectionManager.selSelectedKeys() with focused keys filtered out when button is clicked", () => {
       const spy = jest.fn()
+      const selectedAndFocused = "selectedAndFocused"
+      const selectedButNotFocused = "selectedButNotFocused"
+      const selectedKeys = [selectedAndFocused, selectedButNotFocused]
+      const filteredKeys = [selectedAndFocused]
       ;(useSelectionContext as jest.Mock).mockReturnValue({
         selectionState: {
+          collection: {
+            getKeys: () => filteredKeys,
+          },
           selectionManager: {
             isEmpty: false,
-            clearSelection: spy,
+            setSelectedKeys: spy,
+            selectedKeys,
+            isSelected: id => selectedKeys.includes(id),
           },
         },
       })
@@ -24,17 +33,24 @@ describe("<ClearButton /> - interaction", () => {
       userEvent.click(screen.getByRole("button"))
 
       expect(spy).toHaveBeenCalledTimes(1)
+      expect(spy).toHaveBeenCalledWith([selectedButNotFocused])
     })
   })
 
   describe("Given selection is empty", () => {
-    it("does not trigger selectionManager.clearSelection() when clicks on the button", () => {
+    it("does not trigger selectionManager.setSelectedKeys() when clicks on the button", () => {
       const spy = jest.fn()
+      const filteredKeys = []
+      const selectedKeys = []
       ;(useSelectionContext as jest.Mock).mockReturnValue({
         selectionState: {
+          collection: {
+            getKeys: () => filteredKeys,
+          },
           selectionManager: {
             isEmpty: true,
-            clearSelection: spy,
+            selectedKeys,
+            setSelectedKeys: spy,
           },
         },
       })

--- a/packages/select/src/FilterMultiSelect/components/SelectionControlButton/ClearButton/ClearButton.tsx
+++ b/packages/select/src/FilterMultiSelect/components/SelectionControlButton/ClearButton/ClearButton.tsx
@@ -6,6 +6,7 @@ import styles from "../SelectionControlButton.scss"
 
 export const ClearButton: React.VFC = () => {
   const { selectionState } = useSelectionContext()
+
   return (
     <button
       className={classNames(

--- a/packages/select/src/FilterMultiSelect/components/SelectionControlButton/ClearButton/ClearButton.tsx
+++ b/packages/select/src/FilterMultiSelect/components/SelectionControlButton/ClearButton/ClearButton.tsx
@@ -7,6 +7,9 @@ import styles from "../SelectionControlButton.scss"
 export const ClearButton: React.VFC = () => {
   const { selectionState } = useSelectionContext()
   const filteredOptions = Array.from(selectionState.collection.getKeys())
+  const selectedOptions = Array.from(
+    selectionState.selectionManager.selectedKeys
+  )
   const isDisabled =
     filteredOptions.length === 0 ||
     !Boolean(
@@ -20,8 +23,11 @@ export const ClearButton: React.VFC = () => {
       className={classNames(styles.button, isDisabled ? styles.isDisabled : "")}
       aria-disabled={isDisabled}
       onClick={
-        // use setSelectedKeys(<currently selected - everything filtered>)
-        () => !isDisabled && selectionState.selectionManager.clearSelection()
+        () =>
+          !isDisabled &&
+          selectionState.selectionManager.setSelectedKeys(
+            selectedOptions.filter(option => !filteredOptions.includes(option))
+          )
         // TODO: add annoucemnt here to inform selection cleared
       }
     >

--- a/packages/select/src/FilterMultiSelect/components/SelectionControlButton/ClearButton/ClearButton.tsx
+++ b/packages/select/src/FilterMultiSelect/components/SelectionControlButton/ClearButton/ClearButton.tsx
@@ -23,11 +23,14 @@ export const ClearButton: React.VFC = () => {
       className={classNames(styles.button, isDisabled ? styles.isDisabled : "")}
       aria-disabled={isDisabled}
       onClick={
-        () =>
+        () => {
           !isDisabled &&
-          selectionState.selectionManager.setSelectedKeys(
-            selectedOptions.filter(option => !filteredOptions.includes(option))
-          )
+            selectionState.selectionManager.setSelectedKeys(
+              selectedOptions.filter(
+                option => !filteredOptions.includes(option)
+              )
+            )
+        }
         // TODO: add annoucemnt here to inform selection cleared
       }
     >

--- a/packages/select/src/FilterMultiSelect/components/SelectionControlButton/ClearButton/ClearButton.tsx
+++ b/packages/select/src/FilterMultiSelect/components/SelectionControlButton/ClearButton/ClearButton.tsx
@@ -6,18 +6,22 @@ import styles from "../SelectionControlButton.scss"
 
 export const ClearButton: React.VFC = () => {
   const { selectionState } = useSelectionContext()
+  const filteredOptions = Array.from(selectionState.collection.getKeys())
+  const isDisabled =
+    filteredOptions.length === 0 ||
+    !Boolean(
+      filteredOptions.find(key =>
+        selectionState.selectionManager.isSelected(key)
+      )
+    )
 
   return (
     <button
-      className={classNames(
-        styles.button,
-        selectionState.selectionManager.isEmpty ? styles.isDisabled : ""
-      )}
-      aria-disabled={selectionState.selectionManager.isEmpty}
+      className={classNames(styles.button, isDisabled ? styles.isDisabled : "")}
+      aria-disabled={isDisabled}
       onClick={
-        () =>
-          !selectionState.selectionManager.isEmpty &&
-          selectionState.selectionManager.clearSelection()
+        // use setSelectedKeys(<currently selected - everything filtered>)
+        () => !isDisabled && selectionState.selectionManager.clearSelection()
         // TODO: add annoucemnt here to inform selection cleared
       }
     >

--- a/packages/select/src/FilterMultiSelect/components/SelectionControlButton/SelectAllButton/SelectAllButton.spec.tsx
+++ b/packages/select/src/FilterMultiSelect/components/SelectionControlButton/SelectAllButton/SelectAllButton.spec.tsx
@@ -10,13 +10,29 @@ jest.mock("../../../provider", () => ({
 
 describe("<SelectAllButton /> - interaction", () => {
   describe("Given not all options are selected", () => {
-    it("triggesrs selectionManager.selectAll() when clicks on the button", () => {
+    it("triggers selectionManager.setSelectedKeys() with currently selected and filtered options when button is clicked", () => {
       const spy = jest.fn()
+      const selectedAndFocused = "selectedAndFocused"
+      const filteredButNotSelected = "focusedButNotSelected"
+      const selectedButNotFocused = "selectedButNotFocused"
+      const selectedKeys = [selectedAndFocused, selectedButNotFocused]
+      const filteredKeys = [selectedAndFocused, filteredButNotSelected]
+      const expected = [
+        selectedAndFocused,
+        filteredButNotSelected,
+        selectedButNotFocused,
+      ]
+
       ;(useSelectionContext as jest.Mock).mockReturnValue({
         selectionState: {
+          collection: {
+            getKeys: () => filteredKeys,
+          },
           selectionManager: {
             isSelectAll: false,
-            selectAll: spy,
+            selectedKeys,
+            setSelectedKeys: spy,
+            isSelected: id => selectedKeys.includes(id),
           },
         },
       })
@@ -24,17 +40,27 @@ describe("<SelectAllButton /> - interaction", () => {
       userEvent.click(screen.getByRole("button"))
 
       expect(spy).toHaveBeenCalledTimes(1)
+      expect(spy).toHaveBeenCalledWith([...selectedKeys, ...filteredKeys])
     })
   })
 
-  describe("Given all options are selected", () => {
-    it("does not trigger selectionManager.selectAll() when clicks on the button", () => {
+  describe("Given all filtered options are selected", () => {
+    it("does not trigger selectionManager.setSelectedKeys() when clicks on the button", () => {
       const spy = jest.fn()
+      const selectedAndFocused1 = "selectedAndFocused1"
+      const selectedAndFocused2 = "selectedAndFocused2"
+      const selectedKeys = [selectedAndFocused1, selectedAndFocused2]
+      const filteredKeys = [selectedAndFocused1, selectedAndFocused2]
       ;(useSelectionContext as jest.Mock).mockReturnValue({
         selectionState: {
+          collection: {
+            getKeys: () => filteredKeys,
+          },
           selectionManager: {
             isSelectAll: true,
-            selectAll: spy,
+            selectedKeys,
+            setSelectedKeys: spy,
+            isSelected: id => selectedKeys.includes(id),
           },
         },
       })

--- a/packages/select/src/FilterMultiSelect/components/SelectionControlButton/SelectAllButton/SelectAllButton.tsx
+++ b/packages/select/src/FilterMultiSelect/components/SelectionControlButton/SelectAllButton/SelectAllButton.tsx
@@ -6,6 +6,10 @@ import styles from "../SelectionControlButton.scss"
 
 export const SelectAllButton: React.VFC = () => {
   const { selectionState } = useSelectionContext()
+  const filteredOptions = Array.from(selectionState.collection.getKeys())
+  const selectedOptions = Array.from(
+    selectionState.selectionManager.selectedKeys
+  )
   return (
     <button
       className={classNames(
@@ -16,9 +20,10 @@ export const SelectAllButton: React.VFC = () => {
       onClick={
         () =>
           !selectionState.selectionManager.isSelectAll &&
-          selectionState.selectionManager.setSelectedKeys(
-            selectionState.collection.getKeys()
-          )
+          selectionState.selectionManager.setSelectedKeys([
+            ...selectedOptions,
+            ...filteredOptions,
+          ])
         // TODO: add annoucemnt here to inform all selected
       }
     >

--- a/packages/select/src/FilterMultiSelect/components/SelectionControlButton/SelectAllButton/SelectAllButton.tsx
+++ b/packages/select/src/FilterMultiSelect/components/SelectionControlButton/SelectAllButton/SelectAllButton.tsx
@@ -16,7 +16,9 @@ export const SelectAllButton: React.VFC = () => {
       onClick={
         () =>
           !selectionState.selectionManager.isSelectAll &&
-          selectionState.selectionManager.selectAll()
+          selectionState.selectionManager.setSelectedKeys(
+            selectionState.collection.getKeys()
+          )
         // TODO: add annoucemnt here to inform all selected
       }
     >


### PR DESCRIPTION
## Why
"Select all" and "Clear" buttons are currently scoped to affect all options, instead of just those that are filtered.

## What
Scopes "Select all" and "Clear" button click behaviour to affect only filtered options.

- When options have been filtered, "Select all" will
  - Select all filtered options
  - Not select unselected, un-filtered options
  - Not clear selected un-filtered options
  
- When options have been filtered, "Clear will
  - Deselect all filtered options
  - Not deselect selected unfiltered options