### PR TITLE
fix: Update CustomNavigationTabProps

### DIFF
--- a/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/NavigationTabs.tsx
+++ b/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/NavigationTabs.tsx
@@ -3,10 +3,7 @@ import classnames from "classnames"
 import { NON_REVERSED_VARIANTS, Variant } from "./TitleBlockZen"
 import styles from "./NavigationTabs.module.scss"
 
-export type CustomNavigationTabProps = Omit<
-  NavigationTabProps,
-  "component" | "variant"
-> & {
+export type CustomNavigationTabProps = Omit<NavigationTabProps, "renderTab"> & {
   className: string
 }
 


### PR DESCRIPTION
The `Component` prop was changed to `renderTab` but was not
updated in this prop definition. Also, we do still pass down the
variant, so do not omit it from the props.
