### PR TITLE
fix: Remove unused %caIconBlockLayout scss var

### DIFF
--- a/packages/component-library/components/Icon/Icon.module.scss
+++ b/packages/component-library/components/Icon/Icon.module.scss
@@ -25,10 +25,6 @@
   @extend %caIconInheritSize;
 }
 
-.blockLayout {
-  @extend %caIconBlockLayout;
-}
-
 .interactiveIconWrapper {
   cursor: pointer;
   .icon {

--- a/packages/component-library/components/Icon/styles.scss
+++ b/packages/component-library/components/Icon/styles.scss
@@ -17,7 +17,3 @@ $ca-icon-height: 20px;
   height: inherit;
   display: block;
 }
-
-%caIconBlockLayout {
-  display: block;
-}


### PR DESCRIPTION
## Why
This class rule is unused, and may lead to confusion around whether or not a prop should be available to turn the Icon into a block layout. It is expected that this should be achieved through classNameOverride instead, so removing this should make that less confusing.


## What
Removes an unused css rule that applies `display: block` to the Icon component.


## Breaking change
If importing this variable in your own repo, please replace all instances of `%caIconBlockLayout` with your own `display: block` css rule.
