### PR TITLE
fix(component): use uuid package instead of useId for compatibility with older React versions

### DIFF
--- a/packages/select/package.json
+++ b/packages/select/package.json
@@ -52,7 +52,8 @@
     "@react-stately/select": "^3.2.1",
     "@react-types/button": "^3.5.1",
     "@react-types/shared": "^3.13.1",
-    "classnames": "^2.3.1"
+    "classnames": "^2.3.1",
+    "uuid": "^8.3.2"
   },
   "devDependencies": {
     "rimraf": "^3.0.2"

--- a/packages/select/src/FilterMultiSelect/components/MultiSelectOption/MultiSelectOption.spec.tsx
+++ b/packages/select/src/FilterMultiSelect/components/MultiSelectOption/MultiSelectOption.spec.tsx
@@ -23,11 +23,6 @@ jest.mock("../../provider", () => ({
   useSelectionContext: () => ({ selectionState: {} }),
 }))
 
-jest.mock("react", () => ({
-  ...jest.requireActual("react"),
-  useId: () => "id-mock", // To cover testing in React 16 and 17
-}))
-
 const itemMock: Node<ItemType> = {
   type: "type-mock",
   key: "key-mock",

--- a/packages/select/src/FilterMultiSelect/components/MultiSelectOption/MultiSelectOption.tsx
+++ b/packages/select/src/FilterMultiSelect/components/MultiSelectOption/MultiSelectOption.tsx
@@ -1,4 +1,6 @@
-import React, { useId } from "react"
+import React, { useMemo } from "react"
+import { v4 } from "uuid"
+
 import { mergeProps } from "@react-aria/utils"
 import { useFocusRing } from "@react-aria/focus"
 import { Node } from "@react-types/shared"
@@ -31,7 +33,7 @@ export const MultiSelectOption: React.VFC<MultiSelectOptionProps> = ({
   // Determine whether we should show a keyboard
   // focus ring for accessibility
   const { isFocusVisible, focusProps } = useFocusRing()
-  const countElementId = useId()
+  const countElementId = useMemo(() => v4(), [])
 
   return (
     <li

--- a/packages/select/src/FilterMultiSelect/components/SearchInput/SearchInput.spec.tsx
+++ b/packages/select/src/FilterMultiSelect/components/SearchInput/SearchInput.spec.tsx
@@ -2,15 +2,11 @@ import React from "react"
 import { render, screen } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { useSelectionContext } from "../../provider"
+
 import { SearchInput } from "./"
 
 jest.mock("../../provider", () => ({
   useSelectionContext: jest.fn(),
-}))
-
-jest.mock("react", () => ({
-  ...jest.requireActual("react"),
-  useId: () => "id-mock", // To cover testing in React 16 and 17
 }))
 
 const SearchInputWrapper = () => <SearchInput label="label-mock" />

--- a/packages/select/src/FilterMultiSelect/components/SearchInput/SearchInput.tsx
+++ b/packages/select/src/FilterMultiSelect/components/SearchInput/SearchInput.tsx
@@ -1,4 +1,5 @@
-import React, { useId } from "react"
+import React, { useMemo } from "react"
+import { v4 } from "uuid"
 import { InputSearch } from "@kaizen/draft-form"
 import { useSelectionContext } from "../../provider"
 
@@ -18,9 +19,11 @@ export const SearchInput: React.VFC<SearchInputProps> = ({ label, id }) => {
     setSearchQuery("")
   }
 
+  const inputId = useMemo(() => id ?? v4(), [id])
+
   return (
     <InputSearch
-      id={id ?? useId()}
+      id={inputId}
       aria-label={label ?? "Filter options by search query"}
       secondary
       placeholder="Search…"

--- a/packages/select/src/FilterMultiSelect/provider/SelectionProvider/SelectionProvider.spec.tsx
+++ b/packages/select/src/FilterMultiSelect/provider/SelectionProvider/SelectionProvider.spec.tsx
@@ -12,11 +12,6 @@ import {
 import { ItemType } from "../../types"
 import { SelectionProvider, SelectionProviderProps } from "./SelectionProvider"
 
-jest.mock("react", () => ({
-  ...jest.requireActual("react"),
-  useId: () => "id-mock", // To cover testing in React 16 and 17
-}))
-
 const itemsMock: ItemType[] = [
   {
     label: "option-1-label-mock",


### PR DESCRIPTION
Slack ticket - KDS-760

## Why
In order to use the FilterMultiSelect in older version of React, `useId` has been swapped out for `uuid` as the former is only available in version 18.
