### PR TITLE
fix: Set distinct automation-ids for each usage of TitleBlock Toolbar

### DIFF
--- a/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/MainActions.tsx
+++ b/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/MainActions.tsx
@@ -176,7 +176,7 @@ const MainActions = ({
 
   return (
     <div className={styles.mainActionsContainer}>
-      <Toolbar items={items} />
+      <Toolbar items={items} automationId="title-block-main-actions-toolbar" />
     </div>
   )
 }

--- a/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/SecondaryActions.tsx
+++ b/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/SecondaryActions.tsx
@@ -118,7 +118,11 @@ const SecondaryActions = ({
 
   return (
     <div className={styles.secondaryActionsContainer}>
-      <Toolbar items={toolbarItems} noGap />
+      <Toolbar
+        items={toolbarItems}
+        noGap
+        automationId="title-block-secondary-actions-toolbar"
+      />
     </div>
   )
 }

--- a/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/Toolbar.tsx
+++ b/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/Toolbar.tsx
@@ -14,17 +14,15 @@ type ToolbarProps = {
     node: React.ReactElement<ButtonProps> | React.ReactElement<MenuProps>
   }>
   noGap?: boolean
+  automationId?: string
 }
 
-const Toolbar = ({ items, noGap = false }: ToolbarProps) => {
+const Toolbar = ({ items, noGap = false, automationId }: ToolbarProps) => {
   if (!items || (items && items.length === 0)) {
     return <></>
   }
   return (
-    <div
-      className={styles.toolbar}
-      data-automation-id="title-block-main-actions-toolbar"
-    >
+    <div className={styles.toolbar} data-automation-id={automationId}>
       {items.map((item, i) => (
         <div
           className={classNames(styles.toolbarItem, {


### PR DESCRIPTION
## Why
- Toolbar subcomponent in TitleBlock has a hardcoded `data-automation-id` which makes it hard to distinctively target each usage of it on a page
- See Slack convo: https://cultureamp.slack.com/archives/C0189KBPM4Y/p1662354117952409

## What
- Made `automationId` an optional prop and then passed in an ID for each usage
  * Uses the original `title-block-main-actions-toolbar` for the main actions
  * And `title-block-secondary-actions-toolbar` for the secondary actions

## BREAKING CHANGE!

This is a breaking change because some of our tests might rely on the previous IDs in a way that will break after upgrading to this version.