### PR TITLE
fix(select): fix selected option styling

### DIFF
--- a/draft-packages/select/KaizenDraft/Select/Select.module.scss
+++ b/draft-packages/select/KaizenDraft/Select/Select.module.scss
@@ -117,6 +117,7 @@ $focus-border-color: $color-blue-500;
     color: $color-blue-500;
     border-color: $focus-border-color;
     &.disabledOption {
+      color: $color-purple-800;
       border-style: $border-dashed-border-style;
       border-width: $border-focus-ring-border-width;
       border-color: $color-gray-500;

--- a/draft-packages/select/KaizenDraft/Select/Select.module.scss
+++ b/draft-packages/select/KaizenDraft/Select/Select.module.scss
@@ -123,7 +123,11 @@ $focus-border-color: $color-blue-500;
   }
 
   .selectedOption {
-    background-color: $color-blue-100;
+    &:not(.focusedOption) {
+      background-color: transparent;
+    }
+    font-weight: $typography-paragraph-bold-font-weight;
+    color: $color-blue-500;
   }
 
   .disabledOption {

--- a/draft-packages/select/KaizenDraft/Select/Select.module.scss
+++ b/draft-packages/select/KaizenDraft/Select/Select.module.scss
@@ -116,6 +116,12 @@ $focus-border-color: $color-blue-500;
     background-color: $color-blue-100;
     color: $color-blue-500;
     border-color: $focus-border-color;
+    &.disabledOption {
+      border-style: $border-dashed-border-style;
+      border-width: $border-focus-ring-border-width;
+      border-color: $color-gray-500;
+      background: transparent;
+    }
 
     &:active {
       background-color: $color-blue-100;


### PR DESCRIPTION
Removes blue background unless focused, and fixes font styling

## Why
Implementation is out of sync with the UI kit - screenshots [here](https://cultureamp.atlassian.net/jira/software/projects/KDS/boards/289?selectedIssue=KDS-396&text=select)

## What
- Removes blue-100 background for selected item (unless focused. This is to differentiate between what is focused, and what is selected)
- Adds bold font weight, and color blue-500 to selected item, to distinguish from non-selected items