### PR TITLE
fix: be able to specify root element applying theme

### DIFF
--- a/packages/design-tokens/src/ThemeManager.ts
+++ b/packages/design-tokens/src/ThemeManager.ts
@@ -50,7 +50,9 @@ export class ThemeManager<Theme extends BaseTheme = BaseTheme> {
   }
   public applyCurrentTheme = () => {
     if (typeof window !== "undefined") {
-      this.setRootElement(document.documentElement)
+      this.setRootElement(
+        document.querySelector("#kaizen-root") ?? document.documentElement
+      )
       const cssVariableDefinitions = makeCssVariableDefinitionsMap(this.theme)
       Object.entries(cssVariableDefinitions).forEach(([key, value]) => {
         this.rootElement?.style.setProperty(key, value)

--- a/packages/design-tokens/src/ThemeManager.ts
+++ b/packages/design-tokens/src/ThemeManager.ts
@@ -15,8 +15,8 @@ export class ThemeManager<Theme extends BaseTheme = BaseTheme> {
 
   constructor(
     theme: Theme,
-    /* This allows you to stop the  class from applying the theme automatically during construction. Defaults to true */
     rootElementId: string = "",
+    /* This allows you to stop the  class from applying the theme automatically during construction. Defaults to true */
     apply: boolean = true
   ) {
     /*

--- a/packages/design-tokens/src/ThemeManager.ts
+++ b/packages/design-tokens/src/ThemeManager.ts
@@ -11,10 +11,12 @@ export class ThemeManager<Theme extends BaseTheme = BaseTheme> {
   private themeChangeListeners = [] as Array<(theme: Theme) => void>
   private theme: Theme
   private rootElement: HTMLElement | null = null
+  private rootElementId: string
 
   constructor(
     theme: Theme,
     /* This allows you to stop the  class from applying the theme automatically during construction. Defaults to true */
+    rootElementId: string = "",
     apply: boolean = true
   ) {
     /*
@@ -22,15 +24,19 @@ export class ThemeManager<Theme extends BaseTheme = BaseTheme> {
       If you use `constructor( private theme: Theme, ...)` - theme becomes undefined within the class's methods.
     */
     this.theme = theme
+    this.rootElementId = rootElementId
     if (apply) this.applyCurrentTheme()
   }
 
   public getRootElement = () => this.rootElement
+  public getRootElementId = () => this.rootElementId
   public getCurrentTheme = () => this.theme
 
   public setRootElement = (element: HTMLElement) => {
     this.rootElement = element
   }
+  public setRootElementId = (rootElementId: string) =>
+    (this.rootElementId = rootElementId)
   public setAndApplyTheme = (theme: Theme, force?: boolean) => {
     if (!force) {
       if (this.theme === theme) return
@@ -51,7 +57,7 @@ export class ThemeManager<Theme extends BaseTheme = BaseTheme> {
   public applyCurrentTheme = () => {
     if (typeof window !== "undefined") {
       this.setRootElement(
-        document.querySelector("#kaizen-root") ?? document.documentElement
+        document.getElementById(this.rootElementId) ?? document.documentElement
       )
       const cssVariableDefinitions = makeCssVariableDefinitionsMap(this.theme)
       Object.entries(cssVariableDefinitions).forEach(([key, value]) => {


### PR DESCRIPTION
## Why
In order to let nextjs app set default styles on server-side. We have to set defaultTheme at html component before this fix.

## What
This is an easy fix that, in the nextjs app, we can specify the component with id `kaizen-root` as a root element and it can render default styles on the server side. 
