### PR TITLE
fix: Extra catch around illustration video player

### DIFF
--- a/draft-packages/illustration/KaizenDraft/Illustration/Players/VideoPlayer.tsx
+++ b/draft-packages/illustration/KaizenDraft/Illustration/Players/VideoPlayer.tsx
@@ -101,15 +101,23 @@ export const VideoPlayer = ({
     if (prefersReducedMotion) {
       videoElement.pause()
     } else if (autoplay && !prefersReducedMotion) {
-      videoElement.play().catch(e => {
-        /*
-         * An DOMException _may_ be raised by some browsers if we
-         * programatically interact with the video before the
-         * user has interacted with the page. This is okay - so
-         * we're going to catch this error without handling it. See:
-         * https://developer.mozilla.org/en-US/docs/Web/Media/Autoplay_guide#autoplay_availability
+      try {
+        // Older browsers may not return a promise, so .play could return undefined
+        videoElement.play()?.catch(e => {
+          /*
+           * An DOMException _may_ be raised by some browsers if we
+           * programatically interact with the video before the
+           * user has interacted with the page. This is okay - so
+           * we're going to catch this error without handling it. See:
+           * https://developer.mozilla.org/en-US/docs/Web/Media/Autoplay_guide#autoplay_availability
+           */
+        })
+      } catch (e) {
+        /**
+         * Older browsers will raise a synchronous error because their first implementation
+         * of `.play` was not a promise.
          */
-      })
+      }
     }
     /**
      * Chrome seems to have an issue with changes to autoplay after the video


### PR DESCRIPTION
## Why

Some older (unsupported) browsers did not have a promise as the result of the `.play` function so they are spamming the error logs. Although we don't support those browsers, we do need to add the guard against it as they are spamming our error logs.

## What
Have wrapped the `.play` in a try..catch and also check that the result of `.play` returns a callable `.catch` before adding the catch.