### PR TITLE
feat(Collapsible): Use an IconButton for header toggle (a11y improvement)

### DIFF
--- a/draft-packages/collapsible/KaizenDraft/Collapsible/Collapsible.module.scss
+++ b/draft-packages/collapsible/KaizenDraft/Collapsible/Collapsible.module.scss
@@ -67,10 +67,19 @@ $border-color: rgba($color-gray-600-rgb, 0.2);
   background-color: white;
   border: none;
   transition: background-color $ca-duration-rapid;
-  padding: $spacing-sm $spacing-sm $spacing-sm $spacing-md;
+  padding-top: $spacing-sm;
+  padding-bottom: $spacing-sm;
+  padding-left: $spacing-md;
+  padding-right: $spacing-sm;
 
   &:hover {
     background-color: $heading-active-color;
+  }
+
+  [dir="rtl"] & {
+    text-align: right;
+    padding-left: $spacing-sm;
+    padding-right: $spacing-md;
   }
 }
 

--- a/draft-packages/collapsible/KaizenDraft/Collapsible/Collapsible.module.scss
+++ b/draft-packages/collapsible/KaizenDraft/Collapsible/Collapsible.module.scss
@@ -1,5 +1,6 @@
 @import "~@kaizen/design-tokens/sass/border";
 @import "~@kaizen/design-tokens/sass/shadow";
+@import "~@kaizen/design-tokens/sass/spacing";
 @import "~@kaizen/design-tokens/sass/color";
 @import "~@kaizen/deprecated-component-library-helpers/styles/layout";
 @import "~@kaizen/component-library/styles/border";
@@ -61,23 +62,21 @@ $border-color: rgba($color-gray-600-rgb, 0.2);
 
 .button {
   display: flex;
-  width: 100%;
   align-items: center;
   text-align: left;
   background-color: white;
   border: none;
   transition: background-color $ca-duration-rapid;
-
-  @include ca-padding(
-    $top: $ca-grid,
-    $end: $ca-grid,
-    $bottom: $ca-grid,
-    $start: $ca-grid
-  );
+  padding: $spacing-sm $spacing-md;
 
   &:hover {
     background-color: $heading-active-color;
   }
+}
+
+.chevronButton:hover {
+  // hack to get rid of the IconButton hover styling because it clashes with the hover styling on the Collapsible header
+  background-color: transparent !important; /* stylelint-disable-line declaration-no-important */
 }
 
 .title {

--- a/draft-packages/collapsible/KaizenDraft/Collapsible/Collapsible.module.scss
+++ b/draft-packages/collapsible/KaizenDraft/Collapsible/Collapsible.module.scss
@@ -67,7 +67,7 @@ $border-color: rgba($color-gray-600-rgb, 0.2);
   background-color: white;
   border: none;
   transition: background-color $ca-duration-rapid;
-  padding: $spacing-sm $spacing-md;
+  padding: $spacing-sm $spacing-sm $spacing-sm $spacing-md;
 
   &:hover {
     background-color: $heading-active-color;

--- a/draft-packages/collapsible/KaizenDraft/Collapsible/Collapsible.module.scss
+++ b/draft-packages/collapsible/KaizenDraft/Collapsible/Collapsible.module.scss
@@ -19,7 +19,7 @@ $border-color: rgba($color-gray-600-rgb, 0.2);
 }
 
 .single {
-  .button {
+  .header {
     border-radius: $border-borderless-border-radius;
   }
 }
@@ -29,7 +29,7 @@ $border-color: rgba($color-gray-600-rgb, 0.2);
     @include ca-margin($top: $ca-grid * 0.3);
   }
 
-  .button {
+  .header {
     border-radius: $border-borderless-border-radius;
   }
 }
@@ -42,25 +42,25 @@ $border-color: rgba($color-gray-600-rgb, 0.2);
     border-top: 1px solid $border-color;
   }
 
-  &:first-of-type > .button {
+  &:first-of-type > .header {
     border-top-left-radius: $border-borderless-border-radius;
     border-top-right-radius: $border-borderless-border-radius;
   }
 
-  &:last-of-type > .button:not(.open) {
+  &:last-of-type > .header:not(.open) {
     border-bottom-left-radius: $border-borderless-border-radius;
     border-bottom-right-radius: $border-borderless-border-radius;
   }
 }
 
-// Round the bottom corners of the button so when the container is open, the
-// button background is not rounded on the corners and flush with the content beneath.
-.open .button {
+// Round the bottom corners of the header so when the container is open, the
+// header background is not rounded on the corners and flush with the content beneath.
+.open .header {
   border-bottom-left-radius: 0;
   border-bottom-right-radius: 0;
 }
 
-.button {
+.header {
   display: flex;
   align-items: center;
   text-align: left;

--- a/draft-packages/collapsible/KaizenDraft/Collapsible/Collapsible.spec.tsx
+++ b/draft-packages/collapsible/KaizenDraft/Collapsible/Collapsible.spec.tsx
@@ -58,7 +58,7 @@ it("includes the 'sticky' class on buttons when the 'sticky' prop is specified",
     </CollapsibleGroup>
   )
 
-  const collapsibleContainer = getByTestId("collapsible-button-1")
+  const collapsibleContainer = getByTestId("collapsible-header-1")
 
   expect(collapsibleContainer.classList.contains("sticky")).toBeTruthy()
 })
@@ -112,7 +112,7 @@ it("gives precedence to renderHeader over title", () => {
     </Collapsible>
   )
 
-  const titleText = getByTestId("collapsible-button-1").querySelector("div")
+  const titleText = getByTestId("collapsible-header-1").querySelector("div")
 
   expect(titleText).toHaveTextContent("This title should be rendered")
   expect(
@@ -178,7 +178,7 @@ it("clear variant has correct class", () => {
     </CollapsibleGroup>
   )
 
-  const collapsibleContainer = getByTestId("collapsible-button-1")
+  const collapsibleContainer = getByTestId("collapsible-header-1")
 
   expect(collapsibleContainer.classList.contains("clearVariant")).toBeTruthy()
 })
@@ -195,7 +195,7 @@ it("default variant has correct class", () => {
     </CollapsibleGroup>
   )
 
-  const collapsibleContainer = getByTestId("collapsible-button-1")
+  const collapsibleContainer = getByTestId("collapsible-header-1")
 
   expect(collapsibleContainer.classList.contains("defaultVariant")).toBeTruthy()
 })

--- a/draft-packages/collapsible/KaizenDraft/Collapsible/Collapsible.tsx
+++ b/draft-packages/collapsible/KaizenDraft/Collapsible/Collapsible.tsx
@@ -101,7 +101,7 @@ export class Collapsible extends React.Component<CollapsibleProps, State> {
         {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events,
         jsx-a11y/no-static-element-interactions */}
         <div
-          className={classnames(styles.button, {
+          className={classnames(styles.header, {
             [styles.defaultVariant]: open && variant === "default",
             [styles.clearVariant]: open && variant === "clear",
             [styles.sticky]: sticky,

--- a/draft-packages/collapsible/KaizenDraft/Collapsible/Collapsible.tsx
+++ b/draft-packages/collapsible/KaizenDraft/Collapsible/Collapsible.tsx
@@ -2,7 +2,7 @@ import React, { HTMLAttributes } from "react"
 import classnames from "classnames"
 import AnimateHeight from "react-animate-height"
 import { OverrideClassName } from "@kaizen/component-base"
-import { Icon } from "@kaizen/component-library"
+import { IconButton } from "@kaizen/button"
 import { Heading } from "@kaizen/typography"
 import chevronUp from "@kaizen/component-library/icons/chevron-up.icon.svg"
 import chevronDown from "@kaizen/component-library/icons/chevron-down.icon.svg"
@@ -97,9 +97,10 @@ export class Collapsible extends React.Component<CollapsibleProps, State> {
         data-automation-id={automationId || `collapsible-container-${id}`}
         {...props} // `title` is missing because it is used for the header; requires breaking change to fix
       >
-        <button
-          type="button"
-          id={buttonId}
+        {/* Disabling these a11y linting errors because there is an IconButton that mitigates these concerns. The onClick here is just an additional layer. */}
+        {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events,
+        jsx-a11y/no-static-element-interactions */}
+        <div
           className={classnames(styles.button, {
             [styles.defaultVariant]: open && variant === "default",
             [styles.clearVariant]: open && variant === "clear",
@@ -107,10 +108,8 @@ export class Collapsible extends React.Component<CollapsibleProps, State> {
             [styles.open]: open,
           })}
           style={sticky && { top: sticky.top }}
-          onClick={this.handleClick}
-          aria-expanded={open}
-          aria-controls={sectionId}
-          data-automation-id={`collapsible-button-${id}`}
+          onClick={this.handleSectionToggle}
+          data-automation-id={`collapsible-header-${id}`}
         >
           {renderHeader !== undefined ? (
             renderHeader(title)
@@ -125,9 +124,19 @@ export class Collapsible extends React.Component<CollapsibleProps, State> {
             </div>
           )}
           <div>
-            <Icon icon={open ? chevronUp : chevronDown} role="presentation" />
+            <IconButton
+              label="Toggle section"
+              icon={open ? chevronUp : chevronDown}
+              type="button"
+              aria-expanded={open}
+              aria-controls={sectionId}
+              data-automation-id={`collapsible-button-${id}`}
+              id={buttonId}
+              onClick={this.handleButtonPress}
+              classNameOverride={styles.chevronButton}
+            />
           </div>
-        </button>
+        </div>
         {(!lazyLoad || open) && (
           <AnimateHeight
             height={open ? "auto" : 0}
@@ -152,7 +161,7 @@ export class Collapsible extends React.Component<CollapsibleProps, State> {
   private getOpen = () =>
     this.props.controlled ? this.props.open : this.state.open
 
-  private handleClick = () => {
+  private handleSectionToggle = () => {
     const { onToggle, id, controlled } = this.props
     const open = this.getOpen()
 
@@ -163,5 +172,10 @@ export class Collapsible extends React.Component<CollapsibleProps, State> {
         open: !open,
       })
     }
+  }
+
+  private handleButtonPress = (event: React.MouseEvent) => {
+    event.stopPropagation()
+    this.handleSectionToggle()
   }
 }

--- a/draft-packages/collapsible/package.json
+++ b/draft-packages/collapsible/package.json
@@ -32,6 +32,7 @@
     "@kaizen/component-base": "^1.1.1",
     "@kaizen/component-library": "^16.1.1",
     "@kaizen/typography": "^2.3.2",
+    "@kaizen/button": "^1.3.3",
     "classnames": "^2.3.1",
     "react-animate-height": "^3.0.4"
   },

--- a/draft-packages/collapsible/package.json
+++ b/draft-packages/collapsible/package.json
@@ -29,10 +29,10 @@
   "private": false,
   "license": "MIT",
   "dependencies": {
+    "@kaizen/button": "^1.3.3",
     "@kaizen/component-base": "^1.1.1",
     "@kaizen/component-library": "^16.1.1",
     "@kaizen/typography": "^2.3.2",
-    "@kaizen/button": "^1.3.3",
     "classnames": "^2.3.1",
     "react-animate-height": "^3.0.4"
   },


### PR DESCRIPTION
## What
Rather than the whole Collapsible header being a `button` element, turn the chevron that sits in the header into an `IconButton` which will act as the toggle button for keyboard & screen reader users. Then add add an `onClick` to the header div as an additional layer so that mouse users can still click the header to open and close. 

## Why
Two reasons:

1: There are times where we want the header to contain other actions, e.g.
![image](https://user-images.githubusercontent.com/1811583/189574352-a95ea158-7341-496a-9a41-9ff4fd9b3a2f.png)

In these cases, we're forced to have _buttons inside buttons_, which is invalid HTML and causes many issues.

2: Elements inside of buttons have their semantics stripped and simplified down to a string. If you were to put an `h3` into this heading (and it's wrapped in a button), the document will no longer see the `h3` as an `h3`.