### PR TITLE
fix(radio-field): remove children prop from RadioField

### DIFF
--- a/draft-packages/form/KaizenDraft/Form/RadioField/RadioField.tsx
+++ b/draft-packages/form/KaizenDraft/Form/RadioField/RadioField.tsx
@@ -4,7 +4,6 @@ import { Label, Radio, RadioProps } from "../Primitives"
 import styles from "./RadioField.module.scss"
 
 export interface RadioFieldProps extends RadioProps {
-  children?: React.ReactNode // This should not exist, but it will be a breaking change to fix
   id: string
   labelText: string | React.ReactNode
   selectedStatus?: boolean
@@ -23,7 +22,6 @@ export interface RadioFieldProps extends RadioProps {
  * {@link https://cultureamp.design/storybook/?path=/docs/components-form-radio-field--interactive-kaizen-site-demo Storybook}
  */
 export const RadioField: React.VFC<RadioFieldProps> = ({
-  children, // Not used
   id,
   labelText,
   selectedStatus = false,


### PR DESCRIPTION
Removes children prop from RadioField

BREAKING CHANGE: children can no longer be passed to RadioField

## Why
`children` prop is currently available on the `RadioField` component, despite not being used. This may lead to confusion on behalf of consumers.


## What
Removes `children` prop from `RadioField` component