### PR TITLE
fix(design-tokens/heart): update intro-lede letter spacing

### DIFF
--- a/packages/design-tokens/less/typography.less
+++ b/packages/design-tokens/less/typography.less
@@ -371,7 +371,7 @@
 @typography-paragraph-intro-lede-line-height-id: --typography-paragraph-intro-lede-line-height;
 @typography-paragraph-intro-lede-letter-spacing: var(
   --typography-paragraph-intro-lede-letter-spacing,
-  -0.5px
+  0
 );
 @typography-paragraph-intro-lede-letter-spacing-id: --typography-paragraph-intro-lede-letter-spacing;
 @typography-paragraph-body-font-family: var(

--- a/packages/design-tokens/sass/typography.scss
+++ b/packages/design-tokens/sass/typography.scss
@@ -371,7 +371,7 @@ $typography-paragraph-intro-lede-line-height: var(
 $typography-paragraph-intro-lede-line-height-id: --typography-paragraph-intro-lede-line-height;
 $typography-paragraph-intro-lede-letter-spacing: var(
   --typography-paragraph-intro-lede-letter-spacing,
-  0px
+  0
 );
 $typography-paragraph-intro-lede-letter-spacing-id: --typography-paragraph-intro-lede-letter-spacing;
 $typography-paragraph-body-font-family: var(

--- a/packages/design-tokens/src/themes/heart.ts
+++ b/packages/design-tokens/src/themes/heart.ts
@@ -244,7 +244,7 @@ export const heartTheme: Theme = {
       fontWeight: 400,
       fontSize: "1.25rem",
       lineHeight: "1.875rem",
-      letterSpacing: "-0.5px",
+      letterSpacing: "0",
     },
     paragraphBody: {
       fontFamily: '"Inter", "Noto Sans", Helvetica, Arial, sans-serif',

--- a/packages/design-tokens/tokens/typography.json
+++ b/packages/design-tokens/tokens/typography.json
@@ -165,7 +165,7 @@
       "fontSize-id": "--typography-paragraph-intro-lede-font-size",
       "lineHeight": "var(--typography-paragraph-intro-lede-line-height, 1.875rem)",
       "lineHeight-id": "--typography-paragraph-intro-lede-line-height",
-      "letterSpacing": "var(--typography-paragraph-intro-lede-letter-spacing, -0.5px)",
+      "letterSpacing": "var(--typography-paragraph-intro-lede-letter-spacing, 0)",
       "letterSpacing-id": "--typography-paragraph-intro-lede-letter-spacing"
     },
     "paragraphBody": {


### PR DESCRIPTION
Updates the typography-paragraph-intro-lede-letter-spacing var from -0.5px to 0px

## Why
The current value (-0.5px) is not up to date with the UI-Kit

