### PR TITLE
chore(title-block-zen): Rename renderTab prop to render

### DIFF
--- a/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/NavigationTabs.spec.tsx
+++ b/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/NavigationTabs.spec.tsx
@@ -39,7 +39,7 @@ describe("NavigationTabs", () => {
           href={href}
           handleClick={handleClick}
           active
-          renderTab={CustomComponent}
+          render={CustomComponent}
           variant="education"
         />
       )

--- a/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/NavigationTabs.tsx
+++ b/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/NavigationTabs.tsx
@@ -3,7 +3,7 @@ import classnames from "classnames"
 import { NON_REVERSED_VARIANTS, Variant } from "./TitleBlockZen"
 import styles from "./NavigationTabs.module.scss"
 
-export type CustomNavigationTabProps = Omit<NavigationTabProps, "renderTab"> & {
+export type CustomNavigationTabProps = Omit<NavigationTabProps, "render"> & {
   className: string
 }
 
@@ -20,7 +20,7 @@ export type NavigationTabProps = {
    * Props given to the NavigationTab component will be passed back, along with a decorated className.
    * It is up to you to reapply them to your custom component.
    */
-  renderTab?: (props: CustomNavigationTabProps) => JSX.Element
+  render?: (props: CustomNavigationTabProps) => JSX.Element
 }
 
 const isLight = (variant: Variant | undefined): boolean =>
@@ -32,8 +32,8 @@ const NavigationTab = (props: NavigationTabProps) => {
     [styles.active]: props.active,
   })
 
-  if (props.renderTab) {
-    const { renderTab: Component, ...otherProps } = props
+  if (props.render) {
+    const { render: Component, ...otherProps } = props
     return <Component {...otherProps} className={className} />
   }
 

--- a/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/TitleBlockZen.tsx
+++ b/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/TitleBlockZen.tsx
@@ -295,6 +295,11 @@ type BreadcrumbType = {
   text: string
   path?: string
   handleClick?: (event: React.MouseEvent) => void
+  /**
+   * Custom render for the breadcrumb. Commonly used to replace the parent link with a router link component.
+   * Props given to the breadcrumb component will be passed back, along with a decorated className and children.
+   * It is up to you to reapply them to your custom component.
+   */
   render?: (props: CustomBreadcrumbProps) => JSX.Element
 }
 

--- a/draft-packages/title-block-zen/docs/TitleBlockZen.stories.tsx
+++ b/draft-packages/title-block-zen/docs/TitleBlockZen.stories.tsx
@@ -1232,9 +1232,9 @@ export const RenderProps = () => {
           ),
         }}
         navigationTabs={[
-          <NavigationTab text="Label" href="#" active renderTab={CustomTab} />,
-          <NavigationTab text="Label" href="#" renderTab={CustomTab} />,
-          <NavigationTab text="Label" href="#" renderTab={CustomTab} />,
+          <NavigationTab text="Label" href="#" active render={CustomTab} />,
+          <NavigationTab text="Label" href="#" render={CustomTab} />,
+          <NavigationTab text="Label" href="#" render={CustomTab} />,
         ]}
       />
     </OffsetPadding>


### PR DESCRIPTION
## What
Renames the `renderTab` prop to just `render` on Title Block's `NavigationTab` component.

Also adds a prop description to the `render` prop from the last PR 'cause I forgot.

## Why
To create a consistent name for this prop, rather than having something unique each time.

This should technically be a breaking change, but we just added this prop a couple weeks ago and no one is using it yet so I'm looking to get away without a breaking change :) 