### PR TITLE
ci(chromatic): update chromatic GH action to use turbosnap

### DIFF
--- a/.github/workflows/chromatic.yaml
+++ b/.github/workflows/chromatic.yaml
@@ -24,13 +24,14 @@ jobs:
             packages:
               - 'packages/**'
               - 'draft-packages/**'
+              - 'storybook/**'
 
   visual-testing:
     needs: [paths-filter]
     if: >
       (github.event.action == 'labeled' && github.event.label.name == 'run chromatic') ||
       github.event.review.state == 'approved' ||
-      (github.ref == 'refs/heads/master' && needs.paths-filter.outputs.packages == 'true' ) ||
+      (github.ref == 'refs/heads/master' && needs.paths-filter.outputs.packages == 'true') ||
       startsWith(github.event.head_commit.message, 'Merge branch ''master'' into')
     runs-on: ubuntu-latest
     steps:
@@ -47,12 +48,21 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      # 👇 Adds Chromatic as a step in the workflow
+      - name: Build Storybook
+        run: |
+          yarn storybook:build --webpack-stats-json
+
       - name: Publish to Chromatic
         uses: chromaui/action@v1
-        # Chromatic GitHub Action options
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          # 👇 Chromatic projectToken, refer to the manage page to obtain it.
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+          storybookBuildDir: "./storybook/public"
+          onlyChanged: "!(master)"
+          externals: |
+            [
+              "**/!(*.module).scss",
+              "packages/button/src/Button/*.scss",
+              "packages/component-library/components/Spacing/Base.module.scss"
+            ]
           autoAcceptChanges: master # 👈 Auto accept master builds (why https://www.chromatic.com/docs/github-actions#github-squashrebase-merge-and-the-main-branch)


### PR DESCRIPTION
## What

Enable Turbosnap for Kaizen.

Should update subset:
- [x] Also updates consuming snapshots
- [x] Stories update
- [x] Image updates
  - [x] svg in stories
  - [x] png
- [x] (On branches) Storybook config/components (eg. StoryWrapper)
- [x] Merge `master` into branch
  - Appears to take all the changes from your branch and does a normal `push` check

Should update all:
- [x] Design tokens
- [x] Extended private scss files
  - [x] packages/button (eg. Button.module.scss which is imported into GenericButton.module.scss)
  - [x] component-library/components/Spacing/Base.module.scss
  - [x] packages/loading-skeleton/src/loading-skeleton.module.scss 
    - Imported directly into the components
  - [x] packages/typography/src/fonts.scss
    - Does not have `.module.scss`
- [x] On `master`
  - [x] Storybook config/components (eg. StoryWrapper)
  - [x] Packages / Draft packages
- [x] package.json / yarn.lock updates

Should not update:
- [x] README
- [x] Repo docs
- [x] CI scripts
- [x] Plop templates

Skipped:
- [x] Force push (approval will be dismissed)
  - If you run any of the below triggers, then it will update all snapshots as the commits have changed and Turbosnap doesn't know what to compare to

Triggers (will apply above rules; does not have a specific rule itself):
- [x] Manual trigger (adding label to PR)
- [x] PR approved

## Why

Configure Turbosnap to reduce the number of snapshots registered in Chromatic to save costs (as they charge per snapshot).

## Notes

Looks like `FilterMultiSelect` stylesheets are all using `.scss` as opposed to `.module.scss`. This needs to be fixed to be able to benefit from our Turbosnap config (also not to conflict with upcoming NextJS config).