### PR TITLE
ci: update pipeline slack channel notification

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -22,7 +22,7 @@ steps:
       - docker-compose#v3.9.0:
           run: release
     notify:
-      - slack: "#team_front_end_foundations"
+      - slack: "#wol_kaizen"
         if: build.state == "failed"
 
   - name: ":hatched_chick: Release (canary)"


### PR DESCRIPTION
## Why
build failed ci posts are no longer being post to slack - this should update this to our channel


## What
- updates slack notification channel to wol_kaizen
