### PR TITLE
refactor: upgrade RTE Toolkit to 2.0.0 and update ProseMirror imports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ lerna-*.log
 .DS_Store
 dist
 .cache
+.yalc
+yalc.loc

--- a/packages/rich-text-editor/package.json
+++ b/packages/rich-text-editor/package.json
@@ -29,7 +29,7 @@
   "private": false,
   "license": "MIT",
   "dependencies": {
-    "@cultureamp/rich-text-toolkit": "^1.11.0",
+    "@cultureamp/rich-text-toolkit": "^2.0.0",
     "@kaizen/a11y": "^1.6.4",
     "@kaizen/component-base": "^1.1.1",
     "@kaizen/component-library": "^16.1.1",
@@ -37,24 +37,10 @@
     "@kaizen/draft-tooltip": "^5.4.4",
     "@kaizen/notification": "^0.11.7",
     "classnames": "^2.3.1",
-    "prosemirror-commands": "^1.2.2",
-    "prosemirror-history": "^1.2.0",
-    "prosemirror-inputrules": "^1.1.3",
-    "prosemirror-keymap": "^1.1.5",
-    "prosemirror-model": "^1.16.1",
-    "prosemirror-schema-list": "^1.1.6",
-    "prosemirror-state": "^1.3.4",
     "uuid": "^8.3.2"
   },
   "devDependencies": {
     "@types/classnames": "^2.3.0",
-    "@types/prosemirror-commands": "^1.0.4",
-    "@types/prosemirror-history": "^1.0.3",
-    "@types/prosemirror-inputrules": "^1.0.4",
-    "@types/prosemirror-keymap": "^1.0.4",
-    "@types/prosemirror-model": "^1.16.1",
-    "@types/prosemirror-schema-list": "^1.0.3",
-    "@types/prosemirror-state": "^1.2.8",
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {

--- a/packages/rich-text-editor/src/RichTextContent/RichTextContent.tsx
+++ b/packages/rich-text-editor/src/RichTextContent/RichTextContent.tsx
@@ -1,9 +1,11 @@
 import React, { useState, HTMLAttributes } from "react"
 import classnames from "classnames"
-import { EditorState } from "prosemirror-state"
-import { useRichTextEditor } from "@cultureamp/rich-text-toolkit"
+import {
+  ProseMirrorState,
+  ProseMirrorModel,
+  useRichTextEditor,
+} from "@cultureamp/rich-text-toolkit"
 import { OverrideClassName } from "@kaizen/component-base"
-import { Node, Schema } from "prosemirror-model"
 import { EditorContentArray } from "../types"
 import { createSchemaWithAll } from "../RichTextEditor/schema"
 import styles from "./RichTextContent.module.scss"
@@ -15,11 +17,11 @@ export interface RichTextContentProps
 
 export const RichTextContent = (props: RichTextContentProps) => {
   const { content, classNameOverride, ...restProps } = props
-  const [schema] = useState<Schema>(createSchemaWithAll())
+  const [schema] = useState<ProseMirrorModel.Schema>(createSchemaWithAll())
 
   const [editorRef] = useRichTextEditor(
-    EditorState.create({
-      doc: Node.fromJSON(schema, {
+    ProseMirrorState.EditorState.create({
+      doc: ProseMirrorModel.Node.fromJSON(schema, {
         type: "doc",
         content,
       }),

--- a/packages/rich-text-editor/src/RichTextEditor/RichTextEditor.tsx
+++ b/packages/rich-text-editor/src/RichTextEditor/RichTextEditor.tsx
@@ -1,16 +1,16 @@
 import React, { useState, useEffect, HTMLAttributes, ReactNode } from "react"
 import { v4 } from "uuid"
 import classnames from "classnames"
-import { history } from "prosemirror-history"
-import { keymap } from "prosemirror-keymap"
-import { Node, Schema } from "prosemirror-model"
-import { EditorState } from "prosemirror-state"
-import { Label } from "@kaizen/draft-form"
-import { baseKeymap } from "prosemirror-commands"
 import {
+  ProseMirrorCommands,
+  ProseMirrorState,
+  ProseMirrorModel,
+  ProseMirrorKeymap,
+  ProseMirrorHistory,
   useRichTextEditor,
   createLinkManager,
 } from "@cultureamp/rich-text-toolkit"
+import { Label } from "@kaizen/draft-form"
 import { OverrideClassName } from "@kaizen/component-base"
 import { InlineNotification } from "@kaizen/notification"
 import { ToolbarItems, EditorContentArray, EditorRows } from "../types"
@@ -63,20 +63,22 @@ export const RichTextEditor: React.VFC<RichTextEditorProps> = props => {
     onDataError,
     ...restProps
   } = props
-  const [schema] = useState<Schema>(createSchemaFromControls(controls))
+  const [schema] = useState<ProseMirrorModel.Schema>(
+    createSchemaFromControls(controls)
+  )
   const [labelId] = useState<string>(labelledBy || v4())
   const [editorId] = useState<string>(v4())
 
   const useRichTextEditorResult = (() => {
     try {
       return useRichTextEditor(
-        EditorState.create({
+        ProseMirrorState.EditorState.create({
           doc: value
-            ? Node.fromJSON(schema, {
+            ? ProseMirrorModel.Node.fromJSON(schema, {
                 type: "doc",
                 content: value,
               })
-            : null,
+            : undefined,
           schema,
           plugins: getPlugins(controls, schema),
         }),
@@ -148,14 +150,17 @@ export const RichTextEditor: React.VFC<RichTextEditorProps> = props => {
   )
 }
 
-function getPlugins(controls: ToolbarItems[] | undefined, schema: Schema) {
+function getPlugins(
+  controls: ToolbarItems[] | undefined,
+  schema: ProseMirrorModel.Schema
+) {
   const allControlNames: string[] = controls
     ? controls.reduce((acc: string[], c: ToolbarItems) => [...acc, c.name], [])
     : []
   const plugins = [
-    history(),
-    keymap(buildKeymap(schema)),
-    keymap(baseKeymap),
+    ProseMirrorHistory.history(),
+    ProseMirrorKeymap.keymap(buildKeymap(schema)),
+    ProseMirrorKeymap.keymap(ProseMirrorCommands.baseKeymap),
     buildInputRules(schema),
   ]
 

--- a/packages/rich-text-editor/src/RichTextEditor/controlmap.ts
+++ b/packages/rich-text-editor/src/RichTextEditor/controlmap.ts
@@ -7,11 +7,14 @@ import decreaseIndentIcon from "@kaizen/component-library/icons/decrease-indent.
 import increaseIndentIcon from "@kaizen/component-library/icons/increase-indent.icon.svg"
 import linkIcon from "@kaizen/component-library/icons/add-link.icon.svg"
 
-import { EditorState, Transaction } from "prosemirror-state"
-import { Schema, NodeType, MarkType } from "prosemirror-model"
-import { Command, toggleMark } from "prosemirror-commands"
-import { wrapInList, liftListItem, sinkListItem } from "prosemirror-schema-list"
-import { markIsActive, listIsActive } from "@cultureamp/rich-text-toolkit"
+import {
+  ProseMirrorState,
+  ProseMirrorModel,
+  ProseMirrorCommands,
+  ProseMirrorSchemaList,
+  markIsActive,
+  listIsActive,
+} from "@cultureamp/rich-text-toolkit"
 import { ToolbarItems, ToolbarControlTypes } from "../types"
 
 /** Configuration for individual controls */
@@ -20,10 +23,7 @@ type ToolbarControl = {
   label: string
   isActive: boolean
   disabled?: boolean
-  action: (
-    state: EditorState<any>,
-    dispatch: ((tr: Transaction<any>) => void) | undefined
-  ) => boolean
+  action: ProseMirrorState.Command
 }
 
 /** Toolbar controls mapped to a group */
@@ -37,9 +37,11 @@ type ControlGroupTypes = {
 }
 
 /** Chains multiple commands to dispatch each transitions in sequential order */
-function chainTransactions(...commands: Command[]): Command {
+function chainTransactions(
+  ...commands: ProseMirrorState.Command[]
+): ProseMirrorState.Command {
   return (state, dispatch): boolean => {
-    const updateStateAndDispatch = (tr: Transaction): void => {
+    const updateStateAndDispatch = (tr: ProseMirrorState.Transaction): void => {
       state = state.apply(tr)
       dispatch && dispatch(tr)
     }
@@ -55,8 +57,8 @@ function chainTransactions(...commands: Command[]): Command {
 
 /** Dispatches a transaction to create initial p tag required for pm commands */
 function createInitialParagraph(
-  state: EditorState,
-  dispatch?: (tr: Transaction) => void
+  state: ProseMirrorState.EditorState,
+  dispatch?: (tr: ProseMirrorState.Transaction) => void
 ) {
   if (dispatch) {
     const { tr, schema } = state
@@ -68,69 +70,73 @@ function createInitialParagraph(
 }
 
 /** Create command for toggling Marks */
-function createToggleMarkCommand(mark: MarkType): Command {
+function createToggleMarkCommand(
+  mark: ProseMirrorModel.MarkType
+): ProseMirrorState.Command {
   return (
-    state: EditorState,
-    dispatch: ((tr: Transaction) => void) | undefined
+    state: ProseMirrorState.EditorState,
+    dispatch: ((tr: ProseMirrorState.Transaction) => void) | undefined
   ) => {
     const docIsEmpty = state.doc.content.size === 0
 
     if (docIsEmpty) {
-      return chainTransactions(createInitialParagraph, toggleMark(mark))(
-        state,
-        dispatch
-      )
+      return chainTransactions(
+        createInitialParagraph,
+        ProseMirrorCommands.toggleMark(mark)
+      )(state, dispatch)
     }
-    return toggleMark(mark)(state, dispatch)
+    return ProseMirrorCommands.toggleMark(mark)(state, dispatch)
   }
 }
 
 /** Create command for toggling Lists */
-function createToggleListCommand(node: NodeType): Command {
+function createToggleListCommand(
+  node: ProseMirrorModel.NodeType
+): ProseMirrorState.Command {
   return (
-    state: EditorState,
-    dispatch: ((tr: Transaction) => void) | undefined
+    state: ProseMirrorState.EditorState,
+    dispatch: ((tr: ProseMirrorState.Transaction) => void) | undefined
   ) => {
     const docIsEmpty = state.doc.content.size === 0
 
     if (docIsEmpty) {
-      return chainTransactions(createInitialParagraph, wrapInList(node))(
-        state,
-        dispatch
-      )
+      return chainTransactions(
+        createInitialParagraph,
+        ProseMirrorSchemaList.wrapInList(node)
+      )(state, dispatch)
     }
-    return wrapInList(node)(state, dispatch)
+    return ProseMirrorSchemaList.wrapInList(node)(state, dispatch)
   }
 }
 
 /** Create command for reducing indents in a List */
-function createLiftListCommand(): Command {
+function createLiftListCommand(): ProseMirrorState.Command {
   return (
-    state: EditorState,
-    dispatch: ((tr: Transaction) => void) | undefined
+    state: ProseMirrorState.EditorState,
+    dispatch: ((tr: ProseMirrorState.Transaction) => void) | undefined
   ) => {
     const { $from } = state.selection
     // calculate the parent node from the current tag selected
     const listItemNode = $from.node($from.depth - 1)?.type
-    return liftListItem(listItemNode)(state, dispatch)
+    return ProseMirrorSchemaList.liftListItem(listItemNode)(state, dispatch)
   }
 }
 
 /** Create command for indenting in a List */
-function createIndentListCommand(): Command {
+function createIndentListCommand(): ProseMirrorState.Command {
   return (
-    state: EditorState,
-    dispatch: ((tr: Transaction) => void) | undefined
+    state: ProseMirrorState.EditorState,
+    dispatch: ((tr: ProseMirrorState.Transaction) => void) | undefined
   ) => {
     const { $from } = state.selection
     const listItemNode = $from.node($from.depth - 1)?.type
 
-    return sinkListItem(listItemNode)(state, dispatch)
+    return ProseMirrorSchemaList.sinkListItem(listItemNode)(state, dispatch)
   }
 }
 
 /** handler lift list disabled state */
-function liftListIsDisabled(state: EditorState): boolean {
+function liftListIsDisabled(state: ProseMirrorState.EditorState): boolean {
   const { $from } = state.selection
   const listItemNode = $from.node($from.depth - 1)?.type
   const isValidListItem = listItemNode?.name === "listItem" || false
@@ -139,7 +145,7 @@ function liftListIsDisabled(state: EditorState): boolean {
 }
 
 /** handler indent list disabled state */
-function indentListIsDisabled(state: EditorState): boolean {
+function indentListIsDisabled(state: ProseMirrorState.EditorState): boolean {
   const { $from, $to } = state.selection
   const listItemNode = $from.node($from.depth - 1)?.type
   const isValidListItem = listItemNode?.name === "listItem" || false
@@ -201,8 +207,8 @@ const filterToolbarControls = (
 
 /** Builds an array of object used to map control configuration to rte toolbar buttons */
 export function buildControlMap(
-  schema: Schema,
-  editorState: EditorState,
+  schema: ProseMirrorModel.Schema,
+  editorState: ProseMirrorState.EditorState,
   controls?: ToolbarItems[]
 ): ToolbarControl[][] {
   if (!controls) return []

--- a/packages/rich-text-editor/src/RichTextEditor/inputrules.ts
+++ b/packages/rich-text-editor/src/RichTextEditor/inputrules.ts
@@ -1,13 +1,12 @@
 import {
-  inputRules,
-  smartQuotes,
-  emDash,
-  ellipsis,
-} from "prosemirror-inputrules"
-import { Schema } from "prosemirror-model"
-import { orderedListRule, bulletListRule } from "@cultureamp/rich-text-toolkit"
+  ProseMirrorInputrules,
+  ProseMirrorModel,
+  orderedListRule,
+  bulletListRule,
+} from "@cultureamp/rich-text-toolkit"
 
-export function buildInputRules(schema: Schema) {
+export function buildInputRules(schema: ProseMirrorModel.Schema) {
+  const { smartQuotes, ellipsis, emDash, inputRules } = ProseMirrorInputrules
   const rules = smartQuotes.concat(ellipsis, emDash)
 
   if (schema.nodes.orderedList) {

--- a/packages/rich-text-editor/src/RichTextEditor/keymap.ts
+++ b/packages/rich-text-editor/src/RichTextEditor/keymap.ts
@@ -1,6 +1,13 @@
-import { EditorState, Transaction } from "prosemirror-state"
-import { Schema } from "prosemirror-model"
 import {
+  ProseMirrorCommands,
+  ProseMirrorState,
+  ProseMirrorModel,
+  ProseMirrorSchemaList,
+  ProseMirrorHistory,
+  ProseMirrorInputrules,
+} from "@cultureamp/rich-text-toolkit"
+
+const {
   chainCommands,
   exitCode,
   joinDown,
@@ -9,29 +16,22 @@ import {
   selectParentNode,
   setBlockType,
   toggleMark,
-} from "prosemirror-commands"
-import { redo, undo } from "prosemirror-history"
-import { undoInputRule } from "prosemirror-inputrules"
-import {
-  wrapInList,
-  splitListItem,
-  liftListItem,
-  sinkListItem,
-} from "prosemirror-schema-list"
-
-// Most/all of this file is copied from https://github.com/ProseMirror/prosemirror-example-setup/blob/master/src/keymap.js
+} = ProseMirrorCommands
+const { redo, undo } = ProseMirrorHistory
+const { undoInputRule } = ProseMirrorInputrules
+const { wrapInList, splitListItem, liftListItem, sinkListItem } =
+  ProseMirrorSchemaList
 
 const mac =
   // eslint-disable-next-line ssr-friendly/no-dom-globals-in-module-scope
   typeof navigator != "undefined" ? /Mac/.test(navigator.platform) : false
 
-export function buildKeymap(schema: Schema) {
-  const keys: {
-    [key: string]: (
-      state: EditorState<any>,
-      dispatch?: ((tr: Transaction<any>) => void) | undefined
-    ) => boolean
-  } = {
+interface KeyBinding {
+  [key: string]: ProseMirrorState.Command
+}
+
+export function buildKeymap(schema: ProseMirrorModel.Schema) {
+  const keys: KeyBinding = {
     "Mod-z": undo,
     "Shift-Mod-z": redo,
     Backspace: undoInputRule,

--- a/packages/rich-text-editor/src/RichTextEditor/schema.ts
+++ b/packages/rich-text-editor/src/RichTextEditor/schema.ts
@@ -1,12 +1,13 @@
-import { NodeSpec, Schema } from "prosemirror-model"
 import {
+  ProseMirrorModel,
   nodes as coreNodes,
   marks as coreMarks,
 } from "@cultureamp/rich-text-toolkit"
+
 import { TOOLBAR_CONTROLS } from "../constants"
 import { ToolbarItems, ToolbarControlTypes } from "../types"
 
-export const defaultNodes: NodeSpec = {
+export const defaultNodes: ProseMirrorModel.NodeSpec = {
   doc: coreNodes.doc,
   paragraph: coreNodes.paragraph,
   text: coreNodes.text,
@@ -28,7 +29,7 @@ export const createSchemaWithAll = () => createSchema(TOOLBAR_CONTROLS)
 
 function createSchema(controls?: ToolbarControlTypes[]) {
   if (!controls) {
-    return new Schema({
+    return new ProseMirrorModel.Schema({
       nodes: defaultNodes,
     })
   }
@@ -62,7 +63,7 @@ function createSchema(controls?: ToolbarControlTypes[]) {
     newMarks["link"] = coreMarks.link
   }
 
-  return new Schema({
+  return new ProseMirrorModel.Schema({
     nodes: newNodes,
     marks: newMarks,
   })

--- a/yarn.lock
+++ b/yarn.lock
@@ -1843,10 +1843,10 @@
   resolved "https://registry.yarnpkg.com/@csstools/selector-specificity/-/selector-specificity-2.0.1.tgz#b6b8d81780b9a9f6459f4bfe9226ac6aefaefe87"
   integrity sha512-aG20vknL4/YjQF9BSV7ts4EWm/yrjagAN7OWBNmlbEOUiu0llj4OGrFoOKK3g2vey4/p2omKCoHrWtPxSwV3HA==
 
-"@cultureamp/rich-text-toolkit@^1.11.0":
-  version "1.11.0"
-  resolved "https://npm.pkg.github.com/download/@cultureamp/rich-text-toolkit/1.11.0/2cdbe00397f6b54f3e5f775018fd9973abc176c1531711d443a63eb9c5e4642b#92441bde6927abc124331addbf32efe06cb7cb9a"
-  integrity sha512-rJUOGKrLLhBa++s2bmG+LaQvoJUTvX9m+/Big4z9NLS5SzWsYhsAvlTGUv7MJBtBFN7+bFxQDET/8N8JgD0gLQ==
+"@cultureamp/rich-text-toolkit@^2.0.0":
+  version "2.0.0"
+  resolved "https://npm.pkg.github.com/download/@cultureamp/rich-text-toolkit/2.0.0/3782e700674cf4e5d3b244371c106b2f02188efd#3782e700674cf4e5d3b244371c106b2f02188efd"
+  integrity sha512-o9lvtRB/108uTBEon64ovM0QnbwUKmX5zUfeJ38gqPODdDnrfsdQt87qvjXuIgtZFRrpljUt5FJpcwhTdKNqEw==
   dependencies:
     "@kaizen/button" "^1.2.8"
     "@kaizen/component-library" "^14.3.4"
@@ -1855,15 +1855,16 @@
     "@kaizen/typography" "^2.2.1"
     lodash.debounce "^4.0.8"
     nanobus "^4.5.0"
-    prosemirror-commands "^1.2.1"
-    prosemirror-history "^1.2.0"
-    prosemirror-inputrules "^1.1.3"
-    prosemirror-model "^1.16.1"
-    prosemirror-schema-basic "^1.1.2"
-    prosemirror-schema-list "^1.1.6"
-    prosemirror-state "^1.3.4"
+    prosemirror-commands "^1.3.0"
+    prosemirror-history "^1.3.0"
+    prosemirror-inputrules "^1.2.0"
+    prosemirror-keymap "^1.2.0"
+    prosemirror-model "^1.18.1"
+    prosemirror-schema-basic "^1.2.0"
+    prosemirror-schema-list "^1.2.1"
+    prosemirror-state "^1.4.1"
     prosemirror-utils "^1.0.0-0"
-    prosemirror-view "^1.23.7"
+    prosemirror-view "^1.27.2"
 
 "@discoveryjs/json-ext@^0.5.3":
   version "0.5.6"
@@ -5557,11 +5558,6 @@
   resolved "https://registry.yarnpkg.com/@types/npmlog/-/npmlog-4.1.3.tgz#9c24b49a97e25cf15a890ff404764080d7942132"
   integrity sha512-1TcL7YDYCtnHmLhTWbum+IIwLlvpaHoEKS2KNIngEwLzwgDeHaebaEHHbQp8IqzNQ9IYiboLKUjAf7MZqG63+w==
 
-"@types/orderedmap@*":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@types/orderedmap/-/orderedmap-1.0.0.tgz#807455a192bba52cbbb4517044bc82bdbfa8c596"
-  integrity sha512-dxKo80TqYx3YtBipHwA/SdFmMMyLCnP+5mkEqN0eMjcTBzHkiiX0ES118DsjDBjvD+zeSsSU9jULTZ+frog+Gw==
-
 "@types/parse-json@^4.0.0":
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@types/parse-json/-/parse-json-4.0.0.tgz#2f8bb441434d163b35fb8ffdccd7138927ffb8c0"
@@ -5593,82 +5589,6 @@
   version "15.7.4"
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.4.tgz#fcf7205c25dff795ee79af1e30da2c9790808f11"
   integrity sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ==
-
-"@types/prosemirror-commands@*", "@types/prosemirror-commands@^1.0.4":
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/@types/prosemirror-commands/-/prosemirror-commands-1.0.4.tgz#d08551415127d93ae62e7239d30db0b5e7208e22"
-  integrity sha512-utDNYB3EXLjAfYIcRWJe6pn3kcQ5kG4RijbT/0Y/TFOm6yhvYS/D9eJVnijdg9LDjykapcezchxGRqFD5LcyaQ==
-  dependencies:
-    "@types/prosemirror-model" "*"
-    "@types/prosemirror-state" "*"
-    "@types/prosemirror-view" "*"
-
-"@types/prosemirror-history@^1.0.3":
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/@types/prosemirror-history/-/prosemirror-history-1.0.3.tgz#f1110efbe758129b5475e466ff077f0a8d9b964f"
-  integrity sha512-5TloMDRavgLjOAKXp1Li8u0xcsspzbT1Cm9F2pwHOkgvQOz1jWQb2VIXO7RVNsFjLBZdIXlyfSLivro3DuMWXg==
-  dependencies:
-    "@types/prosemirror-model" "*"
-    "@types/prosemirror-state" "*"
-
-"@types/prosemirror-inputrules@^1.0.4":
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/@types/prosemirror-inputrules/-/prosemirror-inputrules-1.0.4.tgz#4cb75054d954aa0f6f42099be05eb6c0e6958bae"
-  integrity sha512-lJIMpOjO47SYozQybUkpV6QmfuQt7GZKHtVrvS+mR5UekA8NMC5HRIVMyaIauJLWhKU6oaNjpVaXdw41kh165g==
-  dependencies:
-    "@types/prosemirror-model" "*"
-    "@types/prosemirror-state" "*"
-
-"@types/prosemirror-keymap@^1.0.4":
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/@types/prosemirror-keymap/-/prosemirror-keymap-1.0.4.tgz#f73c79810e8d0e0a20d153d84f998f02e5afbc0c"
-  integrity sha512-ycevwkqUh+jEQtPwqO7sWGcm+Sybmhu8MpBsM8DlO3+YTKnXbKA6SDz/+q14q1wK3UA8lHJyfR+v+GPxfUSemg==
-  dependencies:
-    "@types/prosemirror-commands" "*"
-    "@types/prosemirror-model" "*"
-    "@types/prosemirror-state" "*"
-    "@types/prosemirror-view" "*"
-
-"@types/prosemirror-model@*", "@types/prosemirror-model@^1.16.1":
-  version "1.16.1"
-  resolved "https://registry.yarnpkg.com/@types/prosemirror-model/-/prosemirror-model-1.16.1.tgz#0ce6c80cd81b398b8a11b1bf7cf695bff3160c9a"
-  integrity sha512-SrrCe2cHlYrQ9o55e2i/c3wt1yRajTTpRLvzfmB+2DWjWEbBLTByVWyjrdpKtQTxAaTeU2aeDGo1iuwl/jF27w==
-  dependencies:
-    "@types/orderedmap" "*"
-
-"@types/prosemirror-schema-list@^1.0.3":
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/@types/prosemirror-schema-list/-/prosemirror-schema-list-1.0.3.tgz#bdf1893a7915fbdc5c49b3cac9368e96213d70de"
-  integrity sha512-uWybOf+M2Ea7rlbs0yLsS4YJYNGXYtn4N+w8HCw3Vvfl6wBAROzlMt0gV/D/VW/7J/LlAjwMezuGe8xi24HzXA==
-  dependencies:
-    "@types/orderedmap" "*"
-    "@types/prosemirror-model" "*"
-    "@types/prosemirror-state" "*"
-
-"@types/prosemirror-state@*", "@types/prosemirror-state@^1.2.8":
-  version "1.2.8"
-  resolved "https://registry.yarnpkg.com/@types/prosemirror-state/-/prosemirror-state-1.2.8.tgz#65080eeec52f63c50bf7034377f07773b4f6b2ac"
-  integrity sha512-mq9uyQWcpu8jeamO6Callrdvf/e1H/aRLR2kZWSpZrPHctEsxWHBbluD/wqVjXBRIOoMHLf6ZvOkrkmGLoCHVA==
-  dependencies:
-    "@types/prosemirror-model" "*"
-    "@types/prosemirror-transform" "*"
-    "@types/prosemirror-view" "*"
-
-"@types/prosemirror-transform@*":
-  version "1.1.6"
-  resolved "https://registry.yarnpkg.com/@types/prosemirror-transform/-/prosemirror-transform-1.1.6.tgz#4a06979f656331c46c2725039a57360cc35853af"
-  integrity sha512-7HwXOWc5vZQqIfEUUVAz13lPgBqAWJTv89qEpzAtBFB6hOszFmhsvQ02Jqe2LvKauAoJDa3Qpv/dbJAmgyiTuQ==
-  dependencies:
-    "@types/prosemirror-model" "*"
-
-"@types/prosemirror-view@*":
-  version "1.23.1"
-  resolved "https://registry.yarnpkg.com/@types/prosemirror-view/-/prosemirror-view-1.23.1.tgz#a9a926bb6b6e6873e3a9d8caa61c32f3402629eb"
-  integrity sha512-6e1B2oKUnhmZPUrsVvYjDqeVjE6jGezygjtoHsAK4ZENAxHzHqy5NT4jUvdPTWjCYeH0t2Y7pSfRPNrPIyQX4A==
-  dependencies:
-    "@types/prosemirror-model" "*"
-    "@types/prosemirror-state" "*"
-    "@types/prosemirror-transform" "*"
 
 "@types/qs@^6.9.5":
   version "6.9.7"
@@ -15446,10 +15366,10 @@ ora@^6.0.1:
     strip-ansi "^7.0.1"
     wcwidth "^1.0.1"
 
-orderedmap@^1.1.0:
-  version "1.1.5"
-  resolved "https://registry.yarnpkg.com/orderedmap/-/orderedmap-1.1.5.tgz#4174c90b61bd7c25294932edf789f3b5677744d0"
-  integrity sha512-/fzlCGKRmfayGoI9UUXvJfc2nMZlJHW30QqEvwPvlg8tsX7jyiUSomYie6mYqx7Z9bOMGoag0H/q1PS/0PjYkg==
+orderedmap@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/orderedmap/-/orderedmap-2.0.0.tgz#12ff5ef6ea9d12d6430b80c701b35475e1c9ff34"
+  integrity sha512-buf4PoAMlh45b8a8gsGy/X6w279TSqkyAS0C0wdTSJwFSU+ljQFJON5I8NfjLHoCXwpSROIo2wr0g33T+kQshQ==
 
 os-browserify@^0.3.0:
   version "0.3.0"
@@ -16776,74 +16696,75 @@ property-information@^5.0.0, property-information@^5.3.0:
   dependencies:
     xtend "^4.0.0"
 
-prosemirror-commands@^1.2.1, prosemirror-commands@^1.2.2:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/prosemirror-commands/-/prosemirror-commands-1.2.2.tgz#1bd167372ee20abf488aca9cece63c43fab182c9"
-  integrity sha512-TX+KpWudMon06frryfpO/u7hsQv2hu8L4VSVbCpi3/7wXHBgl+35mV85qfa3RpT8xD2f3MdeoTqH0vy5JdbXPg==
+prosemirror-commands@^1.3.0:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/prosemirror-commands/-/prosemirror-commands-1.3.1.tgz#926c88801eebaa50363d4658850b41406d375a31"
+  integrity sha512-XTporPgoECkOQACVw0JTe3RZGi+fls3/byqt+tXwGTkD7qLuB4KdVrJamDMJf4kfKga3uB8hZ+kUUyZ5oWpnfg==
   dependencies:
     prosemirror-model "^1.0.0"
     prosemirror-state "^1.0.0"
     prosemirror-transform "^1.0.0"
 
-prosemirror-history@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/prosemirror-history/-/prosemirror-history-1.2.0.tgz#04cc4df8d2f7b2a46651a2780de191ada6d465ea"
-  integrity sha512-B9v9xtf4fYbKxQwIr+3wtTDNLDZcmMMmGiI3TAPShnUzvo+Rmv1GiUrsQChY1meetHl7rhML2cppF3FTs7f7UQ==
+prosemirror-history@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/prosemirror-history/-/prosemirror-history-1.3.0.tgz#bf5a1ff7759aca759ddf0c722c2fa5b14fb0ddc1"
+  integrity sha512-qo/9Wn4B/Bq89/YD+eNWFbAytu6dmIM85EhID+fz9Jcl9+DfGEo8TTSrRhP15+fFEoaPqpHSxlvSzSEbmlxlUA==
   dependencies:
     prosemirror-state "^1.2.2"
     prosemirror-transform "^1.0.0"
     rope-sequence "^1.3.0"
 
-prosemirror-inputrules@^1.1.3:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/prosemirror-inputrules/-/prosemirror-inputrules-1.1.3.tgz#93f9199ca02473259c30d7e352e4c14022d54638"
-  integrity sha512-ZaHCLyBtvbyIHv0f5p6boQTIJjlD6o2NPZiEaZWT2DA+j591zS29QQEMT4lBqwcLW3qRSf7ZvoKNbf05YrsStw==
+prosemirror-inputrules@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/prosemirror-inputrules/-/prosemirror-inputrules-1.2.0.tgz#476dde2dc244050b3aca00cf58a82adfad6749e7"
+  integrity sha512-eAW/M/NTSSzpCOxfR8Abw6OagdG0MiDAiWHQMQveIsZtoKVYzm0AflSPq/ymqJd56/Su1YPbwy9lM13wgHOFmQ==
   dependencies:
     prosemirror-state "^1.0.0"
     prosemirror-transform "^1.0.0"
 
-prosemirror-keymap@^1.1.5:
-  version "1.1.5"
-  resolved "https://registry.yarnpkg.com/prosemirror-keymap/-/prosemirror-keymap-1.1.5.tgz#b5984c7d30f5c75956c853126c54e9e624c0327b"
-  integrity sha512-8SZgPH3K+GLsHL2wKuwBD9rxhsbnVBTwpHCO4VUO5GmqUQlxd/2GtBVWTsyLq4Dp3N9nGgPd3+lZFKUDuVp+Vw==
+prosemirror-keymap@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/prosemirror-keymap/-/prosemirror-keymap-1.2.0.tgz#d5cc9da9b712020690a994b50b92a0e448a60bf5"
+  integrity sha512-TdSfu+YyLDd54ufN/ZeD1VtBRYpgZnTPnnbY+4R08DDgs84KrIPEPbJL8t1Lm2dkljFx6xeBE26YWH3aIzkPKg==
   dependencies:
     prosemirror-state "^1.0.0"
     w3c-keyname "^2.2.0"
 
-prosemirror-model@^1.0.0, prosemirror-model@^1.16.0, prosemirror-model@^1.16.1, prosemirror-model@^1.2.0:
-  version "1.16.1"
-  resolved "https://registry.yarnpkg.com/prosemirror-model/-/prosemirror-model-1.16.1.tgz#fb388270bc9609b66298d6a7e15d0cc1d6c61253"
-  integrity sha512-r1/w0HDU40TtkXp0DyKBnFPYwd8FSlUSJmGCGFv4DeynfeSlyQF2FD0RQbVEMOe6P3PpUSXM6LZBV7W/YNZ4mA==
+prosemirror-model@^1.0.0, prosemirror-model@^1.16.0, prosemirror-model@^1.18.1, prosemirror-model@^1.2.0:
+  version "1.18.1"
+  resolved "https://registry.yarnpkg.com/prosemirror-model/-/prosemirror-model-1.18.1.tgz#1d5d6b6de7b983ee67a479dc607165fdef3935bd"
+  integrity sha512-IxSVBKAEMjD7s3n8cgtwMlxAXZrC7Mlag7zYsAKDndAqnDScvSmp/UdnRTV/B33lTCVU3CCm7dyAn/rVVD0mcw==
   dependencies:
-    orderedmap "^1.1.0"
+    orderedmap "^2.0.0"
 
-prosemirror-schema-basic@^1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/prosemirror-schema-basic/-/prosemirror-schema-basic-1.1.2.tgz#4bde5c339c845e0d08ec8fe473064e372ca51ae3"
-  integrity sha512-G4q8WflNsR1Q33QAV4MQO0xWrHLOJ+BQcKswGXMy626wlQj6c/1n1v4eC9ns+h2y1r/fJHZEgSZnsNhm9lbrDw==
+prosemirror-schema-basic@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/prosemirror-schema-basic/-/prosemirror-schema-basic-1.2.0.tgz#c33ad74426efae1d41e2260371866f623e8eb10e"
+  integrity sha512-JMN/ammP94ObOUS6cpIy121r0MEDN9V95mAxFVALwC4bbmhpWXGjBGHTA5LHPPdbqZKyR6Jar1Akv4Z5k9CNLw==
   dependencies:
     prosemirror-model "^1.2.0"
 
-prosemirror-schema-list@^1.1.6:
-  version "1.1.6"
-  resolved "https://registry.yarnpkg.com/prosemirror-schema-list/-/prosemirror-schema-list-1.1.6.tgz#c3e13fe2f74750e4a53ff88d798dc0c4ccca6707"
-  integrity sha512-aFGEdaCWmJzouZ8DwedmvSsL50JpRkqhQ6tcpThwJONVVmCgI36LJHtoQ4VGZbusMavaBhXXr33zyD2IVsTlkw==
+prosemirror-schema-list@^1.2.1:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/prosemirror-schema-list/-/prosemirror-schema-list-1.2.2.tgz#bafda37b72367d39accdcaf6ddf8fb654a16e8e5"
+  integrity sha512-rd0pqSDp86p0MUMKG903g3I9VmElFkQpkZ2iOd3EOVg1vo5Cst51rAsoE+5IPy0LPXq64eGcCYlW1+JPNxOj2w==
   dependencies:
     prosemirror-model "^1.0.0"
+    prosemirror-state "^1.0.0"
     prosemirror-transform "^1.0.0"
 
-prosemirror-state@^1.0.0, prosemirror-state@^1.2.2, prosemirror-state@^1.3.4:
-  version "1.3.4"
-  resolved "https://registry.yarnpkg.com/prosemirror-state/-/prosemirror-state-1.3.4.tgz#4c6b52628216e753fc901c6d2bfd84ce109e8952"
-  integrity sha512-Xkkrpd1y/TQ6HKzN3agsQIGRcLckUMA9u3j207L04mt8ToRgpGeyhbVv0HI7omDORIBHjR29b7AwlATFFf2GLA==
+prosemirror-state@^1.0.0, prosemirror-state@^1.2.2, prosemirror-state@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/prosemirror-state/-/prosemirror-state-1.4.1.tgz#f6e26c7b6a7e11206176689eb6ebbf91870953e1"
+  integrity sha512-U/LBDW2gNmVa07sz/D229XigSdDQ5CLFwVB1Vb32MJbAHHhWe/6pOc721faI17tqw4pZ49i1xfY/jEZ9tbIhPg==
   dependencies:
     prosemirror-model "^1.0.0"
     prosemirror-transform "^1.0.0"
 
 prosemirror-transform@^1.0.0, prosemirror-transform@^1.1.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/prosemirror-transform/-/prosemirror-transform-1.4.0.tgz#057344b7ef38d1a4ba370390eba8c35f9afe6b36"
-  integrity sha512-P+bv4JiLHcRy4krHByUglXR1yAMCuzHRAaSKInsoW7Rjy3aomPXM/MwRs+b7TGtC1e6ZM31KbapbvE4wV1X9RA==
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/prosemirror-transform/-/prosemirror-transform-1.7.0.tgz#a8a0768f3ee6418d26ebef435beda9d43c65e472"
+  integrity sha512-O4T697Cqilw06Zvc3Wm+e237R6eZtJL/xGMliCi+Uo8VL6qHk6afz1qq0zNjT3eZMuYwnP8ZS0+YxX/tfcE9TQ==
   dependencies:
     prosemirror-model "^1.0.0"
 
@@ -16852,10 +16773,10 @@ prosemirror-utils@^1.0.0-0:
   resolved "https://registry.yarnpkg.com/prosemirror-utils/-/prosemirror-utils-1.0.0-0.tgz#7dfd112abf69001508a76200f9c8660fda7fa85f"
   integrity sha512-11hTMG4Qwqlux6Vwp/4m16mLDg6IwWb0/odsWXGtWvvRJo61SfG0RGYlA8H72vExmbnWpiXa7PNenZ6t12Rkqw==
 
-prosemirror-view@^1.23.7:
-  version "1.23.10"
-  resolved "https://registry.yarnpkg.com/prosemirror-view/-/prosemirror-view-1.23.10.tgz#a3fb6a7c780c8cd84488fdd451c23becab9dbefb"
-  integrity sha512-/p8Orb1VeJEbf7Z/BltU9GMWADZRqKlna6TlQGK1snJ6fTdLRC4f4yF2MgNK4OMQjmAwJISUtEp5+Vu5CSbR1w==
+prosemirror-view@^1.27.2:
+  version "1.28.2"
+  resolved "https://registry.yarnpkg.com/prosemirror-view/-/prosemirror-view-1.28.2.tgz#e997ef9dc623d01afd170e328fc924e6f4382003"
+  integrity sha512-uK28mJbu0GI8Oz7Aclt6BKL4g+C59EBShBXDB0Y9Y71H25p4bQgmLQLfDWjsT1J9XOw0bR8QQajZmdK8RvXI9g==
   dependencies:
     prosemirror-model "^1.16.0"
     prosemirror-state "^1.0.0"
@@ -17976,9 +17897,9 @@ ripemd160@^2.0.0, ripemd160@^2.0.1:
     inherits "^2.0.1"
 
 rope-sequence@^1.3.0:
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/rope-sequence/-/rope-sequence-1.3.2.tgz#a19e02d72991ca71feb6b5f8a91154e48e3c098b"
-  integrity sha512-ku6MFrwEVSVmXLvy3dYph3LAMNS0890K7fabn+0YIRQ2T96T9F4gkFf0vf0WW0JUraNWwGRtInEpH7yO4tbQZg==
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/rope-sequence/-/rope-sequence-1.3.3.tgz#3f67fc106288b84b71532b4a5fd9d4881e4457f0"
+  integrity sha512-85aZYCxweiD5J8yTEbw+E6A27zSnLPNDL0WfPdw3YYodq7WjnTKo0q4dtyQ2gz23iPT8Q9CUyJtAaUNcTxRf5Q==
 
 rsvp@^4.8.4:
   version "4.8.5"
@@ -20327,9 +20248,9 @@ w3c-hr-time@^1.0.2:
     browser-process-hrtime "^1.0.0"
 
 w3c-keyname@^2.2.0:
-  version "2.2.4"
-  resolved "https://registry.yarnpkg.com/w3c-keyname/-/w3c-keyname-2.2.4.tgz#4ade6916f6290224cdbd1db8ac49eab03d0eef6b"
-  integrity sha512-tOhfEwEzFLJzf6d1ZPkYfGj+FWhIpBux9ppoP3rlclw3Z0BZv3N7b7030Z1kYth+6rDuAsXUFr+d0VE6Ed1ikw==
+  version "2.2.6"
+  resolved "https://registry.yarnpkg.com/w3c-keyname/-/w3c-keyname-2.2.6.tgz#8412046116bc16c5d73d4e612053ea10a189c85f"
+  integrity sha512-f+fciywl1SJEniZHD6H+kUO8gOnwIr7f4ijKA6+ZvJFjeGi1r4PDLl53Ayud9O/rk64RqgoQine0feoeOU0kXg==
 
 w3c-xmlserializer@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
## Why
- Misalignment between prosemirror dependencies (specifically prosemirror-model and prosemirror-state) in the Toolkit and RTE was causing the component to break on render
- As these repo are not connected by the same dependancy bot there is no guarantee that these issue would not regularly arise
- This was surfaced on a lock file [maintenance PR](https://github.com/cultureamp/kaizen-design-system/pull/2868/files), which caused a cascade of issues


## What
- Update import statements
- Fixes type errors
- remove prose-mirror dependencies
- This will rely on this [PR](https://github.com/cultureamp/rich-text-toolkit/actions/runs/3080111238/jobs/4977082827) to be merged in
