### PR TITLE
fix(draft-form): Label margin should be 6px and not 10px

### DIFF
--- a/draft-packages/form/KaizenDraft/Form/Primitives/Label/Label.module.scss
+++ b/draft-packages/form/KaizenDraft/Form/Primitives/Label/Label.module.scss
@@ -3,7 +3,7 @@
 @import "~@kaizen/design-tokens/sass/color";
 @import "../../variables";
 
-$label-start-margin: 10px;
+$label-start-margin: $spacing-xs;
 
 .label,
 :global(.ideal-sans) .label {

--- a/draft-packages/form/KaizenDraft/Form/Primitives/ToggleSwitch/ToggleSwitch.module.scss
+++ b/draft-packages/form/KaizenDraft/Form/Primitives/ToggleSwitch/ToggleSwitch.module.scss
@@ -7,7 +7,7 @@
 
 $animation-timing: $animation-duration-immediate
   $animation-easing-function-linear;
-$focus-ring-offset: 2px;
+$focus-ring-offset: 1px;
 
 .checkbox {
   @include form-input-visually-hidden();
@@ -31,7 +31,7 @@ $focus-ring-offset: 2px;
   .checkbox:hover:focus:not([disabled]) + & {
     border-color: transparent;
     outline: 2px solid $color-blue-500;
-    outline-offset: 2px;
+    outline-offset: $focus-ring-offset;
     background-color: $color-gray-500;
   }
 


### PR DESCRIPTION
[KDS-640](https://cultureamp.atlassian.net/jira/software/projects/KDS/boards/289?selectedIssue=KDS-640)

## Why
The UI Kit components for the [Checkbox Field](https://www.figma.com/file/eZKEE5kXbEMY3lx84oz8iN/%E2%9D%A4%EF%B8%8F-UI-Kit%3A-Heart?node-id=14462%3A196) use different spacing between the checkbox and the label than what is shown in [Storybook](https://dev.cultureamp.design/develop/filter-select/?path=/story/components-form-checkbox-field--interactive-kaizen-site-demo).


