### PR TITLE
feat: use correct heading tag and add heading varient prop so correct…

### DIFF
--- a/draft-packages/empty-state/KaizenDraft/EmptyState/EmptyState.tsx
+++ b/draft-packages/empty-state/KaizenDraft/EmptyState/EmptyState.tsx
@@ -9,7 +9,7 @@ import {
   EmptyStatesPositive,
   AnimatedSceneProps,
 } from "@kaizen/draft-illustration"
-import { Paragraph, Heading } from "@kaizen/typography"
+import { Paragraph, Heading, HeadingVariants } from "@kaizen/typography"
 import styles from "./EmptyState.module.scss"
 
 const ILLUSTRATIONS: { [k: string]: React.VFC<AnimatedSceneProps> } = {
@@ -39,6 +39,7 @@ export interface EmptyStateProps
   headingText: string | React.ReactNode
   bodyText: string | React.ReactNode
   straightCorners?: boolean
+  headingVariant?: HeadingVariants
   /**
    * **Deprecated:** Use test id compatible with your testing library (eg. `data-testid`).
    * @deprecated
@@ -62,6 +63,7 @@ export const EmptyState: React.VFC<EmptyStateProps> = ({
   loop = false,
   automationId,
   classNameOverride,
+  headingVariant: headingVariant = "heading-3",
   ...props
 }) => {
   const IllustrationComponent = ILLUSTRATIONS[illustrationType]
@@ -95,11 +97,7 @@ export const EmptyState: React.VFC<EmptyStateProps> = ({
       </div>
       <div className={styles.textSide}>
         <div className={styles.textSideInner}>
-          <Heading
-            variant="heading-3"
-            classNameOverride={styles.heading}
-            tag="div"
-          >
+          <Heading variant={headingVariant} classNameOverride={styles.heading}>
             {headingText}
           </Heading>
           <Paragraph variant="body" classNameOverride={styles.description}>


### PR DESCRIPTION
## Why
<!-- Why have you created this PR? - Is it a new feature, or a bug fix? Or something else? -->
<!-- Reference any relevant Jira tickets so your reviewer can find more context if needed. -->
<!-- Fixing a GitHub issue? Add "Fixes [issue URL]". -->
**Use heading tag and add `headingVarient` prop in EmptyState component**
Currently the "Empty State" component heading renders as a `<div>`, but is styled as `heading-3` which doesn't follow best a11y semantic practices (and has created a violation on the survey configure questions edit page - [here is ticket](https://cultureamp.atlassian.net/browse/KD-1721))  

## What
<!-- What do your changes do? How do they change/fix the current behavior? -->
<!-- Add screenshots, GIFs or videos to illustrate the changes.  -->
1. Remove `tag="div"` and use `headingVarient` to control heading level
2. use `<h3>` by default when no `headingVarient` provided

> Note: an alternative to this PR could be adding `role="heading"` to the div, but seemed best to make a heading a heading
