### PR TITLE
feat: heading tag for EmptyState component

### DIFF
--- a/draft-packages/empty-state/KaizenDraft/EmptyState/EmptyState.spec.tsx
+++ b/draft-packages/empty-state/KaizenDraft/EmptyState/EmptyState.spec.tsx
@@ -1,4 +1,4 @@
-import { cleanup, render } from "@testing-library/react"
+import { cleanup, render, screen } from "@testing-library/react"
 import * as React from "react"
 
 import { EmptyStateProps } from "./EmptyState"
@@ -101,6 +101,19 @@ describe("<EmptyState />", () => {
       const { getByText } = render(<EmptyState {...props} />)
 
       expect(getByText("EmptyStatesAction_Component")).toBeTruthy()
+    })
+
+    it("renders the correct heading level based on tag provided", () => {
+      const props: EmptyStateProps = {
+        ...defaultProps,
+        headingProps: {
+          variant: "heading-3",
+          children: "Custom heading",
+          tag: "h2",
+        },
+      }
+      render(<EmptyState {...props} />)
+      expect(screen.getByRole("heading", { level: 2 })).toBeInTheDocument()
     })
   })
 })

--- a/draft-packages/empty-state/KaizenDraft/EmptyState/EmptyState.tsx
+++ b/draft-packages/empty-state/KaizenDraft/EmptyState/EmptyState.tsx
@@ -61,11 +61,7 @@ export const EmptyState: React.VFC<EmptyStateProps> = ({
   illustrationType = "informative",
   layoutContext = "sidebarAndContent",
   headingText,
-  headingProps = {
-    variant: "heading-3",
-    tag: "div",
-    color: "dark",
-  },
+  headingProps,
   bodyText,
   straightCorners,
   isAnimated = true,
@@ -105,14 +101,17 @@ export const EmptyState: React.VFC<EmptyStateProps> = ({
       </div>
       <div className={styles.textSide}>
         <div className={styles.textSideInner}>
-          <Heading
-            variant={headingProps.variant}
-            classNameOverride={styles.heading}
-            tag={headingProps.tag}
-            color={headingProps.color}
-          >
-            {headingProps.children || headingText}
-          </Heading>
+          {headingProps ? (
+            <Heading classNameOverride={styles.heading} {...headingProps} />
+          ) : (
+            <Heading
+              variant="heading-3"
+              classNameOverride={styles.heading}
+              tag="div"
+            >
+              {headingText}
+            </Heading>
+          )}
           <Paragraph variant="body" classNameOverride={styles.description}>
             {bodyText}
           </Paragraph>

--- a/draft-packages/empty-state/KaizenDraft/EmptyState/EmptyState.tsx
+++ b/draft-packages/empty-state/KaizenDraft/EmptyState/EmptyState.tsx
@@ -63,7 +63,7 @@ export const EmptyState: React.VFC<EmptyStateProps> = ({
   loop = false,
   automationId,
   classNameOverride,
-  headingVariant: headingVariant = "heading-3",
+  headingVariant,
   ...props
 }) => {
   const IllustrationComponent = ILLUSTRATIONS[illustrationType]
@@ -97,7 +97,11 @@ export const EmptyState: React.VFC<EmptyStateProps> = ({
       </div>
       <div className={styles.textSide}>
         <div className={styles.textSideInner}>
-          <Heading variant={headingVariant} classNameOverride={styles.heading}>
+          <Heading
+            variant={headingVariant ? headingVariant : "heading-3"}
+            tag={headingVariant ? undefined : "div"}
+            classNameOverride={styles.heading}
+          >
             {headingText}
           </Heading>
           <Paragraph variant="body" classNameOverride={styles.description}>

--- a/draft-packages/empty-state/KaizenDraft/EmptyState/EmptyState.tsx
+++ b/draft-packages/empty-state/KaizenDraft/EmptyState/EmptyState.tsx
@@ -9,7 +9,7 @@ import {
   EmptyStatesPositive,
   AnimatedSceneProps,
 } from "@kaizen/draft-illustration"
-import { Paragraph, Heading, HeadingVariants } from "@kaizen/typography"
+import { Paragraph, Heading, HeadingProps } from "@kaizen/typography"
 import styles from "./EmptyState.module.scss"
 
 const ILLUSTRATIONS: { [k: string]: React.VFC<AnimatedSceneProps> } = {
@@ -36,10 +36,14 @@ export interface EmptyStateProps
   id?: string
   illustrationType?: IllustrationType
   layoutContext?: LayoutContextType
-  headingText: string | React.ReactNode
   bodyText: string | React.ReactNode
   straightCorners?: boolean
-  headingVariant?: HeadingVariants
+  headingProps?: HeadingProps
+  /**
+   * **Deprecated:** Use headingProps
+   * @deprecated
+   */
+  headingText?: string | React.ReactNode
   /**
    * **Deprecated:** Use test id compatible with your testing library (eg. `data-testid`).
    * @deprecated
@@ -57,13 +61,17 @@ export const EmptyState: React.VFC<EmptyStateProps> = ({
   illustrationType = "informative",
   layoutContext = "sidebarAndContent",
   headingText,
+  headingProps = {
+    variant: "heading-3",
+    tag: "div",
+    color: "dark",
+  },
   bodyText,
   straightCorners,
   isAnimated = true,
   loop = false,
   automationId,
   classNameOverride,
-  headingVariant,
   ...props
 }) => {
   const IllustrationComponent = ILLUSTRATIONS[illustrationType]
@@ -98,11 +106,12 @@ export const EmptyState: React.VFC<EmptyStateProps> = ({
       <div className={styles.textSide}>
         <div className={styles.textSideInner}>
           <Heading
-            variant={headingVariant ? headingVariant : "heading-3"}
-            tag={headingVariant ? undefined : "div"}
+            variant={headingProps.variant}
             classNameOverride={styles.heading}
+            tag={headingProps.tag}
+            color={headingProps.color}
           >
-            {headingText}
+            {headingProps.children || headingText}
           </Heading>
           <Paragraph variant="body" classNameOverride={styles.description}>
             {bodyText}

--- a/draft-packages/empty-state/KaizenDraft/EmptyState/EmptyState.tsx
+++ b/draft-packages/empty-state/KaizenDraft/EmptyState/EmptyState.tsx
@@ -9,7 +9,7 @@ import {
   EmptyStatesPositive,
   AnimatedSceneProps,
 } from "@kaizen/draft-illustration"
-import { Paragraph, Heading } from "@kaizen/typography"
+import { Paragraph, Heading, HeadingVariants } from "@kaizen/typography"
 import styles from "./EmptyState.module.scss"
 
 const ILLUSTRATIONS: { [k: string]: React.VFC<AnimatedSceneProps> } = {
@@ -39,6 +39,7 @@ export interface EmptyStateProps
   headingText: string | React.ReactNode
   bodyText: string | React.ReactNode
   straightCorners?: boolean
+  headingVariant?: HeadingVariants
   /**
    * **Deprecated:** Use test id compatible with your testing library (eg. `data-testid`).
    * @deprecated
@@ -62,6 +63,7 @@ export const EmptyState: React.VFC<EmptyStateProps> = ({
   loop = false,
   automationId,
   classNameOverride,
+  headingVariant: headingVariant = "heading-3",
   ...props
 }) => {
   const IllustrationComponent = ILLUSTRATIONS[illustrationType]
@@ -95,11 +97,7 @@ export const EmptyState: React.VFC<EmptyStateProps> = ({
       </div>
       <div className={styles.textSide}>
         <div className={styles.textSideInner}>
-          <Heading
-            variant="heading-3"
-            classNameOverride={styles.heading}
-            tag="div"
-          >
+          <Heading variant={headingVariant} classNameOverride={styles.heading}>
             {headingText}
           </Heading>
           <Paragraph variant="body" classNameOverride={styles.description}>

--- a/draft-packages/empty-state/docs/EmptyState.stories.tsx
+++ b/draft-packages/empty-state/docs/EmptyState.stories.tsx
@@ -142,3 +142,17 @@ StraightCorners.args = {
   straightCorners: true,
 }
 StraightCorners.parameters = { chromatic: { disable: false } }
+
+export const CustomHeading = EmptyStateTemplate.bind({})
+CustomHeading.storyName = "Custom heading level"
+CustomHeading.args = {
+  children: "Button (chevron right)",
+  bodyText:
+    "Customise heading level so that the correct semantic heading level can be used for your page.",
+  illustrationType: "positive",
+  headingProps: {
+    variant: "heading-2",
+    children: "Custom heading level",
+  },
+}
+CustomHeading.parameters = { chromatic: { disable: false } }

--- a/draft-packages/empty-state/docs/EmptyState.stories.tsx
+++ b/draft-packages/empty-state/docs/EmptyState.stories.tsx
@@ -51,7 +51,10 @@ const EmptyStateTemplate: ComponentStory<typeof EmptyState> = ({
 export const DefaultKaizenSiteDemo = EmptyStateTemplate.bind({})
 DefaultKaizenSiteDemo.storyName = "Default (Kaizen Site Demo)"
 DefaultKaizenSiteDemo.args = {
-  headingText: "Empty state title",
+  headingProps: {
+    variant: "heading-3",
+    children: "Empty state title",
+  },
   bodyText:
     "If providing further actions, include a link to an action or use a Default or Primary action.",
 }
@@ -59,7 +62,10 @@ DefaultKaizenSiteDemo.args = {
 export const Positive = EmptyStateTemplate.bind({})
 Positive.args = {
   children: "Button (chevron right)",
-  headingText: "Positive empty state",
+  headingProps: {
+    variant: "heading-3",
+    children: "Positive empty state",
+  },
   bodyText:
     "If providing further actions, include a link to an action or use a Default or Primary action.",
   illustrationType: "positive",
@@ -78,7 +84,10 @@ Informative.parameters = { chromatic: { disable: false } }
 export const Action = EmptyStateTemplate.bind({})
 Action.args = {
   children: "Button (chevron right)",
-  headingText: "Action empty state",
+  headingProps: {
+    variant: "heading-3",
+    children: "Action empty state",
+  },
   bodyText:
     "If providing further actions, include a link to an action or use a Default or Primary action.",
   illustrationType: "action",
@@ -87,7 +96,10 @@ Action.parameters = { chromatic: { disable: false } }
 
 export const Neutral = EmptyStateTemplate.bind({})
 Neutral.args = {
-  headingText: "Neutral empty state",
+  headingProps: {
+    variant: "heading-3",
+    children: "Neutral empty state",
+  },
   bodyText:
     "If providing further actions, include a link to an action or use a Default or Primary action.",
   illustrationType: "neutral",
@@ -97,7 +109,10 @@ Neutral.parameters = { chromatic: { disable: false } }
 export const Negative = EmptyStateTemplate.bind({})
 Negative.args = {
   children: "Button (chevron right)",
-  headingText: "Negative empty state",
+  headingProps: {
+    variant: "heading-3",
+    children: "Negative empty state",
+  },
   bodyText:
     "If providing further actions, include a link to an action or use a Default or Primary action.",
   illustrationType: "negative",
@@ -124,7 +139,10 @@ RtlAction.argTypes = {
 }
 RtlAction.args = {
   children: "Button (chevron left)",
-  headingText: "Empty state title",
+  headingProps: {
+    variant: "heading-3",
+    children: "Empty state title",
+  },
   bodyText:
     "If providing further actions, include a link to an action or use a Default or Primary action.",
   illustrationType: "action",
@@ -135,7 +153,10 @@ export const StraightCorners = EmptyStateTemplate.bind({})
 StraightCorners.storyName = "Straight corners"
 StraightCorners.args = {
   children: "Button (chevron right)",
-  headingText: "Empty state title",
+  headingProps: {
+    variant: "heading-3",
+    children: "Straight corners empty state",
+  },
   bodyText:
     "If providing further actions, include a link to an action or use a Default or Primary action.",
   illustrationType: "action",
@@ -144,15 +165,17 @@ StraightCorners.args = {
 StraightCorners.parameters = { chromatic: { disable: false } }
 
 export const CustomHeading = EmptyStateTemplate.bind({})
-CustomHeading.storyName = "Custom heading level"
+CustomHeading.storyName = "Custom heading"
 CustomHeading.args = {
   children: "Button (chevron right)",
   bodyText:
     "Customise heading level so that the correct semantic heading level can be used for your page.",
-  illustrationType: "positive",
+  illustrationType: "neutral",
   headingProps: {
-    variant: "heading-2",
-    children: "Custom heading level",
+    variant: "heading-3",
+    children: "Custom heading empty state",
+    tag: "h2",
+    color: "dark-reduced-opacity",
   },
 }
 CustomHeading.parameters = { chromatic: { disable: false } }


### PR DESCRIPTION
## Why
<!-- Why have you created this PR? - Is it a new feature, or a bug fix? Or something else? -->
<!-- Reference any relevant Jira tickets so your reviewer can find more context if needed. -->
<!-- Fixing a GitHub issue? Add "Fixes [issue URL]". -->
**Use heading tag and add `headingVarient` prop in EmptyState component**
Currently the "Empty State" component heading renders as a `<div>`, but is styled as `heading-3` which doesn't follow best a11y semantic practices (and has created a violation on the survey configure questions edit page - [here is ticket](https://cultureamp.atlassian.net/browse/KD-1721))  

## What
<!-- What do your changes do? How do they change/fix the current behavior? -->
<!-- Add screenshots, GIFs or videos to illustrate the changes.  -->
1. Use `headingVarient` to control heading level
2. Use `tag="div"` when no `headingVarient` provided
3. Add optional `headingVarient` prop so that correct heading can be applied for the page (in cases where no preceding `<h2>`)
4. use `heading-3` styling by default when no `headingVarient` provided

> Note: an alternative to this PR could be adding `role="heading"` to the div, but seemed best to make a heading a heading
