### PR TITLE
fix: correct ID on validation message used for describedBy on text field

### DIFF
--- a/draft-packages/form/KaizenDraft/Form/TextAreaField/TextAreaField.spec.tsx
+++ b/draft-packages/form/KaizenDraft/Form/TextAreaField/TextAreaField.spec.tsx
@@ -89,3 +89,52 @@ describe("Validation message", () => {
     })
   })
 })
+
+describe("aria-describedby value", () => {
+  const defaultProps = {
+    id: "text-area-field-test",
+    labelText: "Label",
+  }
+  it("renders correct aria-describedby when only description provided", () => {
+    render(<TextAreaField {...defaultProps} description="Description text" />)
+    screen.getByRole("textbox", {
+      description: "Description text",
+    })
+  })
+  it("renders correct aria-describedby when only validation message provided", () => {
+    render(
+      <TextAreaField
+        {...defaultProps}
+        description={undefined}
+        validationMessage="Error message"
+      />
+    )
+    screen.getByRole("textbox", {
+      description: "Error message",
+    })
+  })
+  it("renders correct aria-describedby when both description and validation message provided", () => {
+    render(
+      <TextAreaField
+        {...defaultProps}
+        description="Description text"
+        validationMessage="Error message"
+      />
+    )
+    screen.getByRole("textbox", {
+      description: "Description text Error message",
+    })
+  })
+  it("renders empty aria-describedby when no description or validation message provided", () => {
+    render(
+      <TextAreaField
+        {...defaultProps}
+        description={undefined}
+        validationMessage={undefined}
+      />
+    )
+    screen.getByRole("textbox", {
+      description: "",
+    })
+  })
+})

--- a/draft-packages/form/KaizenDraft/Form/TextAreaField/TextAreaField.tsx
+++ b/draft-packages/form/KaizenDraft/Form/TextAreaField/TextAreaField.tsx
@@ -34,6 +34,15 @@ export const TextAreaField: React.VFC<TextAreaFieldProps> = ({
   disabled,
   ...restProps
 }) => {
+  const validationMessageAria = validationMessage
+    ? `${id}-field-validation-message`
+    : ""
+  const descriptionAria = description ? `${id}-field-message` : ""
+  const ariaDescribedBy = [validationMessageAria, descriptionAria].reduce(
+    (prev, curr) => (curr ? [curr, prev].join(" ") : prev),
+    ""
+  )
+
   const renderDescriptionOnTop = variant === "prominent"
   const renderDescription = (position: "top" | "bottom") => {
     if (!description) return null
@@ -44,7 +53,7 @@ export const TextAreaField: React.VFC<TextAreaFieldProps> = ({
         })}
       >
         <FieldMessage
-          id={`${id}-field-message`}
+          id={descriptionAria}
           automationId={`${id}-field-description`}
           message={description}
           reversed={reversed}
@@ -83,12 +92,13 @@ export const TextAreaField: React.VFC<TextAreaFieldProps> = ({
         reversed={reversed}
         status={status}
         disabled={disabled}
+        aria-describedby={ariaDescribedBy}
         {...restProps}
       />
       {!disabled && validationMessage && (
         <FieldMessage
-          id={`${id}-field-message`}
-          automationId={`${id}-field-validation-message`}
+          id={validationMessageAria}
+          automationId={validationMessageAria}
           message={validationMessage}
           status={status}
           reversed={reversed}

--- a/draft-packages/form/KaizenDraft/Form/TextField/TextField.spec.tsx
+++ b/draft-packages/form/KaizenDraft/Form/TextField/TextField.spec.tsx
@@ -34,7 +34,7 @@ describe("<TextField />", () => {
       />
     )
     expect(
-      container.querySelector(`#${defaultProps.id}-field-message`)
+      container.querySelector(`#${defaultProps.id}-field-validation-message`)
     ).toHaveClass("error")
   })
 })

--- a/draft-packages/form/KaizenDraft/Form/TextField/TextField.spec.tsx
+++ b/draft-packages/form/KaizenDraft/Form/TextField/TextField.spec.tsx
@@ -37,4 +37,46 @@ describe("<TextField />", () => {
       container.querySelector(`#${defaultProps.id}-field-validation-message`)
     ).toHaveClass("error")
   })
+  it("renders correct aria-describedby when only description provided", () => {
+    render(<TextField {...defaultProps} description="Description text" />)
+    screen.getByRole("textbox", {
+      description: "Description text",
+    })
+  })
+  it("renders correct aria-describedby when only validation message provided", () => {
+    render(
+      <TextField
+        {...defaultProps}
+        description={undefined}
+        validationMessage="Error message"
+      />
+    )
+    screen.getByRole("textbox", {
+      description: "Error message",
+    })
+  })
+  it("renders correct aria-describedby when both description and validation message provided", () => {
+    render(
+      <TextField
+        {...defaultProps}
+        description="Description text"
+        validationMessage="Error message"
+      />
+    )
+    screen.getByRole("textbox", {
+      description: "Description text Error message",
+    })
+  })
+  it("renders empty aria-describedby when no description or validation message provided", () => {
+    render(
+      <TextField
+        {...defaultProps}
+        description={undefined}
+        validationMessage={undefined}
+      />
+    )
+    screen.getByRole("textbox", {
+      description: "",
+    })
+  })
 })

--- a/draft-packages/form/KaizenDraft/Form/TextField/TextField.tsx
+++ b/draft-packages/form/KaizenDraft/Form/TextField/TextField.tsx
@@ -114,8 +114,8 @@ export const TextField: React.VFC<TextFieldProps> = ({
           })}
         >
           <FieldMessage
-            id={`${id}-field-validation-message`}
-            automationId={`${id}-field-validation-message`}
+            id={validationMessageAria}
+            automationId={validationMessageAria}
             message={validationMessage}
             status={status}
             reversed={reversed}

--- a/draft-packages/form/KaizenDraft/Form/TextField/TextField.tsx
+++ b/draft-packages/form/KaizenDraft/Form/TextField/TextField.tsx
@@ -130,8 +130,8 @@ export const TextField: React.VFC<TextFieldProps> = ({
           })}
         >
           <FieldMessage
-            id={`${id}-field-message`}
-            automationId={`${id}-field-description`}
+            id={descriptionAria}
+            automationId={descriptionAria}
             message={description}
             reversed={reversed}
           />

--- a/draft-packages/form/KaizenDraft/Form/TextField/TextField.tsx
+++ b/draft-packages/form/KaizenDraft/Form/TextField/TextField.tsx
@@ -114,7 +114,7 @@ export const TextField: React.VFC<TextFieldProps> = ({
           })}
         >
           <FieldMessage
-            id={`${id}-field-message`}
+            id={`${id}-field-validation-message`}
             automationId={`${id}-field-validation-message`}
             message={validationMessage}
             status={status}


### PR DESCRIPTION
## Why
<!-- Why have you created this PR? - Is it a new feature, or a bug fix? Or something else? -->
<!-- Reference any relevant Jira tickets so your reviewer can find more context if needed. -->
<!-- Fixing a GitHub issue? Add "Fixes [issue URL]". -->

When using a validation message, the text input field would receive this violation: "ARIA attribute element ID does not exist on the page" . You can see in storybook, the `aria-describedby` on the input field is looking for `kaizen-demo-text-field-field-validation-message` but the ID of the validation message is `kaizen-demo-text-field-field-message`


## What
<!-- What do your changes do? How do they change/fix the current behavior? -->
<!-- Add screenshots, GIFs or videos to illustrate the changes.  -->
Correct ID used for validation text so `aria-describedby` works as intended
