### PR TITLE
chore: Skipping playwright tests on master branch

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -74,7 +74,7 @@ steps:
     key: "playwright-step"
     command: ".buildkite/scripts/run-playwright.sh"
     timeout_in_minutes: 15
-    branches: "!master"
+    branches: "!master !canary"
     depends_on: "publish-step"
     <<: *defaults
     agent_query_rules: ["queue=build-unrestricted-large"]

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -74,6 +74,7 @@ steps:
     key: "playwright-step"
     command: ".buildkite/scripts/run-playwright.sh"
     timeout_in_minutes: 15
+    branches: "!master"
     depends_on: "publish-step"
     <<: *defaults
     agent_query_rules: ["queue=build-unrestricted-large"]


### PR DESCRIPTION
## Why
- Playwright currently runs on our `master` builds, but it's pretty useless then because it only runs after things have been released - and it already ran before the merge


## What
- added branch filtering rule to the Playwright step in our Buildkite config
