### PR TITLE
refactor: Added factory function for spot illus so they fit on one line

### DIFF
--- a/draft-packages/illustration/KaizenDraft/Illustration/Spot.tsx
+++ b/draft-packages/illustration/KaizenDraft/Illustration/Spot.tsx
@@ -199,1106 +199,175 @@ export const Assertive = ({
   return StaticIllustration
 }
 
+function createSpotIllustration(url: string) {
+  return ({ enableAspectRatio, ...props }: SpotProps) => (
+    <Base
+      aspectRatio={enableAspectRatio ? "square" : undefined}
+      {...props}
+      name={url}
+    />
+  )
+}
+
 /**
  * Template Library / Engagement
  */
-export const BenefitsSurvey = ({ enableAspectRatio, ...props }: SpotProps) => (
-  <Base
-    aspectRatio={enableAspectRatio ? "square" : undefined}
-    {...props}
-    name="illustrations/heart/spot/template-library-benefits-survey.svg"
-  />
-)
-
-export const CustomSurvey = ({ enableAspectRatio, ...props }: SpotProps) => (
-  <Base
-    aspectRatio={enableAspectRatio ? "square" : undefined}
-    {...props}
-    name="illustrations/heart/spot/template-library-custom-survey.svg"
-  />
-)
-
-export const CustomUnattributedSurvey = ({
-  enableAspectRatio,
-  ...props
-}: SpotProps) => (
-  <Base
-    aspectRatio={enableAspectRatio ? "square" : undefined}
-    {...props}
-    name="illustrations/heart/spot/template-library-custom-unattributed-survey.svg"
-  />
-)
-
-export const EngagementSurvey = ({
-  enableAspectRatio,
-  ...props
-}: SpotProps) => (
-  <Base
-    aspectRatio={enableAspectRatio ? "square" : undefined}
-    {...props}
-    name="illustrations/heart/spot/template-library-engagement-survey.svg"
-  />
-)
-
-export const InclusionSurvey = ({ enableAspectRatio, ...props }: SpotProps) => (
-  <Base
-    aspectRatio={enableAspectRatio ? "square" : undefined}
-    {...props}
-    name="illustrations/heart/spot/template-library-inclusion-survey.svg"
-  />
-)
-
-export const QuickEngagementSurvey = ({
-  enableAspectRatio,
-  ...props
-}: SpotProps) => (
-  <Base
-    aspectRatio={enableAspectRatio ? "square" : undefined}
-    {...props}
-    name="illustrations/heart/spot/template-library-quick-engagement-survey.svg"
-  />
-)
-
-export const ValuesSurvey1 = ({ enableAspectRatio, ...props }: SpotProps) => (
-  <Base
-    aspectRatio={enableAspectRatio ? "square" : undefined}
-    {...props}
-    name="illustrations/heart/spot/template-library-values-survey-1.svg"
-  />
-)
-
-export const ValuesSurvey2 = ({ enableAspectRatio, ...props }: SpotProps) => (
-  <Base
-    aspectRatio={enableAspectRatio ? "square" : undefined}
-    {...props}
-    name="illustrations/heart/spot/template-library-values-survey-2.svg"
-  />
-)
-
-export const WellbeingSurvey1 = ({
-  enableAspectRatio,
-  ...props
-}: SpotProps) => (
-  <Base
-    aspectRatio={enableAspectRatio ? "square" : undefined}
-    {...props}
-    name="illustrations/heart/spot/template-library-wellbeing-survey-1.svg"
-  />
-)
-
-export const WellbeingSurvey2 = ({
-  enableAspectRatio,
-  ...props
-}: SpotProps) => (
-  <Base
-    aspectRatio={enableAspectRatio ? "square" : undefined}
-    {...props}
-    name="illustrations/heart/spot/template-library-wellbeing-survey-2.svg"
-  />
-)
-
-export const WellbeingSurvey3 = ({
-  enableAspectRatio,
-  ...props
-}: SpotProps) => (
-  <Base
-    aspectRatio={enableAspectRatio ? "square" : undefined}
-    {...props}
-    name="illustrations/heart/spot/template-library-wellbeing-survey-3.svg"
-  />
-)
-
-export const ChangeReadiness = ({ enableAspectRatio, ...props }: SpotProps) => (
-  <Base
-    aspectRatio={enableAspectRatio ? "square" : undefined}
-    {...props}
-    name="illustrations/heart/spot/template-library-change-readiness.svg"
-  />
-)
-
-export const ChangeSuccess = ({ enableAspectRatio, ...props }: SpotProps) => (
-  <Base
-    aspectRatio={enableAspectRatio ? "square" : undefined}
-    {...props}
-    name="illustrations/heart/spot/template-library-change-success.svg"
-  />
-)
-
-export const PerformanceDiagnostics = ({
-  enableAspectRatio,
-  ...props
-}: SpotProps) => (
-  <Base
-    aspectRatio={enableAspectRatio ? "square" : undefined}
-    {...props}
-    name="illustrations/heart/spot/template-library-performance-diagnostics.svg"
-  />
-)
-
-export const LeadingThroughCrisis = ({
-  enableAspectRatio,
-  ...props
-}: SpotProps) => (
-  <Base
-    aspectRatio={enableAspectRatio ? "square" : undefined}
-    {...props}
-    name="illustrations/heart/spot/template-library-leading-through-crisis.svg"
-  />
-)
-
-export const EmergencyResponse = ({
-  enableAspectRatio,
-  ...props
-}: SpotProps) => (
-  <Base
-    aspectRatio={enableAspectRatio ? "square" : undefined}
-    {...props}
-    name="illustrations/heart/spot/template-library-emergency-response.svg"
-  />
-)
+/* prettier-ignore */ export const BenefitsSurvey = createSpotIllustration("illustrations/heart/spot/template-library-benefits-survey.svg")
+/* prettier-ignore */ export const CustomSurvey = createSpotIllustration("illustrations/heart/spot/template-library-custom-survey.svg")
+/* prettier-ignore */ export const CustomUnattributedSurvey = createSpotIllustration("illustrations/heart/spot/template-library-custom-unattributed-survey.svg")
+/* prettier-ignore */ export const EngagementSurvey = createSpotIllustration("illustrations/heart/spot/template-library-engagement-survey.svg")
+/* prettier-ignore */ export const InclusionSurvey = createSpotIllustration("illustrations/heart/spot/template-library-inclusion-survey.svg")
+/* prettier-ignore */ export const QuickEngagementSurvey = createSpotIllustration("illustrations/heart/spot/template-library-quick-engagement-survey.svg")
+/* prettier-ignore */ export const ValuesSurvey1 = createSpotIllustration("illustrations/heart/spot/template-library-values-survey-1.svg")
+/* prettier-ignore */ export const ValuesSurvey2 = createSpotIllustration("illustrations/heart/spot/template-library-values-survey-2.svg")
+/* prettier-ignore */ export const WellbeingSurvey1 = createSpotIllustration("illustrations/heart/spot/template-library-wellbeing-survey-1.svg")
+/* prettier-ignore */ export const WellbeingSurvey2 = createSpotIllustration("illustrations/heart/spot/template-library-wellbeing-survey-2.svg")
+/* prettier-ignore */ export const WellbeingSurvey3 = createSpotIllustration("illustrations/heart/spot/template-library-wellbeing-survey-3.svg")
+/* prettier-ignore */ export const ChangeReadiness = createSpotIllustration("illustrations/heart/spot/template-library-change-readiness.svg")
+/* prettier-ignore */ export const ChangeSuccess = createSpotIllustration("illustrations/heart/spot/template-library-change-success.svg")
+/* prettier-ignore */ export const PerformanceDiagnostics = createSpotIllustration("illustrations/heart/spot/template-library-performance-diagnostics.svg")
+/* prettier-ignore */ export const LeadingThroughCrisis = createSpotIllustration("illustrations/heart/spot/template-library-leading-through-crisis.svg")
+/* prettier-ignore */ export const EmergencyResponse = createSpotIllustration("illustrations/heart/spot/template-library-emergency-response.svg")
 
 /**
  * Template Library / Experience
  */
-export const CandidateSurvey = ({ enableAspectRatio, ...props }: SpotProps) => (
-  <Base
-    aspectRatio={enableAspectRatio ? "square" : undefined}
-    {...props}
-    name="illustrations/heart/spot/template-library-candidate-survey.svg"
-  />
-)
-
-export const CustomOnboardSurvey = ({
-  enableAspectRatio,
-  ...props
-}: SpotProps) => (
-  <Base
-    aspectRatio={enableAspectRatio ? "square" : undefined}
-    {...props}
-    name="illustrations/heart/spot/template-library-custom-onboard-survey.svg"
-  />
-)
-
-export const ExitSurvey = ({ enableAspectRatio, ...props }: SpotProps) => (
-  <Base
-    aspectRatio={enableAspectRatio ? "square" : undefined}
-    {...props}
-    name="illustrations/heart/spot/template-library-exit-survey.svg"
-  />
-)
-
-export const InternSurvey = ({ enableAspectRatio, ...props }: SpotProps) => (
-  <Base
-    aspectRatio={enableAspectRatio ? "square" : undefined}
-    {...props}
-    name="illustrations/heart/spot/template-library-intern-survey.svg"
-  />
-)
-
-export const PhasedWeek1OnboardSurvey = ({
-  enableAspectRatio,
-  ...props
-}: SpotProps) => (
-  <Base
-    aspectRatio={enableAspectRatio ? "square" : undefined}
-    {...props}
-    name="illustrations/heart/spot/template-library-phased-week-1-onboard-survey.svg"
-  />
-)
-
-export const PhasedWeek5OnboardSurvey = ({
-  enableAspectRatio,
-  ...props
-}: SpotProps) => (
-  <Base
-    aspectRatio={enableAspectRatio ? "square" : undefined}
-    {...props}
-    name="illustrations/heart/spot/template-library-phased-week-5-onboard-survey.svg"
-  />
-)
-
-export const SinglePointOnboardSurvey = ({
-  enableAspectRatio,
-  ...props
-}: SpotProps) => (
-  <Base
-    aspectRatio={enableAspectRatio ? "square" : undefined}
-    {...props}
-    name="illustrations/heart/spot/template-library-single-point-onboard-survey.svg"
-  />
-)
-
-export const GeneralOnboardSurvey = ({
-  enableAspectRatio,
-  ...props
-}: SpotProps) => (
-  <Base
-    aspectRatio={enableAspectRatio ? "square" : undefined}
-    {...props}
-    name="illustrations/heart/spot/template-library-general-onboard-survey.svg"
-  />
-)
-
-export const RemoteOnboardSurvey = ({
-  enableAspectRatio,
-  ...props
-}: SpotProps) => (
-  <Base
-    aspectRatio={enableAspectRatio ? "square" : undefined}
-    {...props}
-    name="illustrations/heart/spot/template-library-remote-onboard-survey.svg"
-  />
-)
-
-export const HealthAndSafety = ({ enableAspectRatio, ...props }: SpotProps) => (
-  <Base
-    aspectRatio={enableAspectRatio ? "square" : undefined}
-    {...props}
-    name="illustrations/heart/spot/template-library-health-and-safety.svg"
-  />
-)
-
-export const EndOfProbation = ({ enableAspectRatio, ...props }: SpotProps) => (
-  <Base
-    aspectRatio={enableAspectRatio ? "square" : undefined}
-    {...props}
-    name="illustrations/heart/spot/template-library-end-of-probation.svg"
-  />
-)
-
-export const NewWaysOfWorking = ({
-  enableAspectRatio,
-  ...props
-}: SpotProps) => (
-  <Base
-    aspectRatio={enableAspectRatio ? "square" : undefined}
-    {...props}
-    name="illustrations/heart/spot/template-library-new-ways-of-working.svg"
-  />
-)
-
-export const ReOnboarding = ({ enableAspectRatio, ...props }: SpotProps) => (
-  <Base
-    aspectRatio={enableAspectRatio ? "square" : undefined}
-    {...props}
-    name="illustrations/heart/spot/template-library-re-onboarding.svg"
-  />
-)
+/* prettier-ignore */ export const CandidateSurvey = createSpotIllustration("illustrations/heart/spot/template-library-candidate-survey.svg")
+/* prettier-ignore */ export const CustomOnboardSurvey = createSpotIllustration("illustrations/heart/spot/template-library-custom-onboard-survey.svg")
+/* prettier-ignore */ export const ExitSurvey = createSpotIllustration("illustrations/heart/spot/template-library-exit-survey.svg")
+/* prettier-ignore */ export const InternSurvey = createSpotIllustration("illustrations/heart/spot/template-library-intern-survey.svg")
+/* prettier-ignore */ export const PhasedWeek1OnboardSurvey = createSpotIllustration("illustrations/heart/spot/template-library-phased-week-1-onboard-survey.svg")
+/* prettier-ignore */ export const PhasedWeek5OnboardSurvey = createSpotIllustration("illustrations/heart/spot/template-library-phased-week-5-onboard-survey.svg")
+/* prettier-ignore */ export const SinglePointOnboardSurvey = createSpotIllustration("illustrations/heart/spot/template-library-single-point-onboard-survey.svg")
+/* prettier-ignore */ export const GeneralOnboardSurvey = createSpotIllustration("illustrations/heart/spot/template-library-general-onboard-survey.svg")
+/* prettier-ignore */ export const RemoteOnboardSurvey = createSpotIllustration("illustrations/heart/spot/template-library-remote-onboard-survey.svg")
+/* prettier-ignore */ export const HealthAndSafety = createSpotIllustration("illustrations/heart/spot/template-library-health-and-safety.svg")
+/* prettier-ignore */ export const EndOfProbation = createSpotIllustration("illustrations/heart/spot/template-library-end-of-probation.svg")
+/* prettier-ignore */ export const NewWaysOfWorking = createSpotIllustration("illustrations/heart/spot/template-library-new-ways-of-working.svg")
+/* prettier-ignore */ export const ReOnboarding = createSpotIllustration("illustrations/heart/spot/template-library-re-onboarding.svg")
 
 /**
  * Template Library / Performance
  */
-export const Individual360 = ({ enableAspectRatio, ...props }: SpotProps) => (
-  <Base
-    aspectRatio={enableAspectRatio ? "square" : undefined}
-    {...props}
-    name="illustrations/heart/spot/template-library-individual-360.svg"
-  />
-)
-
-export const Leadership360 = ({ enableAspectRatio, ...props }: SpotProps) => (
-  <Base
-    aspectRatio={enableAspectRatio ? "square" : undefined}
-    {...props}
-    name="illustrations/heart/spot/template-library-leadership-360.svg"
-  />
-)
-
-export const Manager360 = ({ enableAspectRatio, ...props }: SpotProps) => (
-  <Base
-    aspectRatio={enableAspectRatio ? "square" : undefined}
-    {...props}
-    name="illustrations/heart/spot/template-library-manager-360.svg"
-  />
-)
-
-export const Individual180 = ({ enableAspectRatio, ...props }: SpotProps) => (
-  <Base
-    aspectRatio={enableAspectRatio ? "square" : undefined}
-    {...props}
-    name="illustrations/heart/spot/template-library-individual-180.svg"
-  />
-)
-
-export const Leadership180 = ({ enableAspectRatio, ...props }: SpotProps) => (
-  <Base
-    aspectRatio={enableAspectRatio ? "square" : undefined}
-    {...props}
-    name="illustrations/heart/spot/template-library-leadership-180.svg"
-  />
-)
-
-export const Manager180 = ({ enableAspectRatio, ...props }: SpotProps) => (
-  <Base
-    aspectRatio={enableAspectRatio ? "square" : undefined}
-    {...props}
-    name="illustrations/heart/spot/template-library-manager-180.svg"
-  />
-)
-
-export const TeamEffectiveness1 = ({
-  enableAspectRatio,
-  ...props
-}: SpotProps) => (
-  <Base
-    aspectRatio={enableAspectRatio ? "square" : undefined}
-    {...props}
-    name="illustrations/heart/spot/template-library-team-effectiveness-1.svg"
-  />
-)
-
-export const TeamEffectiveness2 = ({
-  enableAspectRatio,
-  ...props
-}: SpotProps) => (
-  <Base
-    aspectRatio={enableAspectRatio ? "square" : undefined}
-    {...props}
-    name="illustrations/heart/spot/template-library-team-effectiveness-2.svg"
-  />
-)
+/* prettier-ignore */ export const Individual360 = createSpotIllustration("illustrations/heart/spot/template-library-individual-360.svg")
+/* prettier-ignore */ export const Leadership360 = createSpotIllustration("illustrations/heart/spot/template-library-leadership-360.svg")
+/* prettier-ignore */ export const Manager360 = createSpotIllustration("illustrations/heart/spot/template-library-manager-360.svg")
+/* prettier-ignore */ export const Individual180 = createSpotIllustration("illustrations/heart/spot/template-library-individual-180.svg")
+/* prettier-ignore */ export const Leadership180 = createSpotIllustration("illustrations/heart/spot/template-library-leadership-180.svg")
+/* prettier-ignore */ export const Manager180 = createSpotIllustration("illustrations/heart/spot/template-library-manager-180.svg")
+/* prettier-ignore */ export const TeamEffectiveness1 = createSpotIllustration("illustrations/heart/spot/template-library-team-effectiveness-1.svg")
+/* prettier-ignore */ export const TeamEffectiveness2 = createSpotIllustration("illustrations/heart/spot/template-library-team-effectiveness-2.svg")
 
 /**
  * Offices
  */
-
-export const London = ({ enableAspectRatio, ...props }: SpotProps) => (
-  <Base
-    aspectRatio={enableAspectRatio ? "square" : undefined}
-    {...props}
-    name="illustrations/heart/spot/offices-london.svg"
-  />
-)
-export const Melbourne = ({ enableAspectRatio, ...props }: SpotProps) => (
-  <Base
-    aspectRatio={enableAspectRatio ? "square" : undefined}
-    {...props}
-    name="illustrations/heart/spot/offices-melbourne.svg"
-  />
-)
-export const NewYork = ({ enableAspectRatio, ...props }: SpotProps) => (
-  <Base
-    aspectRatio={enableAspectRatio ? "square" : undefined}
-    {...props}
-    name="illustrations/heart/spot/offices-new-york.svg"
-  />
-)
-export const SanFrancisco = ({ enableAspectRatio, ...props }: SpotProps) => (
-  <Base
-    aspectRatio={enableAspectRatio ? "square" : undefined}
-    {...props}
-    name="illustrations/heart/spot/offices-san-francisco.svg"
-  />
-)
+/* prettier-ignore */ export const London = createSpotIllustration("illustrations/heart/spot/offices-london.svg")
+/* prettier-ignore */ export const Melbourne = createSpotIllustration("illustrations/heart/spot/offices-melbourne.svg")
+/* prettier-ignore */ export const NewYork = createSpotIllustration("illustrations/heart/spot/offices-new-york.svg")
+/* prettier-ignore */ export const SanFrancisco = createSpotIllustration("illustrations/heart/spot/offices-san-francisco.svg")
 
 /**
  * Values
  */
-
-export const AmplifyOthers = ({ enableAspectRatio, ...props }: SpotProps) => (
-  <Base
-    aspectRatio={enableAspectRatio ? "square" : undefined}
-    {...props}
-    name="illustrations/heart/spot/values-amplify-others.svg"
-  />
-)
-export const HaveTheCourageToBeVulnerable = ({
-  enableAspectRatio,
-  ...props
-}: SpotProps) => (
-  <Base
-    aspectRatio={enableAspectRatio ? "square" : undefined}
-    {...props}
-    name="illustrations/heart/spot/values-have-the-courage-to-be-vulnerable.svg"
-  />
-)
-export const LearnFasterThroughFeedback = ({
-  enableAspectRatio,
-  ...props
-}: SpotProps) => (
-  <Base
-    aspectRatio={enableAspectRatio ? "square" : undefined}
-    {...props}
-    name="illustrations/heart/spot/values-learn-faster-through-feedback.svg"
-  />
-)
-export const TrustOthersToMakeDecisions = ({
-  enableAspectRatio,
-  ...props
-}: SpotProps) => (
-  <Base
-    aspectRatio={enableAspectRatio ? "square" : undefined}
-    {...props}
-    name="illustrations/heart/spot/values-trust-others-to-make-decisions.svg"
-  />
-)
+/* prettier-ignore */ export const AmplifyOthers = createSpotIllustration("illustrations/heart/spot/values-amplify-others.svg")
+/* prettier-ignore */ export const HaveTheCourageToBeVulnerable = createSpotIllustration("illustrations/heart/spot/values-have-the-courage-to-be-vulnerable.svg")
+/* prettier-ignore */ export const LearnFasterThroughFeedback = createSpotIllustration("illustrations/heart/spot/values-learn-faster-through-feedback.svg")
+/* prettier-ignore */ export const TrustOthersToMakeDecisions = createSpotIllustration("illustrations/heart/spot/values-trust-others-to-make-decisions.svg")
 
 /**
  * Template Library / COVID-19
  */
-
-export const WellbeingSurvey = ({ enableAspectRatio, ...props }: SpotProps) => (
-  <Base
-    aspectRatio={enableAspectRatio ? "square" : undefined}
-    {...props}
-    name="illustrations/heart/spot/template-library-wellbeing-survey.svg"
-  />
-)
-
-export const Response = ({ enableAspectRatio, ...props }: SpotProps) => (
-  <Base
-    aspectRatio={enableAspectRatio ? "square" : undefined}
-    {...props}
-    name="illustrations/heart/spot/template-library-response.svg"
-  />
-)
-
-export const RemoteWorkQSet = ({ enableAspectRatio, ...props }: SpotProps) => (
-  <Base
-    aspectRatio={enableAspectRatio ? "square" : undefined}
-    {...props}
-    name="illustrations/heart/spot/template-library-remote-work-q-set.svg"
-  />
-)
-
-export const ReturnToWorkplace = ({
-  enableAspectRatio,
-  ...props
-}: SpotProps) => (
-  <Base
-    aspectRatio={enableAspectRatio ? "square" : undefined}
-    {...props}
-    name="illustrations/heart/spot/template-library-return-to-workplace.svg"
-  />
-)
-
-export const PulseSurvey = ({ enableAspectRatio, ...props }: SpotProps) => (
-  <Base
-    aspectRatio={enableAspectRatio ? "square" : undefined}
-    {...props}
-    name="illustrations/heart/spot/template-library-pulse-survey.svg"
-  />
-)
+/* prettier-ignore */ export const WellbeingSurvey = createSpotIllustration("illustrations/heart/spot/template-library-wellbeing-survey.svg")
+/* prettier-ignore */ export const Response = createSpotIllustration("illustrations/heart/spot/template-library-response.svg")
+/* prettier-ignore */ export const RemoteWorkQSet = createSpotIllustration("illustrations/heart/spot/template-library-remote-work-q-set.svg")
+/* prettier-ignore */ export const ReturnToWorkplace = createSpotIllustration("illustrations/heart/spot/template-library-return-to-workplace.svg")
+/* prettier-ignore */ export const PulseSurvey = createSpotIllustration("illustrations/heart/spot/template-library-pulse-survey.svg")
 
 /**
  * New Account
  */
-export const AccountBasics = ({ enableAspectRatio, ...props }: SpotProps) => (
-  <Base
-    aspectRatio={enableAspectRatio ? "square" : undefined}
-    {...props}
-    name="illustrations/heart/spot/new-account-account-basics.svg"
-  />
-)
-
-export const CompanyDetails = ({ enableAspectRatio, ...props }: SpotProps) => (
-  <Base
-    aspectRatio={enableAspectRatio ? "square" : undefined}
-    {...props}
-    name="illustrations/heart/spot/new-account-company-details.svg"
-  />
-)
-
-export const EmployeeData = ({ enableAspectRatio, ...props }: SpotProps) => (
-  <Base
-    aspectRatio={enableAspectRatio ? "square" : undefined}
-    {...props}
-    name="illustrations/heart/spot/new-account-employee-data.svg"
-  />
-)
-
-export const Gdpr = ({ enableAspectRatio, ...props }: SpotProps) => (
-  <Base
-    aspectRatio={enableAspectRatio ? "square" : undefined}
-    {...props}
-    name="illustrations/heart/spot/new-account-gdpr.svg"
-  />
-)
-
-export const Timezone = ({ enableAspectRatio, ...props }: SpotProps) => (
-  <Base
-    aspectRatio={enableAspectRatio ? "square" : undefined}
-    {...props}
-    name="illustrations/heart/spot/new-account-timezone.svg"
-  />
-)
-
-export const AddUser = ({ enableAspectRatio, ...props }: SpotProps) => (
-  <Base
-    aspectRatio={enableAspectRatio ? "square" : undefined}
-    {...props}
-    name="illustrations/heart/spot/new-account-add-user.svg"
-  />
-)
+/* prettier-ignore */ export const AccountBasics = createSpotIllustration("illustrations/heart/spot/new-account-account-basics.svg")
+/* prettier-ignore */ export const CompanyDetails = createSpotIllustration("illustrations/heart/spot/new-account-company-details.svg")
+/* prettier-ignore */ export const EmployeeData = createSpotIllustration("illustrations/heart/spot/new-account-employee-data.svg")
+/* prettier-ignore */ export const Gdpr = createSpotIllustration("illustrations/heart/spot/new-account-gdpr.svg")
+/* prettier-ignore */ export const Timezone = createSpotIllustration("illustrations/heart/spot/new-account-timezone.svg")
+/* prettier-ignore */ export const AddUser = createSpotIllustration("illustrations/heart/spot/new-account-add-user.svg")
 
 /**
  * Skills Coach (previously referred to as Manager Learning)
  */
-export const Strategy = ({ enableAspectRatio, ...props }: SpotProps) => (
-  <Base
-    aspectRatio={enableAspectRatio ? "square" : undefined}
-    {...props}
-    name="illustrations/heart/spot/skills-coach-strategy.svg"
-  />
-)
-
-export const Resilience = ({ enableAspectRatio, ...props }: SpotProps) => (
-  <Base
-    aspectRatio={enableAspectRatio ? "square" : undefined}
-    {...props}
-    name="illustrations/heart/spot/skills-coach-resilience.svg"
-  />
-)
-export const EssentialResilience = ({
-  enableAspectRatio,
-  ...props
-}: SpotProps) => (
-  <Base
-    aspectRatio={enableAspectRatio ? "square" : undefined}
-    {...props}
-    name="illustrations/heart/spot/skills-coach-essential-resillience.svg"
-  />
-)
-
-export const RemoteManager = ({ enableAspectRatio, ...props }: SpotProps) => (
-  <Base
-    aspectRatio={enableAspectRatio ? "square" : undefined}
-    {...props}
-    name="illustrations/heart/spot/skills-coach-remote-manager.svg"
-  />
-)
-
-export const Productivity = ({ enableAspectRatio, ...props }: SpotProps) => (
-  <Base
-    aspectRatio={enableAspectRatio ? "square" : undefined}
-    {...props}
-    name="illustrations/heart/spot/skills-coach-productivity.svg"
-  />
-)
-export const EssentialProductivity = ({
-  enableAspectRatio,
-  ...props
-}: SpotProps) => (
-  <Base
-    aspectRatio={enableAspectRatio ? "square" : undefined}
-    {...props}
-    name="illustrations/heart/spot/skills-coach-essential-productivity.svg"
-  />
-)
-
-export const InfluentialCommunication = ({
-  enableAspectRatio,
-  ...props
-}: SpotProps) => (
-  <Base
-    aspectRatio={enableAspectRatio ? "square" : undefined}
-    {...props}
-    name="illustrations/heart/spot/skills-coach-influential-communication.svg"
-  />
-)
-
-export const LeadingChange = ({ enableAspectRatio, ...props }: SpotProps) => (
-  <Base
-    aspectRatio={enableAspectRatio ? "square" : undefined}
-    {...props}
-    name="illustrations/heart/spot/skills-coach-leading-change.svg"
-  />
-)
-
-export const ManagerLearning = ({ enableAspectRatio, ...props }: SpotProps) => (
-  <Base
-    aspectRatio={enableAspectRatio ? "square" : undefined}
-    {...props}
-    name="illustrations/heart/spot/skills-coach-manager-learning.svg"
-  />
-)
-
-export const Feedback = ({ enableAspectRatio, ...props }: SpotProps) => (
-  <Base
-    aspectRatio={enableAspectRatio ? "square" : undefined}
-    {...props}
-    name="illustrations/heart/spot/skills-coach-feedback.svg"
-  />
-)
-
-export const Coaching = ({ enableAspectRatio, ...props }: SpotProps) => (
-  <Base
-    aspectRatio={enableAspectRatio ? "square" : undefined}
-    {...props}
-    name="illustrations/heart/spot/skills-coach-coaching.svg"
-  />
-)
-
-export const OneOnOne = ({ enableAspectRatio, ...props }: SpotProps) => (
-  <Base
-    aspectRatio={enableAspectRatio ? "square" : undefined}
-    {...props}
-    name="illustrations/heart/spot/skills-coach-1-on-1.svg"
-  />
-)
+/* prettier-ignore */ export const Strategy = createSpotIllustration("illustrations/heart/spot/skills-coach-strategy.svg")
+/* prettier-ignore */ export const Resilience = createSpotIllustration("illustrations/heart/spot/skills-coach-resilience.svg")
+/* prettier-ignore */ export const EssentialResilience = createSpotIllustration("illustrations/heart/spot/skills-coach-essential-resillience.svg")
+/* prettier-ignore */ export const RemoteManager = createSpotIllustration("illustrations/heart/spot/skills-coach-remote-manager.svg")
+/* prettier-ignore */ export const Productivity = createSpotIllustration("illustrations/heart/spot/skills-coach-productivity.svg")
+/* prettier-ignore */ export const EssentialProductivity = createSpotIllustration("illustrations/heart/spot/skills-coach-essential-productivity.svg")
+/* prettier-ignore */ export const InfluentialCommunication = createSpotIllustration("illustrations/heart/spot/skills-coach-influential-communication.svg")
+/* prettier-ignore */ export const LeadingChange = createSpotIllustration("illustrations/heart/spot/skills-coach-leading-change.svg")
+/* prettier-ignore */ export const ManagerLearning = createSpotIllustration("illustrations/heart/spot/skills-coach-manager-learning.svg")
+/* prettier-ignore */ export const Feedback = createSpotIllustration("illustrations/heart/spot/skills-coach-feedback.svg")
+/* prettier-ignore */ export const Coaching = createSpotIllustration("illustrations/heart/spot/skills-coach-coaching.svg")
+/* prettier-ignore */ export const OneOnOne = createSpotIllustration("illustrations/heart/spot/skills-coach-1-on-1.svg")
 
 /**
  * Miscellaneous
  */
-export const ActionPlans = ({ enableAspectRatio, ...props }: SpotProps) => (
-  <Base
-    aspectRatio={enableAspectRatio ? "square" : undefined}
-    {...props}
-    name="illustrations/heart/spot/miscellaneous-action-plans.svg"
-  />
-)
-export const BCorp = ({ enableAspectRatio, ...props }: SpotProps) => (
-  <Base
-    aspectRatio={enableAspectRatio ? "square" : undefined}
-    {...props}
-    name="illustrations/heart/spot/miscellaneous-b-corp.svg"
-  />
-)
-export const Behaviour = ({ enableAspectRatio, ...props }: SpotProps) => (
-  <Base
-    aspectRatio={enableAspectRatio ? "square" : undefined}
-    {...props}
-    name="illustrations/heart/spot/miscellaneous-behavior.svg"
-  />
-)
-export const ChangeAgents = ({ enableAspectRatio, ...props }: SpotProps) => (
-  <Base
-    aspectRatio={enableAspectRatio ? "square" : undefined}
-    {...props}
-    name="illustrations/heart/spot/miscellaneous-change-agents.svg"
-  />
-)
-export const Communications = ({ enableAspectRatio, ...props }: SpotProps) => (
-  <Base
-    aspectRatio={enableAspectRatio ? "square" : undefined}
-    {...props}
-    name="illustrations/heart/spot/miscellaneous-communications.svg"
-  />
-)
-export const Community = ({ enableAspectRatio, ...props }: SpotProps) => (
-  <Base
-    aspectRatio={enableAspectRatio ? "square" : undefined}
-    {...props}
-    name="illustrations/heart/spot/miscellaneous-community.svg"
-  />
-)
-export const Company = ({ enableAspectRatio, ...props }: SpotProps) => (
-  <Base
-    aspectRatio={enableAspectRatio ? "square" : undefined}
-    {...props}
-    name="illustrations/heart/spot/miscellaneous-company.svg"
-  />
-)
-export const Conversations = ({ enableAspectRatio, ...props }: SpotProps) => (
-  <Base
-    aspectRatio={enableAspectRatio ? "square" : undefined}
-    {...props}
-    name="illustrations/heart/spot/miscellaneous-conversations.svg"
-  />
-)
-export const DataVisualization = ({
-  enableAspectRatio,
-  ...props
-}: SpotProps) => (
-  <Base
-    aspectRatio={enableAspectRatio ? "square" : undefined}
-    {...props}
-    name="illustrations/heart/spot/miscellaneous-data-visualization.svg"
-  />
-)
-export const Goals = ({ enableAspectRatio, ...props }: SpotProps) => (
-  <Base
-    aspectRatio={enableAspectRatio ? "square" : undefined}
-    {...props}
-    name="illustrations/heart/spot/miscellaneous-goals.svg"
-  />
-)
-export const Insights = ({ enableAspectRatio, ...props }: SpotProps) => (
-  <Base
-    aspectRatio={enableAspectRatio ? "square" : undefined}
-    {...props}
-    name="illustrations/heart/spot/miscellaneous-insights.svg"
-  />
-)
-export const Learn = ({ enableAspectRatio, ...props }: SpotProps) => (
-  <Base
-    aspectRatio={enableAspectRatio ? "square" : undefined}
-    {...props}
-    name="illustrations/heart/spot/miscellaneous-learn.svg"
-  />
-)
-export const Microphone = ({ enableAspectRatio, ...props }: SpotProps) => (
-  <Base
-    aspectRatio={enableAspectRatio ? "square" : undefined}
-    {...props}
-    name="illustrations/heart/spot/miscellaneous-microphone.svg"
-  />
-)
-export const PaperPen = ({ enableAspectRatio, ...props }: SpotProps) => (
-  <Base
-    aspectRatio={enableAspectRatio ? "square" : undefined}
-    {...props}
-    name="illustrations/heart/spot/miscellaneous-paper-pen.svg"
-  />
-)
-export const PowerfulInsights = ({
-  enableAspectRatio,
-  ...props
-}: SpotProps) => (
-  <Base
-    aspectRatio={enableAspectRatio ? "square" : undefined}
-    {...props}
-    name="illustrations/heart/spot/miscellaneous-powerful-insights.svg"
-  />
-)
-export const Privacy = ({ enableAspectRatio, ...props }: SpotProps) => (
-  <Base
-    aspectRatio={enableAspectRatio ? "square" : undefined}
-    {...props}
-    name="illustrations/heart/spot/miscellaneous-privacy.svg"
-  />
-)
-export const Process = ({ enableAspectRatio, ...props }: SpotProps) => (
-  <Base
-    aspectRatio={enableAspectRatio ? "square" : undefined}
-    {...props}
-    name="illustrations/heart/spot/miscellaneous-process.svg"
-  />
-)
-export const Resources = ({ enableAspectRatio, ...props }: SpotProps) => (
-  <Base
-    aspectRatio={enableAspectRatio ? "square" : undefined}
-    {...props}
-    name="illustrations/heart/spot/miscellaneous-resources.svg"
-  />
-)
-
-export const ScienceBackedTools = ({
-  enableAspectRatio,
-  ...props
-}: SpotProps) => (
-  <Base
-    aspectRatio={enableAspectRatio ? "square" : undefined}
-    {...props}
-    name="illustrations/heart/spot/miscellaneous-science-backed-tools.svg"
-  />
-)
-export const SkillsDevelopment = ({
-  enableAspectRatio,
-  ...props
-}: SpotProps) => (
-  <Base
-    aspectRatio={enableAspectRatio ? "square" : undefined}
-    {...props}
-    name="illustrations/heart/spot/miscellaneous-skills-development.svg"
-  />
-)
-export const ViewReports = ({ enableAspectRatio, ...props }: SpotProps) => (
-  <Base
-    aspectRatio={enableAspectRatio ? "square" : undefined}
-    {...props}
-    name="illustrations/heart/spot/miscellaneous-view-reports.svg"
-  />
-)
-
-export const ReadArticle = ({ enableAspectRatio, ...props }: SpotProps) => (
-  <Base
-    aspectRatio={enableAspectRatio ? "square" : undefined}
-    {...props}
-    name="illustrations/heart/spot/miscellaneous-read-article.svg"
-  />
-)
-
-export const FastAction = ({ enableAspectRatio, ...props }: SpotProps) => (
-  <Base
-    aspectRatio={enableAspectRatio ? "square" : undefined}
-    {...props}
-    name="illustrations/heart/spot/miscellaneous-fast-action.svg"
-  />
-)
-
-export const BaselineSurvey = ({ enableAspectRatio, ...props }: SpotProps) => (
-  <Base
-    aspectRatio={enableAspectRatio ? "square" : undefined}
-    {...props}
-    name="illustrations/heart/spot/miscellaneous-baseline-survey.svg"
-  />
-)
-
-export const SpreadsheetTemplate = ({
-  enableAspectRatio,
-  ...props
-}: SpotProps) => (
-  <Base
-    aspectRatio={enableAspectRatio ? "square" : undefined}
-    {...props}
-    name="illustrations/heart/spot/miscellaneous-spreadsheet-template.svg"
-  />
-)
-
-export const AddImage = ({ enableAspectRatio, ...props }: SpotProps) => (
-  <Base
-    aspectRatio={enableAspectRatio ? "square" : undefined}
-    {...props}
-    name="illustrations/heart/spot/miscellaneous-add-image.svg"
-  />
-)
-
-export const MeetingVoices = ({ enableAspectRatio, ...props }: SpotProps) => (
-  <Base
-    aspectRatio={enableAspectRatio ? "square" : undefined}
-    {...props}
-    name="illustrations/heart/spot/miscellaneous-meeting-voices.svg"
-  />
-)
-
-export const Workshop = ({ enableAspectRatio, ...props }: SpotProps) => (
-  <Base
-    aspectRatio={enableAspectRatio ? "square" : undefined}
-    {...props}
-    name="illustrations/heart/spot/miscellaneous-workshop.svg"
-  />
-)
-
-export const Video = ({ enableAspectRatio, ...props }: SpotProps) => (
-  <Base
-    aspectRatio={enableAspectRatio ? "square" : undefined}
-    {...props}
-    name="illustrations/heart/spot/miscellaneous-video.svg"
-  />
-)
-
-export const ReportSharing = ({ enableAspectRatio, ...props }: SpotProps) => (
-  <Base
-    aspectRatio={enableAspectRatio ? "square" : undefined}
-    {...props}
-    name="illustrations/heart/spot/miscellaneous-report-sharing.svg"
-  />
-)
-
-export const BlankSurvey = ({ enableAspectRatio, ...props }: SpotProps) => (
-  <Base
-    aspectRatio={enableAspectRatio ? "square" : undefined}
-    {...props}
-    name="illustrations/heart/spot/miscellaneous-blank-survey.svg"
-  />
-)
-
-export const TakeAim = ({ enableAspectRatio, ...props }: SpotProps) => (
-  <Base
-    aspectRatio={enableAspectRatio ? "square" : undefined}
-    {...props}
-    name="illustrations/heart/spot/miscellaneous-take-aim.svg"
-  />
-)
-
-export const Action = ({ enableAspectRatio, ...props }: SpotProps) => (
-  <Base
-    aspectRatio={enableAspectRatio ? "square" : undefined}
-    {...props}
-    name="illustrations/heart/spot/miscellaneous-action.svg"
-  />
-)
-
-export const Training1 = ({ enableAspectRatio, ...props }: SpotProps) => (
-  <Base
-    aspectRatio={enableAspectRatio ? "square" : undefined}
-    {...props}
-    name="illustrations/heart/spot/miscellaneous-training-1.svg"
-  />
-)
-
-export const Training2 = ({ enableAspectRatio, ...props }: SpotProps) => (
-  <Base
-    aspectRatio={enableAspectRatio ? "square" : undefined}
-    {...props}
-    name="illustrations/heart/spot/miscellaneous-training-2.svg"
-  />
-)
-
-export const Training3 = ({ enableAspectRatio, ...props }: SpotProps) => (
-  <Base
-    aspectRatio={enableAspectRatio ? "square" : undefined}
-    {...props}
-    name="illustrations/heart/spot/miscellaneous-training-3.svg"
-  />
-)
-
-export const ShareReport = ({ enableAspectRatio, ...props }: SpotProps) => (
-  <Base
-    aspectRatio={enableAspectRatio ? "square" : undefined}
-    {...props}
-    name="illustrations/heart/spot/miscellaneous-share-report.svg"
-  />
-)
+/* prettier-ignore */ export const ActionPlans = createSpotIllustration("illustrations/heart/spot/miscellaneous-action-plans.svg")
+/* prettier-ignore */ export const BCorp = createSpotIllustration("illustrations/heart/spot/miscellaneous-b-corp.svg")
+/* prettier-ignore */ export const Behaviour = createSpotIllustration("illustrations/heart/spot/miscellaneous-behavior.svg")
+/* prettier-ignore */ export const ChangeAgents = createSpotIllustration("illustrations/heart/spot/miscellaneous-change-agents.svg")
+/* prettier-ignore */ export const Communications = createSpotIllustration("illustrations/heart/spot/miscellaneous-communications.svg")
+/* prettier-ignore */ export const Community = createSpotIllustration("illustrations/heart/spot/miscellaneous-community.svg")
+/* prettier-ignore */ export const Company = createSpotIllustration("illustrations/heart/spot/miscellaneous-company.svg")
+/* prettier-ignore */ export const Conversations = createSpotIllustration("illustrations/heart/spot/miscellaneous-conversations.svg")
+/* prettier-ignore */ export const DataVisualization = createSpotIllustration("illustrations/heart/spot/miscellaneous-data-visualization.svg")
+/* prettier-ignore */ export const Goals = createSpotIllustration("illustrations/heart/spot/miscellaneous-goals.svg")
+/* prettier-ignore */ export const Insights = createSpotIllustration("illustrations/heart/spot/miscellaneous-insights.svg")
+/* prettier-ignore */ export const Learn = createSpotIllustration("illustrations/heart/spot/miscellaneous-learn.svg")
+/* prettier-ignore */ export const Microphone = createSpotIllustration("illustrations/heart/spot/miscellaneous-microphone.svg")
+/* prettier-ignore */ export const PaperPen = createSpotIllustration("illustrations/heart/spot/miscellaneous-paper-pen.svg")
+/* prettier-ignore */ export const PowerfulInsights = createSpotIllustration("illustrations/heart/spot/miscellaneous-powerful-insights.svg")
+/* prettier-ignore */ export const Privacy = createSpotIllustration("illustrations/heart/spot/miscellaneous-privacy.svg")
+/* prettier-ignore */ export const Process = createSpotIllustration("illustrations/heart/spot/miscellaneous-process.svg")
+/* prettier-ignore */ export const Resources = createSpotIllustration("illustrations/heart/spot/miscellaneous-resources.svg")
+/* prettier-ignore */ export const ScienceBackedTools = createSpotIllustration("illustrations/heart/spot/miscellaneous-science-backed-tools.svg")
+/* prettier-ignore */ export const SkillsDevelopment = createSpotIllustration("illustrations/heart/spot/miscellaneous-skills-development.svg")
+/* prettier-ignore */ export const ViewReports = createSpotIllustration("illustrations/heart/spot/miscellaneous-view-reports.svg")
+/* prettier-ignore */ export const ReadArticle = createSpotIllustration("illustrations/heart/spot/miscellaneous-read-article.svg")
+/* prettier-ignore */ export const FastAction = createSpotIllustration("illustrations/heart/spot/miscellaneous-fast-action.svg")
+/* prettier-ignore */ export const BaselineSurvey = createSpotIllustration("illustrations/heart/spot/miscellaneous-baseline-survey.svg")
+/* prettier-ignore */ export const SpreadsheetTemplate = createSpotIllustration("illustrations/heart/spot/miscellaneous-spreadsheet-template.svg")
+/* prettier-ignore */ export const AddImage = createSpotIllustration("illustrations/heart/spot/miscellaneous-add-image.svg")
+/* prettier-ignore */ export const MeetingVoices = createSpotIllustration("illustrations/heart/spot/miscellaneous-meeting-voices.svg")
+/* prettier-ignore */ export const Workshop = createSpotIllustration("illustrations/heart/spot/miscellaneous-workshop.svg")
+/* prettier-ignore */ export const Video = createSpotIllustration("illustrations/heart/spot/miscellaneous-video.svg")
+/* prettier-ignore */ export const ReportSharing = createSpotIllustration("illustrations/heart/spot/miscellaneous-report-sharing.svg")
+/* prettier-ignore */ export const BlankSurvey = createSpotIllustration("illustrations/heart/spot/miscellaneous-blank-survey.svg")
+/* prettier-ignore */ export const TakeAim = createSpotIllustration("illustrations/heart/spot/miscellaneous-take-aim.svg")
+/* prettier-ignore */ export const Action = createSpotIllustration("illustrations/heart/spot/miscellaneous-action.svg")
+/* prettier-ignore */ export const Training1 = createSpotIllustration("illustrations/heart/spot/miscellaneous-training-1.svg")
+/* prettier-ignore */ export const Training2 = createSpotIllustration("illustrations/heart/spot/miscellaneous-training-2.svg")
+/* prettier-ignore */ export const Training3 = createSpotIllustration("illustrations/heart/spot/miscellaneous-training-3.svg")
+/* prettier-ignore */ export const ShareReport = createSpotIllustration("illustrations/heart/spot/miscellaneous-share-report.svg")
 
 // TODO: Component Name change
-export const Team1 = ({ enableAspectRatio, ...props }: SpotProps) => (
-  <Base
-    aspectRatio={enableAspectRatio ? "square" : undefined}
-    {...props}
-    name="illustrations/heart/spot/miscellaneous-team-1.svg"
-  />
-)
-export const Team2 = ({ enableAspectRatio, ...props }: SpotProps) => (
-  <Base
-    aspectRatio={enableAspectRatio ? "square" : undefined}
-    {...props}
-    name="illustrations/heart/spot/miscellaneous-team-2.svg"
-  />
-)
-export const Templates = ({ enableAspectRatio, ...props }: SpotProps) => (
-  <Base
-    aspectRatio={enableAspectRatio ? "square" : undefined}
-    {...props}
-    name="illustrations/heart/spot/miscellaneous-templates.svg"
-  />
-)
-
-export const ExecutiveReportSharing = ({
-  enableAspectRatio,
-  ...props
-}: SpotProps) => (
-  <Base
-    aspectRatio={enableAspectRatio ? "square" : undefined}
-    {...props}
-    name="illustrations/heart/spot/miscellaneous-executive-report-sharing.svg"
-  />
-)
-
-export const ManagerReportSharing = ({
-  enableAspectRatio,
-  ...props
-}: SpotProps) => (
-  <Base
-    aspectRatio={enableAspectRatio ? "square" : undefined}
-    {...props}
-    name="illustrations/heart/spot/miscellaneous-manager-report-sharing.svg"
-  />
-)
-
-export const LeaderReportSharing = ({
-  enableAspectRatio,
-  ...props
-}: SpotProps) => (
-  <Base
-    aspectRatio={enableAspectRatio ? "square" : undefined}
-    {...props}
-    name="illustrations/heart/spot/miscellaneous-leader-report-sharing.svg"
-  />
-)
-
-export const Alarm = ({ enableAspectRatio, ...props }: SpotProps) => (
-  <Base
-    aspectRatio={enableAspectRatio ? "square" : undefined}
-    {...props}
-    name="illustrations/heart/spot/miscellaneous-alarm.svg"
-  />
-)
-
-export const Fire = ({ enableAspectRatio, ...props }: SpotProps) => (
-  <Base
-    aspectRatio={enableAspectRatio ? "square" : undefined}
-    {...props}
-    name="illustrations/heart/spot/miscellaneous-fire.svg"
-  />
-)
-
-export const Fireworks = ({ enableAspectRatio, ...props }: SpotProps) => (
-  <Base
-    aspectRatio={enableAspectRatio ? "square" : undefined}
-    {...props}
-    name="illustrations/heart/spot/miscellaneous-fireworks.svg"
-  />
-)
-
-export const FullImport = ({ enableAspectRatio, ...props }: SpotProps) => (
-  <Base
-    aspectRatio={enableAspectRatio ? "square" : undefined}
-    {...props}
-    name="illustrations/heart/spot/miscellaneous-full-import.svg"
-  />
-)
-
-export const HrisImport = ({ enableAspectRatio, ...props }: SpotProps) => (
-  <Base
-    aspectRatio={enableAspectRatio ? "square" : undefined}
-    {...props}
-    name="illustrations/heart/spot/miscellaneous-hris-import.svg"
-  />
-)
-
-export const PartialImport = ({ enableAspectRatio, ...props }: SpotProps) => (
-  <Base
-    aspectRatio={enableAspectRatio ? "square" : undefined}
-    {...props}
-    name="illustrations/heart/spot/miscellaneous-partial-import.svg"
-  />
-)
-
-export const Starburst = ({ enableAspectRatio, ...props }: SpotProps) => (
-  <Base
-    aspectRatio={enableAspectRatio ? "square" : undefined}
-    {...props}
-    name="illustrations/heart/spot/miscellaneous-starburst.svg"
-  />
-)
-
-export const Stop = ({ enableAspectRatio, ...props }: SpotProps) => (
-  <Base
-    aspectRatio={enableAspectRatio ? "square" : undefined}
-    {...props}
-    name="illustrations/heart/spot/miscellaneous-stop.svg"
-  />
-)
-
-export const TrafficCone = ({ enableAspectRatio, ...props }: SpotProps) => (
-  <Base
-    aspectRatio={enableAspectRatio ? "square" : undefined}
-    {...props}
-    name="illustrations/heart/spot/miscellaneous-traffic-cone.svg"
-  />
-)
-
-export const Trophy = ({ enableAspectRatio, ...props }: SpotProps) => (
-  <Base
-    aspectRatio={enableAspectRatio ? "square" : undefined}
-    {...props}
-    name="illustrations/heart/spot/miscellaneous-trophy.svg"
-  />
-)
-
-export const UnderConstruction = ({
-  enableAspectRatio,
-  ...props
-}: SpotProps) => (
-  <Base
-    aspectRatio={enableAspectRatio ? "square" : undefined}
-    {...props}
-    name="illustrations/heart/spot/miscellaneous-under-construction.svg"
-  />
-)
-
-export const ValueAdd = ({ enableAspectRatio, ...props }: SpotProps) => (
-  <Base
-    aspectRatio={enableAspectRatio ? "square" : undefined}
-    {...props}
-    name="illustrations/heart/spot/miscellaneous-value-add.svg"
-  />
-)
-
-export const Recommendation = ({ enableAspectRatio, ...props }: SpotProps) => (
-  <Base
-    aspectRatio={enableAspectRatio ? "square" : undefined}
-    {...props}
-    name="illustrations/heart/spot/miscellaneous-recommendation.svg"
-  />
-)
-
-export const Objective = ({ enableAspectRatio, ...props }: SpotProps) => (
-  <Base
-    aspectRatio={enableAspectRatio ? "square" : undefined}
-    {...props}
-    name="illustrations/heart/spot/miscellaneous-objective.svg"
-  />
-)
+/* prettier-ignore */ export const Team1 = createSpotIllustration("illustrations/heart/spot/miscellaneous-team-1.svg")
+/* prettier-ignore */ export const Team2 = createSpotIllustration("illustrations/heart/spot/miscellaneous-team-2.svg")
+/* prettier-ignore */ export const Templates = createSpotIllustration("illustrations/heart/spot/miscellaneous-templates.svg")
+/* prettier-ignore */ export const ExecutiveReportSharing = createSpotIllustration("illustrations/heart/spot/miscellaneous-executive-report-sharing.svg")
+/* prettier-ignore */ export const ManagerReportSharing = createSpotIllustration("illustrations/heart/spot/miscellaneous-manager-report-sharing.svg")
+/* prettier-ignore */ export const LeaderReportSharing = createSpotIllustration("illustrations/heart/spot/miscellaneous-leader-report-sharing.svg")
+/* prettier-ignore */ export const Alarm = createSpotIllustration("illustrations/heart/spot/miscellaneous-alarm.svg")
+/* prettier-ignore */ export const Fire = createSpotIllustration("illustrations/heart/spot/miscellaneous-fire.svg")
+/* prettier-ignore */ export const Fireworks = createSpotIllustration("illustrations/heart/spot/miscellaneous-fireworks.svg")
+/* prettier-ignore */ export const FullImport = createSpotIllustration("illustrations/heart/spot/miscellaneous-full-import.svg")
+/* prettier-ignore */ export const HrisImport = createSpotIllustration("illustrations/heart/spot/miscellaneous-hris-import.svg")
+/* prettier-ignore */ export const PartialImport = createSpotIllustration("illustrations/heart/spot/miscellaneous-partial-import.svg")
+/* prettier-ignore */ export const Starburst = createSpotIllustration("illustrations/heart/spot/miscellaneous-starburst.svg")
+/* prettier-ignore */ export const Stop = createSpotIllustration("illustrations/heart/spot/miscellaneous-stop.svg")
+/* prettier-ignore */ export const TrafficCone = createSpotIllustration("illustrations/heart/spot/miscellaneous-traffic-cone.svg")
+/* prettier-ignore */ export const Trophy = createSpotIllustration("illustrations/heart/spot/miscellaneous-trophy.svg")
+/* prettier-ignore */ export const UnderConstruction = createSpotIllustration("illustrations/heart/spot/miscellaneous-under-construction.svg")
+/* prettier-ignore */ export const ValueAdd = createSpotIllustration("illustrations/heart/spot/miscellaneous-value-add.svg")
+/* prettier-ignore */ export const Recommendation = createSpotIllustration("illustrations/heart/spot/miscellaneous-recommendation.svg")
+/* prettier-ignore */ export const Objective = createSpotIllustration("illustrations/heart/spot/miscellaneous-objective.svg")

--- a/draft-packages/illustration/KaizenDraft/Illustration/Spot.tsx
+++ b/draft-packages/illustration/KaizenDraft/Illustration/Spot.tsx
@@ -8,6 +8,10 @@ export type SpotProps = Pick<BaseProps, "alt" | "classNameOverride"> & {
 export type AnimatedSpotProps = SpotProps &
   AnimatedBaseProps & { isAnimated?: boolean }
 
+// ------------------------------------------------------------------------- //
+// ANIMATED ILLUSTRATIONS                                                    //
+// ------------------------------------------------------------------------- //
+
 /**
  * Moods
  */
@@ -199,175 +203,181 @@ export const Assertive = ({
   return StaticIllustration
 }
 
-function createSpotIllustration(url: string) {
-  return ({ enableAspectRatio, ...props }: SpotProps) => (
-    <Base
-      aspectRatio={enableAspectRatio ? "square" : undefined}
-      {...props}
-      name={url}
-    />
-  )
-}
+// ------------------------------------------------------------------------- //
+// STATIC ILLUSTRATIONS                                                      //
+// ------------------------------------------------------------------------- //
+
+const SPOT_ILLUSTRATION_BASE_PATH = "illustrations/heart/spot/"
+const createSpotIllustration =
+  (fileName: string): React.VFC<SpotProps> =>
+  ({ enableAspectRatio, ...props }: SpotProps) =>
+    (
+      <Base
+        aspectRatio={enableAspectRatio ? "square" : undefined}
+        {...props}
+        name={`${SPOT_ILLUSTRATION_BASE_PATH}${fileName}`}
+      />
+    )
 
 /**
  * Template Library / Engagement
  */
-/* prettier-ignore */ export const BenefitsSurvey = createSpotIllustration("illustrations/heart/spot/template-library-benefits-survey.svg")
-/* prettier-ignore */ export const CustomSurvey = createSpotIllustration("illustrations/heart/spot/template-library-custom-survey.svg")
-/* prettier-ignore */ export const CustomUnattributedSurvey = createSpotIllustration("illustrations/heart/spot/template-library-custom-unattributed-survey.svg")
-/* prettier-ignore */ export const EngagementSurvey = createSpotIllustration("illustrations/heart/spot/template-library-engagement-survey.svg")
-/* prettier-ignore */ export const InclusionSurvey = createSpotIllustration("illustrations/heart/spot/template-library-inclusion-survey.svg")
-/* prettier-ignore */ export const QuickEngagementSurvey = createSpotIllustration("illustrations/heart/spot/template-library-quick-engagement-survey.svg")
-/* prettier-ignore */ export const ValuesSurvey1 = createSpotIllustration("illustrations/heart/spot/template-library-values-survey-1.svg")
-/* prettier-ignore */ export const ValuesSurvey2 = createSpotIllustration("illustrations/heart/spot/template-library-values-survey-2.svg")
-/* prettier-ignore */ export const WellbeingSurvey1 = createSpotIllustration("illustrations/heart/spot/template-library-wellbeing-survey-1.svg")
-/* prettier-ignore */ export const WellbeingSurvey2 = createSpotIllustration("illustrations/heart/spot/template-library-wellbeing-survey-2.svg")
-/* prettier-ignore */ export const WellbeingSurvey3 = createSpotIllustration("illustrations/heart/spot/template-library-wellbeing-survey-3.svg")
-/* prettier-ignore */ export const ChangeReadiness = createSpotIllustration("illustrations/heart/spot/template-library-change-readiness.svg")
-/* prettier-ignore */ export const ChangeSuccess = createSpotIllustration("illustrations/heart/spot/template-library-change-success.svg")
-/* prettier-ignore */ export const PerformanceDiagnostics = createSpotIllustration("illustrations/heart/spot/template-library-performance-diagnostics.svg")
-/* prettier-ignore */ export const LeadingThroughCrisis = createSpotIllustration("illustrations/heart/spot/template-library-leading-through-crisis.svg")
-/* prettier-ignore */ export const EmergencyResponse = createSpotIllustration("illustrations/heart/spot/template-library-emergency-response.svg")
+/* prettier-ignore */ export const BenefitsSurvey = createSpotIllustration("template-library-benefits-survey.svg")
+/* prettier-ignore */ export const CustomSurvey = createSpotIllustration("template-library-custom-survey.svg")
+/* prettier-ignore */ export const CustomUnattributedSurvey = createSpotIllustration("template-library-custom-unattributed-survey.svg")
+/* prettier-ignore */ export const EngagementSurvey = createSpotIllustration("template-library-engagement-survey.svg")
+/* prettier-ignore */ export const InclusionSurvey = createSpotIllustration("template-library-inclusion-survey.svg")
+/* prettier-ignore */ export const QuickEngagementSurvey = createSpotIllustration("template-library-quick-engagement-survey.svg")
+/* prettier-ignore */ export const ValuesSurvey1 = createSpotIllustration("template-library-values-survey-1.svg")
+/* prettier-ignore */ export const ValuesSurvey2 = createSpotIllustration("template-library-values-survey-2.svg")
+/* prettier-ignore */ export const WellbeingSurvey1 = createSpotIllustration("template-library-wellbeing-survey-1.svg")
+/* prettier-ignore */ export const WellbeingSurvey2 = createSpotIllustration("template-library-wellbeing-survey-2.svg")
+/* prettier-ignore */ export const WellbeingSurvey3 = createSpotIllustration("template-library-wellbeing-survey-3.svg")
+/* prettier-ignore */ export const ChangeReadiness = createSpotIllustration("template-library-change-readiness.svg")
+/* prettier-ignore */ export const ChangeSuccess = createSpotIllustration("template-library-change-success.svg")
+/* prettier-ignore */ export const PerformanceDiagnostics = createSpotIllustration("template-library-performance-diagnostics.svg")
+/* prettier-ignore */ export const LeadingThroughCrisis = createSpotIllustration("template-library-leading-through-crisis.svg")
+/* prettier-ignore */ export const EmergencyResponse = createSpotIllustration("template-library-emergency-response.svg")
 
 /**
  * Template Library / Experience
  */
-/* prettier-ignore */ export const CandidateSurvey = createSpotIllustration("illustrations/heart/spot/template-library-candidate-survey.svg")
-/* prettier-ignore */ export const CustomOnboardSurvey = createSpotIllustration("illustrations/heart/spot/template-library-custom-onboard-survey.svg")
-/* prettier-ignore */ export const ExitSurvey = createSpotIllustration("illustrations/heart/spot/template-library-exit-survey.svg")
-/* prettier-ignore */ export const InternSurvey = createSpotIllustration("illustrations/heart/spot/template-library-intern-survey.svg")
-/* prettier-ignore */ export const PhasedWeek1OnboardSurvey = createSpotIllustration("illustrations/heart/spot/template-library-phased-week-1-onboard-survey.svg")
-/* prettier-ignore */ export const PhasedWeek5OnboardSurvey = createSpotIllustration("illustrations/heart/spot/template-library-phased-week-5-onboard-survey.svg")
-/* prettier-ignore */ export const SinglePointOnboardSurvey = createSpotIllustration("illustrations/heart/spot/template-library-single-point-onboard-survey.svg")
-/* prettier-ignore */ export const GeneralOnboardSurvey = createSpotIllustration("illustrations/heart/spot/template-library-general-onboard-survey.svg")
-/* prettier-ignore */ export const RemoteOnboardSurvey = createSpotIllustration("illustrations/heart/spot/template-library-remote-onboard-survey.svg")
-/* prettier-ignore */ export const HealthAndSafety = createSpotIllustration("illustrations/heart/spot/template-library-health-and-safety.svg")
-/* prettier-ignore */ export const EndOfProbation = createSpotIllustration("illustrations/heart/spot/template-library-end-of-probation.svg")
-/* prettier-ignore */ export const NewWaysOfWorking = createSpotIllustration("illustrations/heart/spot/template-library-new-ways-of-working.svg")
-/* prettier-ignore */ export const ReOnboarding = createSpotIllustration("illustrations/heart/spot/template-library-re-onboarding.svg")
+/* prettier-ignore */ export const CandidateSurvey = createSpotIllustration("template-library-candidate-survey.svg")
+/* prettier-ignore */ export const CustomOnboardSurvey = createSpotIllustration("template-library-custom-onboard-survey.svg")
+/* prettier-ignore */ export const ExitSurvey = createSpotIllustration("template-library-exit-survey.svg")
+/* prettier-ignore */ export const InternSurvey = createSpotIllustration("template-library-intern-survey.svg")
+/* prettier-ignore */ export const PhasedWeek1OnboardSurvey = createSpotIllustration("template-library-phased-week-1-onboard-survey.svg")
+/* prettier-ignore */ export const PhasedWeek5OnboardSurvey = createSpotIllustration("template-library-phased-week-5-onboard-survey.svg")
+/* prettier-ignore */ export const SinglePointOnboardSurvey = createSpotIllustration("template-library-single-point-onboard-survey.svg")
+/* prettier-ignore */ export const GeneralOnboardSurvey = createSpotIllustration("template-library-general-onboard-survey.svg")
+/* prettier-ignore */ export const RemoteOnboardSurvey = createSpotIllustration("template-library-remote-onboard-survey.svg")
+/* prettier-ignore */ export const HealthAndSafety = createSpotIllustration("template-library-health-and-safety.svg")
+/* prettier-ignore */ export const EndOfProbation = createSpotIllustration("template-library-end-of-probation.svg")
+/* prettier-ignore */ export const NewWaysOfWorking = createSpotIllustration("template-library-new-ways-of-working.svg")
+/* prettier-ignore */ export const ReOnboarding = createSpotIllustration("template-library-re-onboarding.svg")
 
 /**
  * Template Library / Performance
  */
-/* prettier-ignore */ export const Individual360 = createSpotIllustration("illustrations/heart/spot/template-library-individual-360.svg")
-/* prettier-ignore */ export const Leadership360 = createSpotIllustration("illustrations/heart/spot/template-library-leadership-360.svg")
-/* prettier-ignore */ export const Manager360 = createSpotIllustration("illustrations/heart/spot/template-library-manager-360.svg")
-/* prettier-ignore */ export const Individual180 = createSpotIllustration("illustrations/heart/spot/template-library-individual-180.svg")
-/* prettier-ignore */ export const Leadership180 = createSpotIllustration("illustrations/heart/spot/template-library-leadership-180.svg")
-/* prettier-ignore */ export const Manager180 = createSpotIllustration("illustrations/heart/spot/template-library-manager-180.svg")
-/* prettier-ignore */ export const TeamEffectiveness1 = createSpotIllustration("illustrations/heart/spot/template-library-team-effectiveness-1.svg")
-/* prettier-ignore */ export const TeamEffectiveness2 = createSpotIllustration("illustrations/heart/spot/template-library-team-effectiveness-2.svg")
+/* prettier-ignore */ export const Individual360 = createSpotIllustration("template-library-individual-360.svg")
+/* prettier-ignore */ export const Leadership360 = createSpotIllustration("template-library-leadership-360.svg")
+/* prettier-ignore */ export const Manager360 = createSpotIllustration("template-library-manager-360.svg")
+/* prettier-ignore */ export const Individual180 = createSpotIllustration("template-library-individual-180.svg")
+/* prettier-ignore */ export const Leadership180 = createSpotIllustration("template-library-leadership-180.svg")
+/* prettier-ignore */ export const Manager180 = createSpotIllustration("template-library-manager-180.svg")
+/* prettier-ignore */ export const TeamEffectiveness1 = createSpotIllustration("template-library-team-effectiveness-1.svg")
+/* prettier-ignore */ export const TeamEffectiveness2 = createSpotIllustration("template-library-team-effectiveness-2.svg")
 
 /**
  * Offices
  */
-/* prettier-ignore */ export const London = createSpotIllustration("illustrations/heart/spot/offices-london.svg")
-/* prettier-ignore */ export const Melbourne = createSpotIllustration("illustrations/heart/spot/offices-melbourne.svg")
-/* prettier-ignore */ export const NewYork = createSpotIllustration("illustrations/heart/spot/offices-new-york.svg")
-/* prettier-ignore */ export const SanFrancisco = createSpotIllustration("illustrations/heart/spot/offices-san-francisco.svg")
+/* prettier-ignore */ export const London = createSpotIllustration("offices-london.svg")
+/* prettier-ignore */ export const Melbourne = createSpotIllustration("offices-melbourne.svg")
+/* prettier-ignore */ export const NewYork = createSpotIllustration("offices-new-york.svg")
+/* prettier-ignore */ export const SanFrancisco = createSpotIllustration("offices-san-francisco.svg")
 
 /**
  * Values
  */
-/* prettier-ignore */ export const AmplifyOthers = createSpotIllustration("illustrations/heart/spot/values-amplify-others.svg")
-/* prettier-ignore */ export const HaveTheCourageToBeVulnerable = createSpotIllustration("illustrations/heart/spot/values-have-the-courage-to-be-vulnerable.svg")
-/* prettier-ignore */ export const LearnFasterThroughFeedback = createSpotIllustration("illustrations/heart/spot/values-learn-faster-through-feedback.svg")
-/* prettier-ignore */ export const TrustOthersToMakeDecisions = createSpotIllustration("illustrations/heart/spot/values-trust-others-to-make-decisions.svg")
+/* prettier-ignore */ export const AmplifyOthers = createSpotIllustration("values-amplify-others.svg")
+/* prettier-ignore */ export const HaveTheCourageToBeVulnerable = createSpotIllustration("values-have-the-courage-to-be-vulnerable.svg")
+/* prettier-ignore */ export const LearnFasterThroughFeedback = createSpotIllustration("values-learn-faster-through-feedback.svg")
+/* prettier-ignore */ export const TrustOthersToMakeDecisions = createSpotIllustration("values-trust-others-to-make-decisions.svg")
 
 /**
  * Template Library / COVID-19
  */
-/* prettier-ignore */ export const WellbeingSurvey = createSpotIllustration("illustrations/heart/spot/template-library-wellbeing-survey.svg")
-/* prettier-ignore */ export const Response = createSpotIllustration("illustrations/heart/spot/template-library-response.svg")
-/* prettier-ignore */ export const RemoteWorkQSet = createSpotIllustration("illustrations/heart/spot/template-library-remote-work-q-set.svg")
-/* prettier-ignore */ export const ReturnToWorkplace = createSpotIllustration("illustrations/heart/spot/template-library-return-to-workplace.svg")
-/* prettier-ignore */ export const PulseSurvey = createSpotIllustration("illustrations/heart/spot/template-library-pulse-survey.svg")
+/* prettier-ignore */ export const WellbeingSurvey = createSpotIllustration("template-library-wellbeing-survey.svg")
+/* prettier-ignore */ export const Response = createSpotIllustration("template-library-response.svg")
+/* prettier-ignore */ export const RemoteWorkQSet = createSpotIllustration("template-library-remote-work-q-set.svg")
+/* prettier-ignore */ export const ReturnToWorkplace = createSpotIllustration("template-library-return-to-workplace.svg")
+/* prettier-ignore */ export const PulseSurvey = createSpotIllustration("template-library-pulse-survey.svg")
 
 /**
  * New Account
  */
-/* prettier-ignore */ export const AccountBasics = createSpotIllustration("illustrations/heart/spot/new-account-account-basics.svg")
-/* prettier-ignore */ export const CompanyDetails = createSpotIllustration("illustrations/heart/spot/new-account-company-details.svg")
-/* prettier-ignore */ export const EmployeeData = createSpotIllustration("illustrations/heart/spot/new-account-employee-data.svg")
-/* prettier-ignore */ export const Gdpr = createSpotIllustration("illustrations/heart/spot/new-account-gdpr.svg")
-/* prettier-ignore */ export const Timezone = createSpotIllustration("illustrations/heart/spot/new-account-timezone.svg")
-/* prettier-ignore */ export const AddUser = createSpotIllustration("illustrations/heart/spot/new-account-add-user.svg")
+/* prettier-ignore */ export const AccountBasics = createSpotIllustration("new-account-account-basics.svg")
+/* prettier-ignore */ export const CompanyDetails = createSpotIllustration("new-account-company-details.svg")
+/* prettier-ignore */ export const EmployeeData = createSpotIllustration("new-account-employee-data.svg")
+/* prettier-ignore */ export const Gdpr = createSpotIllustration("new-account-gdpr.svg")
+/* prettier-ignore */ export const Timezone = createSpotIllustration("new-account-timezone.svg")
+/* prettier-ignore */ export const AddUser = createSpotIllustration("new-account-add-user.svg")
 
 /**
  * Skills Coach (previously referred to as Manager Learning)
  */
-/* prettier-ignore */ export const Strategy = createSpotIllustration("illustrations/heart/spot/skills-coach-strategy.svg")
-/* prettier-ignore */ export const Resilience = createSpotIllustration("illustrations/heart/spot/skills-coach-resilience.svg")
-/* prettier-ignore */ export const EssentialResilience = createSpotIllustration("illustrations/heart/spot/skills-coach-essential-resillience.svg")
-/* prettier-ignore */ export const RemoteManager = createSpotIllustration("illustrations/heart/spot/skills-coach-remote-manager.svg")
-/* prettier-ignore */ export const Productivity = createSpotIllustration("illustrations/heart/spot/skills-coach-productivity.svg")
-/* prettier-ignore */ export const EssentialProductivity = createSpotIllustration("illustrations/heart/spot/skills-coach-essential-productivity.svg")
-/* prettier-ignore */ export const InfluentialCommunication = createSpotIllustration("illustrations/heart/spot/skills-coach-influential-communication.svg")
-/* prettier-ignore */ export const LeadingChange = createSpotIllustration("illustrations/heart/spot/skills-coach-leading-change.svg")
-/* prettier-ignore */ export const ManagerLearning = createSpotIllustration("illustrations/heart/spot/skills-coach-manager-learning.svg")
-/* prettier-ignore */ export const Feedback = createSpotIllustration("illustrations/heart/spot/skills-coach-feedback.svg")
-/* prettier-ignore */ export const Coaching = createSpotIllustration("illustrations/heart/spot/skills-coach-coaching.svg")
-/* prettier-ignore */ export const OneOnOne = createSpotIllustration("illustrations/heart/spot/skills-coach-1-on-1.svg")
+/* prettier-ignore */ export const Strategy = createSpotIllustration("skills-coach-strategy.svg")
+/* prettier-ignore */ export const Resilience = createSpotIllustration("skills-coach-resilience.svg")
+/* prettier-ignore */ export const EssentialResilience = createSpotIllustration("skills-coach-essential-resillience.svg")
+/* prettier-ignore */ export const RemoteManager = createSpotIllustration("skills-coach-remote-manager.svg")
+/* prettier-ignore */ export const Productivity = createSpotIllustration("skills-coach-productivity.svg")
+/* prettier-ignore */ export const EssentialProductivity = createSpotIllustration("skills-coach-essential-productivity.svg")
+/* prettier-ignore */ export const InfluentialCommunication = createSpotIllustration("skills-coach-influential-communication.svg")
+/* prettier-ignore */ export const LeadingChange = createSpotIllustration("skills-coach-leading-change.svg")
+/* prettier-ignore */ export const ManagerLearning = createSpotIllustration("skills-coach-manager-learning.svg")
+/* prettier-ignore */ export const Feedback = createSpotIllustration("skills-coach-feedback.svg")
+/* prettier-ignore */ export const Coaching = createSpotIllustration("skills-coach-coaching.svg")
+/* prettier-ignore */ export const OneOnOne = createSpotIllustration("skills-coach-1-on-1.svg")
 
 /**
  * Miscellaneous
  */
-/* prettier-ignore */ export const ActionPlans = createSpotIllustration("illustrations/heart/spot/miscellaneous-action-plans.svg")
-/* prettier-ignore */ export const BCorp = createSpotIllustration("illustrations/heart/spot/miscellaneous-b-corp.svg")
-/* prettier-ignore */ export const Behaviour = createSpotIllustration("illustrations/heart/spot/miscellaneous-behavior.svg")
-/* prettier-ignore */ export const ChangeAgents = createSpotIllustration("illustrations/heart/spot/miscellaneous-change-agents.svg")
-/* prettier-ignore */ export const Communications = createSpotIllustration("illustrations/heart/spot/miscellaneous-communications.svg")
-/* prettier-ignore */ export const Community = createSpotIllustration("illustrations/heart/spot/miscellaneous-community.svg")
-/* prettier-ignore */ export const Company = createSpotIllustration("illustrations/heart/spot/miscellaneous-company.svg")
-/* prettier-ignore */ export const Conversations = createSpotIllustration("illustrations/heart/spot/miscellaneous-conversations.svg")
-/* prettier-ignore */ export const DataVisualization = createSpotIllustration("illustrations/heart/spot/miscellaneous-data-visualization.svg")
-/* prettier-ignore */ export const Goals = createSpotIllustration("illustrations/heart/spot/miscellaneous-goals.svg")
-/* prettier-ignore */ export const Insights = createSpotIllustration("illustrations/heart/spot/miscellaneous-insights.svg")
-/* prettier-ignore */ export const Learn = createSpotIllustration("illustrations/heart/spot/miscellaneous-learn.svg")
-/* prettier-ignore */ export const Microphone = createSpotIllustration("illustrations/heart/spot/miscellaneous-microphone.svg")
-/* prettier-ignore */ export const PaperPen = createSpotIllustration("illustrations/heart/spot/miscellaneous-paper-pen.svg")
-/* prettier-ignore */ export const PowerfulInsights = createSpotIllustration("illustrations/heart/spot/miscellaneous-powerful-insights.svg")
-/* prettier-ignore */ export const Privacy = createSpotIllustration("illustrations/heart/spot/miscellaneous-privacy.svg")
-/* prettier-ignore */ export const Process = createSpotIllustration("illustrations/heart/spot/miscellaneous-process.svg")
-/* prettier-ignore */ export const Resources = createSpotIllustration("illustrations/heart/spot/miscellaneous-resources.svg")
-/* prettier-ignore */ export const ScienceBackedTools = createSpotIllustration("illustrations/heart/spot/miscellaneous-science-backed-tools.svg")
-/* prettier-ignore */ export const SkillsDevelopment = createSpotIllustration("illustrations/heart/spot/miscellaneous-skills-development.svg")
-/* prettier-ignore */ export const ViewReports = createSpotIllustration("illustrations/heart/spot/miscellaneous-view-reports.svg")
-/* prettier-ignore */ export const ReadArticle = createSpotIllustration("illustrations/heart/spot/miscellaneous-read-article.svg")
-/* prettier-ignore */ export const FastAction = createSpotIllustration("illustrations/heart/spot/miscellaneous-fast-action.svg")
-/* prettier-ignore */ export const BaselineSurvey = createSpotIllustration("illustrations/heart/spot/miscellaneous-baseline-survey.svg")
-/* prettier-ignore */ export const SpreadsheetTemplate = createSpotIllustration("illustrations/heart/spot/miscellaneous-spreadsheet-template.svg")
-/* prettier-ignore */ export const AddImage = createSpotIllustration("illustrations/heart/spot/miscellaneous-add-image.svg")
-/* prettier-ignore */ export const MeetingVoices = createSpotIllustration("illustrations/heart/spot/miscellaneous-meeting-voices.svg")
-/* prettier-ignore */ export const Workshop = createSpotIllustration("illustrations/heart/spot/miscellaneous-workshop.svg")
-/* prettier-ignore */ export const Video = createSpotIllustration("illustrations/heart/spot/miscellaneous-video.svg")
-/* prettier-ignore */ export const ReportSharing = createSpotIllustration("illustrations/heart/spot/miscellaneous-report-sharing.svg")
-/* prettier-ignore */ export const BlankSurvey = createSpotIllustration("illustrations/heart/spot/miscellaneous-blank-survey.svg")
-/* prettier-ignore */ export const TakeAim = createSpotIllustration("illustrations/heart/spot/miscellaneous-take-aim.svg")
-/* prettier-ignore */ export const Action = createSpotIllustration("illustrations/heart/spot/miscellaneous-action.svg")
-/* prettier-ignore */ export const Training1 = createSpotIllustration("illustrations/heart/spot/miscellaneous-training-1.svg")
-/* prettier-ignore */ export const Training2 = createSpotIllustration("illustrations/heart/spot/miscellaneous-training-2.svg")
-/* prettier-ignore */ export const Training3 = createSpotIllustration("illustrations/heart/spot/miscellaneous-training-3.svg")
-/* prettier-ignore */ export const ShareReport = createSpotIllustration("illustrations/heart/spot/miscellaneous-share-report.svg")
+/* prettier-ignore */ export const ActionPlans = createSpotIllustration("miscellaneous-action-plans.svg")
+/* prettier-ignore */ export const BCorp = createSpotIllustration("miscellaneous-b-corp.svg")
+/* prettier-ignore */ export const Behaviour = createSpotIllustration("miscellaneous-behavior.svg")
+/* prettier-ignore */ export const ChangeAgents = createSpotIllustration("miscellaneous-change-agents.svg")
+/* prettier-ignore */ export const Communications = createSpotIllustration("miscellaneous-communications.svg")
+/* prettier-ignore */ export const Community = createSpotIllustration("miscellaneous-community.svg")
+/* prettier-ignore */ export const Company = createSpotIllustration("miscellaneous-company.svg")
+/* prettier-ignore */ export const Conversations = createSpotIllustration("miscellaneous-conversations.svg")
+/* prettier-ignore */ export const DataVisualization = createSpotIllustration("miscellaneous-data-visualization.svg")
+/* prettier-ignore */ export const Goals = createSpotIllustration("miscellaneous-goals.svg")
+/* prettier-ignore */ export const Insights = createSpotIllustration("miscellaneous-insights.svg")
+/* prettier-ignore */ export const Learn = createSpotIllustration("miscellaneous-learn.svg")
+/* prettier-ignore */ export const Microphone = createSpotIllustration("miscellaneous-microphone.svg")
+/* prettier-ignore */ export const PaperPen = createSpotIllustration("miscellaneous-paper-pen.svg")
+/* prettier-ignore */ export const PowerfulInsights = createSpotIllustration("miscellaneous-powerful-insights.svg")
+/* prettier-ignore */ export const Privacy = createSpotIllustration("miscellaneous-privacy.svg")
+/* prettier-ignore */ export const Process = createSpotIllustration("miscellaneous-process.svg")
+/* prettier-ignore */ export const Resources = createSpotIllustration("miscellaneous-resources.svg")
+/* prettier-ignore */ export const ScienceBackedTools = createSpotIllustration("miscellaneous-science-backed-tools.svg")
+/* prettier-ignore */ export const SkillsDevelopment = createSpotIllustration("miscellaneous-skills-development.svg")
+/* prettier-ignore */ export const ViewReports = createSpotIllustration("miscellaneous-view-reports.svg")
+/* prettier-ignore */ export const ReadArticle = createSpotIllustration("miscellaneous-read-article.svg")
+/* prettier-ignore */ export const FastAction = createSpotIllustration("miscellaneous-fast-action.svg")
+/* prettier-ignore */ export const BaselineSurvey = createSpotIllustration("miscellaneous-baseline-survey.svg")
+/* prettier-ignore */ export const SpreadsheetTemplate = createSpotIllustration("miscellaneous-spreadsheet-template.svg")
+/* prettier-ignore */ export const AddImage = createSpotIllustration("miscellaneous-add-image.svg")
+/* prettier-ignore */ export const MeetingVoices = createSpotIllustration("miscellaneous-meeting-voices.svg")
+/* prettier-ignore */ export const Workshop = createSpotIllustration("miscellaneous-workshop.svg")
+/* prettier-ignore */ export const Video = createSpotIllustration("miscellaneous-video.svg")
+/* prettier-ignore */ export const ReportSharing = createSpotIllustration("miscellaneous-report-sharing.svg")
+/* prettier-ignore */ export const BlankSurvey = createSpotIllustration("miscellaneous-blank-survey.svg")
+/* prettier-ignore */ export const TakeAim = createSpotIllustration("miscellaneous-take-aim.svg")
+/* prettier-ignore */ export const Action = createSpotIllustration("miscellaneous-action.svg")
+/* prettier-ignore */ export const Training1 = createSpotIllustration("miscellaneous-training-1.svg")
+/* prettier-ignore */ export const Training2 = createSpotIllustration("miscellaneous-training-2.svg")
+/* prettier-ignore */ export const Training3 = createSpotIllustration("miscellaneous-training-3.svg")
+/* prettier-ignore */ export const ShareReport = createSpotIllustration("miscellaneous-share-report.svg")
 
 // TODO: Component Name change
-/* prettier-ignore */ export const Team1 = createSpotIllustration("illustrations/heart/spot/miscellaneous-team-1.svg")
-/* prettier-ignore */ export const Team2 = createSpotIllustration("illustrations/heart/spot/miscellaneous-team-2.svg")
-/* prettier-ignore */ export const Templates = createSpotIllustration("illustrations/heart/spot/miscellaneous-templates.svg")
-/* prettier-ignore */ export const ExecutiveReportSharing = createSpotIllustration("illustrations/heart/spot/miscellaneous-executive-report-sharing.svg")
-/* prettier-ignore */ export const ManagerReportSharing = createSpotIllustration("illustrations/heart/spot/miscellaneous-manager-report-sharing.svg")
-/* prettier-ignore */ export const LeaderReportSharing = createSpotIllustration("illustrations/heart/spot/miscellaneous-leader-report-sharing.svg")
-/* prettier-ignore */ export const Alarm = createSpotIllustration("illustrations/heart/spot/miscellaneous-alarm.svg")
-/* prettier-ignore */ export const Fire = createSpotIllustration("illustrations/heart/spot/miscellaneous-fire.svg")
-/* prettier-ignore */ export const Fireworks = createSpotIllustration("illustrations/heart/spot/miscellaneous-fireworks.svg")
-/* prettier-ignore */ export const FullImport = createSpotIllustration("illustrations/heart/spot/miscellaneous-full-import.svg")
-/* prettier-ignore */ export const HrisImport = createSpotIllustration("illustrations/heart/spot/miscellaneous-hris-import.svg")
-/* prettier-ignore */ export const PartialImport = createSpotIllustration("illustrations/heart/spot/miscellaneous-partial-import.svg")
-/* prettier-ignore */ export const Starburst = createSpotIllustration("illustrations/heart/spot/miscellaneous-starburst.svg")
-/* prettier-ignore */ export const Stop = createSpotIllustration("illustrations/heart/spot/miscellaneous-stop.svg")
-/* prettier-ignore */ export const TrafficCone = createSpotIllustration("illustrations/heart/spot/miscellaneous-traffic-cone.svg")
-/* prettier-ignore */ export const Trophy = createSpotIllustration("illustrations/heart/spot/miscellaneous-trophy.svg")
-/* prettier-ignore */ export const UnderConstruction = createSpotIllustration("illustrations/heart/spot/miscellaneous-under-construction.svg")
-/* prettier-ignore */ export const ValueAdd = createSpotIllustration("illustrations/heart/spot/miscellaneous-value-add.svg")
-/* prettier-ignore */ export const Recommendation = createSpotIllustration("illustrations/heart/spot/miscellaneous-recommendation.svg")
-/* prettier-ignore */ export const Objective = createSpotIllustration("illustrations/heart/spot/miscellaneous-objective.svg")
+/* prettier-ignore */ export const Team1 = createSpotIllustration("miscellaneous-team-1.svg")
+/* prettier-ignore */ export const Team2 = createSpotIllustration("miscellaneous-team-2.svg")
+/* prettier-ignore */ export const Templates = createSpotIllustration("miscellaneous-templates.svg")
+/* prettier-ignore */ export const ExecutiveReportSharing = createSpotIllustration("miscellaneous-executive-report-sharing.svg")
+/* prettier-ignore */ export const ManagerReportSharing = createSpotIllustration("miscellaneous-manager-report-sharing.svg")
+/* prettier-ignore */ export const LeaderReportSharing = createSpotIllustration("miscellaneous-leader-report-sharing.svg")
+/* prettier-ignore */ export const Alarm = createSpotIllustration("miscellaneous-alarm.svg")
+/* prettier-ignore */ export const Fire = createSpotIllustration("miscellaneous-fire.svg")
+/* prettier-ignore */ export const Fireworks = createSpotIllustration("miscellaneous-fireworks.svg")
+/* prettier-ignore */ export const FullImport = createSpotIllustration("miscellaneous-full-import.svg")
+/* prettier-ignore */ export const HrisImport = createSpotIllustration("miscellaneous-hris-import.svg")
+/* prettier-ignore */ export const PartialImport = createSpotIllustration("miscellaneous-partial-import.svg")
+/* prettier-ignore */ export const Starburst = createSpotIllustration("miscellaneous-starburst.svg")
+/* prettier-ignore */ export const Stop = createSpotIllustration("miscellaneous-stop.svg")
+/* prettier-ignore */ export const TrafficCone = createSpotIllustration("miscellaneous-traffic-cone.svg")
+/* prettier-ignore */ export const Trophy = createSpotIllustration("miscellaneous-trophy.svg")
+/* prettier-ignore */ export const UnderConstruction = createSpotIllustration("miscellaneous-under-construction.svg")
+/* prettier-ignore */ export const ValueAdd = createSpotIllustration("miscellaneous-value-add.svg")
+/* prettier-ignore */ export const Recommendation = createSpotIllustration("miscellaneous-recommendation.svg")
+/* prettier-ignore */ export const Objective = createSpotIllustration("miscellaneous-objective.svg")


### PR DESCRIPTION
## Why
I was looking into adding a new Spot illustration and noticed that the file was ~1300 lines long and consisted of a lot of repetition as almost all components were identical but for the `url` they used.
The length of the file, plus the noise from the repetition, made it really hard to get an overview of what's going on and how/where to add new illustrations.


## What
I created a simple factory function that creates the illustration component using a given `url`.
Unfortunately, Prettier would still wrap these much simpler statements due to its 80 char max default, which made it still quite "noisy" to look at IMO. Thus Ito add a `// prettier-ignore` to each line (group statements are not supported :( ), which isn't the best - but still better than the alternative, I think.

So previously an illustration would take up 10 lines:
```
export const LeadingThroughCrisis = ({
  enableAspectRatio,
  ...props
}: SpotProps) => (
  <Base
    aspectRatio={enableAspectRatio ? "square" : undefined}
    {...props}
    name="illustrations/heart/spot/template-library-leading-through-crisis.svg"
  />
)
```
but in this PR it's just 1:
```
/* prettier-ignore */ export const LeadingThroughCrisis = createSpotIllustration("illustrations/heart/spot/template-library-leading-through-crisis.svg")
```

Given we use large screens, I find this so much easier to maintain now:
<img width="1318" alt="image" src="https://user-images.githubusercontent.com/763385/192922438-d68f9fef-7869-4e25-97eb-7e0c2ff57f73.png">

