### PR TITLE
fix: Rename competency-library svg to include .icon

### DIFF
--- a/packages/component-library/icons/competency-library.icon.svg
+++ b/packages/component-library/icons/competency-library.icon.svg
@@ -4,3 +4,4 @@
 <path d="M15 3H17V17H15V3Z" fill="black"/>
 <path d="M20 3H18V17H20V3Z" fill="black"/>
 </svg>
+


### PR DESCRIPTION
## Why
The svg wasn't usable as an icon with out this suffix

## What
the svg
