### PR TITLE
feat: Added new “Calendar Sync” spot illustration

### DIFF
--- a/draft-packages/illustration/KaizenDraft/Illustration/Spot.tsx
+++ b/draft-packages/illustration/KaizenDraft/Illustration/Spot.tsx
@@ -381,3 +381,4 @@ const createSpotIllustration =
 /* prettier-ignore */ export const ValueAdd = createSpotIllustration("miscellaneous-value-add.svg")
 /* prettier-ignore */ export const Recommendation = createSpotIllustration("miscellaneous-recommendation.svg")
 /* prettier-ignore */ export const Objective = createSpotIllustration("miscellaneous-objective.svg")
+/* prettier-ignore */ export const CalendarSync = createSpotIllustration("miscellaneous-calendar-sync.svg")

--- a/draft-packages/illustration/KaizenDraft/Illustration/__snapshots__/illustration.spec.tsx.snap
+++ b/draft-packages/illustration/KaizenDraft/Illustration/__snapshots__/illustration.spec.tsx.snap
@@ -600,6 +600,16 @@ exports[`<Illustration /> Spot BlankSurvey should exist and render an alt tag 1`
 </div>
 `;
 
+exports[`<Illustration /> Spot CalendarSync should exist and render an alt tag 1`] = `
+<div>
+  <img
+    alt="My accessible title"
+    class="wrapper"
+    src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/heart/spot/miscellaneous-calendar-sync.svg"
+  />
+</div>
+`;
+
 exports[`<Illustration /> Spot CandidateSurvey should exist and render an alt tag 1`] = `
 <div>
   <img

--- a/draft-packages/illustration/docs/IllustrationSpot.stories.tsx
+++ b/draft-packages/illustration/docs/IllustrationSpot.stories.tsx
@@ -126,6 +126,7 @@ import {
   Behaviour,
   Learn,
   Templates,
+  CalendarSync,
 } from ".."
 import { CATEGORIES, SUB_CATEGORIES } from "../../../storybook/constants"
 
@@ -680,6 +681,10 @@ export const AllSpotIllustrations = () => {
     {
       Component: ChangeAgents,
       name: "Change Agents",
+    },
+    {
+      Component: CalendarSync,
+      name: "Calendar Sync",
     },
   ]
 


### PR DESCRIPTION
## Why
We have a new illustration for "Calendar Sync".


## What
The SVG has already been added to our assets repo, so all that needed to be done here was adding the new component.
<img width="152" alt="image" src="https://user-images.githubusercontent.com/763385/192954659-62a6e0a7-899c-40c7-b143-2f35b938f6b7.png">