### PR TITLE
chore: Release @kaizen/notification v1

### DIFF
--- a/packages/notification/package.json
+++ b/packages/notification/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kaizen/notification",
-  "version": "0.11.8",
+  "version": "1.0.0",
   "description": "Collection of notification components",
   "scripts": {
     "prepublish": "tsc --project tsconfig.dist.json",


### PR DESCRIPTION
## What
Manually bump the notification package to 1.0.0

## Why
Breaking changes on sub v1 versions (0.x.x) don't trigger a major version release, it has to be manually updated to v1 before that happens (something I didn't realise when I made this package starting at 0.0.0)