### PR TITLE
chore: Release @kaizen/eslint-plugin v1

### DIFF
--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kaizen/eslint-plugin",
-  "version": "0.1.3",
+  "version": "1.0.0",
   "main": "dist/src/index.js",
   "license": "MIT",
   "files": [


### PR DESCRIPTION
## What
Manually bump the eslint-plugin package to 1.0.0

## Why
Breaking changes on sub v1 versions (0.x.x) don't trigger a major version release, it has to be manually updated to v1 before that happens