### PR TITLE
fix(draft-form): move InputSearch global cancel button styles under .input class

### DIFF
--- a/draft-packages/form/KaizenDraft/Form/Primitives/InputSearch/InputSearch.module.scss
+++ b/draft-packages/form/KaizenDraft/Form/Primitives/InputSearch/InputSearch.module.scss
@@ -59,6 +59,10 @@ $border-solid-border-radius-curved: $input-height;
       opacity: 0;
     }
   }
+
+  &::-webkit-search-cancel-button {
+    -webkit-appearance: none;
+  }
 }
 
 .input[type="search"]:focus + .focusRing {
@@ -401,12 +405,6 @@ $border-solid-border-radius-curved: $input-height;
       opacity: $input-disabled-opacity;
     }
   }
-}
-
-// We are overriding the cancel button with a custom component, this hides the native
-// browser cancel button.
-::-webkit-search-cancel-button {
-  -webkit-appearance: none;
 }
 
 .cancelButton {


### PR DESCRIPTION
## Why

[KDS-869](https://cultureamp.atlassian.net/jira/software/projects/KDS/boards/289?selectedIssue=KDS-869)

Global pseudo styles within `draft-form/InputSearch` create an error with NextJS builds.

## What

Move `::-webkit-search-cancel-button` styles under `.input`