### PR TITLE
fix(filter-multi-select): manually change @kaizen/select to next majo…

### DIFF
--- a/packages/select/package.json
+++ b/packages/select/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kaizen/select",
-  "version": "2.1.1",
+  "version": "3.0.0",
   "description": "Select components",
   "scripts": {
     "prepublish": "tsc --project tsconfig.dist.json",


### PR DESCRIPTION
[KDS-657](https://github.com/cultureamp/kaizen-design-system/pull/2986) includes a breaking change, but a major version bump wasn't triggered. This PR bumps by a major version manually.