### PR TITLE
refactor: add reuseExisting server flag

### DIFF
--- a/playwright.dev.config.ts
+++ b/playwright.dev.config.ts
@@ -1,6 +1,5 @@
 // playwright.config.ts
 import { type PlaywrightTestConfig } from "@playwright/test"
-
 import config from "./playwright.config"
 
 const LOCALHOST = "http://localhost:6006/"
@@ -10,7 +9,8 @@ const devConfig: PlaywrightTestConfig = {
   webServer: {
     command: "yarn storybook",
     url: LOCALHOST,
-    timeout: 120 * 1000,
+    timeout: 120 * 1000000,
+    reuseExistingServer: true,
   },
 }
 


### PR DESCRIPTION
## Why
Playwright would spin up a new web server or fail if current webserver for local host was already running (6006). This should speed up testing locally on dev


## What
- Adds the `reuseExistingServer` prop
- increase timeout for local dev to ensure there are no timeout test issues on older machines
