### PR TITLE
fix(filter-multi-select): strip items of undefined values

### DIFF
--- a/packages/select/src/FilterMultiSelect/components/ListBox/ListBox.tsx
+++ b/packages/select/src/FilterMultiSelect/components/ListBox/ListBox.tsx
@@ -29,8 +29,12 @@ export const ListBox: React.VFC<ListBoxProps> = ({ children }) => {
     disabledKeys,
     selectionManager: { selectedKeys },
   } = selectionState
-  const disabledItems = Array.from(disabledKeys).map(key => items.getItem(key))
-  const selectedItems = Array.from(selectedKeys).map(key => items.getItem(key))
+  const disabledItems = Array.from(disabledKeys)
+    .map(key => items.getItem(key))
+    .filter(item => item !== undefined)
+  const selectedItems = Array.from(selectedKeys)
+    .map(key => items.getItem(key))
+    .filter(item => item !== undefined)
   const unselectedItems = Array.from(items).filter(
     item => !disabledKeys.has(item.key) && !selectedKeys.has(item.key)
   )


### PR DESCRIPTION
## Why
disabledItems currently returns an array that includes filtered-out items as `undefined`. This causes `disabledItems.length` to return unexpected results, causing confusion for the consumer.


## What
Strips `disabledItems` of all undefined values, leaving only items that are filtered in.