### PR TITLE
fix: remove incorrect design tokens type location

### DIFF
--- a/packages/design-tokens/package.json
+++ b/packages/design-tokens/package.json
@@ -19,7 +19,6 @@
     "!**/*.spec.*",
     "!docs"
   ],
-  "types": "dist/**/*.d.ts",
   "main": "dist/index.js",
   "private": false,
   "license": "MIT",


### PR DESCRIPTION
## Why
`design-tokens@10.0.3` has exported types in different locations, `package.json` has not been updated.

## What
Updated `package.json` to contain no types key, limiting one file pattern. Instead, allow typescript to find types file automatically.

## Referenece 
https://cultureamp.slack.com/archives/C02NUQ27G56/p1664939298139269
