### PR TITLE
ci: Add step to check yarn integrity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,21 @@ name: ci
 on: push
 
 jobs:
+  yarn-integrity:
+    if: github.ref != 'refs/heads/master'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v2
+        with:
+          cache: yarn
+          node-version-file: .nvmrc
+          registry-url: https://npm.pkg.github.com/
+      - run: yarn install --frozen-lockfile
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - run: yarn check --integrity
+
   typescript:
     if: github.ref != 'refs/heads/master'
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What
Adds a new step to our build to run `yarn check --integrity`.

## Why
Currently you can push a `package.json` change without running yarn install and get it all the way to master. This will stop that from happening.