### PR TITLE
fix(pagination): Update ellipse color to purple 800, 70%

### DIFF
--- a/packages/pagination/src/Pagination.module.scss
+++ b/packages/pagination/src/Pagination.module.scss
@@ -119,6 +119,6 @@
   height: 36px;
   width: 36px;
   background-color: transparent;
-  color: $color-blue-500;
+  color: rgba($color-purple-800-rgb, 0.7);
   margin: 0 5px;
 }


### PR DESCRIPTION
## Why
https://cultureamp.slack.com/archives/C0189KBPM4Y/p1637035693120500
Based on the linked design feedback and currently what's in figma, we have changed the colour of the ellipses in `truncateIndicatorWrapper`.

## What
Updates the color of ellipses to distinguish them from clickable pagination links.
