### PR TITLE
feat: Add Expert Advice Variant into the Collapsible component

### DIFF
--- a/packages/select/CHANGELOG.md
+++ b/packages/select/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [4.0.3](https://github.com/cultureamp/kaizen-design-system/compare/@kaizen/select@4.0.2...@kaizen/select@4.0.3) (2022-10-18)
+
+
+### Bug Fixes
+
+* **filtermultiselect:** fix console warnings ([#3027](https://github.com/cultureamp/kaizen-design-system/issues/3027)) ([dddda5c](https://github.com/cultureamp/kaizen-design-system/commit/dddda5cc248aa0780f02d3fe49d7a1ddd345e89c))
+
+
+
+
+
 ## [4.0.2](https://github.com/cultureamp/kaizen-design-system/compare/@kaizen/select@4.0.1...@kaizen/select@4.0.2) (2022-10-12)
 
 

--- a/packages/select/docs/FilterMultiSelect.stories.tsx
+++ b/packages/select/docs/FilterMultiSelect.stories.tsx
@@ -72,10 +72,10 @@ export const DefaultKaizenSiteDemo: ComponentStory<
           </>
         )}
       </FilterMultiSelect>
-      <Paragraph variant={"body"}>
-        Items:{" "}
+      <div style={{ marginTop: 4 }}>
+        <Paragraph variant="body">Items: </Paragraph>{" "}
         <CodeBlock language="json" code={JSON.stringify(items, null, "\t")} />
-      </Paragraph>
+      </div>
     </>
   )
 }
@@ -154,10 +154,10 @@ export const WithSections: ComponentStory<typeof FilterMultiSelect> = () => {
           </>
         )}
       </FilterMultiSelect>
-      <Paragraph variant={"body"}>
-        Items:{" "}
+      <div style={{ marginTop: 4 }}>
+        <Paragraph variant={"body"}>Items: </Paragraph>
         <CodeBlock language="json" code={JSON.stringify(items, null, "\t")} />
-      </Paragraph>
+      </div>
     </>
   )
 }
@@ -278,7 +278,7 @@ export const FilterBarDemo = () => {
         <Button label="Clear All" onClick={clearFilters} secondary />
       </div>
 
-      <Paragraph variant={"body"}>
+      <Paragraph variant="body">
         Selected Values:{" "}
         <CodeBlock
           language="json"

--- a/packages/select/package.json
+++ b/packages/select/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kaizen/select",
-  "version": "4.0.2",
+  "version": "4.0.3",
   "description": "Select components",
   "scripts": {
     "prepublish": "tsc --project tsconfig.dist.json",

--- a/packages/select/src/FilterMultiSelect/FilterMultiSelect.tsx
+++ b/packages/select/src/FilterMultiSelect/FilterMultiSelect.tsx
@@ -27,3 +27,5 @@ export const FilterMultiSelect = Object.assign(Root, {
   MenuFooter, // For layout
   MenuLoadingSkeleton, // Menu Loading Skeleton example
 })
+
+FilterMultiSelect.displayName = "FilterMultiSelect"

--- a/packages/select/src/FilterMultiSelect/provider/MenuTriggerProvider/MenuTriggerProvider.tsx
+++ b/packages/select/src/FilterMultiSelect/provider/MenuTriggerProvider/MenuTriggerProvider.tsx
@@ -68,3 +68,5 @@ export function MenuTriggerProvider({
 export const useMenuTriggerContext = () => useContext(MenuTriggerContext)
 
 export const MenuTriggerConsumer = MenuTriggerContext.Consumer
+
+MenuTriggerContext.displayName = "MenuTriggerContext"

--- a/packages/select/src/FilterMultiSelect/provider/SelectionProvider/SelectionProvider.tsx
+++ b/packages/select/src/FilterMultiSelect/provider/SelectionProvider/SelectionProvider.tsx
@@ -29,7 +29,7 @@ const SelectionContext = React.createContext<SelectionProviderContextType>(
   {} as SelectionProviderContextType
 )
 
-export function SelectionProvider(props: SelectionProviderProps) {
+export const SelectionProvider = (props: SelectionProviderProps) => {
   const [searchQuery, setSearchQuery] = useState<string>("")
 
   const searchFilter = useCallback(
@@ -80,3 +80,5 @@ export function SelectionProvider(props: SelectionProviderProps) {
 export const useSelectionContext = () => useContext(SelectionContext)
 
 export const SelectionConsumer = SelectionContext.Consumer
+
+SelectionProvider.displayName = "SelectionProvider"


### PR DESCRIPTION
## Why
Team Apollo was attempting to achieve the variant of expert advice for the `Collapsible` component but was unable to achieve this with using just `classNameOverride` and Tailwind. 

While it may be possible to achieve this by creating a new style sheet in their repo and doing the following (see below), we believed it was better to introduce the variant so if changes are required we can roll it out to the entire product.

```
.overideClassName {
 > div {
 ... // Expert Advice specific styles for header container 
 }
}
```

## What
- adds new variant to Collapsible
