### PR TITLE
fix(splitbutton): fixing font css for murmur

### DIFF
--- a/packages/split-button/src/SplitButton/components/BaseButton/BaseButton.module.scss
+++ b/packages/split-button/src/SplitButton/components/BaseButton/BaseButton.module.scss
@@ -9,10 +9,12 @@
   border-style: $border-solid-border-style;
   padding: calc(#{$spacing-sm} - #{$border-borderless-border-width})
     calc(#{$spacing-md} - #{$border-borderless-border-width});
-  font: $typography-button-primary-letter-spacing
-    $typography-button-primary-font-weight
-    $typography-button-primary-font-size/$typography-button-primary-line-height
-    $typography-button-primary-font-family;
+
+  font-family: $typography-button-primary-font-family;
+  font-weight: $typography-button-primary-font-weight;
+  letter-spacing: $typography-button-primary-letter-spacing;
+  font-size: $typography-button-primary-font-size;
+  line-height: $typography-button-primary-line-height;
   text-decoration: unset;
   cursor: default;
   white-space: nowrap;


### PR DESCRIPTION
## Why
<!-- Why have you created this PR? - Is it a new feature, or a bug fix? Or something else? -->
<!-- Reference any relevant Jira tickets so your reviewer can find more context if needed. -->
<!-- Fixing a GitHub issue? Add "Fixes [issue URL]". -->
When importing the new SplitButton component into murmur the CSS was failing to compile. 
We identified that the use of `font` was the cause of the issue. Instead, we are using the longwinded way of applying CSS fonts.

## What
<!-- What do your changes do? How do they change/fix the current behavior? -->
<!-- Add screenshots, GIFs or videos to illustrate the changes.  -->
This fix allows murmur to import the package within the CSS failing to compile.

Jira Ticket: https://cultureamp.atlassian.net/browse/KDS-902
