### PR TITLE
chore: Added XSS warning to RTE default story [KDS-526]

### DIFF
--- a/packages/rich-text-editor/docs/RichTextEditor.stories.tsx
+++ b/packages/rich-text-editor/docs/RichTextEditor.stories.tsx
@@ -30,12 +30,13 @@ export const Default = args => {
       <Box pt={1}>
         <InlineNotification
           type="cautionary"
-          title="Security Hint"
+          title="Security hint"
           hideCloseIcon
         >
           Our Rich Text Editor deals with user input which can potentially
-          include malicious content (e.g. XSS, injection attacks). It should
-          always be treated with great care when processing or displaying again.
+          include malicious content (e.g. XSS, injection attacks). The data
+          returned by the RTE should hence always be treated with appropriate
+          caution when being processed or rendered by your application.
         </InlineNotification>
       </Box>
     </>

--- a/packages/rich-text-editor/docs/RichTextEditor.stories.tsx
+++ b/packages/rich-text-editor/docs/RichTextEditor.stories.tsx
@@ -1,5 +1,7 @@
 import React, { useState } from "react"
 import { RichTextEditor, EditorContentArray } from "@kaizen/rich-text-editor"
+import { Box } from "@kaizen/component-library"
+import { InlineNotification } from "@kaizen/notification"
 import { CATEGORIES, SUB_CATEGORIES } from "../../../storybook/constants"
 import dummyContent from "./dummyContent.json"
 import dummyMalformedContent from "./dummyMalformedContent.json"
@@ -19,11 +21,24 @@ export default {
 export const Default = args => {
   const [rteData, setRTEData] = useState<EditorContentArray>([])
   return (
-    <RichTextEditor
-      value={rteData}
-      onChange={data => setRTEData(data)}
-      {...args}
-    />
+    <>
+      <RichTextEditor
+        value={rteData}
+        onChange={data => setRTEData(data)}
+        {...args}
+      />
+      <Box pt={1}>
+        <InlineNotification
+          type="cautionary"
+          title="Security Hint"
+          hideCloseIcon
+        >
+          Our Rich Text Editor deals with user input which can potentially
+          include malicious content (e.g. XSS, injection attacks). It should
+          always be treated with great care when processing or displaying again.
+        </InlineNotification>
+      </Box>
+    </>
   )
 }
 


### PR DESCRIPTION
## Why
- We wanted to call out that dealing with user input from our Rich Text Editor can be a possible security concern as this content can't be trusted. There is a potential for it to include XSS or injection attacks.


## What
- Added a warning to the default story
<img width="959" alt="image" src="https://user-images.githubusercontent.com/763385/197113610-80657a4f-c407-4606-8b9e-c48c48b3fe94.png">

