### PR TITLE
fix(searchfield): update onClear to return focus to input

### DIFF
--- a/draft-packages/form/KaizenDraft/Form/Primitives/InputSearch/InputSearch.tsx
+++ b/draft-packages/form/KaizenDraft/Form/Primitives/InputSearch/InputSearch.tsx
@@ -1,4 +1,4 @@
-import React, { InputHTMLAttributes } from "react"
+import React, { InputHTMLAttributes, useRef } from "react"
 import classnames from "classnames"
 import { OverrideClassName } from "@kaizen/component-base"
 import { Icon } from "@kaizen/component-library"
@@ -32,7 +32,12 @@ export const InputSearch: React.VFC<InputSearchProps> = (
     secondary = false,
     ...restProps
   } = props
+  const inputRef = useRef<HTMLInputElement>(null)
 
+  const handleOnClear = (): void => {
+    inputRef.current?.focus()
+    onClear && onClear()
+  }
   return (
     <div
       className={classnames(
@@ -59,6 +64,7 @@ export const InputSearch: React.VFC<InputSearchProps> = (
       </div>
 
       <input
+        ref={inputRef}
         type="search"
         className={classnames(styles.input, styles.search, classNameOverride, {
           [styles.default]: !reversed,
@@ -82,7 +88,7 @@ export const InputSearch: React.VFC<InputSearchProps> = (
             type="button"
             className={styles.cancelButton}
             aria-label="clear"
-            onClick={onClear}
+            onClick={handleOnClear}
           >
             <Icon icon={clear} role="presentation" />
           </button>


### PR DESCRIPTION
## Why
<!-- Why have you created this PR? - Is it a new feature, or a bug fix? Or something else? -->
<!-- Reference any relevant Jira tickets so your reviewer can find more context if needed. -->
<!-- Fixing a GitHub issue? Add "Fixes [issue URL]". -->
- When user selects the clear button the focus does not return to the input
https://cultureamp.atlassian.net/jira/software/projects/KDS/boards/289?selectedIssue=KDS-611

## What
<!-- What do your changes do? How do they change/fix the current behavior? -->
<!-- Add screenshots, GIFs or videos to illustrate the changes.  -->

- Add a ref to input and force focus back onto the input when the onClear has been called.
