### PR TITLE
fix(filter-multi-select): update MenuLoadingSkeleton to be a component

### DIFF
--- a/packages/select/docs/FilterBarExample/DemographicValueSelect.tsx
+++ b/packages/select/docs/FilterBarExample/DemographicValueSelect.tsx
@@ -54,7 +54,7 @@ export const DemographicValueSelect = ({
     <FilterMultiSelect
       defaultOpen
       isLoading={isLoading}
-      loadingSkeleton={FilterMultiSelect.MenuLoadingSkeleton}
+      loadingSkeleton={<FilterMultiSelect.MenuLoadingSkeleton />}
       label={label}
       items={demographicValueItems}
       selectedKeys={selectedKeys}

--- a/packages/select/docs/FilterMultiSelect.stories.tsx
+++ b/packages/select/docs/FilterMultiSelect.stories.tsx
@@ -90,7 +90,7 @@ export const Loading: ComponentStory<typeof FilterMultiSelect> = args => (
       {...args}
       isLoading
       isOpen
-      loadingSkeleton={FilterMultiSelect.MenuLoadingSkeleton}
+      loadingSkeleton={<FilterMultiSelect.MenuLoadingSkeleton />}
       trigger={() => (
         <FilterMultiSelect.TriggerButton
           selectedOptionLabels={["Front-End"]}
@@ -414,7 +414,7 @@ export const Async: ComponentStory<typeof FilterMultiSelect> = args => {
       <FilterMultiSelect
         {...args}
         isLoading={isLoading}
-        loadingSkeleton={FilterMultiSelect.MenuLoadingSkeleton}
+        loadingSkeleton={<FilterMultiSelect.MenuLoadingSkeleton />}
         items={currentPeople}
         trigger={() => (
           <FilterMultiSelect.TriggerButton

--- a/packages/select/src/FilterMultiSelect/components/MenuLayout/MenuLoadingSkeleton/MenuLoadingSkeleton.tsx
+++ b/packages/select/src/FilterMultiSelect/components/MenuLayout/MenuLoadingSkeleton/MenuLoadingSkeleton.tsx
@@ -4,7 +4,7 @@ import classNames from "classnames"
 import { MenuFooter } from "../MenuFooter"
 import styles from "./MenuLoadingSkeleton.module.scss"
 
-export const MenuLoadingSkeleton = (
+export const MenuLoadingSkeleton: React.VFC = () => (
   <>
     <div className={classNames(styles.loadingContainer)}>
       <LoadingInput classNameOverride={styles.loadingInput} />


### PR DESCRIPTION
BREAKING CHANGE: FilterMultiSelect's loadingSkeleton prop no-longer accepts a variable with JSX. It must be a React Functional Component.

## What
Changes MenuLoadingSkeleton to be a component, and make FilterMultiSelect's loadingSkeleton prop expect a component

## Why
For consistency with the way components are passed as props in other parts of the code base.

