### PR TITLE
style(timefield): swap transparent input background to white

### DIFF
--- a/packages/date-picker/src/TimeField/TimeField.module.scss
+++ b/packages/date-picker/src/TimeField/TimeField.module.scss
@@ -25,7 +25,7 @@ $story-className--timefield-focus: ":global(.story__timefield-focus)";
 .input {
   display: inline-flex;
   align-items: center;
-  background-color: transparent;
+  background-color: $color-white;
   background-clip: padding-box;
   border: $border-solid-border-width $border-solid-border-style $color-gray-500;
   border-radius: $border-solid-border-radius;


### PR DESCRIPTION
## Why
The `TimeField` input had a transparent background, causing issues when it renders on non-white backgroundds


## What
Change the background of the input from `transparent` to white. 
![image](https://user-images.githubusercontent.com/8871941/199379828-d5356fe8-84d0-480d-a290-591b0444c1f5.png)
