### PR TITLE
fix: Ensure legacy safari and legacy edge users don't call missing methods

### DIFF
--- a/draft-packages/illustration/KaizenDraft/Illustration/Players/VideoPlayer.tsx
+++ b/draft-packages/illustration/KaizenDraft/Illustration/Players/VideoPlayer.tsx
@@ -88,9 +88,12 @@ export const VideoPlayer = ({
       setPrefersReducedMotion(matches)
     }
 
+    const isLegacyEdge = navigator.userAgent.match(/Edge/)
+
     const isUnsupportedSafari =
       window.matchMedia("").addEventListener === undefined
-    if (isUnsupportedSafari) return
+
+    if (isLegacyEdge || isUnsupportedSafari) return
 
     reducedMotionQuery.addEventListener("change", updateMotionPreferences, true)
 

--- a/draft-packages/illustration/KaizenDraft/Illustration/Players/VideoPlayer.tsx
+++ b/draft-packages/illustration/KaizenDraft/Illustration/Players/VideoPlayer.tsx
@@ -87,6 +87,11 @@ export const VideoPlayer = ({
       )
       setPrefersReducedMotion(matches)
     }
+
+    const isUnsupportedSafari =
+      window.matchMedia("").addEventListener === undefined
+    if (isUnsupportedSafari) return
+
     reducedMotionQuery.addEventListener("change", updateMotionPreferences, true)
 
     return function cleanup() {


### PR DESCRIPTION
Some of our users are using older versions of safari which do not have the `addEventListener` method on `matchMedia`.

There is a deprecated `addListener` function, but I'm following what was established in `useMediaQueries` and stopping the effect from running, rather than supporting old browsers.
