### PR TITLE
fix(component): accept consumers onClick event for button within Menu

### DIFF
--- a/draft-packages/menu/KaizenDraft/Menu/Menu.spec.tsx
+++ b/draft-packages/menu/KaizenDraft/Menu/Menu.spec.tsx
@@ -31,18 +31,21 @@ describe("Dropdown", () => {
   })
 
   it("shows menu & handles onClick set by the consumer when clicking on the button", async () => {
-    const handleClick = render(<div>Button clicked</div>)
+    const onButtonClick = jest.fn<void, []>()
+
     render(
-      <Menu button={<Button label="Button" onClick={() => handleClick} />}>
+      <Menu button={<Button label="Button" onClick={onButtonClick} />}>
         <div>Item</div>
       </Menu>
     )
-    expect(screen.queryByText("Item")).toBeFalsy()
+
+    expect(screen.queryByText("Item")).not.toBeInTheDocument()
+
     const button = screen.getByText("Button")
-    fireEvent.click(button)
+    userEvent.click(button)
+
     await waitFor(() => {
-      expect(screen.getByText("Button clicked")).toBeInTheDocument()
-      expect(screen.getByText("Item")).toBeInTheDocument()
+      expect(screen.getByText("Item")).toBeVisible()
+      expect(onButtonClick).toBeCalled()
     })
-  })
 })

--- a/draft-packages/menu/KaizenDraft/Menu/Menu.spec.tsx
+++ b/draft-packages/menu/KaizenDraft/Menu/Menu.spec.tsx
@@ -50,4 +50,23 @@ describe("Dropdown", () => {
       expect(onButtonClick).toBeCalled()
     })
   })
+  it("shows menu & handles onMouseDown set by the consumer when mousing down on the button", async () => {
+    const onMouseDown = jest.fn<void, []>()
+
+    render(
+      <Menu button={<Button label="Button" onMouseDown={onMouseDown} />}>
+        <div>Item</div>
+      </Menu>
+    )
+
+    expect(screen.queryByText("Item")).not.toBeInTheDocument()
+
+    const button = screen.getByText("Button")
+    userEvent.click(button)
+
+    await waitFor(() => {
+      expect(screen.getByText("Item")).toBeVisible()
+      expect(onMouseDown).toBeCalled()
+    })
+  })
 })

--- a/draft-packages/menu/KaizenDraft/Menu/Menu.spec.tsx
+++ b/draft-packages/menu/KaizenDraft/Menu/Menu.spec.tsx
@@ -29,4 +29,20 @@ describe("Dropdown", () => {
       expect(screen.getByText("Item")).toBeInTheDocument()
     })
   })
+
+  it("shows menu & handles onClick set by the consumer when clicking on the button", async () => {
+    const handleClick = render(<div>Button clicked</div>)
+    render(
+      <Menu button={<Button label="Button" onClick={() => handleClick} />}>
+        <div>Item</div>
+      </Menu>
+    )
+    expect(screen.queryByText("Item")).toBeFalsy()
+    const button = screen.getByText("Button")
+    fireEvent.click(button)
+    await waitFor(() => {
+      expect(screen.getByText("Button clicked")).toBeInTheDocument()
+      expect(screen.getByText("Item")).toBeInTheDocument()
+    })
+  })
 })

--- a/draft-packages/menu/KaizenDraft/Menu/Menu.spec.tsx
+++ b/draft-packages/menu/KaizenDraft/Menu/Menu.spec.tsx
@@ -2,6 +2,7 @@ import { Button } from "@kaizen/button"
 import { fireEvent } from "@testing-library/dom"
 import { render, screen, waitFor } from "@testing-library/react"
 import * as React from "react"
+import userEvent from "@testing-library/user-event"
 import Menu from "./Menu"
 
 describe("Dropdown", () => {
@@ -48,4 +49,5 @@ describe("Dropdown", () => {
       expect(screen.getByText("Item")).toBeVisible()
       expect(onButtonClick).toBeCalled()
     })
+  })
 })

--- a/draft-packages/menu/KaizenDraft/Menu/Menu.tsx
+++ b/draft-packages/menu/KaizenDraft/Menu/Menu.tsx
@@ -54,7 +54,19 @@ const Menu: React.FunctionComponent<MenuProps> = ({
       // to unexpected behaviour, and it doesn't self document. Hence, the switch
       // to the render function. It would be nice if the `Menu` component also
       // used this pattern, but it's probably not worth the time and effort.
-      renderButton={props => React.cloneElement(button, props)}
+      renderButton={props =>
+        React.cloneElement(button, {
+          ...props,
+          onClick: (e: React.MouseEvent<Element, MouseEvent>) => {
+            props.onClick(e)
+            button.props.onClick?.(e)
+          },
+          onMouseDown: (e: React.MouseEvent<Element, MouseEvent>) => {
+            props.onMouseDown(e)
+            button.props.onMouseDown?.(e)
+          },
+        })
+      }
     />
   )
 }

--- a/draft-packages/menu/KaizenDraft/Menu/StatelessMenu.tsx
+++ b/draft-packages/menu/KaizenDraft/Menu/StatelessMenu.tsx
@@ -68,12 +68,13 @@ export const StatelessMenu: React.FunctionComponent<StatelessMenuProps> = ({
   const portalSelectorElementRef = useRef<Element | null>(null)
 
   const menuButton = renderButton({
-    onClick: (e: any) => {
+    onClick: (e: React.MouseEvent<Element, MouseEvent>) => {
       e.preventDefault()
       e.stopPropagation()
       toggleMenuDropdown()
     },
-    onMouseDown: (e: any) => e.preventDefault(),
+    onMouseDown: (e: React.MouseEvent<Element, MouseEvent>) =>
+      e.preventDefault(),
     "aria-haspopup": true,
     "aria-expanded": isMenuVisible,
   })


### PR DESCRIPTION
## Why
The button within the Menu component was using the onClick to toggle open/closed the menu list. When a consumer of the component was setting their own onClick on the Menu button, it was being overridden and not actioned.

Refer to [KDS-963](https://cultureamp.atlassian.net/browse/KDS-963)

## What
This change combines the onClick set by the consumer with the functionality of the Menu, enabling both onClick events to be actioned.

No visual changes have been made.
