### PR TITLE
feat: allow indicators container to be clickable above select

### DIFF
--- a/draft-packages/select/KaizenDraft/Select/Select.module.scss
+++ b/draft-packages/select/KaizenDraft/Select/Select.module.scss
@@ -329,6 +329,10 @@ $focus-border-color: $color-blue-500;
       }
     }
 
+    .indicatorsContainer {
+      z-index: 1;
+    }
+
     .dropdownIndicator {
       padding-top: 0;
       padding-bottom: 0;

--- a/draft-packages/select/KaizenDraft/Select/Select.tsx
+++ b/draft-packages/select/KaizenDraft/Select/Select.tsx
@@ -220,7 +220,10 @@ const MultiValue: typeof components.MultiValue = props => (
 )
 
 const IndicatorsContainer: typeof components.IndicatorsContainer = props => (
-  <components.IndicatorsContainer {...props} />
+  <components.IndicatorsContainer
+    {...props}
+    className={styles.indicatorsContainer}
+  />
 )
 
 const Input: typeof components.Input = props => (

--- a/draft-packages/select/docs/Select.stories.tsx
+++ b/draft-packages/select/docs/Select.stories.tsx
@@ -53,6 +53,8 @@ DefaultSelectStory.args = {
   fullWidth: true,
   reversed: false,
   status: "default",
+  isClearable: false,
+  isSearchable: false,
 }
 
 export const GroupedStory: ComponentStory<typeof Select> = args => {


### PR DESCRIPTION
## Why
<!-- Why have you created this PR? - Is it a new feature, or a bug fix? Or something else? -->
<!-- Reference any relevant Jira tickets so your reviewer can find more context if needed. -->
<!-- Fixing a GitHub issue? Add "Fixes [issue URL]". -->
- Allow the indicators to be selectable when the dropdown is open

## What
<!-- What do your changes do? How do they change/fix the current behavior? -->
<!-- Add screenshots, GIFs or videos to illustrate the changes.  -->
- add z-index to indicators containers