### PR TITLE
chore(deps): remove gatsby dep from renovate ignore + add node to renovate ignore

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -2,6 +2,8 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "updatePinnedDependencies": false,
   "ignoreDeps": [
+    // We can't always stick to latest due to infra and compatibility with other plugins
+    "node",
     // We include older versions of React things in order to test against React 16 & 17
     "react-16",
     "react-17",
@@ -9,14 +11,6 @@
     "react-dom-17",
     "@testing-library/react-12",
     "react-test-renderer-17",
-    // Gatsby is pinned because upgrades working with our icons
-    "gatsby",
-    "gatsby-plugin-google-tagmanager",
-    "gatsby-plugin-mdx",
-    "gatsby-plugin-react-helmet",
-    "gatsby-plugin-sass",
-    "gatsby-source-filesystem",
-    "gatsby-transformer-remark",
   ],
   "packageRules": [
     {


### PR DESCRIPTION
## Why
We aren't moving to 18, so I added it to the ignore list.
#3087

We also don't use gatsby anymore.


## What
Renovate ignore deps are updated
