### PR TITLE
feat: add isLoading to SearchInput and story

### DIFF
--- a/packages/select/docs/FilterMultiSelect.stories.tsx
+++ b/packages/select/docs/FilterMultiSelect.stories.tsx
@@ -366,27 +366,33 @@ export const Async: ComponentStory<typeof FilterMultiSelect> = args => {
   const [selectedPeople, setSelectedPeople] = useState<string[]>([])
   const [searchState, setSearchState] = useState("")
   const queryClient = useQueryClient()
-  const { data, isLoading, fetchNextPage, isFetchingNextPage, hasNextPage } =
-    useInfiniteQuery(
-      ["startrek-sg1", searchState],
-      ({ pageParam = 1 }) =>
-        fetch(
-          `https://swapi.dev/api/people/?page=${pageParam}&search=${searchState}`
-        ).then(res => res.json()) as Promise<{
-          results: Array<{ name: string; url: string }>
-          next: string
-        }>,
-      {
-        enabled: open,
-        keepPreviousData: true,
-        getNextPageParam: lastPage => {
-          if (!lastPage.next) return undefined
-          const url = new URL(lastPage.next)
-          const params = new URLSearchParams(url.searchParams)
-          return params.get("page")
-        },
-      }
-    )
+  const {
+    data,
+    isLoading,
+    fetchNextPage,
+    isFetchingNextPage,
+    hasNextPage,
+    isRefetching,
+  } = useInfiniteQuery(
+    ["startrek-sg1", searchState],
+    ({ pageParam = 1 }) =>
+      fetch(
+        `https://swapi.dev/api/people/?page=${pageParam}&search=${searchState}`
+      ).then(res => res.json()) as Promise<{
+        results: Array<{ name: string; url: string }>
+        next: string
+      }>,
+    {
+      enabled: open,
+      keepPreviousData: true,
+      getNextPageParam: lastPage => {
+        if (!lastPage.next) return undefined
+        const url = new URL(lastPage.next)
+        const params = new URLSearchParams(url.searchParams)
+        return params.get("page")
+      },
+    }
+  )
 
   /**
    * We need access to the previously fetched people. If a user has selected a
@@ -438,7 +444,9 @@ export const Async: ComponentStory<typeof FilterMultiSelect> = args => {
       >
         {() => (
           <>
-            <FilterMultiSelect.SearchInput />
+            <FilterMultiSelect.SearchInput
+              isLoading={isRefetching && searchState !== ""}
+            />
             <FilterMultiSelect.ListBox>
               {({ allItems }) => (
                 <>

--- a/packages/select/src/FilterMultiSelect/components/SearchInput/SearchInput.tsx
+++ b/packages/select/src/FilterMultiSelect/components/SearchInput/SearchInput.tsx
@@ -7,9 +7,14 @@ import styles from "./SearchInput.module.scss"
 export interface SearchInputProps {
   label?: string
   id?: string
+  isLoading?: boolean
 }
 
-export const SearchInput: React.VFC<SearchInputProps> = ({ label, id }) => {
+export const SearchInput: React.VFC<SearchInputProps> = ({
+  label,
+  id,
+  isLoading,
+}) => {
   const { setSearchQuery, searchQuery } = useSelectionContext()
 
   const handleChange: React.ChangeEventHandler<HTMLInputElement> = e => {
@@ -32,6 +37,7 @@ export const SearchInput: React.VFC<SearchInputProps> = ({ label, id }) => {
         value={searchQuery}
         onChange={handleChange}
         onClear={handleClear}
+        loading={isLoading}
       />
     </div>
   )


### PR DESCRIPTION
## Why
<!-- Why have you created this PR? - Is it a new feature, or a bug fix? Or something else? -->
<!-- Reference any relevant Jira tickets so your reviewer can find more context if needed. -->
<!-- Fixing a GitHub issue? Add "Fixes [issue URL]". -->
- Add the ability to pass the isLoading state to the searchInput

## What
<!-- What do your changes do? How do they change/fix the current behavior? -->
<!-- Add screenshots, GIFs or videos to illustrate the changes.  -->
- Add isLoading prop to `SearchInput` which uses the Kaizen `InputSearch` which has the loading spinner inbuilt
- Update the story to pull out the `isRefetching` boolean from `useInfiniteQuery` and pass to the `SearchInput`
- Check that the searchState is not `"" `and `isRefetching` to avoid displaying the loading spinner when the search is empty initially