### PR TITLE
feat: On hover add a gray-100 background colour to TableCard with href or onClick.

### DIFF
--- a/draft-packages/table/KaizenDraft/Table/Table.module.scss
+++ b/draft-packages/table/KaizenDraft/Table/Table.module.scss
@@ -193,6 +193,7 @@ $row-height-data-variant: 48px;
     width: calc(100% + #{$spacing-md});
   }
 
+  &:focus,
   &:hover {
     background-color: $color-gray-100;
   }

--- a/draft-packages/table/KaizenDraft/Table/Table.module.scss
+++ b/draft-packages/table/KaizenDraft/Table/Table.module.scss
@@ -192,6 +192,10 @@ $row-height-data-variant: 48px;
   &.expanded {
     width: calc(100% + #{$spacing-md});
   }
+
+  &:hover {
+    background-color: $color-gray-100;
+  }
 }
 
 .rowCell {

--- a/draft-packages/table/docs/Table.stories.tsx
+++ b/draft-packages/table/docs/Table.stories.tsx
@@ -199,6 +199,47 @@ export const DataVariant = () => (
 )
 DataVariant.parameters = { chromatic: { disable: false } }
 
+export const LinkVariant = () => (
+  <Container>
+    <TableContainer>
+      <TableHeader>
+        <TableHeaderRow>
+          <TableHeaderRowCell labelText="Header A" width={1 / 3} />
+          <TableHeaderRowCell labelText="Header B" width={1 / 3} />
+          <TableHeaderRowCell labelText="Header C" width={1 / 3} />
+        </TableHeaderRow>
+      </TableHeader>
+      <TableCard onClick={() => alert("Clicked!")}>
+        <TableRow>
+          <TableRowCell width={1 / 3}>
+            <Paragraph variant="body">This row has an onClick</Paragraph>
+          </TableRowCell>
+          <TableRowCell width={1 / 3}>
+            <Paragraph variant="body">24</Paragraph>
+          </TableRowCell>
+          <TableRowCell width={1 / 3}>
+            <Paragraph variant="body">48</Paragraph>
+          </TableRowCell>
+        </TableRow>
+      </TableCard>
+      <TableCard href="#?foo=bar">
+        <TableRow>
+          <TableRowCell width={1 / 3}>
+            <Paragraph variant="body">This row has a href</Paragraph>
+          </TableRowCell>
+          <TableRowCell width={1 / 3}>
+            <Paragraph variant="body">24</Paragraph>
+          </TableRowCell>
+          <TableRowCell width={1 / 3}>
+            <Paragraph variant="body">48</Paragraph>
+          </TableRowCell>
+        </TableRow>
+      </TableCard>
+    </TableContainer>
+  </Container>
+)
+LinkVariant.parameters = { chromatic: { disable: false } }
+
 const ExpandedPopout = isReversed => {
   const [expandedId, setExpandedId] = React.useState<string | null>("second")
   const toggleExpanded = id => {


### PR DESCRIPTION
## Why
Add background colour hover state to TableCard when a href or onClick prop is active.
[KDS-996](https://cultureamp.atlassian.net/browse/KDS-996)


## What
The reports components project has a couple of instances in which a table row has a link with hover state. The screenshot attached shows the expected behaviour, a gray-100 background colour on hover.

<img width="1139" alt="image" src="https://user-images.githubusercontent.com/115598563/203898508-24ca9827-dd96-4482-9d95-2c099ab96f13.png">

