### PR TITLE
fix(FilterMultiSelect): Improve list box spacing

### DIFF
--- a/packages/select/src/FilterMultiSelect/components/ListBox/ListBox.module.scss
+++ b/packages/select/src/FilterMultiSelect/components/ListBox/ListBox.module.scss
@@ -2,9 +2,7 @@
 
 .listBox {
   list-style: none;
-  padding-left: $spacing-sm;
-  padding-top: $spacing-sm;
-  padding-right: $spacing-sm;
+  padding: $spacing-sm;
   margin: 0 $spacing-sm 0 0;
   display: grid;
   max-height: 210px;

--- a/packages/select/src/FilterMultiSelect/components/LoadMoreButton/LoadMoreButton.module.scss
+++ b/packages/select/src/FilterMultiSelect/components/LoadMoreButton/LoadMoreButton.module.scss
@@ -1,5 +1,5 @@
 @import "~@kaizen/design-tokens/sass/spacing";
 
 .container {
-  padding: $spacing-xs;
+  padding: $spacing-sm $spacing-sm 0;
 }

--- a/packages/select/src/FilterMultiSelect/components/SearchInput/SearchInput.module.scss
+++ b/packages/select/src/FilterMultiSelect/components/SearchInput/SearchInput.module.scss
@@ -3,5 +3,4 @@
 .inputSearchContainer {
   position: relative;
   margin: 0 $spacing-sm;
-  margin-bottom: $spacing-sm;
 }


### PR DESCRIPTION
## What
Adjusts some padding and margins inside the filter multi-select dropdown

More specifically:
* Adds the missing padding bottom to the listbox container
* Removes the margin bottom from the search field container (this was adding too much margin and not matching UI Kit)
* Removes the padding bottom from the "Load more" button for async multi-select (this is now covered by the listbox padding bottom mentioned above).

## Why
Fixes this issue where there's no padding at the bottom of the listbox
![image](https://user-images.githubusercontent.com/1811583/204425386-78d9416d-a9ff-4788-9397-9464fbc32a8c.png)

Also fixes this issue where a scroll bar will appear when selecting an item
![image](https://user-images.githubusercontent.com/1811583/204426172-4b0bf3ae-9362-4774-b84c-54ecf44549bf.png)
