### PR TITLE
docs: update themeManager import to resolve tsc error

### DIFF
--- a/packages/design-tokens/docs/pages/examples/themeManager.ts
+++ b/packages/design-tokens/docs/pages/examples/themeManager.ts
@@ -1,4 +1,3 @@
-import { ThemeManager } from "../../../src/ThemeManager"
-import { defaultTheme } from "../../../src/themes"
+import { ThemeManager, defaultTheme } from "@kaizen/design-tokens"
 
 export const themeManager = new ThemeManager(defaultTheme)


### PR DESCRIPTION
## Why
This is something that had been causing a ts error when compiling with `yarn tsc` if you had a compiled /dist folder of the design-tokens. 

![Screen Shot 2022-11-29 at 1 37 39 pm](https://user-images.githubusercontent.com/36558508/204425733-d6665c37-1d66-4cd7-8ec4-8a51dff7b521.png)
![Screen Shot 2022-11-29 at 1 43 19 pm](https://user-images.githubusercontent.com/36558508/204425791-d04f3b45-ff44-4f61-a2a4-dd1a58ccdf5d.png)



## What
- updated the docs component example for themeManager to import for @kaizen/design-system instead of using local paths
