### PR TITLE
feat: Add component for 'No results found' message

### DIFF
--- a/packages/select/docs/FilterBarExample/DemographicValueSelect.tsx
+++ b/packages/select/docs/FilterBarExample/DemographicValueSelect.tsx
@@ -1,5 +1,6 @@
 import React, { Key, useEffect, useState } from "react"
 import { Selection } from "@react-types/shared"
+import { Paragraph } from "@kaizen/typography"
 import {
   FilterMultiSelect,
   getSelectedOptionKeys,
@@ -74,8 +75,18 @@ export const DemographicValueSelect = ({
         <>
           <FilterMultiSelect.SearchInput />
           <FilterMultiSelect.ListBox>
-            {({ selectedItems, unselectedItems, disabledItems }) => (
+            {({
+              selectedItems,
+              unselectedItems,
+              disabledItems,
+              hasNoItems,
+            }) => (
               <>
+                {hasNoItems && (
+                  <FilterMultiSelect.NoResults>
+                    No results found.
+                  </FilterMultiSelect.NoResults>
+                )}
                 <FilterMultiSelect.ListBoxSection
                   items={selectedItems}
                   sectionName="Selected items"

--- a/packages/select/docs/FilterBarExample/DemographicValueSelect.tsx
+++ b/packages/select/docs/FilterBarExample/DemographicValueSelect.tsx
@@ -1,6 +1,5 @@
 import React, { Key, useEffect, useState } from "react"
 import { Selection } from "@react-types/shared"
-import { Paragraph } from "@kaizen/typography"
 import {
   FilterMultiSelect,
   getSelectedOptionKeys,

--- a/packages/select/docs/FilterMultiSelect.stories.tsx
+++ b/packages/select/docs/FilterMultiSelect.stories.tsx
@@ -466,8 +466,17 @@ export const Async: ComponentStory<typeof FilterMultiSelect> = args => {
               isLoading={isRefetching && searchState !== ""}
             />
             <FilterMultiSelect.ListBox>
-              {({ allItems }) => (
+              {({ allItems, hasNoItems }) => (
                 <>
+                  {hasNoItems && (
+                    <FilterMultiSelect.NoResults>
+                      No results found for{" "}
+                      <Paragraph variant="extra-small" tag="span" color="dark">
+                        {searchState}
+                      </Paragraph>
+                      .
+                    </FilterMultiSelect.NoResults>
+                  )}
                   {allItems.map(item => (
                     <FilterMultiSelect.Option key={item.key} item={item} />
                   ))}

--- a/packages/select/docs/FilterMultiSelect.stories.tsx
+++ b/packages/select/docs/FilterMultiSelect.stories.tsx
@@ -63,11 +63,19 @@ export const DefaultKaizenSiteDemo: ComponentStory<
           <>
             <FilterMultiSelect.SearchInput />
             <FilterMultiSelect.ListBox>
-              {({ allItems }) =>
-                allItems.map(item => (
+              {({ allItems, hasNoItems }) => {
+                if (hasNoItems) {
+                  return (
+                    <FilterMultiSelect.NoResults>
+                      No results found.
+                    </FilterMultiSelect.NoResults>
+                  )
+                }
+
+                return allItems.map(item => (
                   <FilterMultiSelect.Option key={item.key} item={item} />
                 ))
-              }
+              }}
             </FilterMultiSelect.ListBox>
             <FilterMultiSelect.MenuFooter>
               <FilterMultiSelect.SelectAllButton />
@@ -143,8 +151,18 @@ export const WithSections: ComponentStory<typeof FilterMultiSelect> = () => {
           <>
             <FilterMultiSelect.SearchInput />
             <FilterMultiSelect.ListBox>
-              {({ selectedItems, unselectedItems, disabledItems }) => (
+              {({
+                selectedItems,
+                unselectedItems,
+                disabledItems,
+                hasNoItems,
+              }) => (
                 <>
+                  {hasNoItems && (
+                    <FilterMultiSelect.NoResults>
+                      No results found.
+                    </FilterMultiSelect.NoResults>
+                  )}
                   <FilterMultiSelect.ListBoxSection
                     items={selectedItems}
                     sectionName="Selected items"
@@ -247,11 +265,18 @@ export const TruncatedLabels: ComponentStory<typeof FilterMultiSelect> = () => {
           <>
             <FilterMultiSelect.SearchInput />
             <FilterMultiSelect.ListBox>
-              {({ allItems }) =>
-                allItems.map(item => (
+              {({ allItems, hasNoItems }) => {
+                if (hasNoItems) {
+                  return (
+                    <FilterMultiSelect.NoResults>
+                      No results found.
+                    </FilterMultiSelect.NoResults>
+                  )
+                }
+                return allItems.map(item => (
                   <FilterMultiSelect.Option key={item.key} item={item} />
                 ))
-              }
+              }}
             </FilterMultiSelect.ListBox>
             <FilterMultiSelect.MenuFooter>
               <FilterMultiSelect.SelectAllButton />
@@ -361,11 +386,18 @@ export const DefaultKaizenSiteDemoWithoutScrollbar = () => {
         <>
           <FilterMultiSelect.SearchInput />
           <FilterMultiSelect.ListBox>
-            {({ allItems }) =>
-              allItems.map(item => (
+            {({ allItems, hasNoItems }) => {
+              if (hasNoItems) {
+                return (
+                  <FilterMultiSelect.NoResults>
+                    No results found.
+                  </FilterMultiSelect.NoResults>
+                )
+              }
+              return allItems.map(item => (
                 <FilterMultiSelect.Option key={item.key} item={item} />
               ))
-            }
+            }}
           </FilterMultiSelect.ListBox>
           <FilterMultiSelect.MenuFooter>
             <FilterMultiSelect.SelectAllButton />

--- a/packages/select/src/FilterMultiSelect/FilterMultiSelect.tsx
+++ b/packages/select/src/FilterMultiSelect/FilterMultiSelect.tsx
@@ -3,6 +3,7 @@ import { ListBoxSection } from "./components/ListBoxSection"
 import { LoadMoreButton } from "./components/LoadMoreButton"
 import { MenuFooter, MenuLoadingSkeleton } from "./components/MenuLayout"
 import { MultiSelectOption } from "./components/MultiSelectOption"
+import { NoResults } from "./components/NoResults"
 import { Root } from "./components/Root"
 import { SearchInput } from "./components/SearchInput/SearchInput"
 import { SectionDivider } from "./components/SectionDivider"
@@ -28,6 +29,7 @@ export const FilterMultiSelect = Object.assign(Root, {
   MenuFooter, // For layout
   MenuLoadingSkeleton, // Menu Loading Skeleton example
   LoadMoreButton,
+  NoResults,
 })
 
 FilterMultiSelect.displayName = "FilterMultiSelect"

--- a/packages/select/src/FilterMultiSelect/components/ListBox/ListBox.module.scss
+++ b/packages/select/src/FilterMultiSelect/components/ListBox/ListBox.module.scss
@@ -12,3 +12,7 @@
 .overflown {
   padding-right: $spacing-sm;
 }
+
+.hidden {
+  display: none;
+}

--- a/packages/select/src/FilterMultiSelect/components/ListBox/ListBox.tsx
+++ b/packages/select/src/FilterMultiSelect/components/ListBox/ListBox.tsx
@@ -40,13 +40,14 @@ export const ListBox: React.VFC<ListBoxProps> = ({ children }) => {
     item => !disabledKeys.has(item.key) && !selectedKeys.has(item.key)
   )
   const allItems = Array.from(items)
+  const hasNoItems = allItems.length === 0
 
   const [itemsState, setItemsState] = useState({
     selectedItems,
     unselectedItems,
     disabledItems,
     allItems,
-    hasNoItems: allItems.length <= 0,
+    hasNoItems,
   })
 
   // Only update rendering of items when filtering.
@@ -57,11 +58,11 @@ export const ListBox: React.VFC<ListBoxProps> = ({ children }) => {
       disabledItems,
       unselectedItems,
       allItems,
-      hasNoItems: allItems.length <= 0,
+      hasNoItems,
     })
   }, [selectionState.collection.size])
 
-  if (allItems.length <= 0) {
+  if (hasNoItems) {
     return (
       <>
         <div>{children(itemsState)}</div>

--- a/packages/select/src/FilterMultiSelect/components/ListBox/ListBox.tsx
+++ b/packages/select/src/FilterMultiSelect/components/ListBox/ListBox.tsx
@@ -11,6 +11,7 @@ export interface ListBoxProps {
     unselectedItems: Array<Node<ItemType>>
     disabledItems: Array<Node<ItemType>>
     allItems: Array<Node<ItemType>>
+    hasNoItems: boolean
   }) => React.ReactNode
 }
 
@@ -45,6 +46,7 @@ export const ListBox: React.VFC<ListBoxProps> = ({ children }) => {
     unselectedItems,
     disabledItems,
     allItems,
+    hasNoItems: allItems.length <= 0,
   })
 
   // Only update rendering of items when filtering.
@@ -55,8 +57,19 @@ export const ListBox: React.VFC<ListBoxProps> = ({ children }) => {
       disabledItems,
       unselectedItems,
       allItems,
+      hasNoItems: allItems.length <= 0,
     })
   }, [selectionState.collection.size])
+
+  if (allItems.length <= 0) {
+    return (
+      <>
+        <div>{children(itemsState)}</div>
+        {/* This ul with the ref needs to exist otherwise it fatals */}
+        <ul ref={listRef} className={styles.hidden} />
+      </>
+    )
+  }
 
   return (
     <ul

--- a/packages/select/src/FilterMultiSelect/components/NoResults/NoResults.module.scss
+++ b/packages/select/src/FilterMultiSelect/components/NoResults/NoResults.module.scss
@@ -1,0 +1,3 @@
+.container {
+  padding: 1.125rem; // There's no spacing token for 18px -_-
+}

--- a/packages/select/src/FilterMultiSelect/components/NoResults/NoResults.tsx
+++ b/packages/select/src/FilterMultiSelect/components/NoResults/NoResults.tsx
@@ -1,13 +1,16 @@
-import * as React from "react"
+import React, { HTMLAttributes } from "react"
 import { Paragraph } from "@kaizen/typography"
 import styles from "./NoResults.module.scss"
 
-interface NoResultsProps {
+interface NoResultsProps extends HTMLAttributes<HTMLDivElement> {
   children: React.ReactNode
 }
 
-export const NoResults: React.VFC<NoResultsProps> = (props: NoResultsProps) => (
-  <div className={styles.container}>
-    <Paragraph variant="extra-small">{props.children}</Paragraph>
+export const NoResults: React.VFC<NoResultsProps> = ({
+  children,
+  ...restProps
+}) => (
+  <div className={styles.container} {...restProps}>
+    <Paragraph variant="extra-small">{children}</Paragraph>
   </div>
 )

--- a/packages/select/src/FilterMultiSelect/components/NoResults/NoResults.tsx
+++ b/packages/select/src/FilterMultiSelect/components/NoResults/NoResults.tsx
@@ -2,7 +2,7 @@ import React, { HTMLAttributes } from "react"
 import { Paragraph } from "@kaizen/typography"
 import styles from "./NoResults.module.scss"
 
-interface NoResultsProps extends HTMLAttributes<HTMLDivElement> {
+export interface NoResultsProps extends HTMLAttributes<HTMLDivElement> {
   children: React.ReactNode
 }
 

--- a/packages/select/src/FilterMultiSelect/components/NoResults/NoResults.tsx
+++ b/packages/select/src/FilterMultiSelect/components/NoResults/NoResults.tsx
@@ -1,0 +1,13 @@
+import * as React from "react"
+import { Paragraph } from "@kaizen/typography"
+import styles from "./NoResults.module.scss"
+
+interface NoResultsProps {
+  children: React.ReactNode
+}
+
+export const NoResults: React.VFC<NoResultsProps> = (props: NoResultsProps) => (
+  <div className={styles.container}>
+    <Paragraph variant="extra-small">{props.children}</Paragraph>
+  </div>
+)

--- a/packages/select/src/FilterMultiSelect/components/NoResults/index.ts
+++ b/packages/select/src/FilterMultiSelect/components/NoResults/index.ts
@@ -1,0 +1,1 @@
+export * from "./NoResults"


### PR DESCRIPTION
## What
Creates a new `FilterMultiSelect.NoResults` component for showing a "No results found for [search term]" message inside the dropdown.

## Why
So that users get a confirmation that there's no results, rather than just getting an empty list and wondering if it's broken, or still loading, etc.


