### PR TITLE
ci: update agent queries to restricted

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -5,7 +5,7 @@ env:
   GITHUB_REGISTRY_TOKEN: ${GITHUB_REGISTRY_TOKEN}
 
 x-defaults: &defaults
-  agent_query_rules: ["queue=build-unrestricted"]
+  agent_query_rules: ["queue=build-restricted"]
   plugins:
     - docker-compose#v3.9.0:
         run: build
@@ -41,7 +41,7 @@ steps:
     timeout_in_minutes: 15
     artifact_paths: "./storybook.tar.gz"
     <<: *defaults
-    agent_query_rules: ["queue=build-unrestricted-large"]
+    agent_query_rules: ["queue=build-restricted-large"]
 
   - wait
 
@@ -67,7 +67,7 @@ steps:
     branches: "!main !canary"
     depends_on: "publish-step"
     <<: *defaults
-    agent_query_rules: ["queue=build-unrestricted-large"]
+    agent_query_rules: ["queue=build-restricted-large"]
     plugins:
       - docker#v3.13.0:
           image: mcr.microsoft.com/playwright:v1.28.0-focal


### PR DESCRIPTION
## Why
Our repo is defining tokens directly in Buildkite settings, specifically our GitHub API token for updating PR status with the branch deploy URL. 

This is not a recommended pattern so we are updating our CI pipeline this to use the restricted the agent queue following a successful merge of  this [PR](https://github.com/cultureamp/base-infrastructure-for-services/pull/2652).


For more context check [this thread](https://cultureamp.slack.com/archives/C2F0Q7LQK/p1656303409189089)

## What
- update the build agent queries to restricted
