### PR TITLE
fix: Resolving clearing issue of legacy multi-select [KDS-1030]

### DIFF
--- a/draft-packages/select/KaizenDraft/Select/Select.module.scss
+++ b/draft-packages/select/KaizenDraft/Select/Select.module.scss
@@ -36,6 +36,7 @@ $focus-border-color: $color-blue-500;
 .specificityIncreaser {
   .multiValue {
     margin: 0.2375rem;
+    z-index: 1;
   }
 
   .dropdownIndicator {
@@ -98,6 +99,7 @@ $focus-border-color: $color-blue-500;
     border: 6px $border-solid-border-style transparent;
     border-radius: $border-solid-border-radius;
     box-shadow: $shadow-large-box-shadow;
+    z-index: 3;
 
     // built-in class of React Select that is not easily styled any other way in CSS
     // (This is the "MenuList" div that wraps all the options)


### PR DESCRIPTION
## Why
- When trying to click the "x" to remove one of the tags from the legacy multi-select, it does not remove it but opens the dropdown instead
- It does however work fine using the keyboard

https://user-images.githubusercontent.com/763385/205181669-3fc6513c-95c7-4849-89c9-ac89a385a003.mov

## What
- I noticed that when trying to look at the `Tags` using the DevTools, it wouldn't select them, but the wrapping `div` they're in instead; I couldn't figure out exactly why, but somehow the rendering order is off, so I added a `z-index` to the `Tags` to get them to be rendered on the top level, which now allows the "x" remove button to be clicked


https://user-images.githubusercontent.com/763385/205181938-dfd59ef3-d65c-4165-838a-aa763f5b4b27.mov


