### PR TITLE
chore(deps): Remove unused @typescript-eslint/eslint-plugin-tslint dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,6 @@
     "@types/react": "^18.0.25",
     "@types/react-dom": "^18.0.9",
     "@typescript-eslint/eslint-plugin": "^5.45.0",
-    "@typescript-eslint/eslint-plugin-tslint": "^5.45.0",
     "@typescript-eslint/parser": "^5.45.0",
     "babel-loader": "^9.1.0",
     "chromatic": "^6.11.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5128,14 +5128,6 @@
   dependencies:
     "@types/yargs-parser" "*"
 
-"@typescript-eslint/eslint-plugin-tslint@^5.45.0":
-  version "5.45.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin-tslint/-/eslint-plugin-tslint-5.45.0.tgz#c92e530390865e64dd0aea50c838d00168d1a830"
-  integrity sha512-U5e4VQlHDA+6fW6fqSciLivioExRK3IPHzunwEY0JddAF+X4gkTDmyF3hS0RAl0xf/+Ld4A12dginyPGtJBsbg==
-  dependencies:
-    "@typescript-eslint/utils" "5.45.0"
-    lodash "^4.17.21"
-
 "@typescript-eslint/eslint-plugin@^5.45.0":
   version "5.45.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.45.0.tgz#ffa505cf961d4844d38cfa19dcec4973a6039e41"


### PR DESCRIPTION
Not being used, and TSLint has been deprecated since 2019