### PR TITLE
fix: move the padding to headerRowCell so that it takes the required …

### DIFF
--- a/draft-packages/table/KaizenDraft/Table/Table.module.scss
+++ b/draft-packages/table/KaizenDraft/Table/Table.module.scss
@@ -36,6 +36,8 @@ $row-height-data-variant: 48px;
   align-items: stretch;
   text-align: start;
   justify-content: flex-start;
+  // The 8px usually makes the height of the header cell 40px
+  padding: 8px $spacing-md;
   // This is required as so the tooltip will display directly above the header cell
   position: relative;
 }
@@ -86,8 +88,6 @@ $row-height-data-variant: 48px;
   display: flex;
   align-items: stretch;
   width: 100%;
-  // The 8px usually makes the height of the header cell 40px
-  padding: 8px $spacing-md;
   // Ensures that the 100% doesn't go outside of the `headerRowCell` width
   box-sizing: border-box;
 }


### PR DESCRIPTION
## Why
This PR corrects the header row cell misalignment with body cells. It looks like the padding was placed in the wrong location which resulted in a width miscalculation.

Before
<img width="985" alt="image" src="https://user-images.githubusercontent.com/115598563/206091734-59514ed3-d83d-4de9-bd7b-957dfd28cf1b.png">

After
<img width="986" alt="image" src="https://user-images.githubusercontent.com/115598563/206091447-7a71142c-bc23-42fa-999e-7edbb24c5357.png">

