### PR TITLE
Kds 1061 remove tooltip icon

### DIFF
--- a/draft-packages/table/KaizenDraft/Table/Table.tsx
+++ b/draft-packages/table/KaizenDraft/Table/Table.tsx
@@ -115,6 +115,7 @@ type TableHeaderRowCellProps = OverrideClassName<
   wrapping?: "nowrap" | "wrap"
   align?: "start" | "center" | "end"
   tooltipInfo?: string
+  showTooltipIcon?: boolean
   sortingArrowsOnHover?: "ascending" | "descending" | undefined
 }
 
@@ -141,7 +142,11 @@ export const TableHeaderRowCell: React.VFC<TableHeaderRowCellProps> = ({
   wrapping = "nowrap",
   align = "start",
   tooltipInfo,
-  // if set, this will show the arrow in the direction provided
+  // If set, this will show the tooltip exclamation icon. Useful in situations where
+  // the table header does not have enough space. Should be true by default based on
+  // design system tooltip guidelines.
+  showTooltipIcon = true,
+  // If set, this will show the arrow in the direction provided
   // when the header cell is hovered over.
   sortingArrowsOnHover,
   classNameOverride,
@@ -181,7 +186,7 @@ export const TableHeaderRowCell: React.VFC<TableHeaderRowCellProps> = ({
           />
         </div>
       )}
-      {tooltipInfo != null ? (
+      {tooltipInfo != null && showTooltipIcon ? (
         <div className={styles.headerRowCellTooltipIcon}>
           <Icon icon={exclamationIcon} role="presentation" />
         </div>

--- a/draft-packages/table/docs/Table.stories.tsx
+++ b/draft-packages/table/docs/Table.stories.tsx
@@ -452,25 +452,23 @@ export const Tooltip = () => (
     <TableContainer>
       <TableHeader>
         <TableHeaderRow>
+          <TableHeaderRowCell labelText="No tooltip" width={1 / 4} />
           <TableHeaderRowCell
-            labelText="This column has no tooltip"
-            width={1 / 4}
-          />
-          <TableHeaderRowCell
-            labelText="This column has a tooltip"
+            labelText="Tooltip"
             width={1 / 4}
             tooltipInfo="This is a tooltip"
           />
           <TableHeaderRowCell
-            labelText="This column has a tooltip, and has wrapped content!"
+            labelText="Tooltip with wrapped content"
             width={1 / 4}
             wrapping="wrap"
             tooltipInfo="This is a tooltip"
           />
           <TableHeaderRowCell
-            labelText="End (right) aligned"
+            labelText="End aligned, no icon"
             width={1 / 4}
-            tooltipInfo="This is a tooltip"
+            tooltipInfo="This is a tooltip even though there was no icon"
+            showTooltipIcon={false}
             align="end"
           />
         </TableHeaderRow>
@@ -479,22 +477,23 @@ export const Tooltip = () => (
         <TableRow>
           <TableRowCell width={1 / 4}>
             <Paragraph tag="div" variant="body">
-              This is a cell
+              This header of this cell does not have a tooltip.
             </Paragraph>
           </TableRowCell>
           <TableRowCell width={1 / 4}>
             <Paragraph tag="div" variant="body">
-              This is a cell
+              This header of this cell does have a tooltip.
             </Paragraph>
           </TableRowCell>
           <TableRowCell width={1 / 4}>
             <Paragraph tag="div" variant="body">
-              This is a cell
+              This header of this cell has a tooltip. It's content is wrapped.
             </Paragraph>
           </TableRowCell>
           <TableRowCell width={1 / 4}>
             <Paragraph tag="div" variant="body">
-              This is a cell
+              This header of this cell has a tooltip. It's content is end
+              (right) aligned. It does not have a tooltip icon.
             </Paragraph>
           </TableRowCell>
         </TableRow>


### PR DESCRIPTION
## Why
This PR adds a `showTooltipIcon` prop which is set to true by default.

The `showTooltipIcon` prop is handy for situations where there is not a lot of room in the TableHeaderRowCell as shown in the example below and in ticket [KDS-1061](https://cultureamp.atlassian.net/browse/KDS-1061).


## What
Example of how the `showTooltipProp` will look when set to false.
<img width="1056" alt="image" src="https://user-images.githubusercontent.com/115598563/208323790-dc2160d5-ed09-4423-9212-49b21f12f598.png">

Example of a Table with not enough room for the tooltip icon in the header.
<img width="1992" alt="image" src="https://user-images.githubusercontent.com/115598563/208323881-926917d9-b44d-428a-8846-a26f7ff513ef.png">
