### PR TITLE
feat(GuidanceBlock): Add content prop to allow for custom markup

### DIFF
--- a/draft-packages/guidance-block/KaizenDraft/GuidanceBlock/GuidanceBlock.tsx
+++ b/draft-packages/guidance-block/KaizenDraft/GuidanceBlock/GuidanceBlock.tsx
@@ -37,17 +37,14 @@ type VariantType =
   | "assertive"
   | "prominent"
 
-export type GuidanceBlockProps = {
+interface BaseGuidanceBlockProps {
   layout?: LayoutType
   illustration: React.ReactElement<SpotProps | SceneProps>
   /*
    * Sets how the width and aspect ratio will respond to the Illustration passed in.
    */
   illustrationType?: IllustrationType
-  text: {
-    title: string
-    description: string | React.ReactNode
-  }
+
   smallScreenTextAlignment?: TextAlignment
   actions?: GuidanceBlockActions
   /*
@@ -63,6 +60,21 @@ export type GuidanceBlockProps = {
   withActionButtonArrow?: boolean
   noMaxWidth?: boolean
 }
+
+interface GuidanceBlockWithText extends BaseGuidanceBlockProps {
+  text: {
+    title: string
+    description: string | React.ReactNode
+  }
+}
+
+interface GuidanceBlockPropsWithContent extends BaseGuidanceBlockProps {
+  content: React.ReactElement
+}
+
+export type GuidanceBlockProps =
+  | GuidanceBlockWithText
+  | GuidanceBlockPropsWithContent
 
 export type GuidanceBlockState = {
   hidden: boolean
@@ -198,7 +210,6 @@ class GuidanceBlock extends React.Component<
     const {
       actions,
       illustration,
-      text,
       persistent,
       withActionButtonArrow,
       noMaxWidth,
@@ -221,14 +232,19 @@ class GuidanceBlock extends React.Component<
         </div>
         <div className={styles.descriptionAndActions}>
           <div className={styles.descriptionContainer}>
-            <div className={styles.headingWrapper}>
-              <Heading tag="h3" variant="heading-3">
-                {text.title}
-              </Heading>
-            </div>
-            <Paragraph tag="p" variant="body">
-              {text.description}
-            </Paragraph>
+            {"content" in this.props && this.props.content}
+            {"text" in this.props && (
+              <>
+                <div className={styles.headingWrapper}>
+                  <Heading tag="h3" variant="heading-3">
+                    {this.props.text.title}
+                  </Heading>
+                </div>
+                <Paragraph tag="p" variant="body">
+                  {this.props.text.description}
+                </Paragraph>
+              </>
+            )}
           </div>
           {actions?.primary &&
             this.renderActions(actions, withActionButtonArrow)}

--- a/draft-packages/guidance-block/docs/GuidanceBlock.stories.tsx
+++ b/draft-packages/guidance-block/docs/GuidanceBlock.stories.tsx
@@ -1,6 +1,7 @@
 import React from "react"
 import { Story } from "@storybook/react"
 import { withDesign } from "storybook-addon-designs"
+import { Box } from "@kaizen/component-library"
 import { GuidanceBlock } from "@kaizen/draft-guidance-block"
 import {
   Informative,
@@ -10,11 +11,13 @@ import {
   EmptyStatesPositive,
   BrandMomentPositiveOutro,
 } from "@kaizen/draft-illustration"
-import { Heading } from "@kaizen/typography"
+import { Tag } from "@kaizen/draft-tag"
+import { Heading, Paragraph } from "@kaizen/typography"
 import { StoryWrapper } from "../../../storybook/components/StoryWrapper"
 import { CATEGORIES } from "../../../storybook/constants"
 import { figmaEmbed } from "../../../storybook/helpers"
 import { GuidanceBlockProps } from "../KaizenDraft/GuidanceBlock/GuidanceBlock"
+import styles from "../KaizenDraft/GuidanceBlock/GuidanceBlock.module.scss"
 
 const ICON_EXTERNAL_LINK =
   require("@kaizen/component-library/icons/external-link.icon.svg").default
@@ -98,6 +101,10 @@ DefaultStory.argTypes = {
     description:
       "This takes a scene scene or spot element, ie: `<Informative />`. This radio button implementation is a storybook only representation to toggle between the two illustration styles.",
   },
+  content: {
+    description:
+      "If you need to render custom content inside of the `GuidanceBlock` that is more than just a title and description use this prop instead of the default `text` option.",
+  },
 }
 
 const PROPS: GuidanceBlockProps = {
@@ -113,6 +120,24 @@ const PROPS: GuidanceBlockProps = {
     },
   },
 }
+
+const CustomContent = () => (
+  <>
+    <Box mb={0.75}>
+      <Tag variant="statusLive" size="small">
+        Early Access
+      </Tag>
+    </Box>
+    <Box mb={1}>
+      <Heading tag="h3" variant="heading-3">
+        {GUIDANCE_BLOCK_TEXT.title}
+      </Heading>
+    </Box>
+    <Paragraph tag="p" variant="body">
+      {GUIDANCE_BLOCK_TEXT.description}
+    </Paragraph>
+  </>
+)
 
 const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({
   isReversed,
@@ -134,6 +159,9 @@ const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({
     <StoryWrapper.Row rowTitle="Negative">
       <GuidanceBlock variant="negative" {...PROPS} />
     </StoryWrapper.Row>
+    <StoryWrapper.Row rowTitle="Prominent">
+      <GuidanceBlock variant="prominent" {...PROPS} />
+    </StoryWrapper.Row>
     <StoryWrapper.Row rowTitle="No arrow">
       <GuidanceBlock
         illustration={<Informative alt="" />}
@@ -152,6 +180,26 @@ const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({
           },
         }}
         persistent
+      />
+    </StoryWrapper.Row>
+    <StoryWrapper.Row rowTitle="Custom Content">
+      <GuidanceBlock
+        illustration={<Informative alt="" />}
+        content={<CustomContent />}
+        noMaxWidth
+        persistent
+        actions={{
+          primary: {
+            label: "Learn more",
+            onClick: () => {
+              alert("tada: 🎉")
+            },
+          },
+          secondary: {
+            label: "Dismiss",
+            href: "#",
+          },
+        }}
       />
     </StoryWrapper.Row>
     <StoryWrapper.Row rowTitle="Tooltip">

--- a/draft-packages/guidance-block/docs/GuidanceBlock.stories.tsx
+++ b/draft-packages/guidance-block/docs/GuidanceBlock.stories.tsx
@@ -17,7 +17,6 @@ import { StoryWrapper } from "../../../storybook/components/StoryWrapper"
 import { CATEGORIES } from "../../../storybook/constants"
 import { figmaEmbed } from "../../../storybook/helpers"
 import { GuidanceBlockProps } from "../KaizenDraft/GuidanceBlock/GuidanceBlock"
-import styles from "../KaizenDraft/GuidanceBlock/GuidanceBlock.module.scss"
 
 const ICON_EXTERNAL_LINK =
   require("@kaizen/component-library/icons/external-link.icon.svg").default

--- a/draft-packages/guidance-block/package.json
+++ b/draft-packages/guidance-block/package.json
@@ -39,6 +39,7 @@
     "react-media": "^1.10.0"
   },
   "devDependencies": {
+    "@kaizen/draft-tag": "^3.2.15",
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -13564,7 +13564,6 @@ moo-color@^1.0.2:
 
 motion-ui@cultureamp/motion-ui:
   version "2.0.3"
-  uid b15622a9afe00d5bb88c07ecf1451e0affdf155c
   resolved "https://codeload.github.com/cultureamp/motion-ui/tar.gz/b15622a9afe00d5bb88c07ecf1451e0affdf155c"
 
 move-concurrently@^1.0.1:


### PR DESCRIPTION
## Why
<!-- Why have you created this PR? - Is it a new feature, or a bug fix? Or something else? -->
<!-- Reference any relevant Jira tickets so your reviewer can find more context if needed. -->
<!-- Fixing a GitHub issue? Add "Fixes [issue URL]". -->

Team Home has a requirement to add an Early Access tag above the GuidanceBlock heading. Currently GuidanceBlock only allows for title and description text field. This limits our ability to add necessary markup to achieve the product vision.

## What
<!-- What do your changes do? How do they change/fix the current behavior? -->
<!-- Add screenshots, GIFs or videos to illustrate the changes.  -->

By adding `content` prop for custom markup, consumers are able to better match design requirements to custom markup.

![image](https://user-images.githubusercontent.com/26860255/209054115-82608be4-7346-44f4-a519-f99c4fded5f6.png)

