### PR TITLE
docs: add return types to stories and tests

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -260,7 +260,6 @@ module.exports = {
       files: ["*.stories.tsx", "*.spec.tsx", "*.docsExample.tsx"],
       rules: {
         "import/no-extraneous-dependencies": "off",
-        "@typescript-eslint/explicit-function-return-type": "off",
       },
     },
   ],

--- a/draft-packages/avatar/KaizenDraft/Avatar/AvatarGroup.spec.tsx
+++ b/draft-packages/avatar/KaizenDraft/Avatar/AvatarGroup.spec.tsx
@@ -1,4 +1,4 @@
-import * as React from "react"
+import React from "react"
 import { render, screen } from "@testing-library/react"
 import { AvatarGroup, AvatarList } from "./AvatarGroup"
 

--- a/draft-packages/avatar/docs/Avatar.stories.tsx
+++ b/draft-packages/avatar/docs/Avatar.stories.tsx
@@ -67,7 +67,9 @@ export default {
   decorators: [withDesign],
 } as ComponentMeta<typeof Avatar>
 
-export const DefaultStory: ComponentStory<typeof Avatar> = args => <Avatar {...args} />
+export const DefaultStory: ComponentStory<typeof Avatar> = args => (
+  <Avatar {...args} />
+)
 DefaultStory.storyName = "Default (Kaizen Demo)"
 DefaultStory.args = {
   avatarSrc:

--- a/draft-packages/avatar/docs/Avatar.stories.tsx
+++ b/draft-packages/avatar/docs/Avatar.stories.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { Story } from "@storybook/react"
+import { ComponentMeta, ComponentStory, Story } from "@storybook/react"
 import { withDesign } from "storybook-addon-designs"
 import { StoryWrapper } from "../../../storybook/components/StoryWrapper"
 import { CATEGORIES } from "../../../storybook/constants"
@@ -65,9 +65,9 @@ export default {
     ),
   },
   decorators: [withDesign],
-}
+} as ComponentMeta<typeof Avatar>
 
-export const DefaultStory = args => <Avatar {...args} />
+export const DefaultStory: ComponentStory<typeof Avatar> = args => <Avatar {...args} />
 DefaultStory.storyName = "Default (Kaizen Demo)"
 DefaultStory.args = {
   avatarSrc:

--- a/draft-packages/avatar/docs/AvatarGroup.stories.tsx
+++ b/draft-packages/avatar/docs/AvatarGroup.stories.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { ComponentStory, Story } from "@storybook/react"
+import { ComponentMeta, ComponentStory, Story } from "@storybook/react"
 import { withDesign } from "storybook-addon-designs"
 import { StoryWrapper } from "../../../storybook/components/StoryWrapper"
 import { CATEGORIES } from "../../../storybook/constants"
@@ -71,12 +71,11 @@ export default {
     ),
   },
   decorators: [withDesign],
-}
+} as ComponentMeta<typeof AvatarGroup>
 
 export const DefaultStory: ComponentStory<typeof AvatarGroup> = args => (
   <AvatarGroup {...args} />
 )
-
 DefaultStory.storyName = "Default (Kaizen Demo)"
 DefaultStory.args = {
   maxVisible: 2,

--- a/draft-packages/badge/KaizenDraft/Badge/Badge.spec.tsx
+++ b/draft-packages/badge/KaizenDraft/Badge/Badge.spec.tsx
@@ -1,11 +1,10 @@
-import * as React from "react"
+import React from "react"
 import { cleanup, render, screen } from "@testing-library/react"
-
 import { Badge, BadgeProps } from "./Badge"
 
 afterEach(cleanup)
 
-const renderBadge = (props?: BadgeProps) => render(<Badge {...props} />)
+const renderBadge = (props?: BadgeProps): ReturnType<typeof render> => render(<Badge {...props} />)
 
 describe("<Badge />", () => {
   describe("default", () => {

--- a/draft-packages/badge/KaizenDraft/Badge/Badge.spec.tsx
+++ b/draft-packages/badge/KaizenDraft/Badge/Badge.spec.tsx
@@ -4,7 +4,8 @@ import { Badge, BadgeProps } from "./Badge"
 
 afterEach(cleanup)
 
-const renderBadge = (props?: BadgeProps): ReturnType<typeof render> => render(<Badge {...props} />)
+const renderBadge = (props?: BadgeProps): ReturnType<typeof render> =>
+  render(<Badge {...props} />)
 
 describe("<Badge />", () => {
   describe("default", () => {

--- a/draft-packages/badge/docs/Badge.stories.tsx
+++ b/draft-packages/badge/docs/Badge.stories.tsx
@@ -56,20 +56,30 @@ const BadgeAnimationStoryWrapper = ({
   )
 }
 
-export const DefaultStory: Story<Omit<BadgeProps, "children">> = ({ variant, ...args }) => (
+export const DefaultStory: Story<Omit<BadgeProps, "children">> = ({
+  variant,
+  ...args
+}) => (
   <BadgeAnimationStoryWrapper>
     {(badgeCount, useAnimation): JSX.Element => {
       if (useAnimation) {
-        return variant === "dot"
-          ? <BadgeAnimated variant={variant} {...args} />
-          : <BadgeAnimated variant={variant} {...args}>{badgeCount}</BadgeAnimated>
+        return variant === "dot" ? (
+          <BadgeAnimated variant={variant} {...args} />
+        ) : (
+          <BadgeAnimated variant={variant} {...args}>
+            {badgeCount}
+          </BadgeAnimated>
+        )
       }
 
-      return variant === "dot"
-         ? <Badge variant={variant} {...args} />
-         : <Badge variant={variant} {...args}>{badgeCount}</Badge>
-      }
-    }
+      return variant === "dot" ? (
+        <Badge variant={variant} {...args} />
+      ) : (
+        <Badge variant={variant} {...args}>
+          {badgeCount}
+        </Badge>
+      )
+    }}
   </BadgeAnimationStoryWrapper>
 )
 DefaultStory.storyName = "Default (Kaizen Demo)"

--- a/draft-packages/badge/docs/Badge.stories.tsx
+++ b/draft-packages/badge/docs/Badge.stories.tsx
@@ -1,8 +1,8 @@
 import React from "react"
-import { Story } from "@storybook/react"
+import { ComponentMeta, Story } from "@storybook/react"
 import { withDesign } from "storybook-addon-designs"
 import { Button } from "@kaizen/button"
-import { Badge, BadgeAnimated } from "@kaizen/draft-badge"
+import { Badge, BadgeAnimated, BadgeProps } from "@kaizen/draft-badge"
 import { ToggleSwitchField, ToggledStatus } from "@kaizen/draft-form"
 import { StoryWrapper } from "../../../storybook/components/StoryWrapper"
 import { CATEGORIES } from "../../../storybook/constants"
@@ -25,10 +25,12 @@ export default {
     ),
   },
   decorators: [withDesign],
-}
+} as ComponentMeta<typeof Badge>
+
 type BadgeAnimationStoryWrapperProps = {
   children: (badgeCount: string, useAnimation: boolean) => void
 }
+
 const BadgeAnimationStoryWrapper = ({
   children,
 }: BadgeAnimationStoryWrapperProps): JSX.Element => {
@@ -41,31 +43,32 @@ const BadgeAnimationStoryWrapper = ({
       <div style={{ height: "40px" }} />
       <ToggleSwitchField
         toggledStatus={useAnimation ? ToggledStatus.ON : ToggledStatus.OFF}
-        onToggle={() => {
-          setUseAnimation(s => !s)
-        }}
+        onToggle={(): void => setUseAnimation(s => !s)}
         labelText="Use Animation"
       />
       {useAnimation && (
         <Button
           label="Add Badge Number"
-          onClick={() => {
-            setBadgeCount(s => s + 1)
-          }}
+          onClick={(): void => setBadgeCount(s => s + 1)}
         />
       )}
     </>
   )
 }
 
-export const DefaultStory = args => (
+export const DefaultStory: Story<Omit<BadgeProps, "children">> = ({ variant, ...args }) => (
   <BadgeAnimationStoryWrapper>
-    {(badgeCount, useAnimation) =>
-      useAnimation ? (
-        <BadgeAnimated {...args}>{badgeCount}</BadgeAnimated>
-      ) : (
-        <Badge {...args}>{badgeCount}</Badge>
-      )
+    {(badgeCount, useAnimation): JSX.Element => {
+      if (useAnimation) {
+        return variant === "dot"
+          ? <BadgeAnimated variant={variant} {...args} />
+          : <BadgeAnimated variant={variant} {...args}>{badgeCount}</BadgeAnimated>
+      }
+
+      return variant === "dot"
+         ? <Badge variant={variant} {...args} />
+         : <Badge variant={variant} {...args}>{badgeCount}</Badge>
+      }
     }
   </BadgeAnimationStoryWrapper>
 )

--- a/draft-packages/card/docs/Card.stories.tsx
+++ b/draft-packages/card/docs/Card.stories.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { Story } from "@storybook/react"
+import { ComponentMeta, ComponentStory, Story } from "@storybook/react"
 import { withDesign } from "storybook-addon-designs"
 import { StoryWrapper } from "../../../storybook/components/StoryWrapper"
 import { CATEGORIES } from "../../../storybook/constants"
@@ -21,9 +21,9 @@ export default {
     ),
   },
   decorators: [withDesign],
-}
+} as ComponentMeta<typeof Card>
 
-export const DefaultStory = args => (
+export const DefaultStory: ComponentStory<typeof Card> = args => (
   <Card {...args}>This is a default container</Card>
 )
 DefaultStory.storyName = "Default (Kaizen Site Demo)"

--- a/draft-packages/collapsible/KaizenDraft/Collapsible/Collapsible.spec.tsx
+++ b/draft-packages/collapsible/KaizenDraft/Collapsible/Collapsible.spec.tsx
@@ -1,4 +1,4 @@
-import * as React from "react"
+import React from "react"
 import { fireEvent, configure, queryByTestId } from "@testing-library/dom"
 import { render } from "@testing-library/react"
 import { Collapsible, CollapsibleGroup } from ".."
@@ -106,7 +106,7 @@ it("gives precedence to renderHeader over title", () => {
       id="1"
       open
       title="Should not be rendered"
-      renderHeader={() => <div>This title should be rendered</div>}
+      renderHeader={(): JSX.Element => <div>This title should be rendered</div>}
     >
       First panel content
     </Collapsible>

--- a/draft-packages/collapsible/KaizenDraft/ExpertAdviceCollapsible/ExpertAdviceCollapsible.spec.tsx
+++ b/draft-packages/collapsible/KaizenDraft/ExpertAdviceCollapsible/ExpertAdviceCollapsible.spec.tsx
@@ -1,4 +1,4 @@
-import * as React from "react"
+import React from "react"
 import { render, screen } from "@testing-library/react"
 import { Paragraph } from "@kaizen/typography"
 import { ExpertAdviceCollapsible } from ".."

--- a/draft-packages/collapsible/docs/CollapsibleGroup.stories.tsx
+++ b/draft-packages/collapsible/docs/CollapsibleGroup.stories.tsx
@@ -28,7 +28,9 @@ export default {
   },
 } as ComponentMeta<typeof CollapsibleGroup>
 
-export const CollapsibleGroupDefault: ComponentStory<typeof CollapsibleGroup> = args => (
+export const CollapsibleGroupDefault: ComponentStory<
+  typeof CollapsibleGroup
+> = args => (
   <CollapsibleGroup {...args}>
     <Collapsible id="collapsible-separate-1" open title="First panel">
       <Paragraph variant="body">{lipsum}</Paragraph>

--- a/draft-packages/collapsible/docs/CollapsibleGroup.stories.tsx
+++ b/draft-packages/collapsible/docs/CollapsibleGroup.stories.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { Story } from "@storybook/react"
+import { ComponentMeta, ComponentStory, Story } from "@storybook/react"
 import { Collapsible, CollapsibleGroup } from "@kaizen/draft-collapsible"
 import { Paragraph } from "@kaizen/typography"
 import { StoryWrapper } from "../../../storybook/components/StoryWrapper"
@@ -26,9 +26,9 @@ export default {
       },
     },
   },
-}
+} as ComponentMeta<typeof CollapsibleGroup>
 
-export const CollapsibleGroupDefault = args => (
+export const CollapsibleGroupDefault: ComponentStory<typeof CollapsibleGroup> = args => (
   <CollapsibleGroup {...args}>
     <Collapsible id="collapsible-separate-1" open title="First panel">
       <Paragraph variant="body">{lipsum}</Paragraph>
@@ -43,7 +43,7 @@ export const CollapsibleGroupDefault = args => (
 )
 CollapsibleGroupDefault.storyName = "Collapsible Group"
 
-const CollapsibleGroupVariantClear = () => (
+const CollapsibleGroupVariantClear = (): JSX.Element => (
   <CollapsibleGroup>
     <Collapsible
       variant="clear"
@@ -69,7 +69,8 @@ const CollapsibleGroupVariantClear = () => (
     </Collapsible>
   </CollapsibleGroup>
 )
-const CollapsibleGroupSeparated = () => (
+
+const CollapsibleGroupSeparated = (): JSX.Element => (
   <CollapsibleGroup separated>
     <Collapsible id="collapsible-separate-1" open title="First panel">
       <Paragraph variant="body">{lipsum}</Paragraph>
@@ -83,7 +84,7 @@ const CollapsibleGroupSeparated = () => (
   </CollapsibleGroup>
 )
 
-const CollapsibleGroupStickyHeaders = () => (
+const CollapsibleGroupStickyHeaders = (): JSX.Element => (
   <CollapsibleGroup separated sticky={{ top: "0" }}>
     <Collapsible id="collapsible-separate-1" title="First panel" open>
       <Paragraph variant="body">{lipsum}</Paragraph>

--- a/draft-packages/collapsible/docs/ExpertAdviceCollapsible.stories.tsx
+++ b/draft-packages/collapsible/docs/ExpertAdviceCollapsible.stories.tsx
@@ -1,13 +1,9 @@
 import React from "react"
+import { ComponentMeta, Story } from "@storybook/react"
 import { Box } from "@kaizen/component-library"
 import { ExpertAdviceCollapsible } from "@kaizen/draft-collapsible"
 import { Paragraph } from "@kaizen/typography"
 import { CATEGORIES } from "../../../storybook/constants"
-import styles from "./Collapsible.stories.module.scss"
-
-const ListItem = ({ children }: { children: JSX.Element }) => (
-  <div className={styles.listItem}>{children}</div>
-)
 
 const lipsum = `Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus
 ac scelerisque sem, vel ultricies justo. Donec eu porttitor ante,
@@ -30,9 +26,9 @@ export default {
       },
     },
   },
-}
+} as ComponentMeta<typeof ExpertAdviceCollapsible>
 
-export const DefaultStory = () => (
+export const DefaultStory: Story = () => (
   <Box m={1}>
     <ExpertAdviceCollapsible id="123" title="Expert advice collapsible">
       <Paragraph variant="body">{lipsum}</Paragraph>

--- a/draft-packages/collapsible/docs/SingleCollapsible.stories.tsx
+++ b/draft-packages/collapsible/docs/SingleCollapsible.stories.tsx
@@ -111,7 +111,9 @@ const SingleCollapsibleLazyLoad = (): JSX.Element => (
   </Collapsible>
 )
 
-export const SingleCollapsibleKaizenSiteDemo: ComponentStory<typeof Collapsible> = args => (
+export const SingleCollapsibleKaizenSiteDemo: ComponentStory<
+  typeof Collapsible
+> = args => (
   <Collapsible {...args}>
     <Paragraph variant="body">{lipsum}</Paragraph>
   </Collapsible>

--- a/draft-packages/collapsible/docs/SingleCollapsible.stories.tsx
+++ b/draft-packages/collapsible/docs/SingleCollapsible.stories.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { Story } from "@storybook/react"
+import { ComponentMeta, ComponentStory, Story } from "@storybook/react"
 import { IconButton } from "@kaizen/button"
 import addIcon from "@kaizen/component-library/icons/add.icon.svg"
 import kebabIcon from "@kaizen/component-library/icons/kebab.icon.svg"
@@ -9,7 +9,7 @@ import { StoryWrapper } from "../../../storybook/components/StoryWrapper"
 import { CATEGORIES } from "../../../storybook/constants"
 import styles from "./Collapsible.stories.module.scss"
 
-const ListItem = ({ children }: { children: JSX.Element }) => (
+const ListItem = ({ children }: { children: JSX.Element }): JSX.Element => (
   <div className={styles.listItem}>{children}</div>
 )
 
@@ -34,9 +34,9 @@ export default {
       },
     },
   },
-}
+} as ComponentMeta<typeof Collapsible>
 
-const SingleCollapsibleNoPadding = () => (
+const SingleCollapsibleNoPadding = (): JSX.Element => (
   <Collapsible
     id="collapsible-single"
     open
@@ -59,13 +59,13 @@ const SingleCollapsibleNoPadding = () => (
   </Collapsible>
 )
 
-const SingleCollapsibleCustomHeader = () => (
+const SingleCollapsibleCustomHeader = (): JSX.Element => (
   <Collapsible
     id="collapsible-single"
     open
     title="Custom header"
     variant="default"
-    renderHeader={title => (
+    renderHeader={(title): JSX.Element => (
       <>
         <div style={{ flex: "1 0 auto" }}>
           <Heading variant="heading-4" tag="span">
@@ -75,7 +75,7 @@ const SingleCollapsibleCustomHeader = () => (
         <IconButton
           icon={addIcon}
           label="Add item"
-          onClick={event => {
+          onClick={(event): void => {
             // When adding extra actions you have to stop propagation to avoid this triggering the collapse/uncollapsible behaviour
             event.stopPropagation()
           }}
@@ -83,7 +83,7 @@ const SingleCollapsibleCustomHeader = () => (
         <IconButton
           icon={kebabIcon}
           label="More actions"
-          onClick={event => {
+          onClick={(event): void => {
             // When adding extra actions you have to stop propagation to avoid this triggering the collapse/uncollapsible behaviour
             event.stopPropagation()
           }}
@@ -97,7 +97,7 @@ const SingleCollapsibleCustomHeader = () => (
   </Collapsible>
 )
 
-const SingleCollapsibleLazyLoad = () => (
+const SingleCollapsibleLazyLoad = (): JSX.Element => (
   <Collapsible id="collapsible-single" title="Single collapsible" lazyLoad>
     <Paragraph variant="body">
       This content won't be rendered until the collapsible is opened. This is
@@ -111,13 +111,14 @@ const SingleCollapsibleLazyLoad = () => (
   </Collapsible>
 )
 
-export const SingleCollapsibleKaizenSiteDemo = args => (
-  <Collapsible id="collapsible-single" {...args}>
+export const SingleCollapsibleKaizenSiteDemo: ComponentStory<typeof Collapsible> = args => (
+  <Collapsible {...args}>
     <Paragraph variant="body">{lipsum}</Paragraph>
   </Collapsible>
 )
 SingleCollapsibleKaizenSiteDemo.storyName = "Collapsible"
 SingleCollapsibleKaizenSiteDemo.args = {
+  id: "collapsible-single",
   open: true,
   title: "Single Collapsible",
 }

--- a/draft-packages/divider/docs/Divider.stories.tsx
+++ b/draft-packages/divider/docs/Divider.stories.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { Story } from "@storybook/react"
+import { ComponentMeta, ComponentStory, Story } from "@storybook/react"
 import { withDesign } from "storybook-addon-designs"
 import { Box } from "@kaizen/component-library"
 import { Card } from "@kaizen/draft-card"
@@ -23,14 +23,17 @@ export default {
     ),
   },
   decorators: [withDesign],
-}
+} as ComponentMeta<typeof Divider>
 
-export const DefaultStory = args => (
+export const DefaultStory: ComponentStory<typeof Divider> = args => (
   <Box m={1}>
-    <Divider variant="canvas" {...args} />
+    <Divider {...args} />
   </Box>
 )
 DefaultStory.storyName = "Default (Kaizen Demo)"
+DefaultStory.args = {
+  variant: "canvas"
+}
 
 const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({
   isReversed,

--- a/draft-packages/divider/docs/Divider.stories.tsx
+++ b/draft-packages/divider/docs/Divider.stories.tsx
@@ -32,7 +32,7 @@ export const DefaultStory: ComponentStory<typeof Divider> = args => (
 )
 DefaultStory.storyName = "Default (Kaizen Demo)"
 DefaultStory.args = {
-  variant: "canvas"
+  variant: "canvas",
 }
 
 const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({

--- a/draft-packages/empty-state/KaizenDraft/EmptyState/EmptyState.spec.tsx
+++ b/draft-packages/empty-state/KaizenDraft/EmptyState/EmptyState.spec.tsx
@@ -5,10 +5,18 @@ import { EmptyStateProps } from "./EmptyState"
 import { EmptyState } from "."
 
 jest.mock("@kaizen/draft-illustration", () => ({
-  EmptyStatesPositive: (): JSX.Element => <div>EmptyStatesPositive_Component</div>,
-  EmptyStatesNeutral: (): JSX.Element => <div>EmptyStatesNeutral_Component</div>,
-  EmptyStatesNegative: (): JSX.Element => <div>EmptyStatesNegative_Component</div>,
-  EmptyStatesInformative: (): JSX.Element => <div>EmptyStatesInformative_Component</div>,
+  EmptyStatesPositive: (): JSX.Element => (
+    <div>EmptyStatesPositive_Component</div>
+  ),
+  EmptyStatesNeutral: (): JSX.Element => (
+    <div>EmptyStatesNeutral_Component</div>
+  ),
+  EmptyStatesNegative: (): JSX.Element => (
+    <div>EmptyStatesNegative_Component</div>
+  ),
+  EmptyStatesInformative: (): JSX.Element => (
+    <div>EmptyStatesInformative_Component</div>
+  ),
   EmptyStatesAction: (): JSX.Element => <div>EmptyStatesAction_Component</div>,
 }))
 

--- a/draft-packages/empty-state/KaizenDraft/EmptyState/EmptyState.spec.tsx
+++ b/draft-packages/empty-state/KaizenDraft/EmptyState/EmptyState.spec.tsx
@@ -1,15 +1,15 @@
-import * as React from "react"
+import React from "react"
 import { cleanup, render, screen } from "@testing-library/react"
 
 import { EmptyStateProps } from "./EmptyState"
 import { EmptyState } from "."
 
 jest.mock("@kaizen/draft-illustration", () => ({
-  EmptyStatesPositive: () => <div>EmptyStatesPositive_Component</div>,
-  EmptyStatesNeutral: () => <div>EmptyStatesNeutral_Component</div>,
-  EmptyStatesNegative: () => <div>EmptyStatesNegative_Component</div>,
-  EmptyStatesInformative: () => <div>EmptyStatesInformative_Component</div>,
-  EmptyStatesAction: () => <div>EmptyStatesAction_Component</div>,
+  EmptyStatesPositive: (): JSX.Element => <div>EmptyStatesPositive_Component</div>,
+  EmptyStatesNeutral: (): JSX.Element => <div>EmptyStatesNeutral_Component</div>,
+  EmptyStatesNegative: (): JSX.Element => <div>EmptyStatesNegative_Component</div>,
+  EmptyStatesInformative: (): JSX.Element => <div>EmptyStatesInformative_Component</div>,
+  EmptyStatesAction: (): JSX.Element => <div>EmptyStatesAction_Component</div>,
 }))
 
 describe("<EmptyState />", () => {

--- a/draft-packages/filter-menu-button/docs/FilterMenuButton.stories.tsx
+++ b/draft-packages/filter-menu-button/docs/FilterMenuButton.stories.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react"
-import { ComponentStory } from "@storybook/react"
+import { ComponentStory, Story } from "@storybook/react"
 import isChromatic from "chromatic/isChromatic"
 import { Button } from "@kaizen/button"
 import { Box } from "@kaizen/component-library"
@@ -63,11 +63,11 @@ const SimpleFilterTemplate: ComponentStory<typeof FilterMenuButton> = ({
     .map(trait => trait.label)
     .join(", ")
 
-  const toggleDropdown = () => setIsDropdownVisible(!isDropdownVisible)
+  const toggleDropdown = (): void => setIsDropdownVisible(!isDropdownVisible)
 
-  const hideDropdown = () => setIsDropdownVisible(false)
+  const hideDropdown = (): void => setIsDropdownVisible(false)
 
-  const onCheckboxChange = (option: DropdownOption) => {
+  const onCheckboxChange = (option: DropdownOption): void => {
     if (appliedFilters.find(filter => filter.id === option.id)) {
       setAppliedFilters(
         appliedFilters.filter(filter => filter.id !== option.id)
@@ -93,7 +93,7 @@ const SimpleFilterTemplate: ComponentStory<typeof FilterMenuButton> = ({
             {DROPDOWN_OPTIONS.map(trait => (
               <CheckboxField
                 key={trait.id}
-                onCheck={() => onCheckboxChange(trait)}
+                onCheck={(): void => onCheckboxChange(trait)}
                 id={`checkbox-${trait.id}`}
                 checkedStatus={
                   appliedFilters.find(({ id }) => id === trait.id)
@@ -128,14 +128,14 @@ DefaultStory.parameters = {
   docs: { source: { type: "code" } },
 }
 
-export const DefaultEmpty = () => {
+export const DefaultEmpty: Story = () => {
   const [isDropdownVisible, setIsDropdownVisible] = useState(
     IS_INITIAL_DROPDOWN_VISIBLE
   )
 
-  const toggleDropdown = () => setIsDropdownVisible(!isDropdownVisible)
+  const toggleDropdown = (): void => setIsDropdownVisible(!isDropdownVisible)
 
-  const hideDropdown = () => setIsDropdownVisible(false)
+  const hideDropdown = (): void => setIsDropdownVisible(false)
 
   return (
     <FilterMenuButton
@@ -170,7 +170,7 @@ DefaultWithChildrenSimpleFilter.parameters = {
   docs: { source: { type: "code" } },
 }
 
-export const DefaultWithChildrenAdvancedFilter = () => {
+export const DefaultWithChildrenAdvancedFilter: Story = () => {
   const [isDropdownVisible, setIsDropdownVisible] = useState(
     IS_INITIAL_DROPDOWN_VISIBLE
   )
@@ -182,11 +182,11 @@ export const DefaultWithChildrenAdvancedFilter = () => {
     .map(trait => trait.label)
     .join(", ")
 
-  const toggleDropdown = () => setIsDropdownVisible(!isDropdownVisible)
+  const toggleDropdown = (): void => setIsDropdownVisible(!isDropdownVisible)
 
-  const hideDropdown = () => setIsDropdownVisible(false)
+  const hideDropdown = (): void => setIsDropdownVisible(false)
 
-  const onCheckboxChange = (option: DropdownOption) => {
+  const onCheckboxChange = (option: DropdownOption): void => {
     if (appliedFilters.find(filter => filter.id === option.id)) {
       setAppliedFilters(
         appliedFilters.filter(filter => filter.id !== option.id)
@@ -196,7 +196,7 @@ export const DefaultWithChildrenAdvancedFilter = () => {
     }
   }
 
-  const clearFilter = () => setAppliedFilters([])
+  const clearFilter = (): void => setAppliedFilters([])
 
   return (
     <FilterMenuButton
@@ -214,7 +214,7 @@ export const DefaultWithChildrenAdvancedFilter = () => {
             {DROPDOWN_OPTIONS.map(trait => (
               <CheckboxField
                 key={trait.id}
-                onCheck={() => onCheckboxChange(trait)}
+                onCheck={(): void => onCheckboxChange(trait)}
                 id={`checkbox-${trait.id}`}
                 checkedStatus={
                   appliedFilters.find(({ id }) => id === trait.id)

--- a/draft-packages/form/KaizenDraft/Form/CheckboxGroup/CheckboxGroup.spec.tsx
+++ b/draft-packages/form/KaizenDraft/Form/CheckboxGroup/CheckboxGroup.spec.tsx
@@ -9,7 +9,7 @@ const defaultCheckboxGroupProps: CheckboxGroupProps = {
   labelText: "Label",
   noBottomMargin: true,
 }
-const renderCheckboxGroupProps = (props?: CheckboxGroupProps) => {
+const renderCheckboxGroupProps = (props?: CheckboxGroupProps): ReturnType<typeof render> => {
   const mergedCheckboxGroupProps = { ...defaultCheckboxGroupProps, ...props }
 
   return render(<CheckboxGroup {...mergedCheckboxGroupProps} />)

--- a/draft-packages/form/KaizenDraft/Form/CheckboxGroup/CheckboxGroup.spec.tsx
+++ b/draft-packages/form/KaizenDraft/Form/CheckboxGroup/CheckboxGroup.spec.tsx
@@ -9,7 +9,9 @@ const defaultCheckboxGroupProps: CheckboxGroupProps = {
   labelText: "Label",
   noBottomMargin: true,
 }
-const renderCheckboxGroupProps = (props?: CheckboxGroupProps): ReturnType<typeof render> => {
+const renderCheckboxGroupProps = (
+  props?: CheckboxGroupProps
+): ReturnType<typeof render> => {
   const mergedCheckboxGroupProps = { ...defaultCheckboxGroupProps, ...props }
 
   return render(<CheckboxGroup {...mergedCheckboxGroupProps} />)

--- a/draft-packages/form/KaizenDraft/Form/Primitives/Checkbox/Checkbox.spec.tsx
+++ b/draft-packages/form/KaizenDraft/Form/Primitives/Checkbox/Checkbox.spec.tsx
@@ -1,8 +1,8 @@
-import * as React from "react"
+import React from "react"
 import { fireEvent } from "@testing-library/dom"
 import { cleanup, render } from "@testing-library/react"
 
-import { CheckboxProps, CheckedStatus } from "./Checkbox"
+import { CheckboxProps } from "./Checkbox"
 import { Checkbox } from "."
 
 afterEach(cleanup)
@@ -16,7 +16,7 @@ const defaultProps: CheckboxProps = {
   onCheck: jest.fn(),
 }
 
-const renderCheckbox = (props?: CheckboxProps) => {
+const renderCheckbox = (props?: CheckboxProps): ReturnType<typeof render> => {
   const mergedInputProps = { ...defaultProps, ...props }
 
   return render(<Checkbox {...mergedInputProps} />)

--- a/draft-packages/form/KaizenDraft/Form/Primitives/FieldGroup/FieldGroup.spec.tsx
+++ b/draft-packages/form/KaizenDraft/Form/Primitives/FieldGroup/FieldGroup.spec.tsx
@@ -8,7 +8,7 @@ const defaultFieldGroupProps = {
   id: "someFieldGroupId",
 }
 
-const renderFieldGroup = (props?: FieldGroupProps) => {
+const renderFieldGroup = (props?: FieldGroupProps): ReturnType<typeof render> => {
   const mergedFieldGroupProps = { ...defaultFieldGroupProps, ...props }
 
   return render(<FieldGroup {...mergedFieldGroupProps} />)

--- a/draft-packages/form/KaizenDraft/Form/Primitives/FieldGroup/FieldGroup.spec.tsx
+++ b/draft-packages/form/KaizenDraft/Form/Primitives/FieldGroup/FieldGroup.spec.tsx
@@ -8,7 +8,9 @@ const defaultFieldGroupProps = {
   id: "someFieldGroupId",
 }
 
-const renderFieldGroup = (props?: FieldGroupProps): ReturnType<typeof render> => {
+const renderFieldGroup = (
+  props?: FieldGroupProps
+): ReturnType<typeof render> => {
   const mergedFieldGroupProps = { ...defaultFieldGroupProps, ...props }
 
   return render(<FieldGroup {...mergedFieldGroupProps} />)

--- a/draft-packages/form/KaizenDraft/Form/Primitives/FieldMessage/FieldMessage.spec.tsx
+++ b/draft-packages/form/KaizenDraft/Form/Primitives/FieldMessage/FieldMessage.spec.tsx
@@ -9,7 +9,7 @@ const defaultFieldMessageProps = {
   message: "Some FieldMessage.",
 }
 
-const renderFieldMessage = (props?: FieldMessageProps) => {
+const renderFieldMessage = (props?: FieldMessageProps): ReturnType<typeof render> => {
   const mergedFieldMessageProps = { ...defaultFieldMessageProps, ...props }
 
   return render(<FieldMessage {...mergedFieldMessageProps} />)

--- a/draft-packages/form/KaizenDraft/Form/Primitives/FieldMessage/FieldMessage.spec.tsx
+++ b/draft-packages/form/KaizenDraft/Form/Primitives/FieldMessage/FieldMessage.spec.tsx
@@ -9,7 +9,9 @@ const defaultFieldMessageProps = {
   message: "Some FieldMessage.",
 }
 
-const renderFieldMessage = (props?: FieldMessageProps): ReturnType<typeof render> => {
+const renderFieldMessage = (
+  props?: FieldMessageProps
+): ReturnType<typeof render> => {
   const mergedFieldMessageProps = { ...defaultFieldMessageProps, ...props }
 
   return render(<FieldMessage {...mergedFieldMessageProps} />)

--- a/draft-packages/form/KaizenDraft/Form/Primitives/Input/Input.spec.tsx
+++ b/draft-packages/form/KaizenDraft/Form/Primitives/Input/Input.spec.tsx
@@ -1,4 +1,4 @@
-import * as React from "react"
+import React from "react"
 import { fireEvent } from "@testing-library/dom"
 import { cleanup, render } from "@testing-library/react"
 
@@ -13,7 +13,7 @@ const defaultInputProps = {
   onChange: jest.fn(),
 }
 
-const renderInput = (props?: InputProps) => {
+const renderInput = (props?: InputProps): ReturnType<typeof render> => {
   const mergedInputProps = { ...defaultInputProps, ...props }
 
   return render(<Input {...mergedInputProps} />)

--- a/draft-packages/form/KaizenDraft/Form/Primitives/InputSearch/InputSearch.spec.tsx
+++ b/draft-packages/form/KaizenDraft/Form/Primitives/InputSearch/InputSearch.spec.tsx
@@ -10,7 +10,7 @@ const defaultInputProps = {
   onChange: jest.fn(),
 }
 
-const renderInput = (props?: InputSearchProps) => {
+const renderInput = (props?: InputSearchProps): ReturnType<typeof render> => {
   const mergedInputProps = { ...defaultInputProps, ...props }
 
   return render(<InputSearch {...mergedInputProps} />)

--- a/draft-packages/form/KaizenDraft/Form/Primitives/Label/Label.spec.tsx
+++ b/draft-packages/form/KaizenDraft/Form/Primitives/Label/Label.spec.tsx
@@ -1,4 +1,4 @@
-import * as React from "react"
+import React from "react"
 import { cleanup, render } from "@testing-library/react"
 
 import { LabelProps } from "./Label"
@@ -11,7 +11,7 @@ const defaultLabelProps = {
   labelText: "Some field label",
 }
 
-const renderLabel = (props?: LabelProps) => {
+const renderLabel = (props?: LabelProps): ReturnType<typeof render> => {
   const mergedLabelProps = { ...defaultLabelProps, ...props }
 
   return render(<Label {...mergedLabelProps} />)

--- a/draft-packages/form/KaizenDraft/Form/Primitives/Radio/Radio.spec.tsx
+++ b/draft-packages/form/KaizenDraft/Form/Primitives/Radio/Radio.spec.tsx
@@ -14,7 +14,7 @@ const defaultRadioProps: RadioProps = {
   onChange: jest.fn(),
   value: "radio-1",
 }
-const renderRadio = (props?: RadioProps) => {
+const renderRadio = (props?: RadioProps): ReturnType<typeof render> => {
   const mergedRadioProps = { ...defaultRadioProps, ...props }
 
   return render(<Radio {...mergedRadioProps} />)

--- a/draft-packages/form/KaizenDraft/Form/Primitives/TextArea/TextArea.spec.tsx
+++ b/draft-packages/form/KaizenDraft/Form/Primitives/TextArea/TextArea.spec.tsx
@@ -10,7 +10,7 @@ const defaultTextAreaProps = {
   onChange: jest.fn(),
 }
 
-const renderTextArea = (props?: TextAreaProps) => {
+const renderTextArea = (props?: TextAreaProps): ReturnType<typeof render> => {
   const mergedTextAreaProps = { ...defaultTextAreaProps, ...props }
 
   return render(<TextArea {...mergedTextAreaProps} />)

--- a/draft-packages/form/KaizenDraft/Form/Primitives/ToggleSwitch/ToggleSwitch.spec.tsx
+++ b/draft-packages/form/KaizenDraft/Form/Primitives/ToggleSwitch/ToggleSwitch.spec.tsx
@@ -1,4 +1,4 @@
-import * as React from "react"
+import React from "react"
 import { cleanup, fireEvent, render, screen } from "@testing-library/react"
 import { ToggledStatus, ToggleSwitchProps } from "./ToggleSwitch"
 import { ToggleSwitch } from "."
@@ -11,7 +11,7 @@ const defaultToggleSwitchProps = {
   onToggle: jest.fn(),
 }
 
-const renderToggleSwitch = (props?: ToggleSwitchProps) => {
+const renderToggleSwitch = (props?: ToggleSwitchProps): ReturnType<typeof render> => {
   const mergedToggleSwitchProps = { ...defaultToggleSwitchProps, ...props }
 
   return render(<ToggleSwitch {...mergedToggleSwitchProps} />)

--- a/draft-packages/form/KaizenDraft/Form/Primitives/ToggleSwitch/ToggleSwitch.spec.tsx
+++ b/draft-packages/form/KaizenDraft/Form/Primitives/ToggleSwitch/ToggleSwitch.spec.tsx
@@ -11,7 +11,9 @@ const defaultToggleSwitchProps = {
   onToggle: jest.fn(),
 }
 
-const renderToggleSwitch = (props?: ToggleSwitchProps): ReturnType<typeof render> => {
+const renderToggleSwitch = (
+  props?: ToggleSwitchProps
+): ReturnType<typeof render> => {
   const mergedToggleSwitchProps = { ...defaultToggleSwitchProps, ...props }
 
   return render(<ToggleSwitch {...mergedToggleSwitchProps} />)

--- a/draft-packages/form/KaizenDraft/Form/RadioField/RadioField.spec.tsx
+++ b/draft-packages/form/KaizenDraft/Form/RadioField/RadioField.spec.tsx
@@ -15,7 +15,7 @@ const defaultRadioFieldProps: RadioFieldProps = {
   inline: false,
   value: "radio-1",
 }
-const renderRadio = (props?: RadioFieldProps) => {
+const renderRadio = (props?: RadioFieldProps): ReturnType<typeof render> => {
   const mergedRadioFieldProps = { ...defaultRadioFieldProps, ...props }
 
   return render(<RadioField {...mergedRadioFieldProps} />)

--- a/draft-packages/form/docs/CheckboxField.stories.tsx
+++ b/draft-packages/form/docs/CheckboxField.stories.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react"
-import { ComponentStory, Story } from "@storybook/react"
+import { ComponentMeta, ComponentStory, Story } from "@storybook/react"
 import { withDesign } from "storybook-addon-designs"
 import { CheckboxField, CheckedStatus } from "@kaizen/draft-form"
 import { StoryWrapper } from "../../../storybook/components/StoryWrapper"
@@ -26,13 +26,13 @@ export default {
     },
   },
   decorators: [withDesign],
-}
+} as ComponentMeta<typeof CheckboxField>
 
 export const InteractiveKaizenSiteDemo: ComponentStory<
   typeof CheckboxField
 > = args => {
   const [status, setStatus] = useState<CheckedStatus>()
-  const onCheckHandler = () => {
+  const onCheckHandler = (): void => {
     const newStatus = status === "on" ? "off" : "on"
     setStatus(newStatus)
   }

--- a/draft-packages/form/docs/CheckboxGroup.stories.tsx
+++ b/draft-packages/form/docs/CheckboxGroup.stories.tsx
@@ -43,7 +43,9 @@ export default {
   decorators: [withDesign],
 } as ComponentMeta<typeof CheckboxField>
 
-export const InteractiveKaizenSiteDemo: ComponentStory<typeof CheckboxField> = args => (
+export const InteractiveKaizenSiteDemo: ComponentStory<
+  typeof CheckboxField
+> = args => (
   <div>
     <CheckboxGroup labelText="Checkbox Group Label">
       <CheckboxGroupExample
@@ -81,7 +83,7 @@ export const InteractiveKaizenSiteDemo: ComponentStory<typeof CheckboxField> = a
 )
 InteractiveKaizenSiteDemo.storyName = "Checkbox Group"
 InteractiveKaizenSiteDemo.args = {
-  labelText: "Label"
+  labelText: "Label",
 }
 
 export const NestedCheckboxGroup: Story = () => {

--- a/draft-packages/form/docs/CheckboxGroup.stories.tsx
+++ b/draft-packages/form/docs/CheckboxGroup.stories.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react"
-import { Story } from "@storybook/react"
+import { ComponentMeta, ComponentStory, Story } from "@storybook/react"
 import { withDesign } from "storybook-addon-designs"
 import { CheckboxGroup, CheckboxField, Label } from "@kaizen/draft-form"
 import { StoryWrapper } from "../../../storybook/components/StoryWrapper"
@@ -19,7 +19,7 @@ const CheckboxGroupExample = ({
   render,
 }: CheckboxGroupExampleProps): JSX.Element => {
   const [checkedStatus, setCheckedStatus] = useState("mixed")
-  const onCheckHandler = () => {
+  const onCheckHandler = (): void => {
     const newStatus = checkedStatus === "on" ? "off" : "on"
     setCheckedStatus(newStatus)
   }
@@ -41,40 +41,37 @@ export default {
     ),
   },
   decorators: [withDesign],
-}
+} as ComponentMeta<typeof CheckboxField>
 
-export const InteractiveKaizenSiteDemo = args => (
+export const InteractiveKaizenSiteDemo: ComponentStory<typeof CheckboxField> = args => (
   <div>
     <CheckboxGroup labelText="Checkbox Group Label">
       <CheckboxGroupExample
-        render={({ checkedStatus, onCheckHandler }) => (
+        render={({ checkedStatus, onCheckHandler }): JSX.Element => (
           <CheckboxField
             onCheck={onCheckHandler}
             id="checkbox-1"
             checkedStatus={checkedStatus as any}
-            labelText="Label"
             {...args}
           />
         )}
       />
       <CheckboxGroupExample
-        render={({ checkedStatus, onCheckHandler }) => (
+        render={({ checkedStatus, onCheckHandler }): JSX.Element => (
           <CheckboxField
             onCheck={onCheckHandler}
             id="checkbox-2"
             checkedStatus={checkedStatus as any}
-            labelText="Label"
             {...args}
           />
         )}
       />
       <CheckboxGroupExample
-        render={({ checkedStatus, onCheckHandler }) => (
+        render={({ checkedStatus, onCheckHandler }): JSX.Element => (
           <CheckboxField
             onCheck={onCheckHandler}
             id="checkbox-3"
             checkedStatus={checkedStatus as any}
-            labelText="Label"
             {...args}
           />
         )}
@@ -83,11 +80,14 @@ export const InteractiveKaizenSiteDemo = args => (
   </div>
 )
 InteractiveKaizenSiteDemo.storyName = "Checkbox Group"
+InteractiveKaizenSiteDemo.args = {
+  labelText: "Label"
+}
 
-export const NestedCheckboxGroup = () => {
+export const NestedCheckboxGroup: Story = () => {
   const [selectedOptions, setSelectedOptions] = React.useState<number[]>([])
 
-  const onCheckHandler = (state: string, value: number) => {
+  const onCheckHandler = (state: string, value: number): void => {
     if (state === "off") {
       setSelectedOptions(prev => [...prev, value])
     } else {
@@ -97,7 +97,7 @@ export const NestedCheckboxGroup = () => {
 
   const checkAllCheckboxOnCheckHandler = (
     event: React.ChangeEvent<HTMLInputElement>
-  ) => {
+  ): void => {
     const state = event.currentTarget.value
     if (state === "off" || state === "mixed") {
       setSelectedOptions([1, 2, 3])
@@ -129,19 +129,19 @@ export const NestedCheckboxGroup = () => {
           id="checkbox-1"
           checkedStatus={selectedOptions.includes(1) ? "on" : "off"}
           labelText="Label"
-          onCheck={e => onCheckHandler(e.currentTarget.value, 1)}
+          onCheck={(e): void => onCheckHandler(e.currentTarget.value, 1)}
         />
         <CheckboxField
           id="checkbox-2"
           checkedStatus={selectedOptions.includes(2) ? "on" : "off"}
           labelText="Label"
-          onCheck={e => onCheckHandler(e.currentTarget.value, 2)}
+          onCheck={(e): void => onCheckHandler(e.currentTarget.value, 2)}
         />
         <CheckboxField
           id="checkbox-3"
           checkedStatus={selectedOptions.includes(3) ? "on" : "off"}
           labelText="Label"
-          onCheck={e => onCheckHandler(e.currentTarget.value, 3)}
+          onCheck={(e): void => onCheckHandler(e.currentTarget.value, 3)}
         />
       </CheckboxGroup>
     </div>

--- a/draft-packages/form/docs/Label.stories.tsx
+++ b/draft-packages/form/docs/Label.stories.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { ComponentStory, Story } from "@storybook/react"
+import { ComponentMeta, ComponentStory, Story } from "@storybook/react"
 import { Label } from "@kaizen/draft-form"
 import { StoryWrapper } from "../../../storybook/components/StoryWrapper"
 import {
@@ -18,7 +18,7 @@ export default {
       },
     },
   },
-}
+} as ComponentMeta<typeof Label>
 
 export const DefaultKaizenSiteDemo: ComponentStory<typeof Label> = args => (
   <Label {...args}></Label>

--- a/draft-packages/form/docs/RadioField.stories.tsx
+++ b/draft-packages/form/docs/RadioField.stories.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react"
-import { ComponentStory, Story } from "@storybook/react"
+import { ComponentMeta, ComponentStory, Story } from "@storybook/react"
 import { withDesign } from "storybook-addon-designs"
 import { RadioField } from "@kaizen/draft-form"
 import { StoryWrapper } from "../../../storybook/components/StoryWrapper"
@@ -26,15 +26,14 @@ export default {
     },
   },
   decorators: [withDesign],
-}
+} as ComponentMeta<typeof RadioField>
 
 export const InteractiveKaizenSiteDemo: ComponentStory<
   typeof RadioField
 > = args => {
   const [status, setStatus] = useState<boolean>()
-  const onCheckHandler = () => {
-    setStatus(!status)
-  }
+  const onCheckHandler = (): void => setStatus(!status)
+
   return (
     <RadioField
       {...args}

--- a/draft-packages/form/docs/RadioGroup.stories.tsx
+++ b/draft-packages/form/docs/RadioGroup.stories.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { Story } from "@storybook/react"
+import { ComponentMeta, Story } from "@storybook/react"
 import { withDesign } from "storybook-addon-designs"
 import { Label, RadioField, RadioGroup } from "@kaizen/draft-form"
 import { StoryWrapper } from "../../../storybook/components/StoryWrapper"
@@ -19,7 +19,7 @@ class RadioGroupExample extends React.Component<Props> {
   state = {
     selectedOption: "",
   }
-  render() {
+  render(): JSX.Element {
     const { render } = this.props
     return (
       <div>
@@ -31,7 +31,7 @@ class RadioGroupExample extends React.Component<Props> {
     )
   }
 
-  onChangeHandler = (event: React.ChangeEvent<HTMLInputElement>) => {
+  onChangeHandler = (event: React.ChangeEvent<HTMLInputElement>): void => {
     this.setState({
       selectedOption: event.target.value,
     })
@@ -52,11 +52,11 @@ export default {
     ),
   },
   decorators: [withDesign],
-}
+} as ComponentMeta<typeof RadioGroup>
 
-export const DefaultKaizenSiteDemo = () => (
+export const DefaultKaizenSiteDemo: Story = () => (
   <RadioGroupExample
-    render={({ selectedOption, onChangeHandler }) => (
+    render={({ selectedOption, onChangeHandler }): JSX.Element => (
       <RadioGroup labelText="Radio group label" labelId="RadioGroupLabel">
         <RadioField
           labelText="Option one"

--- a/draft-packages/form/docs/SearchField.stories.tsx
+++ b/draft-packages/form/docs/SearchField.stories.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react"
-import { Story } from "@storybook/react"
+import { ComponentMeta, ComponentStory, Story } from "@storybook/react"
 import { withDesign } from "storybook-addon-designs"
 import { SearchField } from "@kaizen/draft-form"
 import { StoryWrapper } from "../../../storybook/components/StoryWrapper"
@@ -17,24 +17,26 @@ export default {
     },
   },
   decorators: [withDesign],
-}
+} as ComponentMeta<typeof SearchField>
 
-export const DefaultKaizenDemo = args => {
+export const DefaultKaizenDemo: ComponentStory<typeof SearchField> = args => {
   const [value, setValue] = useState("Some value")
 
   return (
     <SearchField
-      id="search-field"
-      placeholder="Search…"
-      labelText="Label"
       value={value}
-      onChange={e => setValue(e.target.value)}
-      onClear={() => setValue("")}
+      onChange={(e): void => setValue(e.target.value)}
+      onClear={(): void => setValue("")}
       {...args}
     />
   )
 }
 DefaultKaizenDemo.storyName = "Default (Kaizen Demo)"
+DefaultKaizenDemo.args = {
+  id: "search-field",
+  placeholder: "Search…",
+  labelText: "Label",
+}
 
 const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({
   isReversed,

--- a/draft-packages/form/docs/Slider.stories.tsx
+++ b/draft-packages/form/docs/Slider.stories.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { Story } from "@storybook/react"
+import { ComponentMeta, ComponentStory, Story } from "@storybook/react"
 import { Slider } from "@kaizen/draft-form"
 import { StoryWrapper } from "../../../storybook/components/StoryWrapper"
 import { CATEGORIES, SUB_CATEGORIES } from "../../../storybook/constants"
@@ -14,13 +14,14 @@ export default {
       },
     },
   },
-}
+} as ComponentMeta<typeof Slider>
 
-export const DefaultKaizenSiteDemo = args => (
-  <Slider id="make-me-unique-1" {...args} />
+export const DefaultKaizenSiteDemo: ComponentStory<typeof Slider> = args => (
+  <Slider {...args} />
 )
 DefaultKaizenSiteDemo.storyName = "Slider"
 DefaultKaizenSiteDemo.args = {
+  id: "make-me-unique-1",
   labelText: "Work overall",
   minLabel: "Awful",
   maxLabel: "Fantastic",

--- a/draft-packages/form/docs/TextAreaField.stories.tsx
+++ b/draft-packages/form/docs/TextAreaField.stories.tsx
@@ -31,7 +31,9 @@ export default {
   decorators: [withDesign],
 } as ComponentMeta<typeof TextAreaField>
 
-export const DefaultStory: ComponentStory<typeof TextAreaField> = args => <TextAreaField {...args} />
+export const DefaultStory: ComponentStory<typeof TextAreaField> = args => (
+  <TextAreaField {...args} />
+)
 DefaultStory.args = {
   id: "reply",
   labelText: "Your reply",
@@ -56,7 +58,11 @@ const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({
   <StoryWrapper isReversed={isReversed}>
     <StoryWrapper.RowHeader headings={["Base", "Disabled"]} />
     <StoryWrapper.Row rowTitle="Default">
-      <TextAreaField reversed={isReversed} id="text-area-default-base" labelText="Default" />
+      <TextAreaField
+        reversed={isReversed}
+        id="text-area-default-base"
+        labelText="Default"
+      />
       <TextAreaField
         reversed={isReversed}
         disabled

--- a/draft-packages/form/docs/TextAreaField.stories.tsx
+++ b/draft-packages/form/docs/TextAreaField.stories.tsx
@@ -1,4 +1,5 @@
 import React from "react"
+import { ComponentMeta, ComponentStory, Story } from "@storybook/react"
 import { withDesign } from "storybook-addon-designs"
 import { TextAreaField } from "@kaizen/draft-form"
 import { StoryWrapper } from "../../../storybook/components/StoryWrapper"
@@ -28,9 +29,9 @@ export default {
     },
   },
   decorators: [withDesign],
-}
+} as ComponentMeta<typeof TextAreaField>
 
-export const DefaultStory = args => <TextAreaField {...args} />
+export const DefaultStory: ComponentStory<typeof TextAreaField> = args => <TextAreaField {...args} />
 DefaultStory.args = {
   id: "reply",
   labelText: "Your reply",
@@ -49,12 +50,15 @@ DefaultStory.argTypes = {
 }
 DefaultStory.storyName = "Default (Kaizen Demo)"
 
-export const StickerSheetDefault = () => (
-  <StoryWrapper>
+const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({
+  isReversed,
+}) => (
+  <StoryWrapper isReversed={isReversed}>
     <StoryWrapper.RowHeader headings={["Base", "Disabled"]} />
     <StoryWrapper.Row rowTitle="Default">
-      <TextAreaField id="text-area-default-base" labelText="Default" />
+      <TextAreaField reversed={isReversed} id="text-area-default-base" labelText="Default" />
       <TextAreaField
+        reversed={isReversed}
         disabled
         id="text-area-default-disabled"
         labelText="Default"
@@ -62,12 +66,14 @@ export const StickerSheetDefault = () => (
     </StoryWrapper.Row>
     <StoryWrapper.Row rowTitle="Description">
       <TextAreaField
+        reversed={isReversed}
         id="text-area-default-description-base"
         defaultValue="Filled input text"
         labelText="With description"
         description="Example/description text"
       />
       <TextAreaField
+        reversed={isReversed}
         id="text-area-default-description-disabled"
         defaultValue="Filled input text"
         labelText="With description"
@@ -77,6 +83,7 @@ export const StickerSheetDefault = () => (
     </StoryWrapper.Row>
     <StoryWrapper.Row rowTitle="Prominent">
       <TextAreaField
+        reversed={isReversed}
         id="text-area-prominent-base"
         labelText="Prominent"
         description="Example/description text"
@@ -84,6 +91,7 @@ export const StickerSheetDefault = () => (
         variant="prominent"
       />
       <TextAreaField
+        reversed={isReversed}
         id="text-area-prominent-disabled"
         labelText="Prominent"
         description="Example/description text"
@@ -94,6 +102,7 @@ export const StickerSheetDefault = () => (
     </StoryWrapper.Row>
     <StoryWrapper.Row rowTitle="Negative" gridColumns={2}>
       <TextAreaField
+        reversed={isReversed}
         id="text-area-error-base"
         labelText="Error"
         description="Example/description text"
@@ -104,6 +113,7 @@ export const StickerSheetDefault = () => (
     </StoryWrapper.Row>
     <StoryWrapper.Row rowTitle="Cautionary" gridColumns={2}>
       <TextAreaField
+        reversed={isReversed}
         id="text-area-caution-base"
         labelText="Caution"
         description="Example/description text"
@@ -114,83 +124,19 @@ export const StickerSheetDefault = () => (
     </StoryWrapper.Row>
   </StoryWrapper>
 )
-StickerSheetDefault.storyName = "Sticker Sheet (Default)"
-StickerSheetDefault.parameters = { chromatic: { disable: false } }
 
-export const StickerSheetReversed = () => (
-  <StoryWrapper isReversed>
-    <StoryWrapper.RowHeader headings={["Base", "Disabled"]} />
-    <StoryWrapper.Row rowTitle="Default">
-      <TextAreaField id="text-area-default-base" labelText="Default" reversed />
-      <TextAreaField
-        disabled
-        id="text-area-default-disabled-reversed"
-        labelText="Default"
-        reversed
-      />
-    </StoryWrapper.Row>
-    <StoryWrapper.Row rowTitle="Description">
-      <TextAreaField
-        id="text-area-description-base-reversed"
-        defaultValue="Filled input text"
-        labelText="With description"
-        description="Example/description text"
-        reversed
-      />
-      <TextAreaField
-        id="text-area-description-disabled-reversed"
-        defaultValue="Filled input text"
-        labelText="With description"
-        description="Example/description text"
-        disabled
-        reversed
-      />
-    </StoryWrapper.Row>
-    <StoryWrapper.Row rowTitle="Prominent">
-      <TextAreaField
-        id="text-area-prominent-base-reversed"
-        labelText="Prominent"
-        description="Example/description text"
-        defaultValue="Filled input text"
-        variant="prominent"
-        reversed
-      />
-      <TextAreaField
-        id="text-area-prominent-disabled-reversed"
-        labelText="Prominent-base"
-        description="Example/description text"
-        defaultValue="Filled input text"
-        variant="prominent"
-        disabled
-        reversed
-      />
-    </StoryWrapper.Row>
-    <StoryWrapper.Row rowTitle="Negative" gridColumns={2}>
-      <TextAreaField
-        id="text-area-error-base-reversed"
-        labelText="Error"
-        description="Example/description text"
-        defaultValue="Filled input text"
-        status="error"
-        validationMessage="Error message"
-        reversed
-      />
-    </StoryWrapper.Row>
-    <StoryWrapper.Row rowTitle="Cautionary" gridColumns={2}>
-      <TextAreaField
-        id="text-area-caution-base-reversed"
-        labelText="Caution"
-        description="Example/description text"
-        defaultValue="Filled input text"
-        status="caution"
-        validationMessage="Error message"
-        reversed
-      />
-    </StoryWrapper.Row>
-  </StoryWrapper>
-)
+export const StickerSheetDefault = StickerSheetTemplate.bind({})
+StickerSheetDefault.storyName = "Sticker Sheet (Default)"
+StickerSheetDefault.parameters = {
+  chromatic: { disable: false },
+  controls: { disable: true },
+}
+
+export const StickerSheetReversed = StickerSheetTemplate.bind({})
 StickerSheetReversed.storyName = "Sticker Sheet (Reversed)"
+StickerSheetReversed.args = { isReversed: true }
 StickerSheetReversed.parameters = {
+  controls: { disable: true },
   backgrounds: { default: "Purple 700" },
   chromatic: { disable: false },
 }

--- a/draft-packages/form/docs/TextField.stories.tsx
+++ b/draft-packages/form/docs/TextField.stories.tsx
@@ -149,59 +149,59 @@ const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({
   ]
 
   return (
-  <>
-    <StickerSheet heading="Default" isReversed={isReversed}>
-      <StickerSheet.Header
-        headings={["Base", "Disabled"]}
-        headingsWidth="15rem"
-      />
-      <StickerSheet.Body>
-        {DEFAULT__ROW_PROPS.map(({ id, ...restProps }) => (
-          <StickerSheet.Row key={id}>
-            <TextField
-              reversed={isReversed}
-              id={`${id}--base`}
-              {...restProps}
+    <>
+      <StickerSheet heading="Default" isReversed={isReversed}>
+        <StickerSheet.Header
+          headings={["Base", "Disabled"]}
+          headingsWidth="15rem"
+        />
+        <StickerSheet.Body>
+          {DEFAULT__ROW_PROPS.map(({ id, ...restProps }) => (
+            <StickerSheet.Row key={id}>
+              <TextField
+                reversed={isReversed}
+                id={`${id}--base`}
+                {...restProps}
               />
-            <TextField
-              reversed={isReversed}
-              id={`${id}--disabled`}
-              disabled
-              {...restProps}
-            />
-          </StickerSheet.Row>
-        ))}
-      </StickerSheet.Body>
-    </StickerSheet>
+              <TextField
+                reversed={isReversed}
+                id={`${id}--disabled`}
+                disabled
+                {...restProps}
+              />
+            </StickerSheet.Row>
+          ))}
+        </StickerSheet.Body>
+      </StickerSheet>
 
-    <StickerSheet heading="Icon" isReversed={isReversed}>
-      <StickerSheet.Header
-        headings={["Base", "Disabled"]}
-        headingsWidth="15rem"
-      />
-      <StickerSheet.Body>
-        {ICON__ROW_PROPS.map(({ id, ...restProps }) => (
-          <StickerSheet.Row key={id}>
-            <TextField
-              reversed={isReversed}
-              id={`${id}--base`}
-              icon={dateIcon}
-              {...restProps}
+      <StickerSheet heading="Icon" isReversed={isReversed}>
+        <StickerSheet.Header
+          headings={["Base", "Disabled"]}
+          headingsWidth="15rem"
+        />
+        <StickerSheet.Body>
+          {ICON__ROW_PROPS.map(({ id, ...restProps }) => (
+            <StickerSheet.Row key={id}>
+              <TextField
+                reversed={isReversed}
+                id={`${id}--base`}
+                icon={dateIcon}
+                {...restProps}
               />
-            <TextField
-              reversed={isReversed}
-              id={`${id}--disabled`}
-              disabled
-              icon={dateIcon}
-              {...restProps}
-            />
-          </StickerSheet.Row>
-        ))}
-      </StickerSheet.Body>
-    </StickerSheet>
-  </>
-)
-  }
+              <TextField
+                reversed={isReversed}
+                id={`${id}--disabled`}
+                disabled
+                icon={dateIcon}
+                {...restProps}
+              />
+            </StickerSheet.Row>
+          ))}
+        </StickerSheet.Body>
+      </StickerSheet>
+    </>
+  )
+}
 
 export const StickerSheetDefault = StickerSheetTemplate.bind({})
 StickerSheetDefault.storyName = "Sticker Sheet (Default)"

--- a/draft-packages/form/docs/TextField.stories.tsx
+++ b/draft-packages/form/docs/TextField.stories.tsx
@@ -1,42 +1,12 @@
 import React from "react"
+import { ComponentMeta, ComponentStory, Story } from "@storybook/react"
 import { withDesign } from "storybook-addon-designs"
 import dateIcon from "@kaizen/component-library/icons/date-start.icon.svg"
 import { TextField } from "@kaizen/draft-form"
-import { Heading } from "@kaizen/typography"
+import { StickerSheet } from "../../../storybook/components/StickerSheet"
 import { CATEGORIES, SUB_CATEGORIES } from "../../../storybook/constants"
 import { figmaEmbed } from "../../../storybook/helpers"
-
-const StoryContainer = ({ children }) => (
-  <div
-    style={{ display: "inline-flex", width: "100%", flexDirection: "column" }}
-  >
-    {children}
-  </div>
-)
-
-const StoryColumn = ({ children }) => (
-  <div
-    style={{
-      display: "grid",
-      rowGap: "25px",
-    }}
-  >
-    {children}
-  </div>
-)
-
-const StoryGrid = ({ children }) => (
-  <div
-    style={{
-      display: "grid",
-      gridTemplateColumns: "repeat(auto-fill, minmax(10px, 195px))",
-      columnGap: "45px",
-      rowGap: "12px",
-    }}
-  >
-    {children}
-  </div>
-)
+import { TextFieldProps } from "../KaizenDraft/Form/TextField/TextField"
 
 export default {
   title: `${CATEGORIES.components}/${SUB_CATEGORIES.form}/Text Field`,
@@ -52,12 +22,10 @@ export default {
     ),
   },
   decorators: [withDesign],
-}
+} as ComponentMeta<typeof TextField>
 
-export const DefaultStory = args => (
-  <StoryContainer>
-    <TextField {...args} />
-  </StoryContainer>
+export const DefaultStory: ComponentStory<typeof TextField> = args => (
+  <TextField {...args} />
 )
 DefaultStory.args = {
   id: "kaizen-demo-text-field",
@@ -94,568 +62,159 @@ DefaultStory.argTypes = {
 }
 DefaultStory.storyName = "Default (Kaizen Demo)"
 
-export const StickerSheetDefault = () => (
-  <>
-    <Heading variant="heading-3" tag="h2">
-      Default
-    </Heading>
-    <StoryGrid>
-      <StoryColumn>
-        <Heading variant="heading-5" tag="h3">
-          Base
-        </Heading>
-        <StoryContainer>
-          <TextField
-            id="text-default"
-            inputType="email"
-            defaultInputValue=""
-            labelText="Default"
-            placeholder=""
-          />
-        </StoryContainer>
-        <StoryContainer>
-          <TextField
-            id="text"
-            inputType="email"
-            defaultInputValue=""
-            labelText="Description"
-            placeholder=""
-            description="Description text"
-          />
-        </StoryContainer>
-        <StoryContainer>
-          <TextField
-            id="text"
-            inputType="email"
-            defaultInputValue=""
-            labelText="Placeholder"
-            placeholder="jane.doe@email.com"
-            description="Description text"
-          />
-        </StoryContainer>
-        <StoryContainer>
-          <TextField
-            id="text"
-            inputType="email"
-            defaultInputValue="Input Text"
-            labelText="Positive"
-            placeholder="jane.doe@email.com"
-            status="success"
-            description="Description text"
-          />
-        </StoryContainer>
-        <StoryContainer>
-          <TextField
-            id="text"
-            inputType="email"
-            defaultInputValue="Input Text"
-            labelText="Negative"
-            placeholder="jane.doe@email.com"
-            status="error"
-            description="Description text"
-            validationMessage={<span>Error message</span>}
-          />
-        </StoryContainer>
-        <StoryContainer>
-          <TextField
-            id="text"
-            inputType="email"
-            defaultInputValue="Input Text"
-            labelText="Cautionary"
-            placeholder="jane.doe@email.com"
-            status="caution"
-            description="Description text"
-            validationMessage="Error message"
-          />
-        </StoryContainer>
-      </StoryColumn>
-      <StoryColumn>
-        <Heading variant="heading-5" tag="h3">
-          Disabled
-        </Heading>
-        <StoryContainer>
-          <TextField
-            id="text"
-            inputType="email"
-            defaultInputValue=""
-            labelText="Default"
-            placeholder=""
-            disabled={true}
-          />
-        </StoryContainer>
-        <StoryContainer>
-          <TextField
-            id="text"
-            inputType="email"
-            defaultInputValue=""
-            labelText="Description"
-            placeholder=""
-            description="Description text"
-            disabled={true}
-          />
-        </StoryContainer>
-        <StoryContainer>
-          <TextField
-            id="text"
-            inputType="email"
-            defaultInputValue="Input Text"
-            labelText="Placeholder"
-            placeholder="jane.doe@email.com"
-            description="Description text"
-            disabled={true}
-          />
-        </StoryContainer>
-        <StoryContainer>
-          <TextField
-            id="text"
-            inputType="email"
-            defaultInputValue="Input Text"
-            labelText="Positive"
-            placeholder="jane.doe@email.com"
-            status="success"
-            description="Description text"
-            disabled={true}
-          />
-        </StoryContainer>
-        <StoryContainer>
-          <TextField
-            id="text"
-            inputType="email"
-            defaultInputValue="Input Text"
-            labelText="Negative"
-            placeholder="jane.doe@email.com"
-            status="error"
-            description="Description text"
-            validationMessage="Error message"
-            disabled={true}
-          />
-        </StoryContainer>
-        <StoryContainer>
-          <TextField
-            id="text"
-            inputType="email"
-            defaultInputValue="Input Text"
-            labelText="Cautionary"
-            placeholder="jane.doe@email.com"
-            status="caution"
-            description="Description text"
-            validationMessage="Error message"
-            disabled={true}
-          />
-        </StoryContainer>
-      </StoryColumn>
-    </StoryGrid>
-    <Heading variant="heading-3" tag="h2">
-      Icon
-    </Heading>
-    <StoryGrid>
-      <StoryColumn>
-        <Heading variant="heading-5" tag="h3">
-          Base
-        </Heading>
-        <StoryContainer>
-          <TextField
-            id="text"
-            inputType="email"
-            defaultInputValue="Input Text"
-            labelText="Default"
-            placeholder="jane.doe@email.com"
-            description="Description text"
-            icon={dateIcon}
-          />
-        </StoryContainer>
-        <StoryContainer>
-          <TextField
-            id="text"
-            inputType="email"
-            defaultInputValue="Input Text"
-            labelText="Positive"
-            placeholder="jane.doe@email.com"
-            status="success"
-            description="Description text"
-            icon={dateIcon}
-          />
-        </StoryContainer>
-        <StoryContainer>
-          <TextField
-            id="text"
-            inputType="email"
-            defaultInputValue="Input Text"
-            labelText="Negative"
-            placeholder="jane.doe@email.com"
-            status="error"
-            description="Description text"
-            validationMessage="Error message"
-            icon={dateIcon}
-          />
-        </StoryContainer>
-        <StoryContainer>
-          <TextField
-            id="text"
-            inputType="email"
-            defaultInputValue="Input Text"
-            labelText="Cautionary"
-            placeholder="jane.doe@email.com"
-            status="caution"
-            description="Description text"
-            validationMessage="Error message"
-            icon={dateIcon}
-          />
-        </StoryContainer>
-      </StoryColumn>
-      <StoryColumn>
-        <Heading variant="heading-5" tag="h3">
-          Disabled
-        </Heading>
-        <StoryContainer>
-          <TextField
-            id="text"
-            inputType="email"
-            defaultInputValue="Input Text"
-            labelText="Default"
-            placeholder="jane.doe@email.com"
-            description="Description text"
-            icon={dateIcon}
-            disabled={true}
-          />
-        </StoryContainer>
-        <StoryContainer>
-          <TextField
-            id="text"
-            inputType="email"
-            defaultInputValue="Input Text"
-            labelText="Positive"
-            placeholder="jane.doe@email.com"
-            status="success"
-            description="Description text"
-            icon={dateIcon}
-            disabled={true}
-          />
-        </StoryContainer>
-        <StoryContainer>
-          <TextField
-            id="text"
-            inputType="email"
-            defaultInputValue="Input Text"
-            labelText="Negative"
-            placeholder="jane.doe@email.com"
-            status="error"
-            description="Description text"
-            validationMessage="Error message"
-            icon={dateIcon}
-            disabled={true}
-          />
-        </StoryContainer>
-        <StoryContainer>
-          <TextField
-            id="text"
-            inputType="email"
-            defaultInputValue="Input Text"
-            labelText="Cautionary"
-            placeholder="jane.doe@email.com"
-            status="caution"
-            description="Description text"
-            validationMessage="Error message"
-            icon={dateIcon}
-            disabled={true}
-          />
-        </StoryContainer>
-      </StoryColumn>
-    </StoryGrid>
-  </>
-)
-StickerSheetDefault.storyName = "Sticker Sheet (Default)"
+const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({
+  isReversed,
+}) => {
+  const DEFAULT__ROW_PROPS: TextFieldProps[] = [
+    {
+      id: "text-field--default",
+      inputType: "email",
+      labelText: "Default",
+    },
+    {
+      id: "text-field--description",
+      inputType: "email",
+      labelText: "Description",
+      description: "Description text",
+    },
+    {
+      id: "text-field--placeholder",
+      inputType: "email",
+      labelText: "Placeholder",
+      description: "Description text",
+      placeholder: "jane.doe@email.com",
+    },
+    {
+      id: "text-field--positive",
+      inputType: "email",
+      labelText: "Positive",
+      status: "success",
+      defaultInputValue: "Input Text",
+      description: "Description text",
+    },
+    {
+      id: "text-field--negative",
+      inputType: "email",
+      labelText: "Negative",
+      status: "error",
+      defaultInputValue: "Input Text",
+      description: "Description text",
+      validationMessage: <span>Error message</span>,
+    },
+    {
+      id: "text-field--cautionary",
+      inputType: "email",
+      labelText: "Cautionary",
+      status: "caution",
+      defaultInputValue: "Input Text",
+      description: "Description text",
+      validationMessage: "Warning message",
+    },
+  ]
 
-export const StickerSheetReversed = () => (
+  const ICON__ROW_PROPS: TextFieldProps[] = [
+    {
+      id: "text-field--icon--default",
+      inputType: "email",
+      labelText: "Default",
+      defaultInputValue: "Input Text",
+      description: "Description text",
+    },
+    {
+      id: "text-field--icon--positive",
+      inputType: "email",
+      labelText: "Positive",
+      status: "success",
+      defaultInputValue: "Input Text",
+      description: "Description text",
+    },
+    {
+      id: "text-field--icon--negative",
+      inputType: "email",
+      labelText: "Negative",
+      status: "error",
+      defaultInputValue: "Input Text",
+      description: "Description text",
+      validationMessage: <span>Error message</span>,
+    },
+    {
+      id: "text-field--icon--cautionary",
+      inputType: "email",
+      labelText: "Cautionary",
+      status: "caution",
+      defaultInputValue: "Input Text",
+      description: "Description text",
+      validationMessage: "Warning message",
+    },
+  ]
+
+  return (
   <>
-    <Heading color="white" variant="heading-3" tag="h2">
-      Default
-    </Heading>
-    <StoryGrid>
-      <StoryColumn>
-        <Heading color="white" variant="heading-5" tag="h3">
-          Base
-        </Heading>
-        <StoryContainer>
-          <TextField
-            reversed={true}
-            id="text"
-            inputType="email"
-            defaultInputValue=""
-            labelText="Default"
-            placeholder=""
-          />
-        </StoryContainer>
-        <StoryContainer>
-          <TextField
-            reversed={true}
-            id="text"
-            inputType="email"
-            defaultInputValue=""
-            labelText="Description"
-            placeholder=""
-            description="Description text"
-          />
-        </StoryContainer>
-        <StoryContainer>
-          <TextField
-            reversed={true}
-            id="text"
-            inputType="email"
-            defaultInputValue=""
-            labelText="Placeholder"
-            placeholder="jane.doe@email.com"
-            description="Description text"
-          />
-        </StoryContainer>
-        <StoryContainer>
-          <TextField
-            reversed={true}
-            id="text"
-            inputType="email"
-            defaultInputValue="Input Text"
-            labelText="Positive"
-            placeholder="jane.doe@email.com"
-            status="success"
-            description="Description text"
-          />
-        </StoryContainer>
-        <StoryContainer>
-          <TextField
-            reversed={true}
-            id="text"
-            inputType="email"
-            defaultInputValue="Input Text"
-            labelText="Negative"
-            placeholder="jane.doe@email.com"
-            status="error"
-            description="Description text"
-            validationMessage="Error message"
-          />
-        </StoryContainer>
-        <StoryContainer>
-          <TextField
-            reversed={true}
-            id="text"
-            inputType="email"
-            defaultInputValue="Input Text"
-            labelText="Cautionary"
-            placeholder="jane.doe@email.com"
-            status="caution"
-            description="Description text"
-            validationMessage="Error message"
-          />
-        </StoryContainer>
-      </StoryColumn>
-      <StoryColumn>
-        <Heading color="white" variant="heading-5" tag="h3">
-          Disabled
-        </Heading>
-        <StoryContainer>
-          <TextField
-            reversed={true}
-            id="text"
-            inputType="email"
-            labelText="Default"
-            placeholder=""
-            disabled={true}
-          />
-        </StoryContainer>
-        <StoryContainer>
-          <TextField
-            reversed={true}
-            id="text"
-            inputType="email"
-            labelText="Description"
-            placeholder=""
-            description="Description text"
-            disabled={true}
-          />
-        </StoryContainer>
-        <StoryContainer>
-          <TextField
-            reversed={true}
-            id="text"
-            inputType="email"
-            defaultInputValue="Input Text"
-            labelText="Placeholder"
-            placeholder="jane.doe@email.com"
-            description="Description text"
-            disabled={true}
-          />
-        </StoryContainer>
-        <StoryContainer>
-          <TextField
-            reversed={true}
-            id="text"
-            inputType="email"
-            defaultInputValue="Input Text"
-            labelText="Positive"
-            placeholder="jane.doe@email.com"
-            status="success"
-            description="Description text"
-            disabled={true}
-          />
-        </StoryContainer>
-        <StoryContainer>
-          <TextField
-            reversed={true}
-            id="text"
-            inputType="email"
-            defaultInputValue="Input Text"
-            labelText="Negative"
-            placeholder="jane.doe@email.com"
-            status="error"
-            description="Description text"
-            validationMessage="Error message"
-            disabled={true}
-          />
-        </StoryContainer>
-        <StoryContainer>
-          <TextField
-            reversed={true}
-            id="text"
-            inputType="email"
-            defaultInputValue="Input Text"
-            labelText="Cautionary"
-            placeholder="jane.doe@email.com"
-            status="caution"
-            description="Description text"
-            validationMessage="Error message"
-            disabled={true}
-          />
-        </StoryContainer>
-      </StoryColumn>
-    </StoryGrid>
-    <Heading color="white" variant="heading-3" tag="h2">
-      Icon
-    </Heading>
-    <StoryGrid>
-      <StoryColumn>
-        <Heading color="white" variant="heading-5" tag="h3">
-          Base
-        </Heading>
-        <StoryContainer>
-          <TextField
-            reversed={true}
-            id="text"
-            inputType="email"
-            defaultInputValue="Input Text"
-            labelText="Default"
-            placeholder="jane.doe@email.com"
-            description="Description text"
-            icon={dateIcon}
-          />
-        </StoryContainer>
-        <StoryContainer>
-          <TextField
-            reversed={true}
-            id="text"
-            inputType="email"
-            defaultInputValue="Input Text"
-            labelText="Positive"
-            placeholder="jane.doe@email.com"
-            status="success"
-            description="Description text"
-            icon={dateIcon}
-          />
-        </StoryContainer>
-        <StoryContainer>
-          <TextField
-            reversed={true}
-            id="text"
-            inputType="email"
-            defaultInputValue="Input Text"
-            labelText="Negative"
-            placeholder="jane.doe@email.com"
-            status="error"
-            description="Description text"
-            validationMessage="Error message"
-            icon={dateIcon}
-          />
-        </StoryContainer>
-        <StoryContainer>
-          <TextField
-            reversed={true}
-            id="text"
-            inputType="email"
-            defaultInputValue="Input Text"
-            labelText="Cautionary"
-            placeholder="jane.doe@email.com"
-            status="caution"
-            description="Description text"
-            validationMessage="Error message"
-            icon={dateIcon}
-          />
-        </StoryContainer>
-      </StoryColumn>
-      <StoryColumn>
-        <Heading color="white" variant="heading-5" tag="h3">
-          Disabled
-        </Heading>
-        <StoryContainer>
-          <TextField
-            reversed={true}
-            id="text"
-            inputType="email"
-            defaultInputValue="Input Text"
-            labelText="Default"
-            placeholder="jane.doe@email.com"
-            description="Description text"
-            icon={dateIcon}
-            disabled={true}
-          />
-        </StoryContainer>
-        <StoryContainer>
-          <TextField
-            reversed={true}
-            id="text"
-            inputType="email"
-            defaultInputValue="Input Text"
-            labelText="Positive"
-            placeholder="jane.doe@email.com"
-            status="success"
-            description="Description text"
-            icon={dateIcon}
-            disabled={true}
-          />
-        </StoryContainer>
-        <StoryContainer>
-          <TextField
-            reversed={true}
-            id="text"
-            inputType="email"
-            defaultInputValue="Input Text"
-            labelText="Negative"
-            placeholder="jane.doe@email.com"
-            status="error"
-            description="Description text"
-            validationMessage="Error message"
-            icon={dateIcon}
-            disabled={true}
-          />
-        </StoryContainer>
-        <StoryContainer>
-          <TextField
-            reversed={true}
-            id="text"
-            inputType="email"
-            defaultInputValue="Input Text"
-            labelText="Cautionary"
-            placeholder="jane.doe@email.com"
-            status="caution"
-            description="Description text"
-            validationMessage="Error message"
-            icon={dateIcon}
-            disabled={true}
-          />
-        </StoryContainer>
-      </StoryColumn>
-    </StoryGrid>
+    <StickerSheet heading="Default" isReversed={isReversed}>
+      <StickerSheet.Header
+        headings={["Base", "Disabled"]}
+        headingsWidth="15rem"
+      />
+      <StickerSheet.Body>
+        {DEFAULT__ROW_PROPS.map(({ id, ...restProps }) => (
+          <StickerSheet.Row key={id}>
+            <TextField
+              reversed={isReversed}
+              id={`${id}--base`}
+              {...restProps}
+              />
+            <TextField
+              reversed={isReversed}
+              id={`${id}--disabled`}
+              disabled
+              {...restProps}
+            />
+          </StickerSheet.Row>
+        ))}
+      </StickerSheet.Body>
+    </StickerSheet>
+
+    <StickerSheet heading="Icon" isReversed={isReversed}>
+      <StickerSheet.Header
+        headings={["Base", "Disabled"]}
+        headingsWidth="15rem"
+      />
+      <StickerSheet.Body>
+        {ICON__ROW_PROPS.map(({ id, ...restProps }) => (
+          <StickerSheet.Row key={id}>
+            <TextField
+              reversed={isReversed}
+              id={`${id}--base`}
+              icon={dateIcon}
+              {...restProps}
+              />
+            <TextField
+              reversed={isReversed}
+              id={`${id}--disabled`}
+              disabled
+              icon={dateIcon}
+              {...restProps}
+            />
+          </StickerSheet.Row>
+        ))}
+      </StickerSheet.Body>
+    </StickerSheet>
   </>
 )
+  }
+
+export const StickerSheetDefault = StickerSheetTemplate.bind({})
+StickerSheetDefault.storyName = "Sticker Sheet (Default)"
+StickerSheetDefault.parameters = {
+  chromatic: { disable: false },
+  controls: { disable: true },
+}
+
+export const StickerSheetReversed = StickerSheetTemplate.bind({})
 StickerSheetReversed.storyName = "Sticker Sheet (Reversed)"
+StickerSheetReversed.args = { isReversed: true }
 StickerSheetReversed.parameters = {
+  controls: { disable: true },
   backgrounds: { default: "Purple 700" },
   chromatic: { disable: false },
 }

--- a/draft-packages/form/docs/ToggleSwitchField.stories.tsx
+++ b/draft-packages/form/docs/ToggleSwitchField.stories.tsx
@@ -1,7 +1,8 @@
 import React from "react"
+import { ComponentMeta, ComponentStory, Story } from "@storybook/react"
 import { withDesign } from "storybook-addon-designs"
 import { ToggledStatus, ToggleSwitchField } from "@kaizen/draft-form"
-import { Heading } from "@kaizen/typography"
+import { StickerSheet } from "../../../storybook/components/StickerSheet"
 import { CATEGORIES, SUB_CATEGORIES } from "../../../storybook/constants"
 import { figmaEmbed } from "../../../storybook/helpers"
 
@@ -19,7 +20,7 @@ class ToggleStateContainer extends React.Component<
     toggledStatus: this.props.initialToggledStatus,
   }
 
-  render() {
+  render(): JSX.Element {
     return (
       <div>
         {this.props.children({
@@ -30,7 +31,7 @@ class ToggleStateContainer extends React.Component<
     )
   }
 
-  toggle = () => {
+  toggle = (): void => {
     const { toggledStatus } = this.state
     const newStatus =
       toggledStatus === ToggledStatus.ON ? ToggledStatus.OFF : ToggledStatus.ON
@@ -53,11 +54,11 @@ export default {
     ),
   },
   decorators: [withDesign],
-}
+} as ComponentMeta<typeof ToggleSwitchField>
 
-export const Default = props => (
+export const Default: ComponentStory<typeof ToggleSwitchField> = props => (
   <ToggleStateContainer initialToggledStatus={ToggledStatus.ON}>
-    {({ toggledStatus, toggle }) => (
+    {({ toggledStatus, toggle }): JSX.Element => (
       <ToggleSwitchField
         {...props}
         labelText="Label"
@@ -69,128 +70,65 @@ export const Default = props => (
 )
 Default.storyName = "Default (Kaizen Demo)"
 
-export const StickerSheetDefault = () => (
-  <div
-    style={{
-      display: "grid",
-      gridTemplateColumns: "repeat(3, minmax(200px, 400px))",
-      rowGap: "20px",
-    }}
-  >
-    <div>
-      <Heading variant="heading-5" tag="h2">
-        Default
-      </Heading>
-    </div>
-    <div>
-      <Heading variant="heading-5" tag="h2">
-        Label Position End
-      </Heading>
-    </div>
-    <div>
-      <Heading variant="heading-5" tag="h2">
-        Disabled
-      </Heading>
-    </div>
-    <ToggleStateContainer initialToggledStatus={ToggledStatus.ON}>
-      {({ toggledStatus, toggle }) => (
-        <ToggleSwitchField
-          id="1"
-          labelText="Label"
-          toggledStatus={toggledStatus}
-          onToggle={toggle}
-        />
-      )}
-    </ToggleStateContainer>
-    <ToggleStateContainer initialToggledStatus={ToggledStatus.ON}>
-      {({ toggledStatus, toggle }) => (
-        <ToggleSwitchField
-          id="2"
-          labelText="Label"
-          labelPosition="end"
-          toggledStatus={toggledStatus}
-          onToggle={toggle}
-        />
-      )}
-    </ToggleStateContainer>
-    <ToggleStateContainer initialToggledStatus={ToggledStatus.ON}>
-      {({ toggledStatus, toggle }) => (
-        <ToggleSwitchField
-          id="3"
-          labelText="Label"
-          toggledStatus={toggledStatus}
-          onToggle={toggle}
-          disabled
-        />
-      )}
-    </ToggleStateContainer>
-  </div>
+const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({
+  isReversed,
+}) => (
+  <StickerSheet isReversed={isReversed}>
+    <StickerSheet.Header headings={["Default", "Label Position End", "Disabled"]} headingsWidth="12rem" />
+    <StickerSheet.Body>
+      <StickerSheet.Row>
+        <ToggleStateContainer initialToggledStatus={ToggledStatus.ON}>
+          {({ toggledStatus, toggle }): JSX.Element => (
+            <ToggleSwitchField
+              reversed={isReversed}
+              id="toggle-switch-field--default"
+              labelText="Label"
+              toggledStatus={toggledStatus}
+              onToggle={toggle}
+            />
+          )}
+        </ToggleStateContainer>
+        <ToggleStateContainer initialToggledStatus={ToggledStatus.ON}>
+          {({ toggledStatus, toggle }): JSX.Element => (
+            <ToggleSwitchField
+              reversed={isReversed}
+              id="toggle-switch-field--label-end"
+              labelText="Label"
+              labelPosition="end"
+              toggledStatus={toggledStatus}
+              onToggle={toggle}
+            />
+          )}
+        </ToggleStateContainer>
+        <ToggleStateContainer initialToggledStatus={ToggledStatus.ON}>
+          {({ toggledStatus, toggle }): JSX.Element => (
+            <ToggleSwitchField
+              reversed={isReversed}
+              id="toggle-switch-field--disabled"
+              labelText="Label"
+              toggledStatus={toggledStatus}
+              onToggle={toggle}
+              disabled
+            />
+          )}
+        </ToggleStateContainer>
+      </StickerSheet.Row>
+    </StickerSheet.Body>
+  </StickerSheet>
 )
-StickerSheetDefault.storyName = "Sticker Sheet (Default)"
-StickerSheetDefault.parameters = { chromatic: { disable: false } }
 
-export const StickerSheetReversed = () => (
-  <div
-    style={{
-      display: "grid",
-      gridTemplateColumns: "repeat(3, minmax(200px, 400px))",
-      rowGap: "20px",
-    }}
-  >
-    <div>
-      <Heading variant="heading-5" tag="h2" color="white">
-        Default
-      </Heading>
-    </div>
-    <div>
-      <Heading variant="heading-5" tag="h2" color="white">
-        Label Position End
-      </Heading>
-    </div>
-    <div>
-      <Heading variant="heading-5" tag="h2" color="white">
-        Disabled
-      </Heading>
-    </div>
-    <ToggleStateContainer initialToggledStatus={ToggledStatus.ON}>
-      {({ toggledStatus, toggle }) => (
-        <ToggleSwitchField
-          id="4"
-          labelText="Label"
-          toggledStatus={toggledStatus}
-          onToggle={toggle}
-          reversed
-        />
-      )}
-    </ToggleStateContainer>
-    <ToggleStateContainer initialToggledStatus={ToggledStatus.ON}>
-      {({ toggledStatus, toggle }) => (
-        <ToggleSwitchField
-          id="5"
-          labelText="Label"
-          labelPosition="end"
-          toggledStatus={toggledStatus}
-          onToggle={toggle}
-          reversed
-        />
-      )}
-    </ToggleStateContainer>
-    <ToggleStateContainer initialToggledStatus={ToggledStatus.ON}>
-      {({ toggledStatus, toggle }) => (
-        <ToggleSwitchField
-          id="6"
-          labelText="Label"
-          toggledStatus={toggledStatus}
-          onToggle={toggle}
-          disabled
-          reversed
-        />
-      )}
-    </ToggleStateContainer>
-  </div>
-)
+export const StickerSheetDefault = StickerSheetTemplate.bind({})
+StickerSheetDefault.storyName = "Sticker Sheet (Default)"
+StickerSheetDefault.parameters = {
+  chromatic: { disable: false },
+  controls: { disable: true },
+}
+
+export const StickerSheetReversed = StickerSheetTemplate.bind({})
 StickerSheetReversed.storyName = "Sticker Sheet (Reversed)"
+StickerSheetReversed.args = { isReversed: true }
 StickerSheetReversed.parameters = {
+  controls: { disable: true },
   backgrounds: { default: "Purple 700" },
   chromatic: { disable: false },
 }

--- a/draft-packages/form/docs/ToggleSwitchField.stories.tsx
+++ b/draft-packages/form/docs/ToggleSwitchField.stories.tsx
@@ -74,7 +74,10 @@ const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({
   isReversed,
 }) => (
   <StickerSheet isReversed={isReversed}>
-    <StickerSheet.Header headings={["Default", "Label Position End", "Disabled"]} headingsWidth="12rem" />
+    <StickerSheet.Header
+      headings={["Default", "Label Position End", "Disabled"]}
+      headingsWidth="12rem"
+    />
     <StickerSheet.Body>
       <StickerSheet.Row>
         <ToggleStateContainer initialToggledStatus={ToggledStatus.ON}>

--- a/draft-packages/guidance-block/KaizenDraft/GuidanceBlock/GuidanceBlock.spec.tsx
+++ b/draft-packages/guidance-block/KaizenDraft/GuidanceBlock/GuidanceBlock.spec.tsx
@@ -1,4 +1,4 @@
-import * as React from "react"
+import React from "react"
 import { fireEvent, waitFor } from "@testing-library/dom"
 import { cleanup, render } from "@testing-library/react"
 import * as ReactTestUtils from "react-dom/test-utils"
@@ -28,8 +28,8 @@ describe("GuidanceBlock", () => {
             "Mussum Ipsum, cacilds vidis litro abertis. Suco de cevadiss, é um leite divinis.",
         }}
         actions={{
-          primary: { label: "Action!", onClick: () => alert("tada: 🎉") },
-          dismiss: { onClick: () => null },
+          primary: { label: "Action!", onClick: (): void => alert("tada: 🎉") },
+          dismiss: { onClick: (): void => undefined },
         }}
       />
     )
@@ -48,7 +48,7 @@ describe("GuidanceBlock", () => {
             "Mussum Ipsum, cacilds vidis litro abertis. Suco de cevadiss, é um leite divinis.",
         }}
         actions={{
-          primary: { label: "Action!", onClick: () => alert("tada: 🎉") },
+          primary: { label: "Action!", onClick: (): void => alert("tada: 🎉") },
           dismiss: { onClick: onDismiss },
         }}
       />
@@ -95,7 +95,7 @@ describe("GuidanceBlock", () => {
             "Mussum Ipsum, cacilds vidis litro abertis. Suco de cevadiss, é um leite divinis.",
         }}
         actions={{
-          primary: { label: "Action!", onClick: () => null },
+          primary: { label: "Action!", onClick: (): void => undefined },
         }}
       />
     )
@@ -125,7 +125,7 @@ describe("GuidanceBlock", () => {
             "Mussum Ipsum, cacilds vidis litro abertis. Suco de cevadiss, é um leite divinis.",
         }}
         actions={{
-          primary: { label: "Action!", onClick: () => null },
+          primary: { label: "Action!", onClick: (): void => undefined },
         }}
         persistent
       />
@@ -145,8 +145,8 @@ describe("GuidanceBlock", () => {
             "Mussum Ipsum, cacilds vidis litro abertis. Suco de cevadiss, é um leite divinis.",
         }}
         actions={{
-          primary: { label: "Action!", onClick: () => null },
-          secondary: { label: "Secondary action", onClick: () => null },
+          primary: { label: "Action!", onClick: (): void => undefined },
+          secondary: { label: "Secondary action", onClick: (): void => undefined },
         }}
       />
     )

--- a/draft-packages/guidance-block/KaizenDraft/GuidanceBlock/GuidanceBlock.spec.tsx
+++ b/draft-packages/guidance-block/KaizenDraft/GuidanceBlock/GuidanceBlock.spec.tsx
@@ -146,7 +146,10 @@ describe("GuidanceBlock", () => {
         }}
         actions={{
           primary: { label: "Action!", onClick: (): void => undefined },
-          secondary: { label: "Secondary action", onClick: (): void => undefined },
+          secondary: {
+            label: "Secondary action",
+            onClick: (): void => undefined,
+          },
         }}
       />
     )

--- a/draft-packages/guidance-block/docs/GuidanceBlock.stories.tsx
+++ b/draft-packages/guidance-block/docs/GuidanceBlock.stories.tsx
@@ -64,6 +64,7 @@ DefaultStory.storyName = "Default (Kaizen Demo)"
 DefaultStory.args = {
   layout: "default",
   illustrationType: "spot",
+  // @ts-expect-error:next-line - String here is mapped to valid prop value in default controls
   illustration: "spot",
   variant: "default",
   withActionButtonArrow: true,

--- a/draft-packages/guidance-block/docs/GuidanceBlock.stories.tsx
+++ b/draft-packages/guidance-block/docs/GuidanceBlock.stories.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { Story } from "@storybook/react"
+import { ComponentStory, Story } from "@storybook/react"
 import { withDesign } from "storybook-addon-designs"
 import { Box } from "@kaizen/component-library"
 import { GuidanceBlock } from "@kaizen/draft-guidance-block"
@@ -46,16 +46,12 @@ const GUIDANCE_BLOCK_TEXT = {
     "qui tem lupuliz, matis, aguis e fermentis. Mé faiz elementum girarzis, nisi eros vermeio.",
 }
 
-export const DefaultStory = args => (
+export const DefaultStory: ComponentStory<typeof GuidanceBlock> = args => (
   <GuidanceBlock
-    illustration={args.illustration}
-    text={GUIDANCE_BLOCK_TEXT}
     actions={{
       primary: {
         label: "Action",
-        onClick: () => {
-          alert("tada: 🎉")
-        },
+        onClick: () => alert("tada: 🎉"),
       },
       dismiss: {
         onClick: () => alert("tada: 🎉"),
@@ -120,7 +116,7 @@ const PROPS: GuidanceBlockProps = {
   },
 }
 
-const CustomContent = () => (
+const CustomContent = (): JSX.Element => (
   <>
     <Box mb={0.75}>
       <Tag variant="statusLive" size="small">
@@ -169,9 +165,7 @@ const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({
         actions={{
           primary: {
             label: "Learn more",
-            onClick: () => {
-              alert("tada: 🎉")
-            },
+            onClick: () => alert("tada: 🎉"),
           },
           secondary: {
             label: "Dismiss",
@@ -190,9 +184,7 @@ const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({
         actions={{
           primary: {
             label: "Learn more",
-            onClick: () => {
-              alert("tada: 🎉")
-            },
+            onClick: () => alert("tada: 🎉"),
           },
           secondary: {
             label: "Dismiss",
@@ -213,9 +205,7 @@ const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({
         actions={{
           primary: {
             label: "Learn more",
-            onClick: () => {
-              alert("tada: 🎉")
-            },
+            onClick: () => alert("tada: 🎉"),
             tooltip: {
               text: "Opens in a new tab",
               mood: "cautionary",
@@ -238,9 +228,7 @@ const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({
         actions={{
           primary: {
             label: "Action",
-            onClick: () => {
-              alert("tada: 🎉")
-            },
+            onClick: () => alert("tada: 🎉"),
           },
         }}
         persistent
@@ -273,7 +261,7 @@ StickerSheetReversed.parameters = {
   controls: { disable: true },
 }
 
-export const Layouts = () => (
+export const Layouts: Story = () => (
   <div style={{ display: "flex", flexDirection: "column", gap: "36px" }}>
     <Heading tag="h2" variant="heading-4">
       Default
@@ -285,9 +273,7 @@ export const Layouts = () => (
       actions={{
         primary: {
           label: "Action",
-          onClick: () => {
-            alert("tada: 🎉")
-          },
+          onClick: () => alert("tada: 🎉"),
         },
         secondary: {
           label: "Dismiss",
@@ -306,9 +292,7 @@ export const Layouts = () => (
       actions={{
         primary: {
           label: "Action",
-          onClick: () => {
-            alert("tada: 🎉")
-          },
+          onClick: () => alert("tada: 🎉"),
         },
         secondary: {
           label: "Dismiss",
@@ -328,9 +312,7 @@ export const Layouts = () => (
       actions={{
         primary: {
           label: "Action",
-          onClick: () => {
-            alert("tada: 🎉")
-          },
+          onClick: () => alert("tada: 🎉"),
         },
         secondary: {
           label: "Dismiss",
@@ -349,9 +331,7 @@ export const Layouts = () => (
       actions={{
         primary: {
           label: "Action",
-          onClick: () => {
-            alert("tada: 🎉")
-          },
+          onClick: () => alert("tada: 🎉"),
         },
         secondary: {
           label: "Dismiss",
@@ -372,9 +352,7 @@ export const Layouts = () => (
       actions={{
         primary: {
           label: "Action",
-          onClick: () => {
-            alert("tada: 🎉")
-          },
+          onClick: () => alert("tada: 🎉"),
         },
         secondary: {
           label: "Dismiss action",
@@ -394,9 +372,7 @@ export const Layouts = () => (
         actions={{
           primary: {
             label: "Action",
-            onClick: () => {
-              alert("tada: 🎉")
-            },
+            onClick: () => alert("tada: 🎉"),
           },
           secondary: {
             label: "Dismiss",
@@ -412,9 +388,7 @@ export const Layouts = () => (
         actions={{
           primary: {
             label: "Action",
-            onClick: () => {
-              alert("tada: 🎉")
-            },
+            onClick: () => alert("tada: 🎉"),
           },
           secondary: {
             label: "Dismiss",
@@ -428,7 +402,7 @@ export const Layouts = () => (
 )
 Layouts.parameters = { chromatic: { disable: false } }
 
-export const AspectRatio = () => (
+export const AspectRatio: Story = () => (
   <div style={{ display: "flex", flexDirection: "column", gap: "36px" }}>
     <Heading tag="h2" variant="heading-4">
       Scene example
@@ -464,9 +438,7 @@ export const AspectRatio = () => (
         actions={{
           primary: {
             label: "Action",
-            onClick: () => {
-              alert("tada: 🎉")
-            },
+            onClick: () => alert("tada: 🎉"),
           },
           secondary: {
             label: "Dismiss",
@@ -483,9 +455,7 @@ export const AspectRatio = () => (
         actions={{
           primary: {
             label: "Action",
-            onClick: () => {
-              alert("tada: 🎉")
-            },
+            onClick: () => alert("tada: 🎉"),
           },
           secondary: {
             label: "Dismiss",

--- a/draft-packages/hero-card/docs/HeroCard.stories.tsx
+++ b/draft-packages/hero-card/docs/HeroCard.stories.tsx
@@ -1,4 +1,5 @@
 import React from "react"
+import { Story } from "@storybook/react"
 import { withDesign } from "storybook-addon-designs"
 import { Button } from "@kaizen/button"
 import { HeroCard } from "@kaizen/draft-hero-card"
@@ -7,7 +8,7 @@ import { figmaEmbed } from "../../../storybook/helpers"
 
 const ILLUSTRATION_SURVEY = require("./survey.png")
 
-const renderContent = () => (
+const renderContent = (): JSX.Element => (
   <div
     style={{
       width: "560px",
@@ -40,18 +41,18 @@ export default {
   decorators: [withDesign],
 }
 
-export const DefaultKaizenSiteDemo = () => (
+export const DefaultKaizenSiteDemo: Story = () => (
   <HeroCard>{renderContent()}</HeroCard>
 )
 DefaultKaizenSiteDemo.storyName = "Default (Kaizen Site Demo)"
 
-export const Title = () => (
+export const Title: Story = () => (
   <HeroCard title={<h1>Preview the survey questions</h1>}>
     {renderContent()}
   </HeroCard>
 )
 
-export const Badge = () => (
+export const Badge: Story = () => (
   <HeroCard
     title={<h1>Preview the survey questions</h1>}
     badge={<span>1</span>}
@@ -61,7 +62,7 @@ export const Badge = () => (
 )
 Badge.parameters = { chromatic: { disable: false } }
 
-export const Image = () => (
+export const Image: Story = () => (
   <HeroCard
     title={<h1>Preview the survey questions</h1>}
     badge={<span>1</span>}
@@ -83,7 +84,7 @@ export const Image = () => (
 )
 Image.parameters = { chromatic: { disable: false } }
 
-export const CustomLeftContent = () => (
+export const CustomLeftContent: Story = () => (
   <HeroCard
     title={<h1>Preview the survey questions</h1>}
     leftContent={<p>Ta-dah</p>}
@@ -93,7 +94,7 @@ export const CustomLeftContent = () => (
 )
 CustomLeftContent.parameters = { chromatic: { disable: false } }
 
-export const CustomLeftContentAndBadge = () => (
+export const CustomLeftContentAndBadge: Story = () => (
   <HeroCard
     title={<h1>Preview the survey questions</h1>}
     leftContent={<p>Ta-dah</p>}
@@ -104,7 +105,7 @@ export const CustomLeftContentAndBadge = () => (
 )
 CustomLeftContentAndBadge.parameters = { chromatic: { disable: false } }
 
-export const FullWidth = () => (
+export const FullWidth: Story = () => (
   <HeroCard
     title={<h1>Preview the survey questions</h1>}
     leftContent={<p>Ta-dah</p>}
@@ -115,7 +116,7 @@ export const FullWidth = () => (
 )
 FullWidth.parameters = { chromatic: { disable: false } }
 
-export const BackgroundColors = () => (
+export const BackgroundColors: Story = () => (
   <HeroCard
     title={<h1>Preview the survey questions</h1>}
     leftBackgroundColor="cluny200"

--- a/draft-packages/illustration/docs/IllustrationSpot.stories.tsx
+++ b/draft-packages/illustration/docs/IllustrationSpot.stories.tsx
@@ -145,14 +145,16 @@ export default {
   },
 }
 
-export const SpotStoryForKaizenSite: ComponentStory<typeof AccountBasics> = args => (
+export const SpotStoryForKaizenSite: ComponentStory<
+  typeof AccountBasics
+> = args => (
   <div style={{ width: "150px" }}>
     <AccountBasics {...args} />
   </div>
 )
 SpotStoryForKaizenSite.storyName = "Spot (Kaizen Site Demo)"
 SpotStoryForKaizenSite.args = {
-  alt: ""
+  alt: "",
 }
 
 const IllustrationExampleTile = ({ Component, name }): JSX.Element => (
@@ -756,36 +758,16 @@ AllSpotIllustrations.parameters = { chromatic: { disable: false } }
 
 export const AnimatedSpot: Story<AnimatedSpotProps> = args => (
   <div style={{ width: "156px" }}>
-    <Cautionary
-      isAnimated
-      loop
-      {...args}
-    />
-    <Informative
-      isAnimated
-      loop
-      {...args}
-    />
-    <Negative
-      isAnimated
-      loop
-      {...args}
-    />
-    <Positive
-      isAnimated
-      loop
-      {...args}
-    />
-    <Assertive
-      isAnimated
-      loop
-      {...args}
-    />
+    <Cautionary isAnimated loop {...args} />
+    <Informative isAnimated loop {...args} />
+    <Negative isAnimated loop {...args} />
+    <Positive isAnimated loop {...args} />
+    <Assertive isAnimated loop {...args} />
   </div>
 )
 AnimatedSpot.storyName = "Spot, animated"
 AnimatedSpot.args = {
-  alt: "Add useful alt text for screen readers"
+  alt: "Add useful alt text for screen readers",
 }
 AnimatedSpot.parameters = {
   chromatic: {

--- a/draft-packages/illustration/docs/IllustrationSpot.stories.tsx
+++ b/draft-packages/illustration/docs/IllustrationSpot.stories.tsx
@@ -1,4 +1,5 @@
 import React from "react"
+import { ComponentStory, Story } from "@storybook/react"
 import { Heading, Paragraph } from "@kaizen/typography"
 import { CATEGORIES, SUB_CATEGORIES } from "../../../storybook/constants"
 import {
@@ -128,6 +129,7 @@ import {
   Learn,
   Templates,
   CalendarSync,
+  AnimatedSpotProps,
 } from ".."
 
 export default {
@@ -143,21 +145,24 @@ export default {
   },
 }
 
-export const SpotStoryForKaizenSite = args => (
+export const SpotStoryForKaizenSite: ComponentStory<typeof AccountBasics> = args => (
   <div style={{ width: "150px" }}>
-    <AccountBasics alt="" {...args} />
+    <AccountBasics {...args} />
   </div>
 )
 SpotStoryForKaizenSite.storyName = "Spot (Kaizen Site Demo)"
+SpotStoryForKaizenSite.args = {
+  alt: ""
+}
 
-const IllustrationExampleTile = ({ Component, name }) => (
+const IllustrationExampleTile = ({ Component, name }): JSX.Element => (
   <div style={{ width: "150px", display: "inline-block", padding: "2rem" }}>
     <Component alt="" />
     <Paragraph variant="small">{name}</Paragraph>
   </div>
 )
 
-export const AllSpotIllustrations = () => {
+export const AllSpotIllustrations: Story = () => {
   const engagementSpots = [
     {
       Component: BenefitsSurvey,
@@ -749,34 +754,29 @@ export const AllSpotIllustrations = () => {
 }
 AllSpotIllustrations.parameters = { chromatic: { disable: false } }
 
-export const AnimatedSpot = args => (
+export const AnimatedSpot: Story<AnimatedSpotProps> = args => (
   <div style={{ width: "156px" }}>
     <Cautionary
-      alt="Add useful alt text for screen readers"
       isAnimated
       loop
       {...args}
     />
     <Informative
-      alt="Add useful alt text for screen readers"
       isAnimated
       loop
       {...args}
     />
     <Negative
-      alt="Add useful alt text for screen readers"
       isAnimated
       loop
       {...args}
     />
     <Positive
-      alt="Add useful alt text for screen readers"
       isAnimated
       loop
       {...args}
     />
     <Assertive
-      alt="Add useful alt text for screen readers"
       isAnimated
       loop
       {...args}
@@ -784,6 +784,9 @@ export const AnimatedSpot = args => (
   </div>
 )
 AnimatedSpot.storyName = "Spot, animated"
+AnimatedSpot.args = {
+  alt: "Add useful alt text for screen readers"
+}
 AnimatedSpot.parameters = {
   chromatic: {
     disable: false,

--- a/draft-packages/likert-scale-legacy/KaizenDraft/LikertScaleLegacy/LikertScaleLegacy.spec.tsx
+++ b/draft-packages/likert-scale-legacy/KaizenDraft/LikertScaleLegacy/LikertScaleLegacy.spec.tsx
@@ -1,7 +1,5 @@
 import React from "react"
 import { render, screen } from "@testing-library/react"
-import "@testing-library/jest-dom"
-
 import { LikertScaleLegacy, LikertScaleProps } from "./LikertScaleLegacy"
 import { Scale } from "./types"
 
@@ -32,12 +30,12 @@ const scale: Scale = [
   },
 ]
 
-const LikertScaleLegacyWrapper = (props: Partial<LikertScaleProps>) => (
+const LikertScaleLegacyWrapper = (props: Partial<LikertScaleProps>): JSX.Element => (
   <LikertScaleLegacy
     scale={scale}
     labelId="test__likert-scale"
     selectedItem={null}
-    onSelect={() => undefined}
+    onSelect={(): void => undefined}
     {...props}
   />
 )

--- a/draft-packages/likert-scale-legacy/KaizenDraft/LikertScaleLegacy/LikertScaleLegacy.spec.tsx
+++ b/draft-packages/likert-scale-legacy/KaizenDraft/LikertScaleLegacy/LikertScaleLegacy.spec.tsx
@@ -30,7 +30,9 @@ const scale: Scale = [
   },
 ]
 
-const LikertScaleLegacyWrapper = (props: Partial<LikertScaleProps>): JSX.Element => (
+const LikertScaleLegacyWrapper = (
+  props: Partial<LikertScaleProps>
+): JSX.Element => (
   <LikertScaleLegacy
     scale={scale}
     labelId="test__likert-scale"

--- a/draft-packages/likert-scale-legacy/docs/LikertScaleLegacy.stories.tsx
+++ b/draft-packages/likert-scale-legacy/docs/LikertScaleLegacy.stories.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react"
-import { Story } from "@storybook/react"
+import { ComponentStory, Story } from "@storybook/react"
 import {
   LikertScaleLegacy,
   Scale,
@@ -54,24 +54,22 @@ const scale: Scale = [
   },
 ]
 
-export const DefaultStory = args => {
+export const DefaultStory: ComponentStory<typeof LikertScaleLegacy> = args => {
   const [selectedItem, setSelectedItem] = useState<ScaleItem | null>(null)
-  const labelId = "456"
 
   return (
     <>
-      <div style={{ marginBottom: "40px" }} id={labelId}>
+      <div style={{ marginBottom: "40px" }} id={args.labelId}>
         <Heading variant="heading-4" color="dark">
           How would you rate this survey?
         </Heading>
       </div>
       <LikertScaleLegacy
-        scale={scale}
-        automationId="123"
-        labelId={labelId} // Intended to match the id of the label
-        selectedItem={selectedItem}
-        onSelect={item => setSelectedItem(item)}
         {...args}
+        automationId="123"
+        scale={scale}
+        selectedItem={selectedItem}
+        onSelect={setSelectedItem}
       />
     </>
   )
@@ -79,6 +77,9 @@ export const DefaultStory = args => {
 DefaultStory.storyName = "Likert Scale"
 DefaultStory.parameters = {
   docs: { source: { type: "code" } },
+}
+DefaultStory.args = {
+  labelId: "456"
 }
 
 const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({
@@ -98,7 +99,7 @@ const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({
           scale={scale}
           labelId="1"
           selectedItem={scale[0]}
-          onSelect={() => undefined}
+          onSelect={(): void => undefined}
           reversed={isReversed}
         />
       </StoryWrapper.Row>
@@ -107,7 +108,7 @@ const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({
           scale={scale}
           labelId="1"
           selectedItem={scale[1]}
-          onSelect={() => undefined}
+          onSelect={(): void => undefined}
           reversed={isReversed}
         />
       </StoryWrapper.Row>
@@ -116,7 +117,7 @@ const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({
           scale={scale}
           labelId="2"
           selectedItem={scale[2]}
-          onSelect={() => undefined}
+          onSelect={(): void => undefined}
           reversed={isReversed}
         />
       </StoryWrapper.Row>
@@ -125,7 +126,7 @@ const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({
           scale={scale}
           labelId="3"
           selectedItem={scale[3]}
-          onSelect={() => undefined}
+          onSelect={(): void => undefined}
           reversed={isReversed}
         />
       </StoryWrapper.Row>
@@ -134,7 +135,7 @@ const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({
           scale={scale}
           labelId="4"
           selectedItem={scale[4]}
-          onSelect={() => undefined}
+          onSelect={(): void => undefined}
           reversed={isReversed}
         />
       </StoryWrapper.Row>
@@ -143,7 +144,7 @@ const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({
           scale={scale}
           labelId="5"
           selectedItem={scale[5]}
-          onSelect={() => undefined}
+          onSelect={(): void => undefined}
           reversed={isReversed}
         />
       </StoryWrapper.Row>
@@ -154,7 +155,7 @@ const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({
           scale={scale}
           labelId="Error state"
           selectedItem={scale[0]}
-          onSelect={() => undefined}
+          onSelect={(): void => undefined}
           reversed={isReversed}
           validationMessage="Error message here"
           status="error"

--- a/draft-packages/likert-scale-legacy/docs/LikertScaleLegacy.stories.tsx
+++ b/draft-packages/likert-scale-legacy/docs/LikertScaleLegacy.stories.tsx
@@ -79,7 +79,7 @@ DefaultStory.parameters = {
   docs: { source: { type: "code" } },
 }
 DefaultStory.args = {
-  labelId: "456"
+  labelId: "456",
 }
 
 const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({

--- a/draft-packages/menu/KaizenDraft/Menu/Menu.spec.tsx
+++ b/draft-packages/menu/KaizenDraft/Menu/Menu.spec.tsx
@@ -1,4 +1,4 @@
-import * as React from "react"
+import React from "react"
 import { fireEvent } from "@testing-library/dom"
 import { render, screen, waitFor } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"

--- a/draft-packages/menu/docs/Menu.stories.tsx
+++ b/draft-packages/menu/docs/Menu.stories.tsx
@@ -1,14 +1,12 @@
 import React from "react"
-import { Story } from "@storybook/react"
+import { ComponentStory, Story } from "@storybook/react"
 import { withDesign } from "storybook-addon-designs"
-
 import { Button, IconButton } from "@kaizen/button"
 import chevronDown from "@kaizen/component-library/icons/chevron-down.icon.svg"
 import duplicateIcon from "@kaizen/component-library/icons/duplicate.icon.svg"
 import editIcon from "@kaizen/component-library/icons/edit.icon.svg"
 import meatballsIcon from "@kaizen/component-library/icons/meatballs.icon.svg"
 import trashIcon from "@kaizen/component-library/icons/trash.icon.svg"
-
 import { StoryWrapper } from "../../../storybook/components/StoryWrapper"
 import { CATEGORIES } from "../../../storybook/constants"
 import { figmaEmbed } from "../../../storybook/helpers"
@@ -32,7 +30,7 @@ export default {
   decorators: [withDesign],
 }
 
-export const DefaultStory = args => (
+export const DefaultStory: ComponentStory<typeof Menu> = args => (
   <Menu
     {...args}
     button={
@@ -41,7 +39,7 @@ export const DefaultStory = args => (
   >
     <MenuList>
       <MenuItem
-        onClick={e => {
+        onClick={(e: React.MouseEvent): void => {
           e.preventDefault()
           alert("onClick function to duplicate content")
         }}
@@ -49,7 +47,7 @@ export const DefaultStory = args => (
         label="Duplicate item"
       />
       <MenuItem
-        onClick={e => {
+        onClick={(e: React.MouseEvent): void => {
           e.preventDefault()
           alert("onClick function to edit content")
         }}
@@ -57,7 +55,7 @@ export const DefaultStory = args => (
         label="Edit Item"
       />
       <MenuItem
-        onClick={e => {
+        onClick={(e: React.MouseEvent): void => {
           e.preventDefault()
           alert("onClick function to delete content")
         }}
@@ -71,7 +69,7 @@ export const DefaultStory = args => (
       />
       <MenuList heading="Deprecated props">
         <MenuItem
-          action={e => {
+          action={(e): void => {
             e.preventDefault()
             alert("action prop has has been deprecated - use onClick")
           }}
@@ -82,7 +80,6 @@ export const DefaultStory = args => (
     </MenuList>
   </Menu>
 )
-
 DefaultStory.storyName = "Default (Kaizen Site Demo)"
 
 const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({
@@ -141,15 +138,13 @@ const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({
 
 export const StickerSheetDefault = StickerSheetTemplate.bind({})
 StickerSheetDefault.storyName = "Sticker Sheet (Default)"
-
 StickerSheetDefault.decorators = [
-  (StoryComponent: Story) => (
+  (StoryComponent: Story): JSX.Element => (
     <div style={{ minHeight: "500px" }}>
       <StoryComponent />
     </div>
   ),
 ]
-
 StickerSheetDefault.parameters = {
   chromatic: { disable: false },
   controls: { disable: true },
@@ -158,15 +153,13 @@ StickerSheetDefault.parameters = {
 export const StickerSheetReversed = StickerSheetTemplate.bind({})
 StickerSheetReversed.storyName = "Sticker Sheet (Reversed)"
 StickerSheetReversed.args = { isReversed: true }
-
 StickerSheetReversed.decorators = [
-  (StoryComponent: Story) => (
+  (StoryComponent: Story): JSX.Element => (
     <div style={{ minHeight: "500px" }}>
       <StoryComponent />
     </div>
   ),
 ]
-
 StickerSheetReversed.parameters = {
   backgrounds: { default: "Purple 700" },
   chromatic: { disable: false },

--- a/draft-packages/menu/docs/MenuExamples.stories.tsx
+++ b/draft-packages/menu/docs/MenuExamples.stories.tsx
@@ -168,11 +168,7 @@ export const DefaultStatelessMenu: Story = () => {
         Menu status: {isMenuVisible ? "open" : "closed"}
       </Paragraph>
       <Box py={1}>
-        <Button
-          secondary={true}
-          onClick={toggleMenu}
-          label="Toggle menu"
-        />
+        <Button secondary={true} onClick={toggleMenu} label="Toggle menu" />
         <Button secondary={true} onClick={hideMenu} label="Hide menu" />
       </Box>
       <StatelessMenu

--- a/draft-packages/menu/docs/MenuExamples.stories.tsx
+++ b/draft-packages/menu/docs/MenuExamples.stories.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react"
+import { ComponentStory, Story } from "@storybook/react"
 import { withDesign } from "storybook-addon-designs"
 import { Button, IconButton } from "@kaizen/button"
 import { Box } from "@kaizen/component-library"
@@ -12,7 +13,6 @@ import { Paragraph } from "@kaizen/typography"
 import { StoryWrapper } from "../../../storybook/components/StoryWrapper"
 import { CATEGORIES, SUB_CATEGORIES } from "../../../storybook/constants"
 import { figmaEmbed } from "../../../storybook/helpers"
-
 import { Menu, MenuList, MenuItem, StatelessMenu } from ".."
 import { MenuContentExample } from "./components/MenuContentExample"
 
@@ -33,7 +33,7 @@ export default {
   decorators: [withDesign],
 }
 
-export const DefaultStory = args => (
+export const DefaultStory: ComponentStory<typeof Menu> = args => (
   <Menu
     {...args}
     button={
@@ -42,7 +42,7 @@ export const DefaultStory = args => (
   >
     <MenuList>
       <MenuItem
-        onClick={e => {
+        onClick={(e: React.MouseEvent): void => {
           e.preventDefault()
           alert("onClick function to duplicate content")
         }}
@@ -50,7 +50,7 @@ export const DefaultStory = args => (
         label="Duplicate item"
       />
       <MenuItem
-        onClick={e => {
+        onClick={(e: React.MouseEvent): void => {
           e.preventDefault()
           alert("onClick function to edit content")
         }}
@@ -58,7 +58,7 @@ export const DefaultStory = args => (
         label="Edit Item"
       />
       <MenuItem
-        onClick={e => {
+        onClick={(e: React.MouseEvent): void => {
           e.preventDefault()
           alert("onClick function to delete content")
         }}
@@ -69,10 +69,9 @@ export const DefaultStory = args => (
     </MenuList>
   </Menu>
 )
-
 DefaultStory.storyName = "Basic example"
 
-export const IconExample = () => (
+export const IconExample: Story = () => (
   <StoryWrapper>
     <StoryWrapper.RowHeader headings={["Default", "Primary", "Secondary"]} />
     <StoryWrapper.Row rowTitle="Variant">
@@ -94,10 +93,9 @@ export const IconExample = () => (
     </StoryWrapper.Row>
   </StoryWrapper>
 )
-
 IconExample.storyName = "Icon button menus"
 
-export const AutoHideBehaviours = () => (
+export const AutoHideBehaviours: Story = () => (
   <StoryWrapper>
     <StoryWrapper.RowHeader headings={["Default", "Primary", "Secondary"]} />
     <StoryWrapper.Row rowTitle="Behaviour">
@@ -155,19 +153,14 @@ export const AutoHideBehaviours = () => (
     </StoryWrapper.Row>
   </StoryWrapper>
 )
-
 AutoHideBehaviours.storyName = "Auto hide behaviors"
 
-export const DefaultStatelessMenu = () => {
+export const DefaultStatelessMenu: Story = () => {
   const [isMenuVisible, setIsMenuVisible] = useState(false)
 
-  const toggleMenu = () => {
-    setIsMenuVisible(!isMenuVisible)
-  }
+  const toggleMenu = (): void => setIsMenuVisible(!isMenuVisible)
 
-  const hideMenu = () => {
-    setIsMenuVisible(false)
-  }
+  const hideMenu = (): void => setIsMenuVisible(false)
 
   return (
     <>
@@ -177,16 +170,16 @@ export const DefaultStatelessMenu = () => {
       <Box py={1}>
         <Button
           secondary={true}
-          onClick={() => toggleMenu()}
+          onClick={toggleMenu}
           label="Toggle menu"
         />
-        <Button secondary={true} onClick={() => hideMenu()} label="Hide menu" />
+        <Button secondary={true} onClick={hideMenu} label="Hide menu" />
       </Box>
       <StatelessMenu
         isMenuVisible={isMenuVisible}
         toggleMenuDropdown={toggleMenu}
         hideMenuDropdown={hideMenu}
-        renderButton={buttonProps => (
+        renderButton={(buttonProps): JSX.Element => (
           <Button
             label="Label"
             icon={isMenuVisible ? chevronUp : chevronDown}
@@ -194,7 +187,7 @@ export const DefaultStatelessMenu = () => {
             {...buttonProps}
           />
         )}
-        onClick={e => e.stopPropagation()}
+        onClick={(e): void => e.stopPropagation()}
       >
         <MenuContentExample />
       </StatelessMenu>
@@ -222,11 +215,10 @@ export const DefaultStatelessMenu = () => {
     </>
   )
 }
-
 DefaultStatelessMenu.storyName =
   "Exposed menu state with <StatelessMenu/> component"
 
-export const DropdownWidthContain = () => (
+export const DropdownWidthContain: Story = () => (
   <Menu
     button={<Button label="Label" icon={chevronDown} iconPosition="end" />}
     dropdownWidth="contain"
@@ -237,11 +229,10 @@ export const DropdownWidthContain = () => (
     </div>
   </Menu>
 )
-
 DropdownWidthContain.storyName =
   "Flexible dropdown container width with dropdownWidth prop"
 
-export const MenuWithActiveItem = () => (
+export const MenuWithActiveItem: Story = () => (
   <>
     <Box mb={1}>
       <Paragraph variant="body">
@@ -265,10 +256,9 @@ export const MenuWithActiveItem = () => (
     </Menu>
   </>
 )
-
 MenuWithActiveItem.storyName = "Displaying active menu items in Menu"
 
-export const OverflowScroll = () => (
+export const OverflowScroll: Story = () => (
   <>
     <div style={{ overflowX: "scroll", width: "200px", height: "100px" }}>
       <div style={{ width: "500px", textAlign: "center" }}>
@@ -290,11 +280,10 @@ export const OverflowScroll = () => (
     </Paragraph>
   </>
 )
-
 OverflowScroll.storyName =
   "Menu behavior with overflow: scroll parent container"
 
-export const ContentAndList = () => (
+export const ContentAndList: Story = () => (
   <>
     <Menu
       button={<Button label="Label" icon={chevronDown} iconPosition="end" />}

--- a/draft-packages/menu/docs/MenuItem.stories.tsx
+++ b/draft-packages/menu/docs/MenuItem.stories.tsx
@@ -1,4 +1,5 @@
 import React from "react"
+import { ComponentStory } from "@storybook/react"
 import { withDesign } from "storybook-addon-designs"
 import {
   CATEGORIES,
@@ -24,9 +25,8 @@ export default {
   decorators: [withDesign],
 }
 
-export const DefaultStory = args => <MenuItem {...args} />
-
+export const DefaultStory: ComponentStory<typeof MenuItem> = args => <MenuItem {...args} />
+DefaultStory.storyName = "Default (Kaizen Site Demo)"
 DefaultStory.args = {
   label: "Menu Item",
 }
-DefaultStory.storyName = "Default (Kaizen Site Demo)"

--- a/draft-packages/menu/docs/MenuItem.stories.tsx
+++ b/draft-packages/menu/docs/MenuItem.stories.tsx
@@ -25,7 +25,9 @@ export default {
   decorators: [withDesign],
 }
 
-export const DefaultStory: ComponentStory<typeof MenuItem> = args => <MenuItem {...args} />
+export const DefaultStory: ComponentStory<typeof MenuItem> = args => (
+  <MenuItem {...args} />
+)
 DefaultStory.storyName = "Default (Kaizen Site Demo)"
 DefaultStory.args = {
   label: "Menu Item",

--- a/draft-packages/menu/docs/MenuList.stories.tsx
+++ b/draft-packages/menu/docs/MenuList.stories.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { Story } from "@storybook/react"
+import { ComponentStory } from "@storybook/react"
 import { withDesign } from "storybook-addon-designs"
 import {
   CATEGORIES,
@@ -25,16 +25,14 @@ export default {
   decorators: [withDesign],
 }
 
-export const DefaultStory = args => (
+export const DefaultStory: ComponentStory<typeof MenuList> = args => (
   <MenuList {...args}>
     <MenuItem label="Item 1" />
     <MenuItem label="Item 2" />
     <MenuItem label="Item 3" />
   </MenuList>
 )
-
+DefaultStory.storyName = "Default (Kaizen Site Demo)"
 DefaultStory.args = {
   heading: "Menu example list",
 }
-
-DefaultStory.storyName = "Default (Kaizen Site Demo)"

--- a/draft-packages/modal/KaizenDraft/Modal/Presets/ConfirmationModal.spec.tsx
+++ b/draft-packages/modal/KaizenDraft/Modal/Presets/ConfirmationModal.spec.tsx
@@ -1,17 +1,17 @@
-import * as React from "react"
+import React from "react"
 import { cleanup, render, fireEvent } from "@testing-library/react"
 import ConfirmationModal, { ConfirmationModalProps } from "./ConfirmationModal"
 import "./matchMedia.mock"
 
 afterEach(cleanup)
 
-const ConfirmationModalWrapper = (props: Partial<ConfirmationModalProps>) => (
+const ConfirmationModalWrapper = (props: Partial<ConfirmationModalProps>): JSX.Element => (
   <ConfirmationModal
     mood="informative"
     isOpen={true}
     title="Example Modal Title"
-    onDismiss={() => undefined}
-    onConfirm={() => undefined}
+    onDismiss={(): void => undefined}
+    onConfirm={(): void => undefined}
     children="Example Modal body"
     {...props}
   />

--- a/draft-packages/modal/KaizenDraft/Modal/Presets/ConfirmationModal.spec.tsx
+++ b/draft-packages/modal/KaizenDraft/Modal/Presets/ConfirmationModal.spec.tsx
@@ -5,7 +5,9 @@ import "./matchMedia.mock"
 
 afterEach(cleanup)
 
-const ConfirmationModalWrapper = (props: Partial<ConfirmationModalProps>): JSX.Element => (
+const ConfirmationModalWrapper = (
+  props: Partial<ConfirmationModalProps>
+): JSX.Element => (
   <ConfirmationModal
     mood="informative"
     isOpen={true}

--- a/draft-packages/modal/KaizenDraft/Modal/Presets/ContextModal.spec.tsx
+++ b/draft-packages/modal/KaizenDraft/Modal/Presets/ContextModal.spec.tsx
@@ -1,19 +1,19 @@
-import * as React from "react"
+import React from "react"
 import { cleanup, render, fireEvent } from "@testing-library/react"
 import ContextModal, { ContextModalProps } from "./ContextModal"
 import "./matchMedia.mock"
 
 afterEach(cleanup)
 
-const ContextModalWrapper = (props: Partial<ContextModalProps>) => (
+const ContextModalWrapper = (props: Partial<ContextModalProps>): JSX.Element => (
   <ContextModal
     isOpen={true}
     title="Example modal title"
-    onConfirm={() => undefined}
-    onDismiss={() => undefined}
+    onConfirm={(): void => undefined}
+    onDismiss={(): void => undefined}
     children="Example modal body"
     secondaryLabel="Example secondary"
-    onSecondaryAction={() => undefined}
+    onSecondaryAction={(): void => undefined}
     {...props}
   />
 )

--- a/draft-packages/modal/KaizenDraft/Modal/Presets/ContextModal.spec.tsx
+++ b/draft-packages/modal/KaizenDraft/Modal/Presets/ContextModal.spec.tsx
@@ -5,7 +5,9 @@ import "./matchMedia.mock"
 
 afterEach(cleanup)
 
-const ContextModalWrapper = (props: Partial<ContextModalProps>): JSX.Element => (
+const ContextModalWrapper = (
+  props: Partial<ContextModalProps>
+): JSX.Element => (
   <ContextModal
     isOpen={true}
     title="Example modal title"

--- a/draft-packages/modal/KaizenDraft/Modal/Presets/InputEditModal.spec.tsx
+++ b/draft-packages/modal/KaizenDraft/Modal/Presets/InputEditModal.spec.tsx
@@ -1,17 +1,17 @@
-import * as React from "react"
+import React from "react"
 import { cleanup, render, fireEvent } from "@testing-library/react"
 import InputEditModal, { InputEditModalProps } from "./InputEditModal"
 import "./matchMedia.mock"
 
 afterEach(cleanup)
 
-const InputEditModalWrapper = (props: Partial<InputEditModalProps>) => (
+const InputEditModalWrapper = (props: Partial<InputEditModalProps>): JSX.Element => (
   <InputEditModal
     isOpen={true}
     mood="positive"
     title="Example modal title"
-    onSubmit={() => undefined}
-    onDismiss={() => undefined}
+    onSubmit={(): void => undefined}
+    onDismiss={(): void => undefined}
     children="Example modal body"
     {...props}
   />

--- a/draft-packages/modal/KaizenDraft/Modal/Presets/InputEditModal.spec.tsx
+++ b/draft-packages/modal/KaizenDraft/Modal/Presets/InputEditModal.spec.tsx
@@ -5,7 +5,9 @@ import "./matchMedia.mock"
 
 afterEach(cleanup)
 
-const InputEditModalWrapper = (props: Partial<InputEditModalProps>): JSX.Element => (
+const InputEditModalWrapper = (
+  props: Partial<InputEditModalProps>
+): JSX.Element => (
   <InputEditModal
     isOpen={true}
     mood="positive"

--- a/draft-packages/modal/KaizenDraft/Modal/Presets/RoadblockModal.spec.tsx
+++ b/draft-packages/modal/KaizenDraft/Modal/Presets/RoadblockModal.spec.tsx
@@ -1,15 +1,15 @@
-import * as React from "react"
+import React from "react"
 import { cleanup, render, fireEvent } from "@testing-library/react"
 import RoadblockModal, { RoadblockModalProps } from "./RoadblockModal"
 import "./matchMedia.mock"
 
 afterEach(cleanup)
 
-const RoadblockModalWrapper = (props: Partial<RoadblockModalProps>) => (
+const RoadblockModalWrapper = (props: Partial<RoadblockModalProps>): JSX.Element => (
   <RoadblockModal
     isOpen={true}
     title="Example modal title"
-    onDismiss={() => undefined}
+    onDismiss={(): void => undefined}
     children="Example modal body"
     {...props}
   />

--- a/draft-packages/modal/KaizenDraft/Modal/Presets/RoadblockModal.spec.tsx
+++ b/draft-packages/modal/KaizenDraft/Modal/Presets/RoadblockModal.spec.tsx
@@ -5,7 +5,9 @@ import "./matchMedia.mock"
 
 afterEach(cleanup)
 
-const RoadblockModalWrapper = (props: Partial<RoadblockModalProps>): JSX.Element => (
+const RoadblockModalWrapper = (
+  props: Partial<RoadblockModalProps>
+): JSX.Element => (
   <RoadblockModal
     isOpen={true}
     title="Example modal title"

--- a/draft-packages/modal/KaizenDraft/Modal/Primitives/GenericModal.spec.tsx
+++ b/draft-packages/modal/KaizenDraft/Modal/Primitives/GenericModal.spec.tsx
@@ -1,4 +1,4 @@
-import * as React from "react"
+import React from "react"
 import {
   render,
   fireEvent,
@@ -16,9 +16,7 @@ const ExampleModalWithState = (props: {
   children: React.ReactNode
 }): JSX.Element => {
   const [isOpen, setIsOpen] = React.useState<boolean>(true)
-  const handleDismiss = () => {
-    setIsOpen(false)
-  }
+  const handleDismiss = (): void => setIsOpen(false)
 
   return (
     <GenericModal
@@ -76,6 +74,7 @@ describe("<GenericModal />", () => {
     fireEvent.click(getByTestId("GenericModalAutomationId-scrollLayer"))
     expect(handleDismiss).toHaveBeenCalledTimes(1)
   })
+
   it("warns when a <ModalAccessibleLabel /> is not rendered", async () => {
     const mockWarnFn = jest.fn()
     const spy = jest

--- a/draft-packages/modal/docs/ConfirmationModal.stories.tsx
+++ b/draft-packages/modal/docs/ConfirmationModal.stories.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from "react"
-import { ComponentStory } from "@storybook/react"
+import { DecoratorFunction } from "@storybook/addons"
+import { ComponentMeta, ComponentStory } from "@storybook/react"
 import isChromatic from "chromatic/isChromatic"
 import { withDesign } from "storybook-addon-designs"
 import { Button } from "@kaizen/button"
@@ -14,7 +15,7 @@ const IS_CHROMATIC = isChromatic()
 // Modals have fixed position and would be cropped from snapshot tests.
 // Setting height to 100vh ensures we capture as much content of the
 // modal, as it's height responds to the content within it.
-const withMinHeight = Story => {
+const withMinHeight: DecoratorFunction<JSX.Element> = Story => {
   if (IS_CHROMATIC) {
     return <div style={{ minHeight: "100vh" }}>{Story()}</div>
   }
@@ -47,15 +48,15 @@ export default {
     },
   },
   decorators: [withDesign, withMinHeight],
-}
+} as ComponentMeta<typeof ConfirmationModal>
 
 const ConfirmationModalTemplate: ComponentStory<
   typeof ConfirmationModal
 > = args => {
   const [isOpen, setIsOpen] = useState<boolean>(IS_CHROMATIC)
 
-  const handleOpen = () => setIsOpen(true)
-  const handleClose = () => setIsOpen(false)
+  const handleOpen = (): void => setIsOpen(true)
+  const handleClose = (): void => setIsOpen(false)
 
   return (
     <>

--- a/draft-packages/modal/docs/ContextModal.stories.tsx
+++ b/draft-packages/modal/docs/ContextModal.stories.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from "react"
-import { ComponentStory } from "@storybook/react"
+import { DecoratorFunction } from "@storybook/addons"
+import { ComponentMeta, ComponentStory } from "@storybook/react"
 import isChromatic from "chromatic/isChromatic"
 import { withDesign } from "storybook-addon-designs"
 import { Button } from "@kaizen/button"
@@ -16,7 +17,7 @@ const IS_CHROMATIC = isChromatic()
 // Modals have fixed position and would be cropped from snapshot tests.
 // Setting height to 100vh ensures we capture as much content of the
 // modal, as it's height responds to the content within it.
-const withMinHeight = Story => {
+const withMinHeight: DecoratorFunction<JSX.Element> = Story => {
   if (IS_CHROMATIC) {
     return <div style={{ minHeight: "100vh" }}>{Story()}</div>
   }
@@ -47,13 +48,13 @@ export default {
     },
   },
   decorators: [withDesign, withMinHeight],
-}
+} as ComponentMeta<typeof ContextModal>
 
 const ContextModalTemplate: ComponentStory<typeof ContextModal> = args => {
   const [isOpen, setIsOpen] = useState<boolean>(IS_CHROMATIC)
 
-  const handleOpen = () => setIsOpen(true)
-  const handleClose = () => setIsOpen(false)
+  const handleOpen = (): void => setIsOpen(true)
+  const handleClose = (): void => setIsOpen(false)
 
   return (
     <>

--- a/draft-packages/modal/docs/InputEditModal.stories.tsx
+++ b/draft-packages/modal/docs/InputEditModal.stories.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from "react"
-import { ComponentStory } from "@storybook/react"
+import { DecoratorFunction } from "@storybook/addons"
+import { ComponentMeta, ComponentStory } from "@storybook/react"
 import isChromatic from "chromatic/isChromatic"
 import { withDesign } from "storybook-addon-designs"
 import { Button } from "@kaizen/button"
@@ -16,7 +17,7 @@ const IS_CHROMATIC = isChromatic()
 // Modals have fixed position and would be cropped from snapshot tests.
 // Setting height to 100vh ensures we capture as much content of the
 // modal, as it's height responds to the content within it.
-const withMinHeight = Story => {
+const withMinHeight: DecoratorFunction<JSX.Element> = Story => {
   if (IS_CHROMATIC) {
     return <div style={{ minHeight: "100vh" }}>{Story()}</div>
   }
@@ -44,13 +45,13 @@ export default {
     ),
   },
   decorators: [withDesign, withMinHeight],
-}
+} as ComponentMeta<typeof InputEditModal>
 
 const InputEditModalTemplate: ComponentStory<typeof InputEditModal> = args => {
   const [isOpen, setIsOpen] = useState<boolean>(IS_CHROMATIC)
 
-  const handleOpen = () => setIsOpen(true)
-  const handleClose = () => setIsOpen(false)
+  const handleOpen = (): void => setIsOpen(true)
+  const handleClose = (): void => setIsOpen(false)
 
   const SELECT_OPTIONS = [
     { value: "Mindy", label: "Mindy" },

--- a/draft-packages/page-layout/KaizenDraft/useResizeObserver.spec.tsx
+++ b/draft-packages/page-layout/KaizenDraft/useResizeObserver.spec.tsx
@@ -3,12 +3,12 @@ import { renderHook } from "@testing-library/react-hooks"
 import { act } from "react-test-renderer"
 import { useResizeObserver } from "./useResizeObserver"
 
-function MockResizeObserver(callback) {
+function MockResizeObserver(callback: unknown): void {
   // @ts-ignore
   this.callback = callback
 }
 
-MockResizeObserver.prototype.observe = async function observe() {
+MockResizeObserver.prototype.observe = async function observe(): Promise<void> {
   this.callback(["first"])
   await new Promise(r => setImmediate(r))
   this.callback(["second"])

--- a/draft-packages/page-layout/docs/PageLayout.stories.tsx
+++ b/draft-packages/page-layout/docs/PageLayout.stories.tsx
@@ -1,4 +1,5 @@
 import React from "react"
+import { Story } from "@storybook/react"
 import { withDesign } from "storybook-addon-designs"
 import { Box } from "@kaizen/component-library"
 import { NavigationTab, TitleBlockZen } from "@kaizen/draft-title-block-zen"
@@ -25,11 +26,11 @@ export default {
   decorators: [withDesign],
 }
 
-const OffsetPadding = ({ children }: { children: React.ReactNode }) => (
+const OffsetPadding = ({ children }: { children: React.ReactNode }): JSX.Element => (
   <div style={{ margin: "-1rem" }}>{children}</div>
 )
 
-export const DefaultStory = () => (
+export const DefaultStory: Story = () => (
   <OffsetPadding>
     <TitleBlockZen title="Page title" collapseNavigationAreaWhenPossible />
     <Container>
@@ -57,7 +58,7 @@ export const DefaultStory = () => (
 )
 DefaultStory.storyName = "Container/Content (default)"
 
-export const FullBleedBackgroundStory = () => (
+export const FullBleedBackgroundStory: Story = () => (
   <OffsetPadding>
     <Container classNameOverride={styles.pink}>
       <Content classNameOverride={styles.white}>
@@ -84,16 +85,14 @@ export const FullBleedBackgroundStory = () => (
 FullBleedBackgroundStory.storyName = "Container/Content (Full-bleed background)"
 FullBleedBackgroundStory.parameters = { chromatic: { disable: false } }
 
-export const SkirtStory = () => (
+export const SkirtStory: Story = () => (
   <>
     <TitleBlockZen
       title="Skirt"
       breadcrumb={{
         path: "#",
         text: "Back to home",
-        handleClick: event => {
-          alert("breadcrumb clicked!")
-        },
+        handleClick: () => alert("breadcrumb clicked!"),
       }}
       navigationTabs={[<NavigationTab text="Label" href="#" active />]}
     />
@@ -146,7 +145,7 @@ export const SkirtStory = () => (
 )
 SkirtStory.storyName = "Skirt (default)"
 
-export const SkirtEducationVariant = () => (
+export const SkirtEducationVariant: Story = () => (
   <>
     <TitleBlockZen
       variant="education"
@@ -154,9 +153,7 @@ export const SkirtEducationVariant = () => (
       breadcrumb={{
         path: "#",
         text: "Back to home",
-        handleClick: event => {
-          alert("breadcrumb clicked!")
-        },
+        handleClick: () => alert("breadcrumb clicked!"),
       }}
       navigationTabs={[
         <NavigationTab variant="education" text="Label" href="#" active />,
@@ -177,16 +174,14 @@ export const SkirtEducationVariant = () => (
 SkirtEducationVariant.storyName = "Skirt (Education variant)"
 SkirtEducationVariant.parameters = { chromatic: { disable: false } }
 
-export const SkirtWithoutTitleBlockNavigation = () => (
+export const SkirtWithoutTitleBlockNavigation: Story = () => (
   <>
     <TitleBlockZen
       title="Without Title Block navigation"
       breadcrumb={{
         path: "#",
         text: "Back to home",
-        handleClick: event => {
-          alert("breadcrumb clicked!")
-        },
+        handleClick: () => alert("breadcrumb clicked!"),
       }}
       collapseNavigationAreaWhenPossible={true}
     />
@@ -247,16 +242,14 @@ SkirtWithoutTitleBlockNavigation.storyName =
   "Skirt (Title Block without navigation)"
 SkirtWithoutTitleBlockNavigation.parameters = { chromatic: { disable: false } }
 
-export const WithoutSkirtCard = () => (
+export const WithoutSkirtCard: Story = () => (
   <>
     <TitleBlockZen
       title="Without Skirt Card"
       breadcrumb={{
         path: "#",
         text: "Back to home",
-        handleClick: event => {
-          alert("breadcrumb clicked!")
-        },
+        handleClick: () => alert("breadcrumb clicked!"),
       }}
       collapseNavigationAreaWhenPossible
     />

--- a/draft-packages/page-layout/docs/PageLayout.stories.tsx
+++ b/draft-packages/page-layout/docs/PageLayout.stories.tsx
@@ -26,9 +26,11 @@ export default {
   decorators: [withDesign],
 }
 
-const OffsetPadding = ({ children }: { children: React.ReactNode }): JSX.Element => (
-  <div style={{ margin: "-1rem" }}>{children}</div>
-)
+const OffsetPadding = ({
+  children,
+}: {
+  children: React.ReactNode
+}): JSX.Element => <div style={{ margin: "-1rem" }}>{children}</div>
 
 export const DefaultStory: Story = () => (
   <OffsetPadding>

--- a/draft-packages/popover/docs/Popover.stories.tsx
+++ b/draft-packages/popover/docs/Popover.stories.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable jsx-a11y/anchor-is-valid */
 import React, { useState } from "react"
-import { Story } from "@storybook/react"
+import { ComponentStory, Story } from "@storybook/react"
 import isChromatic from "chromatic/isChromatic"
 import { withDesign } from "storybook-addon-designs"
 import { IconButton } from "@kaizen/button"
@@ -35,7 +35,7 @@ export default {
   decorators: [withDesign],
 }
 
-const Container = ({ children }: { children: React.ReactNode }) => (
+const Container = ({ children }: { children: React.ReactNode }): JSX.Element => (
   <>
     <p>
       Default Placement is 'above'. Scroll horizontally or vertically to view
@@ -82,7 +82,7 @@ const InlineBlockTargetElement = ({
   openPopover?: () => void
   ElementRef: (element: HTMLElement | null) => void
   isReversed?: boolean
-}) => (
+}): JSX.Element => (
   <div
     ref={ElementRef}
     style={{
@@ -101,11 +101,12 @@ const InlineBlockTargetElement = ({
   </div>
 )
 
-export const DefaultKaizenSiteDemo = props => {
+export const DefaultKaizenSiteDemo: ComponentStory<typeof PopoverRaw> = props => {
   const [ElementRef, Popover] = usePopover()
   // set the popover open state to be true when testing on chromatic
   const [isOpen, setIsOpen] = useState(DEFAULT_IS_OPEN)
-  const openPopover = () => setIsOpen(true)
+  const openPopover = (): void => setIsOpen(true)
+
   return (
     <div
       style={{
@@ -124,9 +125,7 @@ export const DefaultKaizenSiteDemo = props => {
           {...props}
           dismissible
           heading="Heading"
-          onClose={() => {
-            setIsOpen(false)
-          }}
+          onClose={(): void => setIsOpen(false)}
         >
           Popover body that explains something useful, is optional, and not
           critical to completing a task. <a href="#">Optional link</a>
@@ -137,10 +136,10 @@ export const DefaultKaizenSiteDemo = props => {
 }
 DefaultKaizenSiteDemo.storyName = "Default (Kaizen Site Demo)"
 
-export const OverflowScroll = props => {
+export const OverflowScroll: ComponentStory<typeof PopoverRaw> = props => {
   const [ElementRef, Popover] = usePopover()
   const [isOpen, setIsOpen] = useState(DEFAULT_IS_OPEN)
-  const openPopover = () => setIsOpen(true)
+  const openPopover = (): void => setIsOpen(true)
 
   return (
     <Container>
@@ -153,9 +152,7 @@ export const OverflowScroll = props => {
         <Popover
           heading="Heading"
           dismissible
-          onClose={() => {
-            setIsOpen(false)
-          }}
+          onClose={(): void => setIsOpen(false)}
           {...props}
         >
           Popover body that explains something useful, is optional, and not

--- a/draft-packages/popover/docs/Popover.stories.tsx
+++ b/draft-packages/popover/docs/Popover.stories.tsx
@@ -35,7 +35,11 @@ export default {
   decorators: [withDesign],
 }
 
-const Container = ({ children }: { children: React.ReactNode }): JSX.Element => (
+const Container = ({
+  children,
+}: {
+  children: React.ReactNode
+}): JSX.Element => (
   <>
     <p>
       Default Placement is 'above'. Scroll horizontally or vertically to view
@@ -101,7 +105,9 @@ const InlineBlockTargetElement = ({
   </div>
 )
 
-export const DefaultKaizenSiteDemo: ComponentStory<typeof PopoverRaw> = props => {
+export const DefaultKaizenSiteDemo: ComponentStory<
+  typeof PopoverRaw
+> = props => {
   const [ElementRef, Popover] = usePopover()
   // set the popover open state to be true when testing on chromatic
   const [isOpen, setIsOpen] = useState(DEFAULT_IS_OPEN)

--- a/draft-packages/select/docs/Select.stories.tsx
+++ b/draft-packages/select/docs/Select.stories.tsx
@@ -100,7 +100,7 @@ GroupedStory.args = {
 export const DefaultAsyncSelectStory: ComponentStory<
   typeof AsyncSelect
 > = args => {
-  const filterNames = (inputValue: string) =>
+  const filterNames = (inputValue: string): typeof OPTIONS =>
     OPTIONS.filter(({ label }) =>
       label.toLowerCase().includes(inputValue.toLowerCase())
     )
@@ -134,77 +134,73 @@ const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({
   isReversed,
 }) => (
   <div>
-    {/* {!isReversed && ( */}
-    <>
-      <StoryWrapper isReversed={isReversed}>
-        <Heading variant="heading-3" color={isReversed ? "white" : "dark"}>
-          Default Select
-        </Heading>
-        <StoryWrapper.RowHeader headings={["Base", "Clearable", "Disabled"]} />
-        <StoryWrapper.Row rowTitle="Default">
-          <Select
-            options={OPTIONS}
-            reversed={isReversed}
-            placeholder="Edit survey"
-          />
-          <Select
-            options={OPTIONS}
-            reversed={isReversed}
-            defaultValue={OPTIONS[0]}
-            isClearable
-          />
-          <Select
-            options={OPTIONS}
-            reversed={isReversed}
-            placeholder="Edit survey"
-            isDisabled
-          />
-        </StoryWrapper.Row>
-        <StoryWrapper.Row rowTitle="Ellipsis">
-          <Select
-            options={OPTIONS}
-            reversed={isReversed}
-            defaultValue={OPTIONS[9]}
-            placeholder="Edit survey"
-          />
-          <Select
-            options={OPTIONS}
-            reversed={isReversed}
-            defaultValue={OPTIONS[9]}
-            placeholder="Edit survey"
-            isClearable
-          />
-          <Select
-            options={OPTIONS}
-            reversed={isReversed}
-            defaultValue={OPTIONS[9]}
-            placeholder="Edit survey"
-            isDisabled
-          />
-        </StoryWrapper.Row>
-      </StoryWrapper>
+    <StoryWrapper isReversed={isReversed}>
+      <Heading variant="heading-3" color={isReversed ? "white" : "dark"}>
+        Default Select
+      </Heading>
+      <StoryWrapper.RowHeader headings={["Base", "Clearable", "Disabled"]} />
+      <StoryWrapper.Row rowTitle="Default">
+        <Select
+          options={OPTIONS}
+          reversed={isReversed}
+          placeholder="Edit survey"
+        />
+        <Select
+          options={OPTIONS}
+          reversed={isReversed}
+          defaultValue={OPTIONS[0]}
+          isClearable
+        />
+        <Select
+          options={OPTIONS}
+          reversed={isReversed}
+          placeholder="Edit survey"
+          isDisabled
+        />
+      </StoryWrapper.Row>
+      <StoryWrapper.Row rowTitle="Ellipsis">
+        <Select
+          options={OPTIONS}
+          reversed={isReversed}
+          defaultValue={OPTIONS[9]}
+          placeholder="Edit survey"
+        />
+        <Select
+          options={OPTIONS}
+          reversed={isReversed}
+          defaultValue={OPTIONS[9]}
+          placeholder="Edit survey"
+          isClearable
+        />
+        <Select
+          options={OPTIONS}
+          reversed={isReversed}
+          defaultValue={OPTIONS[9]}
+          placeholder="Edit survey"
+          isDisabled
+        />
+      </StoryWrapper.Row>
+    </StoryWrapper>
 
-      <StoryWrapper isReversed={isReversed}>
-        <StoryWrapper.RowHeader headings={["Base", "Disabled"]} />
-        <StoryWrapper.Row rowTitle="Multi Select">
-          <Select
-            options={OPTIONS}
-            reversed={isReversed}
-            isMulti={true}
-            defaultValue={OPTIONS[0]}
-          />
-          <Select
-            options={OPTIONS}
-            reversed={isReversed}
-            defaultValue={OPTIONS[0]}
-            placeholder="Edit survey"
-            isDisabled
-            isMulti
-          />
-        </StoryWrapper.Row>
-      </StoryWrapper>
-    </>
-    {/* )} */}
+    <StoryWrapper isReversed={isReversed}>
+      <StoryWrapper.RowHeader headings={["Base", "Disabled"]} />
+      <StoryWrapper.Row rowTitle="Multi Select">
+        <Select
+          options={OPTIONS}
+          reversed={isReversed}
+          isMulti={true}
+          defaultValue={OPTIONS[0]}
+        />
+        <Select
+          options={OPTIONS}
+          reversed={isReversed}
+          defaultValue={OPTIONS[0]}
+          placeholder="Edit survey"
+          isDisabled
+          isMulti
+        />
+      </StoryWrapper.Row>
+    </StoryWrapper>
 
     <StoryWrapper isReversed={isReversed}>
       <Heading variant="heading-3" color={isReversed ? "white" : "dark"}>

--- a/draft-packages/table/KaizenDraft/Table/Table.spec.tsx
+++ b/draft-packages/table/KaizenDraft/Table/Table.spec.tsx
@@ -49,16 +49,16 @@ const Wrapper = (): JSX.Element => (
         <TableHeaderRowCell
           checkable={true}
           checkedStatus={"on"}
-          onCheck={_ => true}
+          onCheck={(): void => undefined}
           active={true}
-          onClick={_ => true}
+          onClick={(): void => undefined}
           labelText="Resource name"
           width={12 / 12}
           data-testid={TestId.tableHeaderRowCell}
         />
       </TableHeaderRow>
     </TableHeader>
-    <TableCard data-testid={TestId.tableCard} onClick={() => alert("clicked!")}>
+    <TableCard data-testid={TestId.tableCard} onClick={(): void => alert("clicked!")}>
       <TableRow data-testid={TestId.tableRow}>
         <TableRowCell width={12 / 12} data-testid={TestId.tableRowCell}>
           <div></div>

--- a/draft-packages/table/KaizenDraft/Table/Table.spec.tsx
+++ b/draft-packages/table/KaizenDraft/Table/Table.spec.tsx
@@ -58,7 +58,10 @@ const Wrapper = (): JSX.Element => (
         />
       </TableHeaderRow>
     </TableHeader>
-    <TableCard data-testid={TestId.tableCard} onClick={(): void => alert("clicked!")}>
+    <TableCard
+      data-testid={TestId.tableCard}
+      onClick={(): void => alert("clicked!")}
+    >
       <TableRow data-testid={TestId.tableRow}>
         <TableRowCell width={12 / 12} data-testid={TestId.tableRowCell}>
           <div></div>

--- a/draft-packages/table/docs/Table.stories.tsx
+++ b/draft-packages/table/docs/Table.stories.tsx
@@ -305,7 +305,11 @@ export const LinkVariant: Story = () => (
 )
 LinkVariant.parameters = { chromatic: { disable: false } }
 
-const ExpandedPopout = ({ isReversed }: { isReversed: boolean }): JSX.Element => {
+const ExpandedPopout = ({
+  isReversed,
+}: {
+  isReversed: boolean
+}): JSX.Element => {
   const [expandedId, setExpandedId] = React.useState<string | null>("second")
   const toggleExpanded = (id: string): void => {
     if (expandedId === id) {

--- a/draft-packages/table/docs/Table.stories.tsx
+++ b/draft-packages/table/docs/Table.stories.tsx
@@ -40,16 +40,14 @@ const ExampleTableHeaderRow = ({
   checkable = false,
   showHover = false,
   reversed = false,
-}) => (
+}): JSX.Element => (
   <TableHeaderRow>
     <TableHeaderRowCell
       checkable={checkable}
       checkedStatus={"on"}
-      onCheck={evt => {
-        alert(evt.target.value)
-      }}
+      onCheck={(evt): void => alert(evt.target.value)}
       sorting="descending"
-      onClick={() => alert("Sort!")}
+      onClick={(): void => alert("Sort!")}
       labelText="Resource name"
       width={4 / 12}
       wrapping="wrap"
@@ -57,7 +55,7 @@ const ExampleTableHeaderRow = ({
       reversed={reversed}
     />
     <TableHeaderRowCell
-      onClick={() => alert("Sort!")}
+      onClick={(): void => alert("Sort!")}
       labelText="Supplementary information"
       width={4 / 12}
       wrapping="wrap"
@@ -67,7 +65,7 @@ const ExampleTableHeaderRow = ({
     <TableHeaderRowCell
       labelText="Date"
       width={2 / 12}
-      onClick={() => alert("Sort!")}
+      onClick={(): void => alert("Sort!")}
       wrapping="wrap"
       sortingArrowsOnHover={showHover ? "descending" : undefined}
       reversed={reversed}
@@ -75,7 +73,7 @@ const ExampleTableHeaderRow = ({
     <TableHeaderRowCell
       labelText="Comments"
       width={2 / 12}
-      onClick={() => alert("Sort!")}
+      onClick={(): void => alert("Sort!")}
       wrapping="wrap"
       sortingArrowsOnHover={showHover ? "descending" : undefined}
       reversed={reversed}
@@ -88,7 +86,7 @@ const ExampleTableRow = ({
   expandable = true,
   multiline = false,
   description = "Table row label",
-}) => (
+}): JSX.Element => (
   <TableRow>
     <TableRowCell width={4 / 12}>
       {multiline ? (
@@ -145,7 +143,7 @@ export default {
   decorators: [withDesign],
 }
 
-export const DefaultKaizenSiteDemo = () => (
+export const DefaultKaizenSiteDemo: Story = () => (
   <Container>
     <TableContainer>
       <TableHeader>
@@ -165,7 +163,7 @@ export const DefaultKaizenSiteDemo = () => (
 )
 DefaultKaizenSiteDemo.storyName = "Default (Kaizen Site Demo)"
 
-const Multiline = isReversed => (
+const Multiline = ({ isReversed }: { isReversed: boolean }): JSX.Element => (
   <Container>
     <TableContainer>
       <TableHeader>
@@ -184,7 +182,7 @@ const Multiline = isReversed => (
   </Container>
 )
 
-export const DataVariant = () => (
+export const DataVariant: Story = () => (
   <Container>
     <TableContainer variant="data">
       <TableHeader>
@@ -204,7 +202,7 @@ export const DataVariant = () => (
 )
 DataVariant.parameters = { chromatic: { disable: false } }
 
-export const IconVariant = () => (
+export const IconVariant: Story = () => (
   <Container>
     <TableContainer>
       <TableHeader>
@@ -266,7 +264,7 @@ export const IconVariant = () => (
 )
 IconVariant.parameters = { chromatic: { disable: false } }
 
-export const LinkVariant = () => (
+export const LinkVariant: Story = () => (
   <Container>
     <TableContainer>
       <TableHeader>
@@ -276,7 +274,7 @@ export const LinkVariant = () => (
           <TableHeaderRowCell labelText="Header C" width={1 / 3} />
         </TableHeaderRow>
       </TableHeader>
-      <TableCard onClick={() => alert("Clicked!")}>
+      <TableCard onClick={(): void => alert("Clicked!")}>
         <TableRow>
           <TableRowCell width={1 / 3}>
             <Paragraph variant="body">This row has an onClick</Paragraph>
@@ -307,9 +305,9 @@ export const LinkVariant = () => (
 )
 LinkVariant.parameters = { chromatic: { disable: false } }
 
-const ExpandedPopout = isReversed => {
+const ExpandedPopout = ({ isReversed }: { isReversed: boolean }): JSX.Element => {
   const [expandedId, setExpandedId] = React.useState<string | null>("second")
-  const toggleExpanded = id => {
+  const toggleExpanded = (id: string): void => {
     if (expandedId === id) {
       setExpandedId(null)
       return
@@ -329,7 +327,7 @@ const ExpandedPopout = isReversed => {
               key={id}
               expandedStyle="popout"
               expanded={expanded}
-              onClick={() => toggleExpanded(id)}
+              onClick={(): void => toggleExpanded(id)}
             >
               <ExampleTableRow expanded={expanded} />
               {expanded && (
@@ -359,7 +357,7 @@ const ExpandedPopout = isReversed => {
   )
 }
 
-const Compact = () => (
+const Compact = (): JSX.Element => (
   <Container>
     <TableContainer>
       <TableCard>
@@ -375,7 +373,7 @@ const Compact = () => (
   </Container>
 )
 
-const Default = () => (
+const Default = (): JSX.Element => (
   <Container>
     <TableContainer variant="default">
       <TableCard>
@@ -391,7 +389,7 @@ const Default = () => (
   </Container>
 )
 
-export const HeaderAlignmentAndWrapping = () => (
+export const HeaderAlignmentAndWrapping: Story = () => (
   <Container>
     <TableContainer>
       <TableHeader>
@@ -449,7 +447,7 @@ export const HeaderAlignmentAndWrapping = () => (
 )
 HeaderAlignmentAndWrapping.parameters = { chromatic: { disable: false } }
 
-export const Tooltip = () => (
+export const Tooltip: Story = () => (
   // Extra margin added, so we can see the tooltip above
   <Container style={{ marginTop: "200px" }}>
     <TableContainer>
@@ -506,7 +504,7 @@ export const Tooltip = () => (
 )
 Tooltip.parameters = { chromatic: { disable: false } }
 
-export const AnchorLink = () => (
+export const AnchorLink: Story = () => (
   <Container>
     <TableContainer>
       <TableHeader>
@@ -514,7 +512,7 @@ export const AnchorLink = () => (
           <TableHeaderRowCell
             labelText="This is an anchor"
             width={1 / 2}
-            onClick={e => {
+            onClick={(e: React.MouseEvent): void => {
               e.preventDefault()
               alert("Header was clicked")
             }}
@@ -524,7 +522,7 @@ export const AnchorLink = () => (
           <TableHeaderRowCell
             labelText="This is an anchor"
             width={1 / 2}
-            onClick={e => {
+            onClick={(e: React.MouseEvent): void => {
               e.preventDefault()
               alert("Header was clicked")
             }}
@@ -563,7 +561,7 @@ const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({
       <Default />
     </StoryWrapper.Row>
     <StoryWrapper.Row rowTitle="Multiline">
-      <Multiline />
+      <Multiline isReversed={isReversed} />
     </StoryWrapper.Row>
     <StoryWrapper.Row rowTitle="Expanded popout">
       <ExpandedPopout isReversed={isReversed} />

--- a/draft-packages/tabs/KaizenDraft/Tabs/Tabs.spec.tsx
+++ b/draft-packages/tabs/KaizenDraft/Tabs/Tabs.spec.tsx
@@ -1,4 +1,4 @@
-import * as React from "react"
+import React from "react"
 import { fireEvent } from "@testing-library/dom"
 import { cleanup, render } from "@testing-library/react"
 
@@ -67,7 +67,7 @@ describe("Tabs", () => {
             tabClassName,
             activeTabClassName,
             disabledTabClassName,
-          }) => (
+          }): JSX.Element => (
             <div key={tab.label}>
               <span>{tab.label}</span>
               <span>{tabClassName}</span>

--- a/draft-packages/tag/KaizenDraft/Tag/Tag.spec.tsx
+++ b/draft-packages/tag/KaizenDraft/Tag/Tag.spec.tsx
@@ -1,4 +1,4 @@
-import * as React from "react"
+import React from "react"
 import { cleanup, render } from "@testing-library/react"
 import { Avatar } from "@kaizen/draft-avatar"
 
@@ -7,7 +7,7 @@ import { Tag } from "."
 
 afterEach(cleanup)
 
-const renderTag = (props: TagProps) => {
+const renderTag = (props: TagProps): ReturnType<typeof render> => {
   const mergedTagProps = { ...props }
 
   return render(<Tag {...mergedTagProps}>Default</Tag>)

--- a/draft-packages/tag/docs/Tag.stories.tsx
+++ b/draft-packages/tag/docs/Tag.stories.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { Story } from "@storybook/react"
+import { ComponentStory, Story } from "@storybook/react"
 import { withDesign } from "storybook-addon-designs"
 import { Avatar } from "@kaizen/draft-avatar"
 import { Tag } from "@kaizen/draft-tag"
@@ -23,7 +23,7 @@ export default {
   decorators: [withDesign],
 }
 
-export const DefaultStory = args => (
+export const DefaultStory: ComponentStory<typeof Tag> = args => (
   <Tag variant="default" {...args}>
     Default
   </Tag>

--- a/draft-packages/tile/docs/Tile.stories.tsx
+++ b/draft-packages/tile/docs/Tile.stories.tsx
@@ -1,4 +1,5 @@
 import React from "react"
+import { ComponentStory, Story } from "@storybook/react"
 import { withDesign } from "storybook-addon-designs"
 import bookmarkIcon from "@kaizen/component-library/icons/bookmark-off.icon.svg"
 import { Coaching } from "@kaizen/draft-illustration"
@@ -64,7 +65,7 @@ const information: TileInformation = {
   },
 }
 
-export const MultiAction = () => (
+export const MultiAction: ComponentStory<typeof MultiActionTile> = () => (
   <MultiActionTile
     title="Tile heading"
     metadata="Metadata"
@@ -73,7 +74,7 @@ export const MultiAction = () => (
 )
 MultiAction.storyName = "Multi action tile"
 
-export const MultiActionMoods = () => (
+export const MultiActionMoods: Story = () => (
   <TileGrid>
     <MultiActionTile
       title="Default"
@@ -121,7 +122,7 @@ export const MultiActionMoods = () => (
 MultiActionMoods.storyName = "Multi action tile moods"
 MultiActionMoods.parameters = { chromatic: { disable: false } }
 
-export const MultiActionWithSecondary = () => (
+export const MultiActionWithSecondary: Story = () => (
   <MultiActionTile
     title="Tile heading"
     metadata="Metadata"
@@ -132,7 +133,7 @@ export const MultiActionWithSecondary = () => (
 MultiActionWithSecondary.storyName = "Multi action tile with secondary action"
 MultiActionWithSecondary.parameters = { chromatic: { disable: false } }
 
-export const MultiActionWithChildren = () => (
+export const MultiActionWithChildren: Story = () => (
   <MultiActionTile
     title="Tile heading"
     metadata="Metadata"
@@ -144,7 +145,7 @@ export const MultiActionWithChildren = () => (
 MultiActionWithChildren.storyName = "Multi action tile with children"
 MultiActionWithChildren.parameters = { chromatic: { disable: false } }
 
-export const MultiActionWithCustomTitle = () => (
+export const MultiActionWithCustomTitle: Story = () => (
   <MultiActionTile
     title="Custom title"
     primaryAction={primaryAction}
@@ -155,7 +156,7 @@ export const MultiActionWithCustomTitle = () => (
 )
 MultiActionWithCustomTitle.storyName = "Multi action tile with custom title tag"
 
-export const MultiActionWithInformation = () => (
+export const MultiActionWithInformation: Story = () => (
   <MultiActionTile
     title="Tile heading"
     metadata="Metadata"
@@ -165,7 +166,7 @@ export const MultiActionWithInformation = () => (
 )
 MultiActionWithInformation.storyName = "Multi action tile with information"
 
-export const MultiActionActionInNewTabs = () => (
+export const MultiActionActionInNewTabs: Story = () => (
   <MultiActionTile
     title="Tile heading"
     metadata="Metadata"
@@ -184,7 +185,7 @@ export const MultiActionActionInNewTabs = () => (
 MultiActionActionInNewTabs.storyName =
   "Multi action tile with actions opening in new tabs"
 
-export const Information = () => (
+export const Information: Story = () => (
   <InformationTile
     title="Tile heading"
     metadata="Metadata"
@@ -195,7 +196,7 @@ export const Information = () => (
 Information.storyName = "Information tile"
 Information.parameters = { chromatic: { disable: false } }
 
-export const InformationMood = () => (
+export const InformationMood: Story = () => (
   <TileGrid>
     <InformationTile
       title="Default"
@@ -249,7 +250,7 @@ export const InformationMood = () => (
 )
 InformationMood.storyName = "Information tile moods"
 
-export const InformationWithChildren = () => (
+export const InformationWithChildren: Story = () => (
   <InformationTile
     title="Tile heading"
     metadata="Metadata"
@@ -261,7 +262,7 @@ export const InformationWithChildren = () => (
 )
 InformationWithChildren.storyName = "Information tile with children"
 
-export const InformationWithCustomTitle = () => (
+export const InformationWithCustomTitle: Story = () => (
   <InformationTile
     title="Custom title"
     information={information}
@@ -273,7 +274,7 @@ export const InformationWithCustomTitle = () => (
 )
 InformationMood.storyName = "Information tile moods"
 
-export const InformationCustomInfoElement = () => (
+export const InformationCustomInfoElement: Story = () => (
   <InformationTile
     title="Tile heading"
     metadata="Metadata"
@@ -284,7 +285,7 @@ export const InformationCustomInfoElement = () => (
 InformationCustomInfoElement.storyName =
   "Information tile (custom information element)"
 
-export const InformationCustomTitleTag = () => (
+export const InformationCustomTitleTag: Story = () => (
   <InformationTile
     title="Tile heading"
     titleTag="div"
@@ -295,7 +296,7 @@ export const InformationCustomTitleTag = () => (
 )
 InformationCustomTitleTag.storyName = "Information tile (custom title tag)"
 
-export const TileGridWithTiles = () => (
+export const TileGridWithTiles: Story = () => (
   <TileGrid>
     <InformationTile
       title="Tile heading"
@@ -338,7 +339,7 @@ export const TileGridWithTiles = () => (
 TileGridWithTiles.storyName = "Tile Grid"
 TileGridWithTiles.parameters = { chromatic: { disable: false } }
 
-export const TileGridWithFewTiles = () => (
+export const TileGridWithFewTiles: Story = () => (
   <TileGrid>
     <InformationTile
       title="Tile heading"

--- a/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/NavigationTabs.spec.tsx
+++ b/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/NavigationTabs.spec.tsx
@@ -3,7 +3,7 @@ import { fireEvent } from "@storybook/testing-library"
 import { render, screen } from "@testing-library/react"
 import NavigationTab, { CustomNavigationTabProps } from "./NavigationTabs"
 
-const CustomComponent = (props: CustomNavigationTabProps) => (
+const CustomComponent = (props: CustomNavigationTabProps): JSX.Element => (
   <button
     onClick={props.handleClick}
     className={props.className}

--- a/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/TitleBlockZen.spec.tsx
+++ b/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/TitleBlockZen.spec.tsx
@@ -1,10 +1,9 @@
-import "./matchMedia.mock"
-
-import * as React from "react"
+import React from "react"
 import { configure, fireEvent } from "@testing-library/dom"
 import { render, waitFor, screen } from "@testing-library/react"
 import { TitleBlockZen, CustomBreadcrumbProps } from "./index"
 import "@testing-library/jest-dom"
+import "./matchMedia.mock"
 
 configure({
   testIdAttribute: "data-automation-id",
@@ -12,14 +11,12 @@ configure({
 
 describe("<TitleBlockZen />", () => {
   describe("when the primary action is a button with only an href", () => {
-    let primaryActionAsLink
-    beforeEach(() => {
-      primaryActionAsLink = {
-        label: "primaryActionLabel",
-        href: "#primaryActionHref",
-        primary: true,
-      }
-    })
+    const primaryActionAsLink = {
+      label: "primaryActionLabel",
+      href: "#primaryActionHref",
+      primary: true,
+    }
+
     it("renders the primary action button label and href", () => {
       const { getByTestId } = render(
         <TitleBlockZen title="Test Title" primaryAction={primaryActionAsLink}>
@@ -43,16 +40,17 @@ describe("<TitleBlockZen />", () => {
   })
 
   describe("when the primary action is a button with only an onClick", () => {
-    let testOnClickFn
-    let primaryActionAsButton
+    const testOnClickFn = jest.fn()
+    const primaryActionAsButton = {
+      label: "primaryActionLabel",
+      onClick: testOnClickFn,
+      primary: true,
+    }
+
     beforeEach(() => {
-      testOnClickFn = jest.fn()
-      primaryActionAsButton = {
-        label: "primaryActionLabel",
-        onClick: testOnClickFn,
-        primary: true,
-      }
+      testOnClickFn.mockClear()
     })
+
     it("renders the primary action button label and onClick", () => {
       const { getByTestId } = render(
         <TitleBlockZen title="Test Title" primaryAction={primaryActionAsButton}>
@@ -80,24 +78,23 @@ describe("<TitleBlockZen />", () => {
   })
 
   describe("when the primary action is disabled", () => {
-    let testOnClickFn
-    let primaryActionAsButton
-    let primaryActionAsLink
+    const testOnClickFn = jest.fn()
+    const primaryActionAsButton = {
+      label: "primaryActionLabel",
+      onClick: testOnClickFn,
+      disabled: true,
+      primary: true,
+    }
+    const primaryActionAsLink = {
+      label: "primaryActionLabel",
+      href: "#primaryActionHref",
+      disabled: true,
+      primary: true,
+    }
     beforeEach(() => {
-      testOnClickFn = jest.fn()
-      primaryActionAsButton = {
-        label: "primaryActionLabel",
-        onClick: testOnClickFn,
-        disabled: true,
-        primary: true,
-      }
-      primaryActionAsLink = {
-        label: "primaryActionLabel",
-        href: "#primaryActionHref",
-        disabled: true,
-        primary: true,
-      }
+      testOnClickFn.mockClear()
     })
+
     it("renders a disabled primary action button", () => {
       const { getByTestId } = render(
         <TitleBlockZen title="Test Title" primaryAction={primaryActionAsButton}>
@@ -157,17 +154,18 @@ describe("<TitleBlockZen />", () => {
   })
 
   describe("when the primary action is a button with both an href and an onClick", () => {
-    let testOnClickFn
-    let primaryActionAsLinkAndOnClick
+    const testOnClickFn = jest.fn()
+    const primaryActionAsLinkAndOnClick = {
+      label: "primaryActionLabel",
+      href: "#primaryActionHref",
+      onClick: testOnClickFn,
+      primary: true,
+    }
+
     beforeEach(() => {
-      testOnClickFn = jest.fn()
-      primaryActionAsLinkAndOnClick = {
-        label: "primaryActionLabel",
-        href: "#primaryActionHref",
-        onClick: testOnClickFn,
-        primary: true,
-      }
+      testOnClickFn.mockClear()
     })
+
     it("renders the primary action button label, href and onClick", () => {
       const { getByTestId } = render(
         <TitleBlockZen
@@ -205,22 +203,20 @@ describe("<TitleBlockZen />", () => {
   })
 
   describe("when the primary action is a menu", () => {
-    let primaryActionAsMenu
-    beforeEach(() => {
-      primaryActionAsMenu = {
-        label: "primaryActionLabel",
-        menuItems: [
-          {
-            label: "Menu item 1",
-            action: "#",
-          },
-          {
-            label: "Menu item 1",
-            action: "#",
-          },
-        ],
-      }
-    })
+    const primaryActionAsMenu = {
+      label: "primaryActionLabel",
+      menuItems: [
+        {
+          label: "Menu item 1",
+          action: "#",
+        },
+        {
+          label: "Menu item 1",
+          action: "#",
+        },
+      ],
+    }
+
     it("renders the primary action menu button with label and menu items", async () => {
       const { getByTestId, getAllByTestId } = render(
         <TitleBlockZen title="Test Title" primaryAction={primaryActionAsMenu}>
@@ -250,13 +246,11 @@ describe("<TitleBlockZen />", () => {
   })
 
   describe("when the default action is a button with only an href", () => {
-    let defaultActionAsLink
-    beforeEach(() => {
-      defaultActionAsLink = {
-        label: "defaultActionLabel",
-        href: "#defaultActionHref",
-      }
-    })
+    const defaultActionAsLink = {
+      label: "defaultActionLabel",
+      href: "#defaultActionHref",
+    }
+
     it("renders the default action button label and href", () => {
       const { getByTestId } = render(
         <TitleBlockZen title="Test Title" defaultAction={defaultActionAsLink}>
@@ -294,15 +288,16 @@ describe("<TitleBlockZen />", () => {
   })
 
   describe("when the default action is a button with only an onClick", () => {
-    let testOnClickFn
-    let defaultActionAsButton
+    const testOnClickFn = jest.fn()
+    const defaultActionAsButton = {
+      label: "defaultActionLabel",
+      onClick: testOnClickFn,
+    }
+
     beforeEach(() => {
-      testOnClickFn = jest.fn()
-      defaultActionAsButton = {
-        label: "defaultActionLabel",
-        onClick: testOnClickFn,
-      }
+      testOnClickFn.mockClear()
     })
+
     it("renders the default action button label and onClick", () => {
       const { getByTestId } = render(
         <TitleBlockZen title="Test Title" defaultAction={defaultActionAsButton}>
@@ -342,16 +337,17 @@ describe("<TitleBlockZen />", () => {
   })
 
   describe("when the default action is a button with both an href and an onClick", () => {
-    let testOnClickFn
-    let defaultActionAsLinkAndOnClick
+    const testOnClickFn = jest.fn()
+    const defaultActionAsLinkAndOnClick = {
+      label: "defaultActionLabel",
+      href: "#defaultActionHref",
+      onClick: testOnClickFn,
+    }
+
     beforeEach(() => {
-      testOnClickFn = jest.fn()
-      defaultActionAsLinkAndOnClick = {
-        label: "defaultActionLabel",
-        href: "#defaultActionHref",
-        onClick: testOnClickFn,
-      }
+      testOnClickFn.mockClear()
     })
+
     it("renders the default action button label, href and onClick", () => {
       const { getByTestId } = render(
         <TitleBlockZen
@@ -397,22 +393,22 @@ describe("<TitleBlockZen />", () => {
   })
 
   describe("when the default action is disabled", () => {
-    let testOnClickFn
-    let defaultActionAsButton
-    let defaultActionAsLink
+    const testOnClickFn = jest.fn()
+    const defaultActionAsButton = {
+      label: "defaultActionLabel",
+      onClick: testOnClickFn,
+      disabled: true,
+    }
+    const defaultActionAsLink = {
+      label: "defaultActionLabel",
+      href: "#defaultActionHref",
+      disabled: true,
+    }
+
     beforeEach(() => {
-      testOnClickFn = jest.fn()
-      defaultActionAsButton = {
-        label: "defaultActionLabel",
-        onClick: testOnClickFn,
-        disabled: true,
-      }
-      defaultActionAsLink = {
-        label: "defaultActionLabel",
-        href: "#defaultActionHref",
-        disabled: true,
-      }
+      testOnClickFn.mockClear()
     })
+
     it("renders a disabled default action button", () => {
       const { getByTestId } = render(
         <TitleBlockZen title="Test Title" defaultAction={defaultActionAsButton}>
@@ -472,16 +468,17 @@ describe("<TitleBlockZen />", () => {
   })
 
   describe("when a secondary action is passed with both an href and an onClick", () => {
-    let testOnClickFn
-    let secondaryActionWithLinkAndOnClick
+    const testOnClickFn = jest.fn()
+    const secondaryActionWithLinkAndOnClick = {
+      label: "secondaryActionLabel",
+      href: "#secondaryActionHref",
+      onClick: testOnClickFn,
+    }
+
     beforeEach(() => {
-      testOnClickFn = jest.fn()
-      secondaryActionWithLinkAndOnClick = {
-        label: "secondaryActionLabel",
-        href: "#secondaryActionHref",
-        onClick: testOnClickFn,
-      }
+      testOnClickFn.mockClear()
     })
+
     it("renders the secondary action with both the href and onClick", async () => {
       const mockWarnFn = jest.fn()
       const spy = jest
@@ -534,13 +531,11 @@ describe("<TitleBlockZen />", () => {
   })
 
   describe("when a secondary action is passed with only an href", () => {
-    let secondaryActionWithLinkAndOnClick
-    beforeEach(() => {
-      secondaryActionWithLinkAndOnClick = {
-        label: "secondaryActionLabel",
-        href: "#secondaryActionHref",
-      }
-    })
+    const secondaryActionWithLinkAndOnClick = {
+      label: "secondaryActionLabel",
+      href: "#secondaryActionHref",
+    }
+
     it("renders the action as a single mobile actions drawer item with the correct href", () => {
       const { getAllByTestId } = render(
         <TitleBlockZen
@@ -559,14 +554,12 @@ describe("<TitleBlockZen />", () => {
   })
 
   describe("when a disabled secondary action is passed with only an href", () => {
-    let secondaryActionWithLink
-    beforeEach(() => {
-      secondaryActionWithLink = {
-        label: "secondaryActionLabel",
-        href: "#secondaryActionHref",
-        disabled: true,
-      }
-    })
+    const secondaryActionWithLink = {
+      label: "secondaryActionLabel",
+      href: "#secondaryActionHref",
+      disabled: true,
+    }
+
     it("renders the action as a single disabled mobile actions drawer item with no href", () => {
       const { getAllByTestId } = render(
         <TitleBlockZen
@@ -585,16 +578,13 @@ describe("<TitleBlockZen />", () => {
   })
 
   describe("when a disabled secondary action is passed with only an onClick", () => {
-    let testOnClickFn
-    let secondaryActionWithOnClick
-    beforeEach(() => {
-      testOnClickFn = jest.fn()
-      secondaryActionWithOnClick = {
-        label: "secondaryActionLabel",
-        onClick: testOnClickFn,
-        disabled: true,
-      }
-    })
+    const testOnClickFn = jest.fn()
+    const secondaryActionWithOnClick = {
+      label: "secondaryActionLabel",
+      onClick: testOnClickFn,
+      disabled: true,
+    }
+
     it("renders the action as a single disabled mobile actions drawer item with no onClick", () => {
       const { getAllByTestId } = render(
         <TitleBlockZen
@@ -612,16 +602,13 @@ describe("<TitleBlockZen />", () => {
   })
 
   describe("when a disabled secondary overflow menu item is passed with only an onClick for the action", () => {
-    let testOnClickFn
-    let secondaryOverflowMenuItemWithOnClick
-    beforeEach(() => {
-      testOnClickFn = jest.fn()
-      secondaryOverflowMenuItemWithOnClick = {
-        label: "secondaryActionOverflowMenuItemLabel",
-        action: testOnClickFn,
-        disabled: true,
-      }
-    })
+    const testOnClickFn = jest.fn()
+    const secondaryOverflowMenuItemWithOnClick = {
+      label: "secondaryActionOverflowMenuItemLabel",
+      action: testOnClickFn,
+      disabled: true,
+    }
+
     it("renders the action as a single disabled mobile actions drawer item with no onClick", () => {
       const { getAllByTestId } = render(
         <TitleBlockZen
@@ -707,7 +694,7 @@ describe("<TitleBlockZen />", () => {
             breadcrumb={{
               text: "Test Breadcrumb",
               path: "/",
-              handleClick: () => jest.fn(),
+              handleClick: jest.fn(),
             }}
             sectionTitle="Test Section Title"
             sectionTitleDescription="Test Section Title Description"
@@ -745,7 +732,7 @@ describe("<TitleBlockZen />", () => {
             breadcrumb={{
               text: "Test Breadcrumb",
               path: "/",
-              handleClick: () => jest.fn(),
+              handleClick: jest.fn(),
             }}
             sectionTitle="Test Section Title"
             sectionTitleDescription="Test Section Title Description"
@@ -782,7 +769,7 @@ describe("<TitleBlockZen />", () => {
           breadcrumb={{
             text: "Back",
             path: "/path/to/somewhere",
-            handleClick: () => null,
+            handleClick: (): void => undefined,
           }}
         >
           Example
@@ -798,7 +785,7 @@ describe("<TitleBlockZen />", () => {
           title="Test Title"
           breadcrumb={{
             text: "Back",
-            handleClick: () => null,
+            handleClick: (): void => undefined,
           }}
         >
           Example
@@ -811,7 +798,7 @@ describe("<TitleBlockZen />", () => {
     it("renders a custom component when you pass a 'render' prop", () => {
       const mockFn = jest.fn()
 
-      const CustomComponent = (props: CustomBreadcrumbProps) => (
+      const CustomComponent = (props: CustomBreadcrumbProps): JSX.Element => (
         // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
         <div
           data-automation-id="custom-component"

--- a/draft-packages/title-block-zen/docs/TitleBlockZen.stories.tsx
+++ b/draft-packages/title-block-zen/docs/TitleBlockZen.stories.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { Args, Story } from "@storybook/react"
+import { ComponentStory, Story } from "@storybook/react"
 import { withDesign } from "storybook-addon-designs"
 import { Box } from "@kaizen/component-library"
 import addIcon from "@kaizen/component-library/icons/add.icon.svg"
@@ -34,7 +34,7 @@ export default {
   decorators: [withDesign],
 }
 
-const OffsetPadding = ({ children }: { children: React.ReactNode }) => (
+const OffsetPadding = ({ children }: { children: React.ReactNode }): JSX.Element => (
   <div style={{ margin: "-1rem" }}>{children}</div>
 )
 
@@ -43,36 +43,30 @@ const SECONDARY_ACTIONS = [
     label: "Secondary menu",
     menuItems: [
       {
-        onClick: () => {
-          alert("test")
-        },
+        onClick: (): void => alert("test"),
         label: "Secondary menu action 1",
       },
       {
-        onClick: () => {
-          alert("test")
-        },
+        onClick: (): void => alert("test"),
         label: "Secondary menu action 2",
         icon: starIcon,
       },
     ],
   },
   {
-    onClick: () => {
-      alert("test")
-    },
+    onClick: (): void => alert("test"),
     href: "foo",
     label: "Secondary action",
   },
 ]
 
-const DefaultTemplate = args => (
+const DefaultTemplate: ComponentStory<typeof TitleBlockZen> = args => (
   <OffsetPadding>
     <TitleBlockZen {...args} />
   </OffsetPadding>
 )
 
-export const Default: Story<Args> = DefaultTemplate.bind({})
+export const Default: ComponentStory<typeof TitleBlockZen> = DefaultTemplate.bind({})
 Default.args = {
   title: "Page title",
   surveyStatus: { text: "Live", status: "live" },
@@ -89,9 +83,7 @@ Default.args = {
   secondaryActions: SECONDARY_ACTIONS,
   secondaryOverflowMenuItems: [
     {
-      action: () => {
-        alert("test")
-      },
+      action: (): void => alert("test"),
       label: "Overflow action 1",
       icon: starIcon,
     },
@@ -101,17 +93,13 @@ Default.args = {
       icon: starIcon,
     },
   ],
-  handleHamburgerClick: () => {
-    alert("Hamburger clicked")
-  },
+  handleHamburgerClick: (): void => alert("Hamburger clicked"),
   breadcrumb: {
     path: "#",
     text: "Back to home",
-    handleClick: event => {
-      alert("breadcrumb clicked!")
-    },
+    handleClick: (): void => alert("breadcrumb clicked!"),
   },
-  navigationTabs: () => [
+  navigationTabs: [
     <NavigationTab text="Label" href="#" active />,
     <NavigationTab text="Label" href="#" />,
     <NavigationTab text="Label" href="#" />,
@@ -121,7 +109,7 @@ Default.args = {
   ],
 }
 
-export const WithBadge = () => {
+export const WithBadge: Story = () => {
   const [badgeCount, setBadgeCount] = React.useState(1)
   return (
     <OffsetPadding>
@@ -147,9 +135,7 @@ export const WithBadge = () => {
         breadcrumb={{
           path: "#",
           text: "Back to home",
-          handleClick: event => {
-            alert("breadcrumb clicked!")
-          },
+          handleClick: () => alert("breadcrumb clicked!"),
         }}
       />
     </OffsetPadding>
@@ -158,7 +144,7 @@ export const WithBadge = () => {
 WithBadge.storyName = "With Primary Action Badge"
 WithBadge.parameters = { chromatic: { disable: false } }
 
-export const WithDefaultTag = () => (
+export const WithDefaultTag: Story = () => (
   <OffsetPadding>
     <TitleBlockZen
       title="Page title"
@@ -172,9 +158,7 @@ export const WithDefaultTag = () => (
       breadcrumb={{
         path: "#",
         text: "Back to home",
-        handleClick: event => {
-          alert("breadcrumb clicked!")
-        },
+        handleClick: () => alert("breadcrumb clicked!"),
       }}
     />
   </OffsetPadding>
@@ -182,7 +166,7 @@ export const WithDefaultTag = () => (
 WithDefaultTag.storyName = "With Default Survey Status (Tag)"
 WithDefaultTag.parameters = { chromatic: { disable: false } }
 
-export const AdminWithDefaultTag = () => (
+export const AdminWithDefaultTag: Story = () => (
   <OffsetPadding>
     <TitleBlockZen
       variant="admin"
@@ -197,9 +181,7 @@ export const AdminWithDefaultTag = () => (
       breadcrumb={{
         path: "#",
         text: "Back to home",
-        handleClick: event => {
-          alert("breadcrumb clicked!")
-        },
+        handleClick: () => alert("breadcrumb clicked!"),
       }}
     />
   </OffsetPadding>
@@ -207,7 +189,7 @@ export const AdminWithDefaultTag = () => (
 AdminWithDefaultTag.storyName = "Admin With Default Survey Status (Tag)"
 AdminWithDefaultTag.parameters = { chromatic: { disable: false } }
 
-export const DefaultWithMenuButton = () => (
+export const DefaultWithMenuButton: Story = () => (
   <OffsetPadding>
     <TitleBlockZen
       title="Page title"
@@ -220,9 +202,7 @@ export const DefaultWithMenuButton = () => (
             label: "Item 1",
           },
           {
-            action: () => {
-              alert("Item 2 clicked")
-            },
+            action: () => alert("Item 2 clicked"),
             label: "Item 2",
           },
           {
@@ -236,15 +216,11 @@ export const DefaultWithMenuButton = () => (
         icon: addIcon,
       }}
       secondaryActions={SECONDARY_ACTIONS}
-      handleHamburgerClick={() => {
-        alert("Hamburger clicked")
-      }}
+      handleHamburgerClick={(): void => alert("Hamburger clicked")}
       breadcrumb={{
         path: "#",
         text: "Back to home",
-        handleClick: event => {
-          alert("breadcrumb clicked!")
-        },
+        handleClick: () => alert("breadcrumb clicked!"),
       }}
       navigationTabs={[
         <NavigationTab text="Label" href="#" active />,
@@ -260,7 +236,7 @@ export const DefaultWithMenuButton = () => (
 DefaultWithMenuButton.storyName = "Default (Menu Button)"
 DefaultWithMenuButton.parameters = { chromatic: { disable: false } }
 
-export const AdminVariant = () => (
+export const AdminVariant: Story = () => (
   <OffsetPadding>
     <TitleBlockZen
       title="Page title"
@@ -282,15 +258,11 @@ export const AdminVariant = () => (
       }}
       defaultAction={{ label: "Default link", href: "#" }}
       secondaryActions={SECONDARY_ACTIONS}
-      handleHamburgerClick={() => {
-        alert("Hamburger clicked")
-      }}
+      handleHamburgerClick={(): void => alert("Hamburger clicked")}
       breadcrumb={{
         path: "#",
         text: "Back to home",
-        handleClick: event => {
-          alert("breadcrumb clicked!")
-        },
+        handleClick: () => alert("breadcrumb clicked!"),
       }}
     />
   </OffsetPadding>
@@ -298,7 +270,7 @@ export const AdminVariant = () => (
 AdminVariant.storyName = "Admin variant"
 AdminVariant.parameters = { chromatic: { disable: false } }
 
-export const AdminVariantWithNavTabs = () => (
+export const AdminVariantWithNavTabs: Story = () => (
   <OffsetPadding>
     <TitleBlockZen
       title="Page title"
@@ -306,15 +278,11 @@ export const AdminVariantWithNavTabs = () => (
       primaryAction={{ label: "Primary link", href: "#" }}
       defaultAction={{ label: "Default link", href: "#" }}
       secondaryActions={SECONDARY_ACTIONS}
-      handleHamburgerClick={() => {
-        alert("Hamburger clicked")
-      }}
+      handleHamburgerClick={(): void => alert("Hamburger clicked")}
       breadcrumb={{
         path: "#",
         text: "Back to home",
-        handleClick: event => {
-          alert("breadcrumb clicked!")
-        },
+        handleClick: () => alert("breadcrumb clicked!"),
       }}
       navigationTabs={[
         <NavigationTab text="Label" href="#" active variant="admin" />,
@@ -330,7 +298,7 @@ export const AdminVariantWithNavTabs = () => (
 AdminVariantWithNavTabs.storyName = "Admin variant with Navigation Tabs"
 AdminVariantWithNavTabs.parameters = { chromatic: { disable: false } }
 
-export const EducationVariant = () => (
+export const EducationVariant: Story = () => (
   <OffsetPadding>
     <TitleBlockZen
       title="Page title"
@@ -343,9 +311,7 @@ export const EducationVariant = () => (
       secondaryActions={SECONDARY_ACTIONS}
       secondaryOverflowMenuItems={[
         {
-          action: () => {
-            alert("test")
-          },
+          action: () => alert("test"),
           label: "Overflow action 1",
           icon: starIcon,
         },
@@ -355,15 +321,11 @@ export const EducationVariant = () => (
           icon: starIcon,
         },
       ]}
-      handleHamburgerClick={() => {
-        alert("Hamburger clicked")
-      }}
+      handleHamburgerClick={(): void => alert("Hamburger clicked")}
       breadcrumb={{
         path: "#",
         text: "Back to home",
-        handleClick: event => {
-          alert("breadcrumb clicked!")
-        },
+        handleClick: () => alert("breadcrumb clicked!"),
       }}
     />
     <Skirt variant="education">
@@ -392,7 +354,7 @@ export const EducationVariant = () => (
 EducationVariant.storyName = "Education variant"
 EducationVariant.parameters = { chromatic: { disable: false } }
 
-export const Engagement = () => (
+export const Engagement: Story = () => (
   <OffsetPadding>
     <TitleBlockZen
       title="Baseline Engagement Survey"
@@ -408,24 +370,18 @@ export const Engagement = () => (
         href: "#",
       }}
       secondaryActions={SECONDARY_ACTIONS}
-      handleHamburgerClick={() => {
-        alert("Hamburger clicked")
-      }}
+      handleHamburgerClick={(): void => alert("Hamburger clicked")}
       breadcrumb={{
         path: "#",
         text: "Back to home",
-        handleClick: event => {
-          alert("breadcrumb clicked!")
-        },
+        handleClick: () => alert("breadcrumb clicked!"),
       }}
       navigationTabs={[
         <NavigationTab text="Summary" href="#" />,
         <NavigationTab
           text="Insight"
           href="#"
-          handleClick={event => {
-            alert("Label clicked!")
-          }}
+          handleClick={(): void => alert("Label clicked!")}
         />,
         <NavigationTab text="Participation" href="#" />,
         <NavigationTab text="Questions" href="#" active />,
@@ -437,7 +393,7 @@ export const Engagement = () => (
 )
 Engagement.parameters = { chromatic: { disable: false } }
 
-export const Performance = () => (
+export const Performance: Story = () => (
   <OffsetPadding>
     <TitleBlockZen
       title="Blanca Wheeler"
@@ -453,38 +409,28 @@ export const Performance = () => (
       }}
       secondaryActions={[
         {
-          onClick: () => {
-            alert("test")
-          },
+          onClick: () => alert("test"),
           label: "Quick comment",
           icon: commentIcon,
         },
         {
-          onClick: () => {
-            alert("test")
-          },
+          onClick: () => alert("test"),
           label: "Review skills",
           icon: starIcon,
         },
       ]}
-      handleHamburgerClick={() => {
-        alert("Hamburger clicked")
-      }}
+      handleHamburgerClick={(): void => alert("Hamburger clicked")}
       breadcrumb={{
         path: "#",
         text: "Back to home",
-        handleClick: event => {
-          alert("breadcrumb clicked!")
-        },
+        handleClick: () => alert("breadcrumb clicked!"),
       }}
       navigationTabs={[
         <NavigationTab text="Feedback" href="#" active />,
         <NavigationTab
           text="Self-reflection"
           href="#"
-          handleClick={event => {
-            alert("Self-reflection clicked!")
-          }}
+          handleClick={(): void => alert("Self-reflection clicked!")}
         />,
         <NavigationTab text="Goal" href="#" />,
         <NavigationTab text="Evaluations" href="#" />,
@@ -495,7 +441,7 @@ export const Performance = () => (
 )
 Performance.parameters = { chromatic: { disable: false } }
 
-export const PerformanceWithAvatarProps = () => (
+export const PerformanceWithAvatarProps: Story = () => (
   <OffsetPadding>
     <TitleBlockZen
       title="Blanca Wheeler"
@@ -514,38 +460,28 @@ export const PerformanceWithAvatarProps = () => (
       }}
       secondaryActions={[
         {
-          onClick: () => {
-            alert("test")
-          },
+          onClick: () => alert("test"),
           label: "Quick comment",
           icon: commentIcon,
         },
         {
-          onClick: () => {
-            alert("test")
-          },
+          onClick: () => alert("test"),
           label: "Review skills",
           icon: starIcon,
         },
       ]}
-      handleHamburgerClick={() => {
-        alert("Hamburger clicked")
-      }}
+      handleHamburgerClick={(): void => alert("Hamburger clicked")}
       breadcrumb={{
         path: "#",
         text: "Back to home",
-        handleClick: event => {
-          alert("breadcrumb clicked!")
-        },
+        handleClick: () => alert("breadcrumb clicked!"),
       }}
       navigationTabs={[
         <NavigationTab text="Feedback" href="#" active />,
         <NavigationTab
           text="Self-reflection"
           href="#"
-          handleClick={event => {
-            alert("Self-reflection clicked!")
-          }}
+          handleClick={(): void => alert("Self-reflection clicked!")}
         />,
         <NavigationTab text="Goal" href="#" />,
         <NavigationTab text="Evaluations" href="#" />,
@@ -556,7 +492,7 @@ export const PerformanceWithAvatarProps = () => (
 )
 PerformanceWithAvatarProps.storyName = "Performance with AvatarProps"
 
-export const PerformanceWithEmptyAvatarProps = () => (
+export const PerformanceWithEmptyAvatarProps: Story = () => (
   <OffsetPadding>
     <TitleBlockZen
       title="Blanca Wheeler"
@@ -572,38 +508,28 @@ export const PerformanceWithEmptyAvatarProps = () => (
       }}
       secondaryActions={[
         {
-          onClick: () => {
-            alert("test")
-          },
+          onClick: () => alert("test"),
           label: "Quick comment",
           icon: commentIcon,
         },
         {
-          onClick: () => {
-            alert("test")
-          },
+          onClick: () => alert("test"),
           label: "Review skills",
           icon: starIcon,
         },
       ]}
-      handleHamburgerClick={() => {
-        alert("Hamburger clicked")
-      }}
+      handleHamburgerClick={(): void => alert("Hamburger clicked")}
       breadcrumb={{
         path: "#",
         text: "Back to home",
-        handleClick: event => {
-          alert("breadcrumb clicked!")
-        },
+        handleClick: () => alert("breadcrumb clicked!"),
       }}
       navigationTabs={[
         <NavigationTab text="Feedback" href="#" active />,
         <NavigationTab
           text="Self-reflection"
           href="#"
-          handleClick={event => {
-            alert("Self-reflection clicked!")
-          }}
+          handleClick={(): void => alert("Self-reflection clicked!")}
         />,
         <NavigationTab text="Goal" href="#" />,
         <NavigationTab text="Evaluations" href="#" />,
@@ -614,7 +540,7 @@ export const PerformanceWithEmptyAvatarProps = () => (
 )
 PerformanceWithEmptyAvatarProps.storyName = "Performance with Empty AvatarProps"
 
-export const LongLabels = () => (
+export const LongLabels: Story = () => (
   <OffsetPadding>
     <TitleBlockZen
       title="Wolfeschlegelsteino Hausenbergerdorffsch Hausenbergerdorffsch"
@@ -622,9 +548,7 @@ export const LongLabels = () => (
       primaryAction={{
         label: "Feedback anfordern",
         href: "#",
-        onClick: () => {
-          alert("test")
-        },
+        onClick: (): void => alert("test"),
       }}
       defaultAction={{
         label: "Feedback geben",
@@ -633,28 +557,20 @@ export const LongLabels = () => (
       secondaryActions={[
         {
           label: "Schneller Kommentar",
-          onClick: () => {
-            alert("test")
-          },
+          onClick: () => alert("test"),
           icon: commentIcon,
         },
         {
           label: "Fähigkeiten überprüfen",
-          onClick: () => {
-            alert("test")
-          },
+          onClick: () => alert("test"),
           icon: starIcon,
         },
       ]}
-      handleHamburgerClick={() => {
-        alert("Hamburger clicked")
-      }}
+      handleHamburgerClick={(): void => alert("Hamburger clicked")}
       breadcrumb={{
         path: "#",
         text: "Drehen Sie sich um und kehren Sie zur Startseite zurück",
-        handleClick: event => {
-          alert("breadcrumb clicked!")
-        },
+        handleClick: () => alert("breadcrumb clicked!"),
       }}
       avatar={<img alt="" src={assetUrl("site/empty-state.png")} />}
       subtitle="Wissenschaftlicher Mitarbeiter (Habilitation)"
@@ -663,9 +579,7 @@ export const LongLabels = () => (
         <NavigationTab
           text="Selbstreflexion"
           href="#"
-          handleClick={event => {
-            alert("Self-reflection clicked!")
-          }}
+          handleClick={(): void => alert("Self-reflection clicked!")}
         />,
         <NavigationTab text="Tor" href="#" />,
         <NavigationTab text="Bewertungen" href="#" />,
@@ -687,21 +601,17 @@ const MENU_LINKS = [
   },
   {
     label: "Primary menu action 1",
-    action: () => {
-      alert("test")
-    },
+    action: (): void => alert("test"),
     icon: reportSharingIcon,
   },
   {
     label: "Primary menu action 2",
-    action: () => {
-      alert("test")
-    },
+    action: (): void => alert("test"),
     icon: starIcon,
   },
 ]
 
-export const DefaultWithContent = () => (
+export const DefaultWithContent: Story = () => (
   <OffsetPadding>
     <TitleBlockZen
       title="Page title"
@@ -716,15 +626,11 @@ export const DefaultWithContent = () => (
         href: "#",
       }}
       secondaryActions={SECONDARY_ACTIONS}
-      handleHamburgerClick={() => {
-        alert("Hamburger clicked")
-      }}
+      handleHamburgerClick={(): void => alert("Hamburger clicked")}
       breadcrumb={{
         path: "#",
         text: "Back to home",
-        handleClick: event => {
-          alert("breadcrumb clicked!")
-        },
+        handleClick: () => alert("breadcrumb clicked!"),
       }}
       navigationTabs={[
         <NavigationTab text="Label" href="#" active />,
@@ -819,7 +725,7 @@ export const DefaultWithContent = () => (
 DefaultWithContent.storyName = "Default with content"
 DefaultWithContent.parameters = { chromatic: { disable: false } }
 
-export const DefaultNoSecondary = () => (
+export const DefaultNoSecondary: Story = () => (
   <OffsetPadding>
     <TitleBlockZen
       title="Page title"
@@ -833,15 +739,11 @@ export const DefaultNoSecondary = () => (
         label: "Default link",
         href: "#",
       }}
-      handleHamburgerClick={() => {
-        alert("Hamburger clicked")
-      }}
+      handleHamburgerClick={(): void => alert("Hamburger clicked")}
       breadcrumb={{
         path: "#",
         text: "Back to home",
-        handleClick: event => {
-          alert("breadcrumb clicked!")
-        },
+        handleClick: () => alert("breadcrumb clicked!"),
       }}
       navigationTabs={[
         <NavigationTab text="Label" href="#" active />,
@@ -930,13 +832,11 @@ export const DefaultNoSecondary = () => (
         </Paragraph>
       </Box>
     </Box>
-    {/* </SkirtCard>
-    </Skirt> */}
   </OffsetPadding>
 )
 DefaultNoSecondary.storyName = "Default (no secondary actions)"
 
-export const DefaultOnlyPrimary = () => (
+export const DefaultOnlyPrimary: Story = () => (
   <OffsetPadding>
     <TitleBlockZen
       title="Page title"
@@ -946,15 +846,11 @@ export const DefaultOnlyPrimary = () => (
         icon: addIcon,
         href: "#",
       }}
-      handleHamburgerClick={() => {
-        alert("Hamburger clicked")
-      }}
+      handleHamburgerClick={(): void => alert("Hamburger clicked")}
       breadcrumb={{
         path: "#",
         text: "Back to home",
-        handleClick: event => {
-          alert("breadcrumb clicked!")
-        },
+        handleClick: () => alert("breadcrumb clicked!"),
       }}
       navigationTabs={[
         <NavigationTab text="Label" href="#" active />,
@@ -969,7 +865,7 @@ export const DefaultOnlyPrimary = () => (
 )
 DefaultOnlyPrimary.storyName = "Default (only primary action)"
 
-export const DefaultWithReportSwitcher = () => (
+export const DefaultWithReportSwitcher: Story = () => (
   <OffsetPadding>
     <TitleBlockZen
       title="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat."
@@ -1002,15 +898,11 @@ export const DefaultWithReportSwitcher = () => (
         icon: addIcon,
         href: "#",
       }}
-      handleHamburgerClick={() => {
-        alert("Hamburger clicked")
-      }}
+      handleHamburgerClick={(): void => alert("Hamburger clicked")}
       breadcrumb={{
         path: "#",
         text: "Back to home",
-        handleClick: event => {
-          alert("breadcrumb clicked!")
-        },
+        handleClick: () => alert("breadcrumb clicked!"),
       }}
       navigationTabs={[
         <NavigationTab text="Label" href="#" active />,
@@ -1026,7 +918,7 @@ export const DefaultWithReportSwitcher = () => (
 DefaultWithReportSwitcher.storyName = "Default with report switcher"
 DefaultWithReportSwitcher.parameters = { chromatic: { disable: false } }
 
-export const DefaultNoLink = () => (
+export const DefaultNoLink: Story = () => (
   <OffsetPadding>
     <TitleBlockZen
       title="Page title"
@@ -1044,9 +936,7 @@ export const DefaultNoLink = () => (
       secondaryActions={SECONDARY_ACTIONS}
       secondaryOverflowMenuItems={[
         {
-          action: () => {
-            alert("test")
-          },
+          action: () => alert("test"),
           label: "Overflow action 1",
           icon: starIcon,
         },
@@ -1056,14 +946,10 @@ export const DefaultNoLink = () => (
           icon: starIcon,
         },
       ]}
-      handleHamburgerClick={() => {
-        alert("Hamburger clicked")
-      }}
+      handleHamburgerClick={(): void => alert("Hamburger clicked")}
       breadcrumb={{
         text: "Back to home",
-        handleClick: event => {
-          alert("breadcrumb clicked!")
-        },
+        handleClick: () => alert("breadcrumb clicked!"),
       }}
       navigationTabs={[
         <NavigationTab text="Label" href="#" active />,
@@ -1087,40 +973,32 @@ export const DefaultNoLink = () => (
 )
 DefaultNoLink.storyName = "Default (no link in breadcrumb)"
 
-export const DefaultOnlyLongTitle = () => (
+export const DefaultOnlyLongTitle: Story = () => (
   <OffsetPadding>
     <TitleBlockZen
       title="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat."
       subtitle="Subtitle goes here"
-      handleHamburgerClick={() => {
-        alert("Hamburger clicked")
-      }}
+      handleHamburgerClick={(): void => alert("Hamburger clicked")}
       breadcrumb={{
         path: "#",
         text: "Back to home",
-        handleClick: event => {
-          alert("breadcrumb clicked!")
-        },
+        handleClick: () => alert("breadcrumb clicked!"),
       }}
     />
   </OffsetPadding>
 )
 DefaultOnlyLongTitle.storyName = "Default (only long title)"
 
-export const DefaultCollapsedNavigation = () => (
+export const DefaultCollapsedNavigation: Story = () => (
   <OffsetPadding>
     <TitleBlockZen
       title="Page title"
       subtitle="Subtitle goes here"
-      handleHamburgerClick={() => {
-        alert("Hamburger clicked")
-      }}
+      handleHamburgerClick={(): void => alert("Hamburger clicked")}
       breadcrumb={{
         path: "#",
         text: "Back to home",
-        handleClick: event => {
-          alert("breadcrumb clicked!")
-        },
+        handleClick: () => alert("breadcrumb clicked!"),
       }}
       collapseNavigationAreaWhenPossible
     />
@@ -1136,20 +1014,16 @@ export const DefaultCollapsedNavigation = () => (
 DefaultCollapsedNavigation.storyName = "Default (collapsed navigation)"
 DefaultCollapsedNavigation.parameters = { chromatic: { disable: false } }
 
-export const DefaultCollapsedNavigationCard = () => (
+export const DefaultCollapsedNavigationCard: Story = () => (
   <OffsetPadding>
     <TitleBlockZen
       title="Page title"
       subtitle="Subtitle goes here"
-      handleHamburgerClick={() => {
-        alert("Hamburger clicked")
-      }}
+      handleHamburgerClick={(): void => alert("Hamburger clicked")}
       breadcrumb={{
         path: "#",
         text: "Back to home",
-        handleClick: event => {
-          alert("breadcrumb clicked!")
-        },
+        handleClick: () => alert("breadcrumb clicked!"),
       }}
       collapseNavigationAreaWhenPossible
     />
@@ -1167,21 +1041,17 @@ export const DefaultCollapsedNavigationCard = () => (
 DefaultCollapsedNavigationCard.storyName =
   "Default (collapsed navigation with card)"
 
-export const AdminVariantNavigation = () => (
+export const AdminVariantNavigation: Story = () => (
   <OffsetPadding>
     <TitleBlockZen
       variant="admin"
       title="Page title"
       subtitle="Subtitle goes here"
-      handleHamburgerClick={() => {
-        alert("Hamburger clicked")
-      }}
+      handleHamburgerClick={(): void => alert("Hamburger clicked")}
       breadcrumb={{
         path: "#",
         text: "Back to home",
-        handleClick: event => {
-          alert("breadcrumb clicked!")
-        },
+        handleClick: () => alert("breadcrumb clicked!"),
       }}
       collapseNavigationAreaWhenPossible
     />
@@ -1198,8 +1068,8 @@ export const AdminVariantNavigation = () => (
 )
 AdminVariantNavigation.storyName = "Admin (collapsed navigation)"
 
-export const RenderProps = () => {
-  const CustomTab = props => (
+export const RenderProps: Story = () => {
+  const CustomTab = (props: { href: string, className: string, text: string }): JSX.Element => (
     // In real life, you'll likely use this to insert a router Link component
     <a href={props.href} className={props.className}>
       {props.text}

--- a/draft-packages/title-block-zen/docs/TitleBlockZen.stories.tsx
+++ b/draft-packages/title-block-zen/docs/TitleBlockZen.stories.tsx
@@ -34,9 +34,11 @@ export default {
   decorators: [withDesign],
 }
 
-const OffsetPadding = ({ children }: { children: React.ReactNode }): JSX.Element => (
-  <div style={{ margin: "-1rem" }}>{children}</div>
-)
+const OffsetPadding = ({
+  children,
+}: {
+  children: React.ReactNode
+}): JSX.Element => <div style={{ margin: "-1rem" }}>{children}</div>
 
 const SECONDARY_ACTIONS = [
   {
@@ -66,7 +68,8 @@ const DefaultTemplate: ComponentStory<typeof TitleBlockZen> = args => (
   </OffsetPadding>
 )
 
-export const Default: ComponentStory<typeof TitleBlockZen> = DefaultTemplate.bind({})
+export const Default: ComponentStory<typeof TitleBlockZen> =
+  DefaultTemplate.bind({})
 Default.args = {
   title: "Page title",
   surveyStatus: { text: "Live", status: "live" },
@@ -1069,7 +1072,11 @@ export const AdminVariantNavigation: Story = () => (
 AdminVariantNavigation.storyName = "Admin (collapsed navigation)"
 
 export const RenderProps: Story = () => {
-  const CustomTab = (props: { href: string, className: string, text: string }): JSX.Element => (
+  const CustomTab = (props: {
+    href: string
+    className: string
+    text: string
+  }): JSX.Element => (
     // In real life, you'll likely use this to insert a router Link component
     <a href={props.href} className={props.className}>
       {props.text}

--- a/draft-packages/tooltip/KaizenDraft/Tooltip/AppearanceAnim.spec.tsx
+++ b/draft-packages/tooltip/KaizenDraft/Tooltip/AppearanceAnim.spec.tsx
@@ -1,5 +1,5 @@
-import * as React from "react"
-import { cleanup, render } from "@testing-library/react"
+import React from "react"
+import { render } from "@testing-library/react"
 import useDebounce from "use-debounce"
 import { AnimationProvider } from "./AppearanceAnim"
 import "@testing-library/jest-dom"
@@ -10,7 +10,7 @@ let mockReturnValue
 
 beforeEach(() => {
   mockReturnValue = jest.fn()
-  mockReturnValue.cancel = () => undefined
+  mockReturnValue.cancel = (): void => undefined
   useDebouncedCallback.mockImplementation(() => mockReturnValue)
 })
 

--- a/draft-packages/tooltip/KaizenDraft/Tooltip/Tooltip.spec.tsx
+++ b/draft-packages/tooltip/KaizenDraft/Tooltip/Tooltip.spec.tsx
@@ -1,4 +1,4 @@
-import * as React from "react"
+import React from "react"
 import { cleanup, render } from "@testing-library/react"
 import * as AppearanceAnim from "./AppearanceAnim"
 import { Tooltip } from "./index"

--- a/draft-packages/tooltip/docs/Tooltip.stories.tsx
+++ b/draft-packages/tooltip/docs/Tooltip.stories.tsx
@@ -1,5 +1,7 @@
 /* eslint-disable jsx-a11y/anchor-is-valid */
 import React from "react"
+import { DecoratorFunction } from "@storybook/addons"
+import { ComponentMeta, ComponentStory, Story } from "@storybook/react"
 import isChromatic from "chromatic/isChromatic"
 import { withDesign } from "storybook-addon-designs"
 import { Button, IconButton } from "@kaizen/button"
@@ -12,7 +14,7 @@ import { Paragraph, Heading } from "@kaizen/typography"
 import { CATEGORIES } from "../../../storybook/constants"
 import { figmaEmbed } from "../../../storybook/helpers"
 
-const openTooltipInChromatic = (story, config) => {
+const openTooltipInChromatic: DecoratorFunction = (story, config) => {
   if (isChromatic()) config.args.isInitiallyVisible = true
   return story()
 }
@@ -36,9 +38,9 @@ export default {
     ),
   },
   decorators: [withDesign, openTooltipInChromatic],
-}
+} as ComponentMeta<typeof Tooltip>
 
-export const DefaultKaizenSiteDemo = props => (
+export const DefaultKaizenSiteDemo: ComponentStory<typeof Tooltip> = props => (
   <div
     style={{ marginTop: "100px", display: "flex", justifyContent: "center" }}
   >
@@ -56,7 +58,7 @@ DefaultKaizenSiteDemo.parameters = {
   },
 }
 
-export const WithNoAnimationDelay = props => (
+export const WithNoAnimationDelay: ComponentStory<typeof Tooltip> = props => (
   <div
     style={{ marginTop: "100px", display: "flex", justifyContent: "center" }}
   >
@@ -67,7 +69,7 @@ export const WithNoAnimationDelay = props => (
 )
 WithNoAnimationDelay.storyName = "With no animation delay"
 
-export const StickerSheet = props => (
+export const StickerSheet: ComponentStory<typeof Tooltip> = props => (
   <div
     style={{
       marginTop: "100px",
@@ -275,7 +277,7 @@ export const StickerSheet = props => (
 )
 StickerSheet.parameters = { chromatic: { disable: false } }
 
-export const OverflowScroll = props => (
+export const OverflowScroll: ComponentStory<typeof Tooltip> = props => (
   <>
     <p>
       Default Placement is 'above'. Scroll horizontally or vertically to view

--- a/draft-packages/well/Well.spec.tsx
+++ b/draft-packages/well/Well.spec.tsx
@@ -1,6 +1,5 @@
-import * as React from "react"
+import React from "react"
 import { cleanup, render } from "@testing-library/react"
-
 import { WellProps } from "./Well"
 import { Well } from "."
 
@@ -12,7 +11,7 @@ const defaultWellProps = {
   children: "",
 }
 
-const renderWell = (props?: WellProps) => {
+const renderWell = (props?: WellProps): ReturnType<typeof render> => {
   const mergedWellProps = { ...defaultWellProps, ...props }
 
   return render(<Well {...mergedWellProps} />)

--- a/draft-packages/well/docs/Well.stories.tsx
+++ b/draft-packages/well/docs/Well.stories.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { Story } from "@storybook/react"
+import { ComponentStory, Story } from "@storybook/react"
 import { withDesign } from "storybook-addon-designs"
 import { TextField } from "@kaizen/draft-form"
 import { Well } from "@kaizen/draft-well"
@@ -8,7 +8,7 @@ import { StoryWrapper } from "../../../storybook/components/StoryWrapper"
 import { CATEGORIES } from "../../../storybook/constants"
 import { figmaEmbed } from "../../../storybook/helpers"
 
-const ExampleContent = () => (
+const ExampleContent = (): JSX.Element => (
   <div style={{ padding: "1rem" }}>
     <Heading tag="h3" variant="heading-3">
       Heading
@@ -23,7 +23,7 @@ const ExampleContent = () => (
       id="blerg"
       labelText="Example text field"
       inputValue=""
-      onChange={() => undefined}
+      onChange={(): void => undefined}
     />
   </div>
 )
@@ -44,7 +44,7 @@ export default {
   decorators: [withDesign],
 }
 
-export const DefaultWithSolidBorderKaizenSiteDemo = args => (
+export const DefaultWithSolidBorderKaizenSiteDemo: ComponentStory<typeof Well> = args => (
   <Well {...args}>
     <ExampleContent />
   </Well>

--- a/draft-packages/well/docs/Well.stories.tsx
+++ b/draft-packages/well/docs/Well.stories.tsx
@@ -44,7 +44,9 @@ export default {
   decorators: [withDesign],
 }
 
-export const DefaultWithSolidBorderKaizenSiteDemo: ComponentStory<typeof Well> = args => (
+export const DefaultWithSolidBorderKaizenSiteDemo: ComponentStory<
+  typeof Well
+> = args => (
   <Well {...args}>
     <ExampleContent />
   </Well>

--- a/packages/a11y/docs/SkipLink.stories.tsx
+++ b/packages/a11y/docs/SkipLink.stories.tsx
@@ -8,6 +8,7 @@ import {
   Stories,
   PRIMARY_STORY,
 } from "@storybook/addon-docs"
+import { Story } from "@storybook/react"
 import { Box } from "@kaizen/component-library"
 import { Paragraph } from "@kaizen/typography"
 import { CATEGORIES } from "../../../storybook/constants"
@@ -21,7 +22,7 @@ export default {
       description: {
         component: 'import { SkipLink } from "@kaizen/a11y"',
       },
-      page: () => (
+      page: (): JSX.Element => (
         <>
           <Title />
           <Subtitle />
@@ -54,8 +55,8 @@ export default {
   },
 }
 
-export const SkipLinkExample = () => {
-  const renderPointers = () =>
+export const SkipLinkExample: Story = () => {
+  const renderPointers = (): JSX.Element[] =>
     Array.from(Array(10)).map((_, i) => (
       <div key={`pointer-${i}`} style={{ paddingTop: "10rem" }}>
         👇

--- a/packages/a11y/docs/VisuallyHidden.stories.tsx
+++ b/packages/a11y/docs/VisuallyHidden.stories.tsx
@@ -1,4 +1,5 @@
 import React from "react"
+import { Story } from "@storybook/react"
 import { CATEGORIES, SUB_CATEGORIES } from "../../../storybook/constants"
 import { VisuallyHidden } from ".."
 
@@ -14,12 +15,11 @@ export default {
   },
 }
 
-export const TextWithVisuallyHidden = () => (
+export const TextWithVisuallyHidden: Story = () => (
   <div>
     There is visually hidden text between the two brackets (click "Show code" to
     see more): [<VisuallyHidden>👋 Hello!</VisuallyHidden>]
   </div>
 )
-
 TextWithVisuallyHidden.storyName = "Hidden text embedded in visible text"
 TextWithVisuallyHidden.parameters = { chromatic: { disable: false } }

--- a/packages/brand-moment/docs/BrandMoment.stories.tsx
+++ b/packages/brand-moment/docs/BrandMoment.stories.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable jsx-a11y/anchor-is-valid */
 import React from "react"
+import { ComponentStory } from "@storybook/react"
 import { BrandMoment } from "@kaizen/brand-moment"
 import { Box } from "@kaizen/component-library"
 import arrowLeftIcon from "@kaizen/component-library/icons/arrow-left.icon.svg"
@@ -31,7 +32,7 @@ export default {
     },
   },
   decorators: [
-    (story, { globals: { textDirection } }) => (
+    (story, { globals: { textDirection } }): JSX.Element => (
       <div id="brand-moment-container" style={{ margin: "-1rem" }}>
         {story({ isRTL: textDirection === "rtl" })}
       </div>
@@ -39,7 +40,7 @@ export default {
   ],
 }
 
-export const InformativeIntro = (_, { isRTL }) => (
+export const InformativeIntro: ComponentStory<typeof BrandMoment> = (_, { isRTL }) => (
   <BrandMoment
     mood="informative"
     illustration={<BrandMomentCaptureIntro isAnimated loop />}
@@ -59,7 +60,7 @@ export const InformativeIntro = (_, { isRTL }) => (
 InformativeIntro.storyName = "Informative intro"
 InformativeIntro.parameters = { chromatic: { disable: false } }
 
-export const PositiveOutro = (_, { isRTL }) => (
+export const PositiveOutro: ComponentStory<typeof BrandMoment> = (_, { isRTL }) => (
   <BrandMoment
     mood="positive"
     illustration={<BrandMomentPositiveOutro isAnimated loop />}
@@ -84,7 +85,7 @@ export const PositiveOutro = (_, { isRTL }) => (
 )
 PositiveOutro.storyName = "Positive outro"
 
-export const InformativeIntroCustomerFocused = (_, { isRTL }) => (
+export const InformativeIntroCustomerFocused: ComponentStory<typeof BrandMoment> = (_, { isRTL }) => (
   <BrandMoment
     mood="informative"
     illustration={<BrandMomentCaptureIntro isAnimated loop />}
@@ -118,7 +119,7 @@ export const InformativeIntroCustomerFocused = (_, { isRTL }) => (
 InformativeIntroCustomerFocused.storyName =
   "Informative intro (customer focused)"
 
-export const PositiveOutroCustomerFocused = (_, { isRTL }) => (
+export const PositiveOutroCustomerFocused: ComponentStory<typeof BrandMoment> = (_, { isRTL }) => (
   <BrandMoment
     mood="positive"
     illustration={<BrandMomentPositiveOutro isAnimated loop />}
@@ -157,7 +158,7 @@ export const PositiveOutroCustomerFocused = (_, { isRTL }) => (
 PositiveOutroCustomerFocused.storyName = "Positive outro (customer focused)"
 PositiveOutroCustomerFocused.parameters = { chromatic: { disable: false } }
 
-export const Error = (_, { isRTL }) => (
+export const Error: ComponentStory<typeof BrandMoment> = (_, { isRTL }) => (
   <BrandMoment
     mood="negative"
     illustration={<BrandMomentError isAnimated loop />}

--- a/packages/brand-moment/docs/BrandMoment.stories.tsx
+++ b/packages/brand-moment/docs/BrandMoment.stories.tsx
@@ -40,7 +40,10 @@ export default {
   ],
 }
 
-export const InformativeIntro: ComponentStory<typeof BrandMoment> = (_, { isRTL }) => (
+export const InformativeIntro: ComponentStory<typeof BrandMoment> = (
+  _,
+  { isRTL }
+) => (
   <BrandMoment
     mood="informative"
     illustration={<BrandMomentCaptureIntro isAnimated loop />}
@@ -60,7 +63,10 @@ export const InformativeIntro: ComponentStory<typeof BrandMoment> = (_, { isRTL 
 InformativeIntro.storyName = "Informative intro"
 InformativeIntro.parameters = { chromatic: { disable: false } }
 
-export const PositiveOutro: ComponentStory<typeof BrandMoment> = (_, { isRTL }) => (
+export const PositiveOutro: ComponentStory<typeof BrandMoment> = (
+  _,
+  { isRTL }
+) => (
   <BrandMoment
     mood="positive"
     illustration={<BrandMomentPositiveOutro isAnimated loop />}
@@ -85,7 +91,9 @@ export const PositiveOutro: ComponentStory<typeof BrandMoment> = (_, { isRTL }) 
 )
 PositiveOutro.storyName = "Positive outro"
 
-export const InformativeIntroCustomerFocused: ComponentStory<typeof BrandMoment> = (_, { isRTL }) => (
+export const InformativeIntroCustomerFocused: ComponentStory<
+  typeof BrandMoment
+> = (_, { isRTL }) => (
   <BrandMoment
     mood="informative"
     illustration={<BrandMomentCaptureIntro isAnimated loop />}
@@ -119,7 +127,9 @@ export const InformativeIntroCustomerFocused: ComponentStory<typeof BrandMoment>
 InformativeIntroCustomerFocused.storyName =
   "Informative intro (customer focused)"
 
-export const PositiveOutroCustomerFocused: ComponentStory<typeof BrandMoment> = (_, { isRTL }) => (
+export const PositiveOutroCustomerFocused: ComponentStory<
+  typeof BrandMoment
+> = (_, { isRTL }) => (
   <BrandMoment
     mood="positive"
     illustration={<BrandMomentPositiveOutro isAnimated loop />}

--- a/packages/brand/docs/Brand.stories.tsx
+++ b/packages/brand/docs/Brand.stories.tsx
@@ -21,7 +21,9 @@ export default {
   },
 }
 
-export const DefaultStory: ComponentStory<typeof Brand> = args => <Brand {...args} />
+export const DefaultStory: ComponentStory<typeof Brand> = args => (
+  <Brand {...args} />
+)
 DefaultStory.storyName = "Default (Kaizen Demo)"
 DefaultStory.args = {
   alt: "Culture Amp",

--- a/packages/brand/docs/Brand.stories.tsx
+++ b/packages/brand/docs/Brand.stories.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { Story } from "@storybook/react"
+import { ComponentStory, Story } from "@storybook/react"
 import { StoryWrapper } from "../../../storybook/components/StoryWrapper"
 import { CATEGORIES } from "../../../storybook/constants"
 import { figmaEmbed } from "../../../storybook/helpers/figmaEmbed"
@@ -21,7 +21,7 @@ export default {
   },
 }
 
-export const DefaultStory = args => <Brand {...args} />
+export const DefaultStory: ComponentStory<typeof Brand> = args => <Brand {...args} />
 DefaultStory.storyName = "Default (Kaizen Demo)"
 DefaultStory.args = {
   alt: "Culture Amp",

--- a/packages/button/docs/PaginationButtons.stories.tsx
+++ b/packages/button/docs/PaginationButtons.stories.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { Story } from "@storybook/react"
+import { ComponentStory, Story } from "@storybook/react"
 import { withDesign } from "storybook-addon-designs"
 import { Heading } from "@kaizen/typography"
 import { StoryWrapper } from "../../../storybook/components/StoryWrapper"
@@ -32,15 +32,21 @@ export default {
   decorators: [withDesign],
 }
 
-export const DefaultKaizenDirectionalLink = args => (
-  <DirectionalLink direction="prev" {...args} />
+export const DefaultKaizenDirectionalLink: ComponentStory<typeof DirectionalLink> = args => (
+  <DirectionalLink {...args} />
 )
 DefaultKaizenDirectionalLink.storyName = "Directional Link"
+DefaultKaizenDirectionalLink.args = {
+  direction: "prev"
+}
 
-export const DefaultKaizenPaginationLink = args => (
-  <PaginationLink pageNumber={1} {...args} />
+export const DefaultKaizenPaginationLink: ComponentStory<typeof PaginationLink> = args => (
+  <PaginationLink {...args} />
 )
 DefaultKaizenPaginationLink.storyName = "Pagination Link"
+DefaultKaizenPaginationLink.args = {
+  pageNumber: 1
+}
 
 const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({
   isReversed,

--- a/packages/button/docs/PaginationButtons.stories.tsx
+++ b/packages/button/docs/PaginationButtons.stories.tsx
@@ -32,20 +32,20 @@ export default {
   decorators: [withDesign],
 }
 
-export const DefaultKaizenDirectionalLink: ComponentStory<typeof DirectionalLink> = args => (
-  <DirectionalLink {...args} />
-)
+export const DefaultKaizenDirectionalLink: ComponentStory<
+  typeof DirectionalLink
+> = args => <DirectionalLink {...args} />
 DefaultKaizenDirectionalLink.storyName = "Directional Link"
 DefaultKaizenDirectionalLink.args = {
-  direction: "prev"
+  direction: "prev",
 }
 
-export const DefaultKaizenPaginationLink: ComponentStory<typeof PaginationLink> = args => (
-  <PaginationLink {...args} />
-)
+export const DefaultKaizenPaginationLink: ComponentStory<
+  typeof PaginationLink
+> = args => <PaginationLink {...args} />
 DefaultKaizenPaginationLink.storyName = "Pagination Link"
 DefaultKaizenPaginationLink.args = {
-  pageNumber: 1
+  pageNumber: 1,
 }
 
 const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({

--- a/packages/button/src/Button/IconButton.spec.tsx
+++ b/packages/button/src/Button/IconButton.spec.tsx
@@ -10,7 +10,7 @@ it("renders an accessible label when it's a link", () => {
 it("renders an accessible label when it's a button", () => {
   render(
     <IconButton
-      onClick={() => null}
+      onClick={(): void => undefined}
       label="Accessible label on the button version"
     />
   )
@@ -18,7 +18,7 @@ it("renders an accessible label when it's a button", () => {
 })
 
 it("renders an accessible label when it's a custom component", () => {
-  const CustomComponent = (buttonProps: CustomButtonProps) => (
+  const CustomComponent = (buttonProps: CustomButtonProps): JSX.Element => (
     <div {...buttonProps} />
   )
 

--- a/packages/component-library/stories/Box.stories.tsx
+++ b/packages/component-library/stories/Box.stories.tsx
@@ -8,6 +8,7 @@ import {
   Stories,
   PRIMARY_STORY,
 } from "@storybook/addon-docs"
+import { ComponentStory } from "@storybook/react"
 import { Paragraph } from "@kaizen/typography"
 import { CATEGORIES } from "../../../storybook/constants"
 import { Box } from "../components/Box"
@@ -18,7 +19,7 @@ export default {
   component: Box,
   parameters: {
     docs: {
-      page: () => (
+      page: (): JSX.Element => (
         <>
           <Title />
           <Subtitle />
@@ -33,7 +34,7 @@ export default {
   },
 }
 
-const Documentation = ({ reversed }: { reversed?: boolean }) => (
+const Documentation = ({ reversed }: { reversed?: boolean }): JSX.Element => (
   <Box mt={2}>
     <Paragraph variant="body" color={reversed ? "white" : "dark"}>
       <ul>
@@ -62,7 +63,7 @@ const Documentation = ({ reversed }: { reversed?: boolean }) => (
   </Box>
 )
 
-export const BoxDefault = args => (
+export const BoxDefault: ComponentStory<typeof Box> = args => (
   <div className={styles.boxStoriesWrapper}>
     <Box {...args}>
       A box with no props has a default margin and padding of 0. The children of

--- a/packages/component-library/stories/Icon.stories.tsx
+++ b/packages/component-library/stories/Icon.stories.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { Story } from "@storybook/react"
+import { ComponentStory, Story } from "@storybook/react"
 import { Icon } from "@kaizen/component-library"
 import { Heading, Paragraph } from "@kaizen/typography"
 import { CATEGORIES } from "../../../storybook/constants"
@@ -29,7 +29,7 @@ export default {
   },
 }
 
-export const MeaningfulKaizenSiteDemo = () => (
+export const MeaningfulKaizenSiteDemo: Story = () => (
   // the wrapper with the fixed with is to solve a problem when this is used
   // as a site demo: the iframe was getting a height of 0px in Firefox
   <div
@@ -48,7 +48,11 @@ export const MeaningfulKaizenSiteDemo = () => (
 )
 MeaningfulKaizenSiteDemo.storyName = "Icon"
 
-const IconExampleTile = ({ icon, figmaName, filename }) => (
+const IconExampleTile = ({ icon, figmaName, filename }: {
+  icon: React.SVGAttributes<SVGSymbolElement>,
+  figmaName: string,
+  filename: string
+}): JSX.Element => (
   <div
     style={{
       width: "200px",
@@ -84,7 +88,7 @@ const StickerSheetTemplate: Story = () => {
   const effectivenessIcons = [...Object.entries(Effectiveness)]
   const miscellaneousIcons = [...Object.entries(Miscellaneous)]
 
-  const getFileName = (id: string) => {
+  const getFileName = (id: string): string => {
     const filename = id.replace(".icon", "")
     return filename.replace("ca-icon-", "")
   }

--- a/packages/component-library/stories/Icon.stories.tsx
+++ b/packages/component-library/stories/Icon.stories.tsx
@@ -48,9 +48,13 @@ export const MeaningfulKaizenSiteDemo: Story = () => (
 )
 MeaningfulKaizenSiteDemo.storyName = "Icon"
 
-const IconExampleTile = ({ icon, figmaName, filename }: {
-  icon: React.SVGAttributes<SVGSymbolElement>,
-  figmaName: string,
+const IconExampleTile = ({
+  icon,
+  figmaName,
+  filename,
+}: {
+  icon: React.SVGAttributes<SVGSymbolElement>
+  figmaName: string
   filename: string
 }): JSX.Element => (
   <div

--- a/packages/component-library/stories/Text.stories.tsx
+++ b/packages/component-library/stories/Text.stories.tsx
@@ -1,4 +1,5 @@
-import * as React from "react"
+import React from "react"
+import { ComponentStory } from "@storybook/react"
 import { Text } from "@kaizen/component-library"
 import { CATEGORIES } from "../../../storybook/constants"
 
@@ -15,51 +16,43 @@ export default {
   },
 }
 
-export const H1 = () => <Text tag="h1">This is a Page Title (H1)</Text>
-
+export const H1: ComponentStory<typeof Text> = () => <Text tag="h1">This is a Page Title (H1)</Text>
 H1.storyName = "H1"
 
-export const H1InheritBaseline = () => (
+export const H1InheritBaseline: ComponentStory<typeof Text> = () => (
   <Text tag="h1" inheritBaseline>
     This is a Page Title (H1) that inherits the baseline
   </Text>
 )
-
 H1InheritBaseline.storyName = "H1 (inherit baseline)"
 
-export const H2 = () => <Text tag="h2">This is a Title (H2)</Text>
-
+export const H2: ComponentStory<typeof Text> = () => <Text tag="h2">This is a Title (H2)</Text>
 H2.storyName = "H2"
 
-export const H2NoBottomMargin = () => (
+export const H2NoBottomMargin: ComponentStory<typeof Text> = () => (
   <Text tag="h2" inline={true}>
     This is a Title (H2)
   </Text>
 )
-
 H2NoBottomMargin.storyName = "H2 (no bottom margin)"
 
-export const H3 = () => <Text tag="h3">This is a Display Heading (H3)</Text>
-
+export const H3: ComponentStory<typeof Text> = () => <Text tag="h3">This is a Display Heading (H3)</Text>
 H3.storyName = "H3"
 
-export const H4 = () => <Text tag="h4">This is a Heading (H4)</Text>
-
+export const H4: ComponentStory<typeof Text> = () => <Text tag="h4">This is a Heading (H4)</Text>
 H4.storyName = "H4"
 
-export const H5 = () => (
+export const H5: ComponentStory<typeof Text> = () => (
   <Text tag="h5">This is a H5, which uses Heading styles</Text>
 )
-
 H5.storyName = "H5"
 
-export const H6 = () => (
+export const H6: ComponentStory<typeof Text> = () => (
   <Text tag="h6">This is a H6, which uses Heading styles</Text>
 )
-
 H6.storyName = "H6"
 
-export const Paragraph = () => (
+export const Paragraph: ComponentStory<typeof Text> = () => (
   <Text tag="p">
     Dr. Brené Brown, author of Daring Greatly, is a research professor from the
     University of Houston who studies human emotions, including shame and
@@ -70,7 +63,7 @@ export const Paragraph = () => (
   </Text>
 )
 
-export const ParagraphNoMargin = () => (
+export const ParagraphNoMargin: ComponentStory<typeof Text> = () => (
   <Text tag="p" style="body">
     Dr. Brené Brown, author of Daring Greatly, is a research professor from the
     University of Houston who studies human emotions, including shame and
@@ -83,7 +76,7 @@ export const ParagraphNoMargin = () => (
 
 ParagraphNoMargin.storyName = "Paragraph (no margin)"
 
-export const LedeParagraph = () => (
+export const LedeParagraph: ComponentStory<typeof Text> = () => (
   <Text tag="p" style="lede">
     Dr. Brené Brown, author of Daring Greatly, is a research professor from the
     University of Houston who studies human emotions, including shame and
@@ -94,7 +87,7 @@ export const LedeParagraph = () => (
   </Text>
 )
 
-export const Div = () => (
+export const Div: ComponentStory<typeof Text> = () => (
   <Text tag="div">
     Dr. Brené Brown, author of Daring Greatly, is a research professor from the
     University of Houston who studies human emotions, including shame and
@@ -105,39 +98,36 @@ export const Div = () => (
   </Text>
 )
 
-export const DivWithPageTitleStyles = () => (
+export const DivWithPageTitleStyles: ComponentStory<typeof Text> = () => (
   <Text tag="div" style="page-title">
     Div with "Page Title" styles
   </Text>
 )
-
 DivWithPageTitleStyles.storyName = "Div with Page Title styles"
 
-export const Span = () => <Text tag="span">Span text</Text>
+export const Span: ComponentStory<typeof Text> = () => <Text tag="span">Span text</Text>
 
-export const BodyBold = () => (
+export const BodyBold: ComponentStory<typeof Text> = () => (
   <Text tag="div" style="body-bold">
     Div with "Body Bold" styles
   </Text>
 )
-
 BodyBold.storyName = "Body-bold"
 
-export const Small = () => (
+export const Small: ComponentStory<typeof Text> = () => (
   <Text tag="div" style="small">
     Div with "Small" styles
   </Text>
 )
 
-export const SmallBold = () => (
+export const SmallBold: ComponentStory<typeof Text> = () => (
   <Text tag="div" style="small-bold">
     Div with "Small Bold" styles
   </Text>
 )
-
 SmallBold.storyName = "Small-bold"
 
-export const Notification = () => (
+export const Notification: ComponentStory<typeof Text> = () => (
   <Text tag="div" style="notification">
     Div with "Notification" styles
     <br />
@@ -145,81 +135,80 @@ export const Notification = () => (
   </Text>
 )
 
-export const Label = () => (
+export const Label: ComponentStory<typeof Text> = () => (
   <Text tag="div" style="label">
     Div with "Label" styles
   </Text>
 )
 
-export const ControlAction = () => (
+export const ControlAction: ComponentStory<typeof Text> = () => (
   <Text tag="div" style="control-action">
     Div with "Control Action" styles
   </Text>
 )
-
 ControlAction.storyName = "Control-action"
 
-export const Button = () => (
+export const Button: ComponentStory<typeof Text> = () => (
   <Text tag="div" style="button">
     Div with "Button" styles
   </Text>
 )
 
-export const ZenDisplay0 = () => (
+export const ZenDisplay0: ComponentStory<typeof Text> = () => (
   <Text style="zen-display-0" tag="p">
     This is a Zen Display 0, which uses Heading styles
   </Text>
 )
 
-export const ZenHeading1 = () => (
+export const ZenHeading1: ComponentStory<typeof Text> = () => (
   <Text style="zen-heading-1" tag="h1">
     This is a Zen Heading 1, which uses Heading styles
   </Text>
 )
 
-export const ZenHeading2 = () => (
+export const ZenHeading2: ComponentStory<typeof Text> = () => (
   <Text style="zen-heading-2" tag="h2">
     This is a Zen Heading 2, which uses Heading styles
   </Text>
 )
 
-export const ZenHeading3 = () => (
+export const ZenHeading3: ComponentStory<typeof Text> = () => (
   <Text style="zen-heading-3" tag="h3">
     This is a Zen Heading 3, which uses Heading styles
   </Text>
 )
 
-export const ZenDataLarge = () => (
+export const ZenDataLarge: ComponentStory<typeof Text> = () => (
   <Text style="zen-data-large" tag="span">
     42
   </Text>
 )
 
-export const ZenDataLargeUnits = () => (
+export const ZenDataLargeUnits: ComponentStory<typeof Text> = () => (
   <Text style="zen-data-large-units" tag="span">
     %
   </Text>
 )
 
-export const ZenDataMedium = () => (
+export const ZenDataMedium: ComponentStory<typeof Text> = () => (
   <Text style="zen-data-medium" tag="span">
     42
   </Text>
 )
 
-export const ZenDataMediumUnits = () => (
+export const ZenDataMediumUnits: ComponentStory<typeof Text> = () => (
   <Text style="zen-data-medium-units" tag="span">
     %
   </Text>
 )
 
-export const ZenDataSmall = () => (
+export const ZenDataSmall: ComponentStory<typeof Text> = () => (
   <Text style="zen-data-small" tag="span">
     42
   </Text>
 )
 
-export const ZenDataSmallUnits = () => (
+export const ZenDataSmallUnits: ComponentStory<typeof Text> = () => (
   <Text style="zen-data-small-units" tag="span">
     %
   </Text>

--- a/packages/component-library/stories/Text.stories.tsx
+++ b/packages/component-library/stories/Text.stories.tsx
@@ -16,7 +16,9 @@ export default {
   },
 }
 
-export const H1: ComponentStory<typeof Text> = () => <Text tag="h1">This is a Page Title (H1)</Text>
+export const H1: ComponentStory<typeof Text> = () => (
+  <Text tag="h1">This is a Page Title (H1)</Text>
+)
 H1.storyName = "H1"
 
 export const H1InheritBaseline: ComponentStory<typeof Text> = () => (
@@ -26,7 +28,9 @@ export const H1InheritBaseline: ComponentStory<typeof Text> = () => (
 )
 H1InheritBaseline.storyName = "H1 (inherit baseline)"
 
-export const H2: ComponentStory<typeof Text> = () => <Text tag="h2">This is a Title (H2)</Text>
+export const H2: ComponentStory<typeof Text> = () => (
+  <Text tag="h2">This is a Title (H2)</Text>
+)
 H2.storyName = "H2"
 
 export const H2NoBottomMargin: ComponentStory<typeof Text> = () => (
@@ -36,10 +40,14 @@ export const H2NoBottomMargin: ComponentStory<typeof Text> = () => (
 )
 H2NoBottomMargin.storyName = "H2 (no bottom margin)"
 
-export const H3: ComponentStory<typeof Text> = () => <Text tag="h3">This is a Display Heading (H3)</Text>
+export const H3: ComponentStory<typeof Text> = () => (
+  <Text tag="h3">This is a Display Heading (H3)</Text>
+)
 H3.storyName = "H3"
 
-export const H4: ComponentStory<typeof Text> = () => <Text tag="h4">This is a Heading (H4)</Text>
+export const H4: ComponentStory<typeof Text> = () => (
+  <Text tag="h4">This is a Heading (H4)</Text>
+)
 H4.storyName = "H4"
 
 export const H5: ComponentStory<typeof Text> = () => (
@@ -105,7 +113,9 @@ export const DivWithPageTitleStyles: ComponentStory<typeof Text> = () => (
 )
 DivWithPageTitleStyles.storyName = "Div with Page Title styles"
 
-export const Span: ComponentStory<typeof Text> = () => <Text tag="span">Span text</Text>
+export const Span: ComponentStory<typeof Text> = () => (
+  <Text tag="span">Span text</Text>
+)
 
 export const BodyBold: ComponentStory<typeof Text> = () => (
   <Text tag="div" style="body-bold">

--- a/packages/date-picker/docs/Calendars.stories.tsx
+++ b/packages/date-picker/docs/Calendars.stories.tsx
@@ -132,10 +132,10 @@ StickerSheetDefault.parameters = {
   controls: { disable: true },
 }
 
-StickerSheetDefault.play = ({ canvasElement }) => {
+StickerSheetDefault.play = ({ canvasElement }): void => {
   const canvas = within(canvasElement)
 
-  const getElementWithinCalendar = (id: string, name: string) => {
+  const getElementWithinCalendar = (id: string, name: string): HTMLElement => {
     const calendar = canvas.getByTestId(id)
     return within(calendar).getByRole("button", {
       name,

--- a/packages/date-picker/docs/DatePicker.stories.tsx
+++ b/packages/date-picker/docs/DatePicker.stories.tsx
@@ -240,7 +240,7 @@ const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({
             id="datepicker-selected"
             labelText="Label"
             selectedDay={new Date(2022, 1, 5)}
-            onDayChange={() => undefined}
+            onDayChange={(): void => undefined}
             isReversed={isReversed}
             locale="en-AU"
           />
@@ -248,7 +248,7 @@ const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({
             id="datepicker-description"
             labelText="Label"
             selectedDay={undefined}
-            onDayChange={() => undefined}
+            onDayChange={(): void => undefined}
             isReversed={isReversed}
             description={
               <>
@@ -267,7 +267,7 @@ const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({
             id="datepicker-disabled"
             labelText="Label"
             selectedDay={undefined}
-            onDayChange={() => undefined}
+            onDayChange={(): void => undefined}
             isReversed={isReversed}
             locale="en-AU"
             disabled
@@ -276,7 +276,7 @@ const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({
             id="datepicker-error"
             labelText="Label"
             selectedDay={new Date("potato")}
-            onDayChange={() => undefined}
+            onDayChange={(): void => undefined}
             isReversed={isReversed}
             locale="en-AU"
           />
@@ -290,7 +290,7 @@ const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({
             id="datepicker-enAU"
             labelText="Label"
             selectedDay={new Date("2022, 1, 5")}
-            onDayChange={() => undefined}
+            onDayChange={(): void => undefined}
             isReversed={isReversed}
             locale="en-AU"
           />
@@ -298,7 +298,7 @@ const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({
             id="datepicker-enUS"
             labelText="Label"
             selectedDay={new Date("2022, 1, 5")}
-            onDayChange={() => undefined}
+            onDayChange={(): void => undefined}
             isReversed={isReversed}
             locale="en-US"
           />

--- a/packages/date-picker/docs/DateRangePicker.stories.tsx
+++ b/packages/date-picker/docs/DateRangePicker.stories.tsx
@@ -1,10 +1,10 @@
 import React, { useEffect, useState } from "react"
-import { Story } from "@storybook/react"
+import { ComponentStory, Story } from "@storybook/react"
 import { enAU } from "date-fns/locale"
 import { StoryWrapper } from "../../../storybook/components/StoryWrapper"
 import { CATEGORIES, SUB_CATEGORIES } from "../../../storybook/constants"
 import { figmaEmbed } from "../../../storybook/helpers"
-import { DateRangePicker } from "../src/DateRangePicker"
+import { DateRangePicker, DateRangePickerProps } from "../src/DateRangePicker"
 import { formatDateRangeValue } from "../src/DateRangePicker/utils/formatDateRangeValue"
 import { LegacyCalendarRange } from "../src/_subcomponents/Calendar"
 import { DateRange } from "../src/types"
@@ -24,19 +24,19 @@ export default {
   },
 }
 
-export const DateRangePickerStoryDefault = props => (
+export const DateRangePickerStoryDefault: ComponentStory<typeof DateRangePicker> = props => (
   <DateRangePickerTemplate {...props} />
 )
 DateRangePickerStoryDefault.storyName = "Date Range Picker"
 
-const DateRangePickerTemplate: Story = props => {
+const DateRangePickerTemplate = (props: Partial<DateRangePickerProps>): JSX.Element => {
   const [selectedDateRange, setSelectedDateRange] = useState<DateRange>({
     from: undefined,
     to: undefined,
   })
   const [value, setValue] = useState("")
 
-  const onDateRangeChange = (dateRange: DateRange) => {
+  const onDateRangeChange = (dateRange: DateRange): void => {
     setSelectedDateRange(dateRange)
   }
 
@@ -68,7 +68,7 @@ const LegacyCalendarRangeTemplate: Story = props => {
   return (
     <LegacyCalendarRange
       id="calendar-dialog"
-      onDayChange={() => undefined}
+      onDayChange={(): void => undefined}
       weekStartsOn={0}
       defaultMonth={new Date(2022, 2)}
       selectedRange={selectedDateRange}

--- a/packages/date-picker/docs/DateRangePicker.stories.tsx
+++ b/packages/date-picker/docs/DateRangePicker.stories.tsx
@@ -24,12 +24,14 @@ export default {
   },
 }
 
-export const DateRangePickerStoryDefault: ComponentStory<typeof DateRangePicker> = props => (
-  <DateRangePickerTemplate {...props} />
-)
+export const DateRangePickerStoryDefault: ComponentStory<
+  typeof DateRangePicker
+> = props => <DateRangePickerTemplate {...props} />
 DateRangePickerStoryDefault.storyName = "Date Range Picker"
 
-const DateRangePickerTemplate = (props: Partial<DateRangePickerProps>): JSX.Element => {
+const DateRangePickerTemplate = (
+  props: Partial<DateRangePickerProps>
+): JSX.Element => {
   const [selectedDateRange, setSelectedDateRange] = useState<DateRange>({
     from: undefined,
     to: undefined,

--- a/packages/date-picker/docs/FilterDateRangePicker.stories.tsx
+++ b/packages/date-picker/docs/FilterDateRangePicker.stories.tsx
@@ -143,7 +143,7 @@ const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({
               locale="en-AU"
               selectedRange={rangeRemovableBase}
               onRangeChange={setRangeRemovableBase}
-              onRemoveFilter={() => undefined}
+              onRemoveFilter={(): void => undefined}
             />
           </div>
           <div>
@@ -153,7 +153,7 @@ const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({
               locale="en-AU"
               selectedRange={rangeRemovableExisting}
               onRangeChange={setRangeRemovableExisting}
-              onRemoveFilter={() => undefined}
+              onRemoveFilter={(): void => undefined}
             />
           </div>
         </StoryWrapper.Row>
@@ -182,7 +182,7 @@ StickerSheetDefault.parameters = {
   controls: { disable: true },
 }
 
-StickerSheetDefault.play = ({ canvasElement }) => {
+StickerSheetDefault.play = ({ canvasElement }): void => {
   const canvas = within(canvasElement)
   const filterButtonOpen = canvas
     .getByTestId("test__stickersheet--filter-drp--open")

--- a/packages/date-picker/docs/TimeField.stories.tsx
+++ b/packages/date-picker/docs/TimeField.stories.tsx
@@ -70,7 +70,7 @@ const StickerSheetTemplate: Story = () => {
           label="Label (en-AU)"
           locale="en-AU"
           value={{ hour: 1, minutes: 30 }}
-          onChange={() => undefined}
+          onChange={(): void => undefined}
           isDisabled
         />
         <TimeField
@@ -91,7 +91,7 @@ const StickerSheetTemplate: Story = () => {
           label="Label (hover on hour)"
           locale="en-AU"
           value={{ hour: 22, minutes: 30 }}
-          onChange={() => undefined}
+          onChange={(): void => undefined}
           classNameOverride="story__timefield-hover"
         />
         <TimeField
@@ -99,7 +99,7 @@ const StickerSheetTemplate: Story = () => {
           label="Label (focus on hour)"
           locale="en-AU"
           value={{ hour: 22, minutes: 30 }}
-          onChange={() => undefined}
+          onChange={(): void => undefined}
           classNameOverride="story__timefield-focus"
         />
       </StoryWrapper.Row>

--- a/packages/date-picker/src/DatePicker/DatePicker.spec.tsx
+++ b/packages/date-picker/src/DatePicker/DatePicker.spec.tsx
@@ -8,7 +8,7 @@ import { DatePickerProps } from "."
 const DatePickerWrapper = ({
   selectedDay,
   ...restProps
-}: Partial<DatePickerProps>) => {
+}: Partial<DatePickerProps>): JSX.Element => {
   const [selectedDate, setValueDate] = useState<Date | undefined>(selectedDay)
 
   return (

--- a/packages/date-picker/src/DatePicker/components/DateInputField/DateInputField.spec.tsx
+++ b/packages/date-picker/src/DatePicker/components/DateInputField/DateInputField.spec.tsx
@@ -13,9 +13,9 @@ const defaultProps: DateInputFieldProps = {
   locale: enUS,
 }
 
-const DateInputFieldWrapper = (props: Partial<DateInputFieldProps>): JSX.Element => (
-  <DateInputField {...defaultProps} {...props} />
-)
+const DateInputFieldWrapper = (
+  props: Partial<DateInputFieldProps>
+): JSX.Element => <DateInputField {...defaultProps} {...props} />
 
 describe("<DateInputField />", () => {
   describe("Input", () => {
@@ -40,7 +40,10 @@ describe("<DateInputField />", () => {
 
     it("has helpful label showing the current date when one is selected", () => {
       render(
-        <DateInputFieldWrapper value="Mar 1, 2022" onChange={(): void => undefined} />
+        <DateInputFieldWrapper
+          value="Mar 1, 2022"
+          onChange={(): void => undefined}
+        />
       )
       expect(
         screen.getByRole("button", { name: "Change date, Mar 1, 2022" })

--- a/packages/date-picker/src/DatePicker/components/DateInputField/DateInputField.spec.tsx
+++ b/packages/date-picker/src/DatePicker/components/DateInputField/DateInputField.spec.tsx
@@ -13,7 +13,7 @@ const defaultProps: DateInputFieldProps = {
   locale: enUS,
 }
 
-const DateInputFieldWrapper = (props: Partial<DateInputFieldProps>) => (
+const DateInputFieldWrapper = (props: Partial<DateInputFieldProps>): JSX.Element => (
   <DateInputField {...defaultProps} {...props} />
 )
 
@@ -40,7 +40,7 @@ describe("<DateInputField />", () => {
 
     it("has helpful label showing the current date when one is selected", () => {
       render(
-        <DateInputFieldWrapper value="Mar 1, 2022" onChange={() => undefined} />
+        <DateInputFieldWrapper value="Mar 1, 2022" onChange={(): void => undefined} />
       )
       expect(
         screen.getByRole("button", { name: "Change date, Mar 1, 2022" })
@@ -90,12 +90,12 @@ describe("<DateInputField />", () => {
         [string | null | undefined, string | null | undefined]
       >()
 
-      const Wrapper = () => {
+      const Wrapper = (): JSX.Element => {
         const inputRef = useRef<HTMLInputElement>(null)
         const buttonRef = useRef<HTMLButtonElement>(null)
         const ref = useRef({ inputRef, buttonRef })
 
-        const handleClick = () =>
+        const handleClick = (): void =>
           onButtonClick(
             inputRef.current?.id,
             buttonRef.current?.getAttribute("aria-label")

--- a/packages/date-picker/src/DateRangePicker/DateRangePicker.spec.tsx
+++ b/packages/date-picker/src/DateRangePicker/DateRangePicker.spec.tsx
@@ -5,16 +5,14 @@ import { DateRange } from "react-day-picker"
 import { DateRangePicker, DateRangePickerProps } from "./DateRangePicker"
 import { formatDateRangeValue } from "./utils/formatDateRangeValue"
 
-const DateRangePickerWrapper = ({
-  ...restProps
-}: Partial<DateRangePickerProps>) => {
+const DateRangePickerWrapper = (props: Partial<DateRangePickerProps>): JSX.Element => {
   const [selectedDateRange, setSelectedDateRange] = useState<DateRange>({
     from: undefined,
     to: undefined,
   })
   const [value, setValue] = useState("")
 
-  const onDateRangeChange = (dateRange: DateRange) => {
+  const onDateRangeChange = (dateRange: DateRange): void => {
     setSelectedDateRange(dateRange)
   }
 
@@ -30,7 +28,7 @@ const DateRangePickerWrapper = ({
       onChange={onDateRangeChange}
       value={value}
       defaultMonth={new Date("2022-03-01")}
-      {...restProps}
+      {...props}
     />
   )
 }

--- a/packages/date-picker/src/DateRangePicker/DateRangePicker.spec.tsx
+++ b/packages/date-picker/src/DateRangePicker/DateRangePicker.spec.tsx
@@ -5,7 +5,9 @@ import { DateRange } from "react-day-picker"
 import { DateRangePicker, DateRangePickerProps } from "./DateRangePicker"
 import { formatDateRangeValue } from "./utils/formatDateRangeValue"
 
-const DateRangePickerWrapper = (props: Partial<DateRangePickerProps>): JSX.Element => {
+const DateRangePickerWrapper = (
+  props: Partial<DateRangePickerProps>
+): JSX.Element => {
   const [selectedDateRange, setSelectedDateRange] = useState<DateRange>({
     from: undefined,
     to: undefined,

--- a/packages/date-picker/src/FilterDateRangePicker/FilterDateRangePicker.spec.tsx
+++ b/packages/date-picker/src/FilterDateRangePicker/FilterDateRangePicker.spec.tsx
@@ -81,7 +81,9 @@ describe("<FilterDateRangePicker />", () => {
     })
 
     it("should show the remove button when remove filter callback is provided", () => {
-      render(<FilterDateRangePickerWrapper onRemoveFilter={(): void => undefined} />)
+      render(
+        <FilterDateRangePickerWrapper onRemoveFilter={(): void => undefined} />
+      )
       const removeButton = screen.getByRole("button", {
         name: "Remove filter - Dates",
       })

--- a/packages/date-picker/src/FilterDateRangePicker/FilterDateRangePicker.spec.tsx
+++ b/packages/date-picker/src/FilterDateRangePicker/FilterDateRangePicker.spec.tsx
@@ -5,7 +5,7 @@ import { DateRange } from "../types"
 import { FilterDateRangePicker, FilterDateRangePickerProps } from "."
 
 // For testing within the open filter
-const openFilter = async () => {
+const openFilter = async (): Promise<void> => {
   const filterButton = screen.getByRole("button", { expanded: false })
   await userEvent.click(filterButton)
   await waitFor(() => {
@@ -16,7 +16,7 @@ const openFilter = async () => {
 const FilterDateRangePickerWrapper = ({
   selectedRange,
   ...restProps
-}: Partial<FilterDateRangePickerProps>) => {
+}: Partial<FilterDateRangePickerProps>): JSX.Element => {
   const [selectedDateRange, setSelectedDateRange] = useState<
     DateRange | undefined
   >(selectedRange)
@@ -81,7 +81,7 @@ describe("<FilterDateRangePicker />", () => {
     })
 
     it("should show the remove button when remove filter callback is provided", () => {
-      render(<FilterDateRangePickerWrapper onRemoveFilter={() => undefined} />)
+      render(<FilterDateRangePickerWrapper onRemoveFilter={(): void => undefined} />)
       const removeButton = screen.getByRole("button", {
         name: "Remove filter - Dates",
       })

--- a/packages/date-picker/src/FilterDateRangePicker/components/DateRangeInputField/DateRangeInputField.spec.tsx
+++ b/packages/date-picker/src/FilterDateRangePicker/components/DateRangeInputField/DateRangeInputField.spec.tsx
@@ -9,7 +9,7 @@ import {
 
 const DateRangeInputFieldWrapper = (
   props: Partial<DateRangeInputFieldProps>
-) => (
+): JSX.Element => (
   <DateRangeInputField
     id="test__date-range-input-field"
     legend="Dates"
@@ -73,12 +73,12 @@ describe("<DateRangeInputField />", () => {
         [string | undefined, string | undefined]
       >()
 
-      const Wrapper = () => {
+      const Wrapper = (): JSX.Element => {
         const inputRangeStartRef = useRef<HTMLInputElement>(null)
         const inputRangeEndRef = useRef<HTMLInputElement>(null)
         const ref = useRef({ inputRangeStartRef, inputRangeEndRef })
 
-        const handleClick = () =>
+        const handleClick = (): void =>
           onButtonClick(
             inputRangeStartRef.current?.id,
             inputRangeEndRef.current?.id

--- a/packages/date-picker/src/FilterDateRangePicker/components/Trigger/FilterTriggerButton/FilterTriggerButton.spec.tsx
+++ b/packages/date-picker/src/FilterDateRangePicker/components/Trigger/FilterTriggerButton/FilterTriggerButton.spec.tsx
@@ -4,7 +4,7 @@ import { FilterTriggerButton, FilterTriggerButtonProps } from "."
 
 const FilterTriggerButtonWrapper = (
   props: Partial<FilterTriggerButtonProps>
-) => <FilterTriggerButton label="Desserts" isOpen={false} {...props} />
+): JSX.Element => <FilterTriggerButton label="Desserts" isOpen={false} {...props} />
 
 describe("<FilterTriggerButton />", () => {
   it("has the required attributes when not expanded", () => {

--- a/packages/date-picker/src/FilterDateRangePicker/components/Trigger/FilterTriggerButton/FilterTriggerButton.spec.tsx
+++ b/packages/date-picker/src/FilterDateRangePicker/components/Trigger/FilterTriggerButton/FilterTriggerButton.spec.tsx
@@ -4,7 +4,9 @@ import { FilterTriggerButton, FilterTriggerButtonProps } from "."
 
 const FilterTriggerButtonWrapper = (
   props: Partial<FilterTriggerButtonProps>
-): JSX.Element => <FilterTriggerButton label="Desserts" isOpen={false} {...props} />
+): JSX.Element => (
+  <FilterTriggerButton label="Desserts" isOpen={false} {...props} />
+)
 
 describe("<FilterTriggerButton />", () => {
   it("has the required attributes when not expanded", () => {

--- a/packages/date-picker/src/FilterDateRangePicker/components/Trigger/RemovableFilterTriggerButton/RemovableFilterTriggerButton.spec.tsx
+++ b/packages/date-picker/src/FilterDateRangePicker/components/Trigger/RemovableFilterTriggerButton/RemovableFilterTriggerButton.spec.tsx
@@ -10,7 +10,7 @@ const RemovableFilterTriggerButtonWrapper = ({
   triggerButtonProps,
   removeButtonProps,
   ...restProps
-}: Partial<RemovableFilterTriggerButtonProps>) => (
+}: Partial<RemovableFilterTriggerButtonProps>): JSX.Element => (
   <RemovableFilterTriggerButton
     triggerButtonProps={{
       ...triggerButtonProps,
@@ -38,7 +38,7 @@ describe("<RemovableFilterTriggerButton />", () => {
         [string | null | undefined, string | null | undefined]
       >()
 
-      const Wrapper = () => {
+      const Wrapper = (): JSX.Element => {
         const triggerButtonRef = useRef<HTMLButtonElement>(null)
         const removeButtonRef = useRef<HTMLButtonElement>(null)
         const ref = useRef({ triggerButtonRef, removeButtonRef })

--- a/packages/date-picker/src/_subcomponents/DateInput/DateInputWithIconButton.spec.tsx
+++ b/packages/date-picker/src/_subcomponents/DateInput/DateInputWithIconButton.spec.tsx
@@ -15,7 +15,7 @@ const defaultProps: DateInputWithIconButtonProps = {
 
 const DateInputWithIconButtonWrapper = (
   props: Partial<DateInputWithIconButtonProps>
-) => <DateInputWithIconButton {...defaultProps} {...props} />
+): JSX.Element => <DateInputWithIconButton {...defaultProps} {...props} />
 
 describe("<DateInputWithIconButton />", () => {
   describe("Icon button", () => {
@@ -30,7 +30,7 @@ describe("<DateInputWithIconButton />", () => {
       render(
         <DateInputWithIconButtonWrapper
           value="Mar 1, 2022"
-          onChange={() => undefined}
+          onChange={(): void => undefined}
         />
       )
       expect(
@@ -56,12 +56,12 @@ describe("<DateInputWithIconButton />", () => {
         [string | null | undefined, string | null | undefined]
       >()
 
-      const Wrapper = () => {
+      const Wrapper = (): JSX.Element => {
         const inputRef = useRef<HTMLInputElement>(null)
         const buttonRef = useRef<HTMLButtonElement>(null)
         const ref = useRef({ inputRef, buttonRef })
 
-        const handleClick = () =>
+        const handleClick = (): void =>
           onButtonClick(
             inputRef.current?.id,
             buttonRef.current?.getAttribute("aria-label")

--- a/packages/date-picker/src/hooks/useDateInputHandlers.spec.tsx
+++ b/packages/date-picker/src/hooks/useDateInputHandlers.spec.tsx
@@ -46,7 +46,7 @@ const Wrapper = ({
   )
 }
 
-const getDateInput = () => screen.getByLabelText("Label")
+const getDateInput = (): HTMLInputElement => screen.getByLabelText("Label")
 
 describe("useDateInputHandlers", () => {
   describe("onChange", () => {

--- a/packages/date-picker/src/utils/setFocusInCalendar.spec.tsx
+++ b/packages/date-picker/src/utils/setFocusInCalendar.spec.tsx
@@ -10,7 +10,7 @@ const CalendarWrapper = (props: Partial<CalendarSingleProps>): JSX.Element => (
     id="calendar-dialog"
     onDayClick={jest.fn<void, [Date]>()}
     locale={enUS}
-    onMount={calendarElement =>
+    onMount={(calendarElement): void =>
       setFocusInCalendar(calendarElement, props.selected)
     }
     {...props}

--- a/packages/design-tokens/docs/pages/examples/useThemeExample.docsExample.tsx
+++ b/packages/design-tokens/docs/pages/examples/useThemeExample.docsExample.tsx
@@ -1,7 +1,7 @@
 import React from "react"
 import { useTheme } from "@kaizen/design-tokens"
 
-export const App = () => {
+export const App = (): JSX.Element => {
   const theme = useTheme()
   return (
     <div

--- a/packages/loading-skeleton/docs/LoadingGraphic.stories.tsx
+++ b/packages/loading-skeleton/docs/LoadingGraphic.stories.tsx
@@ -30,7 +30,9 @@ export default {
   decorators: [withDesign],
 }
 
-export const DefaultLoadingGraphic: ComponentStory<typeof LoadingGraphic> = args => <LoadingGraphic {...args} />
+export const DefaultLoadingGraphic: ComponentStory<
+  typeof LoadingGraphic
+> = args => <LoadingGraphic {...args} />
 DefaultLoadingGraphic.storyName = "Loading Graphic"
 DefaultLoadingGraphic.args = { size: "xlarge" }
 

--- a/packages/loading-skeleton/docs/LoadingGraphic.stories.tsx
+++ b/packages/loading-skeleton/docs/LoadingGraphic.stories.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { Story } from "@storybook/react"
+import { ComponentStory, Story } from "@storybook/react"
 import { withDesign } from "storybook-addon-designs"
 import { Icon } from "@kaizen/component-library"
 import configureIcon from "@kaizen/component-library/icons/configure.icon.svg"
@@ -30,7 +30,7 @@ export default {
   decorators: [withDesign],
 }
 
-export const DefaultLoadingGraphic = args => <LoadingGraphic {...args} />
+export const DefaultLoadingGraphic: ComponentStory<typeof LoadingGraphic> = args => <LoadingGraphic {...args} />
 DefaultLoadingGraphic.storyName = "Loading Graphic"
 DefaultLoadingGraphic.args = { size: "xlarge" }
 

--- a/packages/loading-skeleton/docs/LoadingHeading.stories.tsx
+++ b/packages/loading-skeleton/docs/LoadingHeading.stories.tsx
@@ -23,7 +23,9 @@ export default {
   decorators: [withDesign],
 }
 
-export const DefaultLoadingHeading: ComponentStory<typeof LoadingHeading> = args => <LoadingHeading {...args} />
+export const DefaultLoadingHeading: ComponentStory<
+  typeof LoadingHeading
+> = args => <LoadingHeading {...args} />
 DefaultLoadingHeading.storyName = "Loading Heading"
 DefaultLoadingHeading.args = { variant: "heading-1" }
 

--- a/packages/loading-skeleton/docs/LoadingHeading.stories.tsx
+++ b/packages/loading-skeleton/docs/LoadingHeading.stories.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { Story } from "@storybook/react"
+import { ComponentStory, Story } from "@storybook/react"
 import { withDesign } from "storybook-addon-designs"
 import { Heading } from "@kaizen/typography"
 import { StoryWrapper } from "../../../storybook/components/StoryWrapper"
@@ -23,7 +23,7 @@ export default {
   decorators: [withDesign],
 }
 
-export const DefaultLoadingHeading = args => <LoadingHeading {...args} />
+export const DefaultLoadingHeading: ComponentStory<typeof LoadingHeading> = args => <LoadingHeading {...args} />
 DefaultLoadingHeading.storyName = "Loading Heading"
 DefaultLoadingHeading.args = { variant: "heading-1" }
 

--- a/packages/loading-skeleton/docs/LoadingInput.stories.tsx
+++ b/packages/loading-skeleton/docs/LoadingInput.stories.tsx
@@ -23,7 +23,9 @@ export default {
   decorators: [withDesign],
 }
 
-export const DefaultLoadingInput: ComponentStory<typeof LoadingInput> = args => <LoadingInput {...args} />
+export const DefaultLoadingInput: ComponentStory<
+  typeof LoadingInput
+> = args => <LoadingInput {...args} />
 DefaultLoadingInput.storyName = "Loading Input"
 
 const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({

--- a/packages/loading-skeleton/docs/LoadingInput.stories.tsx
+++ b/packages/loading-skeleton/docs/LoadingInput.stories.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { Story } from "@storybook/react"
+import { ComponentStory, Story } from "@storybook/react"
 import { withDesign } from "storybook-addon-designs"
 import { TextAreaField, TextField } from "@kaizen/draft-form"
 import { StoryWrapper } from "../../../storybook/components/StoryWrapper"
@@ -23,7 +23,7 @@ export default {
   decorators: [withDesign],
 }
 
-export const DefaultLoadingInput = args => <LoadingInput {...args} />
+export const DefaultLoadingInput: ComponentStory<typeof LoadingInput> = args => <LoadingInput {...args} />
 DefaultLoadingInput.storyName = "Loading Input"
 
 const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({

--- a/packages/loading-skeleton/docs/LoadingParagraph.stories.tsx
+++ b/packages/loading-skeleton/docs/LoadingParagraph.stories.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { Story } from "@storybook/react"
+import { ComponentStory, Story } from "@storybook/react"
 import { withDesign } from "storybook-addon-designs"
 import { Paragraph } from "@kaizen/typography"
 import { StoryWrapper } from "../../../storybook/components/StoryWrapper"
@@ -24,7 +24,7 @@ export default {
   decorators: [withDesign],
 }
 
-export const DefaultLoadingParagraph = args => <LoadingParagraph {...args} />
+export const DefaultLoadingParagraph: ComponentStory<typeof LoadingParagraph> = args => <LoadingParagraph {...args} />
 DefaultLoadingParagraph.storyName = "Loading Paragraph"
 
 const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({

--- a/packages/loading-skeleton/docs/LoadingParagraph.stories.tsx
+++ b/packages/loading-skeleton/docs/LoadingParagraph.stories.tsx
@@ -24,7 +24,9 @@ export default {
   decorators: [withDesign],
 }
 
-export const DefaultLoadingParagraph: ComponentStory<typeof LoadingParagraph> = args => <LoadingParagraph {...args} />
+export const DefaultLoadingParagraph: ComponentStory<
+  typeof LoadingParagraph
+> = args => <LoadingParagraph {...args} />
 DefaultLoadingParagraph.storyName = "Loading Paragraph"
 
 const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({

--- a/packages/loading-spinner/docs/LoadingSpinner.stories.tsx
+++ b/packages/loading-spinner/docs/LoadingSpinner.stories.tsx
@@ -1,4 +1,5 @@
 import React from "react"
+import { ComponentStory, Story } from "@storybook/react"
 import { withDesign } from "storybook-addon-designs"
 import { Box } from "@kaizen/component-library"
 import colorTokens from "@kaizen/design-tokens/tokens/color.json"
@@ -24,7 +25,7 @@ export default {
   decorators: [withDesign],
 }
 
-export const DefaultStory = args => (
+export const DefaultStory: ComponentStory<typeof LoadingSpinner> = args => (
   <div
     style={{
       color: colorTokens.color.green["400"],
@@ -51,7 +52,7 @@ DefaultStory.args = {
   size: "sm",
 }
 
-export const StickerSheet = () => (
+export const StickerSheet: Story = () => (
   <>
     <div
       style={{

--- a/packages/notification/docs/InlineNotification.stories.tsx
+++ b/packages/notification/docs/InlineNotification.stories.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { Story } from "@storybook/react"
+import { ComponentStory, Story } from "@storybook/react"
 import { withDesign } from "storybook-addon-designs"
 import { InlineNotification } from "@kaizen/notification"
 import { Heading, HeadingProps } from "@kaizen/typography"
@@ -23,22 +23,25 @@ export default {
   decorators: [withDesign],
 }
 
-export const DefaultKaizenDemo = props => (
-  <InlineNotification type="positive" title="Success" {...props}>
+export const DefaultKaizenDemo: ComponentStory<typeof InlineNotification> = props => (
+  <InlineNotification {...props}>
     New user data, imported by mackenzie@hooli.com has successfully uploaded.{" "}
     <a href="/">Manage users is now available</a>
   </InlineNotification>
 )
 DefaultKaizenDemo.storyName = "Default (Kaizen Demo)"
+DefaultKaizenDemo.args = {
+  type: "positive",
+  title: "Success"
+}
 
 const customHeadingProps: HeadingProps = {
   variant: "heading-6",
   tag: "h2",
   children: "Custom",
 }
-export const CustomHeadingLevel = props => (
+export const CustomHeadingLevel: ComponentStory<typeof InlineNotification> = props => (
   <InlineNotification
-    type="positive"
     headingProps={customHeadingProps}
     {...props}
   >
@@ -46,6 +49,9 @@ export const CustomHeadingLevel = props => (
   </InlineNotification>
 )
 CustomHeadingLevel.storyName = "Custom heading level"
+CustomHeadingLevel.args = {
+  type: "positive"
+}
 
 const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({
   isReversed,
@@ -157,10 +163,9 @@ StickerSheetReversed.parameters = {
   controls: { disable: true },
 }
 
-export const AutohideDemo = props => (
+export const AutohideDemo: ComponentStory<typeof InlineNotification> = props => (
   <>
     <InlineNotification
-      type="positive"
       title="Success"
       {...props}
       autohide
@@ -172,3 +177,6 @@ export const AutohideDemo = props => (
     <p>Content below the notification</p>
   </>
 )
+AutohideDemo.args = {
+  type: "positive"
+}

--- a/packages/notification/docs/InlineNotification.stories.tsx
+++ b/packages/notification/docs/InlineNotification.stories.tsx
@@ -23,7 +23,9 @@ export default {
   decorators: [withDesign],
 }
 
-export const DefaultKaizenDemo: ComponentStory<typeof InlineNotification> = props => (
+export const DefaultKaizenDemo: ComponentStory<
+  typeof InlineNotification
+> = props => (
   <InlineNotification {...props}>
     New user data, imported by mackenzie@hooli.com has successfully uploaded.{" "}
     <a href="/">Manage users is now available</a>
@@ -32,7 +34,7 @@ export const DefaultKaizenDemo: ComponentStory<typeof InlineNotification> = prop
 DefaultKaizenDemo.storyName = "Default (Kaizen Demo)"
 DefaultKaizenDemo.args = {
   type: "positive",
-  title: "Success"
+  title: "Success",
 }
 
 const customHeadingProps: HeadingProps = {
@@ -40,17 +42,16 @@ const customHeadingProps: HeadingProps = {
   tag: "h2",
   children: "Custom",
 }
-export const CustomHeadingLevel: ComponentStory<typeof InlineNotification> = props => (
-  <InlineNotification
-    headingProps={customHeadingProps}
-    {...props}
-  >
+export const CustomHeadingLevel: ComponentStory<
+  typeof InlineNotification
+> = props => (
+  <InlineNotification headingProps={customHeadingProps} {...props}>
     New user data
   </InlineNotification>
 )
 CustomHeadingLevel.storyName = "Custom heading level"
 CustomHeadingLevel.args = {
-  type: "positive"
+  type: "positive",
 }
 
 const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({
@@ -163,7 +164,9 @@ StickerSheetReversed.parameters = {
   controls: { disable: true },
 }
 
-export const AutohideDemo: ComponentStory<typeof InlineNotification> = props => (
+export const AutohideDemo: ComponentStory<
+  typeof InlineNotification
+> = props => (
   <>
     <InlineNotification
       title="Success"
@@ -178,5 +181,5 @@ export const AutohideDemo: ComponentStory<typeof InlineNotification> = props => 
   </>
 )
 AutohideDemo.args = {
-  type: "positive"
+  type: "positive",
 }

--- a/packages/notification/docs/ToastNotification.stories.tsx
+++ b/packages/notification/docs/ToastNotification.stories.tsx
@@ -1,5 +1,5 @@
-import * as React from "react"
-import { Story } from "@storybook/react"
+import React from "react"
+import { ComponentStory, Story } from "@storybook/react"
 import isChromatic from "chromatic"
 import { withDesign } from "storybook-addon-designs"
 import { v4 } from "uuid"
@@ -20,20 +20,18 @@ import styles from "./ToastNotification.stories.module.scss"
 
 const IS_CHROMATIC = isChromatic()
 
-const withNavigation = (StoryChild: () => JSX.Element) => (
-  <>
-    <div style={{ margin: "-1rem", minHeight: "150px" }}>
-      <TitleBlockZen title="Page title" collapseNavigationAreaWhenPossible />
-      <StoryChild />
-    </div>
-  </>
+const withNavigation = (StoryChild: () => JSX.Element): JSX.Element => (
+  <div style={{ margin: "-1rem", minHeight: "150px" }}>
+    <TitleBlockZen title="Page title" collapseNavigationAreaWhenPossible />
+    <StoryChild />
+  </div>
 )
 
 const Triggers = ({
   notifications,
 }: {
   notifications: ToastNotificationWithOptionals[]
-}) => {
+}): JSX.Element => {
   const [local] = React.useState(notifications.map(n => ({ ...n, id: v4() })))
 
   return (
@@ -43,7 +41,7 @@ const Triggers = ({
           <Box mr={0.25}>
             <Button
               label={`Show notification${local.length > 1 ? "s" : ""}`}
-              onClick={() => {
+              onClick={(): void => {
                 local.forEach(addToastNotification)
               }}
             />
@@ -51,14 +49,14 @@ const Triggers = ({
           <Box mr={0.25}>
             <Button
               label="Remove"
-              onClick={() => {
+              onClick={(): void => {
                 local.forEach(({ id }) => removeToastNotification(id))
               }}
             />
           </Box>
           <Button
             label="Clear"
-            onClick={() => {
+            onClick={(): void => {
               clearToastNotifications()
             }}
           />
@@ -85,7 +83,7 @@ export default {
   decorators: [withDesign, withNavigation],
 }
 
-export const PositiveKaizenSiteDemo = args => {
+export const PositiveKaizenSiteDemo: Story<ToastNotificationWithOptionals> = args => {
   React.useEffect(() => {
     addToastNotification({ ...args })
   })
@@ -107,7 +105,7 @@ PositiveKaizenSiteDemo.args = {
 
 PositiveKaizenSiteDemo.storyName = "Toast Notification"
 
-export const OverflowNotifications = () => {
+export const OverflowNotifications: ComponentStory<typeof Triggers> = () => {
   const seed = Math.random() * 1000
   return (
     <Triggers
@@ -128,14 +126,14 @@ export const OverflowNotifications = () => {
 }
 OverflowNotifications.storyName = "Overflow notifications"
 
-export const UpdatedNotification = () => (
+export const UpdatedNotification: Story = () => (
   <Container>
     <Content>
       <Box py={1} classNameOverride={styles.triggerContainer}>
         <Box mr={0.25}>
           <Button
             label={"Create initial notification"}
-            onClick={() => {
+            onClick={(): void => {
               addToastNotification({
                 id: "consistent-id",
                 automationId: "notification1",
@@ -153,7 +151,7 @@ export const UpdatedNotification = () => (
         </Box>
         <Button
           label={"Update initial notification"}
-          onClick={() => {
+          onClick={(): void => {
             addToastNotification({
               id: "consistent-id",
               automationId: "notification1",

--- a/packages/notification/docs/ToastNotification.stories.tsx
+++ b/packages/notification/docs/ToastNotification.stories.tsx
@@ -83,7 +83,9 @@ export default {
   decorators: [withDesign, withNavigation],
 }
 
-export const PositiveKaizenSiteDemo: Story<ToastNotificationWithOptionals> = args => {
+export const PositiveKaizenSiteDemo: Story<
+  ToastNotificationWithOptionals
+> = args => {
   React.useEffect(() => {
     addToastNotification({ ...args })
   })

--- a/packages/pagination/docs/Pagination.stories.tsx
+++ b/packages/pagination/docs/Pagination.stories.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react"
+import { ComponentStory } from "@storybook/react"
 import { Pagination } from "@kaizen/pagination"
 import { CATEGORIES } from "../../../storybook/constants"
 
@@ -13,7 +14,7 @@ export default {
     },
   },
   decorators: [
-    (story, { globals: { textDirection } }) => (
+    (story, { globals: { textDirection } }): JSX.Element => (
       <div
         style={{
           display: "flex",
@@ -27,7 +28,7 @@ export default {
   ],
 }
 
-export const Default = args => {
+export const Default: ComponentStory<typeof Pagination> = args => {
   const [currentPage, setCurrentPage] = useState(1)
 
   return (
@@ -37,7 +38,7 @@ export const Default = args => {
       ariaLabelNextPage="Next page"
       ariaLabelPreviousPage="Previous page"
       pageCount={10}
-      onPageChange={(newPage: number) => setCurrentPage(newPage)}
+      onPageChange={setCurrentPage}
     />
   )
 }

--- a/packages/pagination/src/Pagination.spec.tsx
+++ b/packages/pagination/src/Pagination.spec.tsx
@@ -26,7 +26,9 @@ describe("<Pagination />", () => {
       { length: pageCount },
       (_, i) => i + 1
     )) {
-      expect(screen.getByRole("button", { name: `Page ${pageNumber}` })).toBeInTheDocument()
+      expect(
+        screen.getByRole("button", { name: `Page ${pageNumber}` })
+      ).toBeInTheDocument()
     }
   })
 

--- a/packages/pagination/src/Pagination.spec.tsx
+++ b/packages/pagination/src/Pagination.spec.tsx
@@ -9,17 +9,16 @@ const defaultProps = {
   ariaLabelNextPage: "Next page",
   ariaLabelPreviousPage: "Previous page",
   ariaLabelPage: "Page",
-  onPageChange: () => jest.fn(),
+  onPageChange: jest.fn<void, [number]>(),
 }
 
 describe("<Pagination />", () => {
-  it("should render pagination component", async () => {
+  it("should render pagination component", () => {
     render(<Pagination {...defaultProps} />)
-
-    await screen.getByRole("navigation")
+    expect(screen.getByRole("navigation")).toBeInTheDocument()
   })
 
-  it("should render all pages when pageCount is less than 8", async () => {
+  it("should render all pages when pageCount is less than 8", () => {
     const pageCount = 7
     render(<Pagination {...defaultProps} pageCount={pageCount} />)
 
@@ -27,36 +26,33 @@ describe("<Pagination />", () => {
       { length: pageCount },
       (_, i) => i + 1
     )) {
-      await screen.getByRole("button", { name: `Page ${pageNumber}` })
+      expect(screen.getByRole("button", { name: `Page ${pageNumber}` })).toBeInTheDocument()
     }
   })
 
-  it("should not render all pages and render truncated indicator when pageCount is greater than 7", async () => {
+  it("should not render all pages and render truncated indicator when pageCount is greater than 7", () => {
     render(<Pagination {...defaultProps} />)
-
-    await screen.getByTestId("truncate-indicator")
+    expect(screen.getByTestId("truncate-indicator")).toBeInTheDocument()
   })
 
-  it("should render a disabled back button when current page less than 1", async () => {
+  it("should render a disabled back button when current page less than 1", () => {
     render(<Pagination {...defaultProps} />)
-
     expect(
       screen.getByRole("button", { name: defaultProps.ariaLabelPreviousPage })
     ).toBeDisabled
   })
 
-  it("should render a disabled forward button when current page equals page count", async () => {
+  it("should render a disabled forward button when current page equals page count", () => {
     render(
       <Pagination {...defaultProps} currentPage={defaultProps.pageCount} />
     )
-
     expect(
       screen.getByRole("button", { name: defaultProps.ariaLabelPreviousPage })
     ).toBeDisabled
   })
 
   it("should call onPageChange when clicking page number", async () => {
-    const onPageChange = jest.fn()
+    const onPageChange = jest.fn<void, [number]>()
 
     render(<Pagination {...defaultProps} onPageChange={onPageChange} />)
 

--- a/packages/responsive/docs/useMediaQueries.stories.tsx
+++ b/packages/responsive/docs/useMediaQueries.stories.tsx
@@ -1,4 +1,5 @@
 import React from "react"
+import { Story } from "@storybook/react"
 import { CATEGORIES, SUB_CATEGORIES } from "../../../storybook/constants"
 import { useMediaQueries } from "../"
 
@@ -14,7 +15,7 @@ export default {
   },
 }
 
-export const Components = () => {
+export const Components: Story = () => {
   const { components } = useMediaQueries()
   const { SmallOnly, MediumOnly, LargeOnly, MediumOrSmaller, MediumOrLarger } =
     components
@@ -40,7 +41,7 @@ export const Components = () => {
   )
 }
 
-export const Queries = () => {
+export const Queries: Story = () => {
   const { queries } = useMediaQueries()
   const { isSmall, isMedium, isLarge, isMediumOrLarger, isMediumOrSmaller } =
     queries
@@ -56,7 +57,7 @@ export const Queries = () => {
   )
 }
 
-export const CustomQueries = () => {
+export const CustomQueries: Story = () => {
   const { queries, components } = useMediaQueries({
     prefersReducedMotion: "(prefers-reduced-motion: reduce)",
   })

--- a/packages/responsive/src/useMediaQueries.spec.tsx
+++ b/packages/responsive/src/useMediaQueries.spec.tsx
@@ -1,9 +1,8 @@
-import * as React from "react"
+import React from "react"
 import { render, screen } from "@testing-library/react"
 import { useMediaQueries, subtractOnePixel } from "../"
-import "@testing-library/jest-dom/extend-expect"
 
-const ExampleComponent = () => {
+const ExampleComponent = (): JSX.Element => {
   const { queries, components } = useMediaQueries({
     prefersReducedMotion: "(prefers-reduced-motion: reduce)",
   })
@@ -23,7 +22,7 @@ const ExampleComponent = () => {
   )
 }
 
-const mockMatchMedia = (matches: boolean) => {
+const mockMatchMedia = (matches: boolean): void => {
   Object.defineProperty(window, "matchMedia", {
     writable: true,
     value: jest.fn().mockImplementation(query => ({

--- a/packages/rich-text-editor/docs/EditableRichTextContent.stories.tsx
+++ b/packages/rich-text-editor/docs/EditableRichTextContent.stories.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react"
+import { ComponentStory } from "@storybook/react"
 import { Button } from "@kaizen/button"
 import { Box } from "@kaizen/component-library"
 import {
@@ -22,24 +23,23 @@ export default {
   },
 }
 
-export const EditableRichTextContentStory = args => <InlineEditor {...args} />
+export const EditableRichTextContentStory: ComponentStory<typeof InlineEditor> = args => <InlineEditor {...args} />
 EditableRichTextContentStory.storyName = "Default"
 EditableRichTextContentStory.args = {
   content: dummyContent,
   labelText: "Shared notes",
-  isLabelHidden: false,
 }
 
 function InlineEditor(props: {
   content: EditorContentArray
   labelText: string
-}) {
+}): JSX.Element {
   const [editMode, setEditMode] = useState<boolean>(false)
   const [rteData, setRTEData] = useState<EditorContentArray>(
     props.content || dummyContent
   )
-  const handleContentClick = () => setEditMode(true)
-  const handleCancel = () => setEditMode(false)
+  const handleContentClick = (): void => setEditMode(true)
+  const handleCancel = (): void => setEditMode(false)
 
   if (editMode) {
     return (
@@ -55,7 +55,7 @@ function InlineEditor(props: {
             { name: "link", group: "link" },
           ]}
           value={rteData}
-          onChange={data => setRTEData(data)}
+          onChange={setRTEData}
         />
         <Box mt={0.5} style={{ display: "flex", justifyContent: "end" }}>
           <Button label="Cancel" secondary onClick={handleCancel} />

--- a/packages/rich-text-editor/docs/EditableRichTextContent.stories.tsx
+++ b/packages/rich-text-editor/docs/EditableRichTextContent.stories.tsx
@@ -23,7 +23,9 @@ export default {
   },
 }
 
-export const EditableRichTextContentStory: ComponentStory<typeof InlineEditor> = args => <InlineEditor {...args} />
+export const EditableRichTextContentStory: ComponentStory<
+  typeof InlineEditor
+> = args => <InlineEditor {...args} />
 EditableRichTextContentStory.storyName = "Default"
 EditableRichTextContentStory.args = {
   content: dummyContent,

--- a/packages/rich-text-editor/docs/RichTextContent.stories.tsx
+++ b/packages/rich-text-editor/docs/RichTextContent.stories.tsx
@@ -16,7 +16,9 @@ export default {
   },
 }
 
-export const RichTextContentStory: ComponentStory<typeof RichTextContent> = args => <RichTextContent {...args} />
+export const RichTextContentStory: ComponentStory<
+  typeof RichTextContent
+> = args => <RichTextContent {...args} />
 
 RichTextContentStory.storyName = "Default"
 RichTextContentStory.args = {

--- a/packages/rich-text-editor/docs/RichTextContent.stories.tsx
+++ b/packages/rich-text-editor/docs/RichTextContent.stories.tsx
@@ -1,4 +1,5 @@
 import React from "react"
+import { ComponentStory } from "@storybook/react"
 import { RichTextContent } from "@kaizen/rich-text-editor"
 import { CATEGORIES, SUB_CATEGORIES } from "../../../storybook/constants"
 import dummyContent from "./dummyContent.json"
@@ -15,7 +16,7 @@ export default {
   },
 }
 
-export const RichTextContentStory = args => <RichTextContent {...args} />
+export const RichTextContentStory: ComponentStory<typeof RichTextContent> = args => <RichTextContent {...args} />
 
 RichTextContentStory.storyName = "Default"
 RichTextContentStory.args = {

--- a/packages/rich-text-editor/docs/RichTextEditor.stories.tsx
+++ b/packages/rich-text-editor/docs/RichTextEditor.stories.tsx
@@ -1,11 +1,17 @@
 import React, { useState } from "react"
 import { Story } from "@storybook/react"
-import { RichTextEditor, EditorContentArray, RichTextEditorProps } from "@kaizen/rich-text-editor"
+import {
+  RichTextEditor,
+  EditorContentArray,
+  RichTextEditorProps,
+} from "@kaizen/rich-text-editor"
 import { CATEGORIES, SUB_CATEGORIES } from "../../../storybook/constants"
 import dummyContent from "./dummyContent.json"
 import dummyMalformedContent from "./dummyMalformedContent.json"
 
-type RTEStory = Story<Omit<RichTextEditorProps, "value" | "onChange" | "aria-labelledby">>
+type RTEStory = Story<
+  Omit<RichTextEditorProps, "value" | "onChange" | "aria-labelledby">
+>
 
 export default {
   title: `${CATEGORIES.components}/${SUB_CATEGORIES.richTextEditor}/Rich Text Editor`,
@@ -98,7 +104,10 @@ WithBadData.args = {
   ],
 }
 
-export const WithDescriptionAndValidationMessage: RTEStory = ({ labelText, ...args }) => {
+export const WithDescriptionAndValidationMessage: RTEStory = ({
+  labelText,
+  ...args
+}) => {
   const [rteData, setRTEData] = useState<EditorContentArray>(dummyContent)
   return (
     <>
@@ -108,7 +117,7 @@ export const WithDescriptionAndValidationMessage: RTEStory = ({ labelText, ...ar
         onChange={setRTEData}
         status="error"
         {...args}
-        />
+      />
       <RichTextEditor
         labelText={labelText}
         value={rteData}

--- a/packages/rich-text-editor/docs/RichTextEditor.stories.tsx
+++ b/packages/rich-text-editor/docs/RichTextEditor.stories.tsx
@@ -1,8 +1,11 @@
 import React, { useState } from "react"
-import { RichTextEditor, EditorContentArray } from "@kaizen/rich-text-editor"
+import { Story } from "@storybook/react"
+import { RichTextEditor, EditorContentArray, RichTextEditorProps } from "@kaizen/rich-text-editor"
 import { CATEGORIES, SUB_CATEGORIES } from "../../../storybook/constants"
 import dummyContent from "./dummyContent.json"
 import dummyMalformedContent from "./dummyMalformedContent.json"
+
+type RTEStory = Story<Omit<RichTextEditorProps, "value" | "onChange" | "aria-labelledby">>
 
 export default {
   title: `${CATEGORIES.components}/${SUB_CATEGORIES.richTextEditor}/Rich Text Editor`,
@@ -16,12 +19,13 @@ export default {
   },
 }
 
-export const Default = args => {
+export const Default: RTEStory = ({ labelText, ...args }) => {
   const [rteData, setRTEData] = useState<EditorContentArray>([])
   return (
     <RichTextEditor
+      labelText={labelText}
       value={rteData}
-      onChange={data => setRTEData(data)}
+      onChange={setRTEData}
       {...args}
     />
   )
@@ -41,17 +45,17 @@ Default.args = {
   ],
 }
 
-export const WithData = args => {
+export const WithData: RTEStory = ({ labelText, ...args }) => {
   const [rteData, setRTEData] = useState<EditorContentArray>(dummyContent)
   return (
     <RichTextEditor
+      labelText={labelText}
       value={rteData}
-      onChange={data => setRTEData(data)}
+      onChange={setRTEData}
       {...args}
     />
   )
 }
-
 WithData.storyName = "With data"
 WithData.args = {
   labelText: "Label",
@@ -66,14 +70,15 @@ WithData.args = {
   ],
 }
 
-export const WithBadData = args => {
+export const WithBadData: RTEStory = ({ labelText, ...args }) => {
   const [rteData, setRTEData] = useState<EditorContentArray>(
     dummyMalformedContent
   )
   return (
     <RichTextEditor
+      labelText={labelText}
       value={rteData}
-      onChange={data => setRTEData(data)}
+      onChange={setRTEData}
       {...args}
     />
   )
@@ -93,19 +98,21 @@ WithBadData.args = {
   ],
 }
 
-export const WithDescriptionAndValidationMessage = args => {
+export const WithDescriptionAndValidationMessage: RTEStory = ({ labelText, ...args }) => {
   const [rteData, setRTEData] = useState<EditorContentArray>(dummyContent)
   return (
     <>
       <RichTextEditor
+        labelText={labelText}
         value={rteData}
-        onChange={data => setRTEData(data)}
+        onChange={setRTEData}
         status="error"
         {...args}
-      />
+        />
       <RichTextEditor
+        labelText={labelText}
         value={rteData}
-        onChange={data => setRTEData(data)}
+        onChange={setRTEData}
         status="caution"
         {...args}
       />

--- a/packages/rich-text-editor/docs/ToggleIconButton.stories.tsx
+++ b/packages/rich-text-editor/docs/ToggleIconButton.stories.tsx
@@ -1,5 +1,5 @@
-import React, { Children } from "react"
-import { Story } from "@storybook/react"
+import React from "react"
+import { ComponentStory, Story } from "@storybook/react"
 import { withDesign } from "storybook-addon-designs"
 import boldIcon from "@kaizen/component-library/icons/bold.icon.svg"
 import { StoryWrapper } from "../../../storybook/components/StoryWrapper"
@@ -9,7 +9,7 @@ import {
   SUB_COMPONENTS_FOLDER_NAME,
 } from "../../../storybook/constants"
 import { figmaEmbed } from "../../../storybook/helpers"
-import { ToggleIconButton, ToggleIconButtonProps } from "../"
+import { ToggleIconButton } from "../"
 
 export default {
   title: `${CATEGORIES.components}/${SUB_CATEGORIES.richTextEditor}/${SUB_COMPONENTS_FOLDER_NAME}/Toggle Icon Button`,
@@ -31,14 +31,13 @@ export default {
   decorators: [withDesign],
 }
 
-export const DefaultStory = (args: ToggleIconButtonProps) => (
-  <ToggleIconButton {...args} />
-)
 const defaultButton = {
   label: "Bold",
   icon: boldIcon,
 }
-
+export const DefaultStory: ComponentStory<typeof ToggleIconButton> = args => (
+  <ToggleIconButton {...args} />
+)
 DefaultStory.storyName = "Default (Kaizen Demo)"
 DefaultStory.args = { isActive: false, label: "Bold", icon: boldIcon }
 

--- a/packages/rich-text-editor/docs/Toolbar.stories.tsx
+++ b/packages/rich-text-editor/docs/Toolbar.stories.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { Story } from "@storybook/react"
+import { ComponentStory } from "@storybook/react"
 import { withDesign } from "storybook-addon-designs"
 import linkIcon from "@kaizen/component-library/icons/add-link.icon.svg"
 import boldIcon from "@kaizen/component-library/icons/bold.icon.svg"
@@ -13,7 +13,7 @@ import {
   SUB_COMPONENTS_FOLDER_NAME,
 } from "../../../storybook/constants"
 import { figmaEmbed } from "../../../storybook/helpers"
-import { ToggleIconButton, Toolbar, ToolbarProps, ToolbarSection } from "../"
+import { ToggleIconButton, Toolbar, ToolbarSection } from "../"
 
 export default {
   title: `${CATEGORIES.components}/${SUB_CATEGORIES.richTextEditor}/${SUB_COMPONENTS_FOLDER_NAME}/Toolbar`,
@@ -34,7 +34,7 @@ export default {
   decorators: [withDesign],
 }
 
-const ToolbarStoryTemplate: Story<ToolbarProps> = (args: ToolbarProps) => (
+const ToolbarStoryTemplate: ComponentStory<typeof Toolbar> = args => (
   <Toolbar {...args}>
     <ToolbarSection>
       <ToggleIconButton label="Bold" icon={boldIcon} />
@@ -52,14 +52,11 @@ const ToolbarStoryTemplate: Story<ToolbarProps> = (args: ToolbarProps) => (
 )
 
 export const DefaultStory = ToolbarStoryTemplate.bind({})
-
 DefaultStory.storyName = "Default (Kaizen Demo)"
-
 DefaultStory.args = {
   "aria-label": "Toolbar",
   "aria-controls": "editable-id",
 }
-
 DefaultStory.argTypes = {
   children: {
     name: "children",
@@ -75,7 +72,7 @@ export const ToolBarWithTopContent = ToolbarStoryTemplate.bind({})
 
 ToolBarWithTopContent.storyName = "Toolbar with top content"
 ToolBarWithTopContent.decorators = [
-  StoryComponent => (
+  (StoryComponent): JSX.Element => (
     <div>
       <p style={{ paddingBottom: "100px" }}>
         This is an example to showcase the tooltip positioning when the page

--- a/packages/rich-text-editor/src/RichTextEditor/RichTextEditor.spec.tsx
+++ b/packages/rich-text-editor/src/RichTextEditor/RichTextEditor.spec.tsx
@@ -17,7 +17,11 @@ const getSelectionOfNode = (node: Node): void => {
   selection?.addRange(range)
 }
 
-const TestRTE = (args: Omit<RichTextEditorProps, "value" | "onChange" | "aria-labelledby"> & { rteMockData?: RichTextEditorProps["value"]}): JSX.Element => {
+const TestRTE = (
+  args: Omit<RichTextEditorProps, "value" | "onChange" | "aria-labelledby"> & {
+    rteMockData?: RichTextEditorProps["value"]
+  }
+): JSX.Element => {
   const { rteMockData, ...rest } = args
   const [rteData, setRTEData] = useState<EditorContentArray>(
     args.rteMockData || []

--- a/packages/rich-text-editor/src/RichTextEditor/RichTextEditor.spec.tsx
+++ b/packages/rich-text-editor/src/RichTextEditor/RichTextEditor.spec.tsx
@@ -2,11 +2,11 @@ import React, { useState } from "react"
 import { render, screen, fireEvent, waitFor } from "@testing-library/react"
 import "@testing-library/jest-dom"
 import { EditorContentArray } from "../types"
-import { RichTextEditor } from "./"
+import { RichTextEditor, RichTextEditorProps } from "./"
 
 // This helper is needed to simulate selection of a component since we
 // cannot userEvent.type with contenteditable
-const getSelectionOfNode = node => {
+const getSelectionOfNode = (node: Node): void => {
   // Clear any current selection
   const selection = window.getSelection()
   selection?.removeAllRanges()
@@ -17,34 +17,29 @@ const getSelectionOfNode = node => {
   selection?.addRange(range)
 }
 
-const TestRTE = args => {
+const TestRTE = (args: Omit<RichTextEditorProps, "value" | "onChange" | "aria-labelledby"> & { rteMockData?: RichTextEditorProps["value"]}): JSX.Element => {
   const { rteMockData, ...rest } = args
   const [rteData, setRTEData] = useState<EditorContentArray>(
     args.rteMockData || []
   )
   return (
-    <>
-      <RichTextEditor
-        value={rteData}
-        onChange={data => setRTEData(data)}
-        {...rest}
-      />
-    </>
+    <RichTextEditor
+      labelText="List RTE"
+      rows={3}
+      controls={[
+        { name: "orderedList", group: "list" },
+        { name: "bulletList", group: "list" },
+      ]}
+      value={rteData}
+      onChange={setRTEData}
+      {...rest}
+    />
   )
 }
 
 describe("RTE receives list controls", () => {
-  const defaultListArgs = {
-    labelText: "List RTE",
-    rows: 3,
-    controls: [
-      { name: "orderedList", group: "list" },
-      { name: "bulletList", group: "list" },
-    ],
-  }
-
   it("renders list buttons when receiving a list controls", () => {
-    render(<TestRTE {...defaultListArgs} />)
+    render(<TestRTE />)
 
     const bulletButton = screen.getByRole("button", { name: "Bullet List" })
     const orderedButton = screen.getByRole("button", { name: "Numbered List" })
@@ -53,7 +48,7 @@ describe("RTE receives list controls", () => {
   })
 
   it("renders indent buttons when receiving a list controls", () => {
-    render(<TestRTE {...defaultListArgs} />)
+    render(<TestRTE />)
 
     const decreaseIndentBtn = screen.getByRole("button", {
       name: "Decrease indent",
@@ -67,7 +62,7 @@ describe("RTE receives list controls", () => {
 
   describe("Creating list nodes with buttons", () => {
     it("will create a <ul> when user clicks the bullet list button", async () => {
-      render(<TestRTE {...defaultListArgs} />)
+      render(<TestRTE />)
 
       // We would use userEvent.type but contenteditable is not supported
       // see thread: https://github.com/testing-library/user-event/issues/230
@@ -84,7 +79,7 @@ describe("RTE receives list controls", () => {
     })
 
     it("will create a <ol> when user clicks the numbered list button", async () => {
-      render(<TestRTE {...defaultListArgs} />)
+      render(<TestRTE />)
 
       fireEvent.focus(screen.getByRole("textbox", { name: "List RTE" }), {
         target: { textContent: "this will be a ol" },
@@ -136,7 +131,7 @@ describe("RTE receives list controls", () => {
     ]
 
     it("will render indent buttons as 'disabled'", () => {
-      render(<TestRTE {...defaultListArgs} />)
+      render(<TestRTE />)
 
       const decreaseIndentBtn = screen.getByRole("button", {
         name: "Decrease indent",
@@ -150,7 +145,7 @@ describe("RTE receives list controls", () => {
     })
 
     it("will enable increase indent when on a list item", () => {
-      render(<TestRTE {...defaultListArgs} rteMockData={rteListData} />)
+      render(<TestRTE rteMockData={rteListData} />)
 
       const firstListNode = document.querySelectorAll("li")[0]
       const decreaseIndentBtn = screen.getByRole("button", {

--- a/packages/rich-text-editor/src/RichTextEditor/components/Toolbar/Toolbar.spec.tsx
+++ b/packages/rich-text-editor/src/RichTextEditor/components/Toolbar/Toolbar.spec.tsx
@@ -7,7 +7,7 @@ import { ToggleIconButton } from "../ToggleIconButton"
 import { ToolbarSection } from "../ToolbarSection"
 import { Toolbar } from "./"
 
-const ExampleToolbar = () => (
+const ExampleToolbar = (): JSX.Element => (
   <Toolbar aria-label="Toolbar" aria-controls="editable-id">
     <ToolbarSection>
       <ToggleIconButton label="Bold" icon={boldIcon} />

--- a/packages/select/docs/FilterMultiSelect.stories.tsx
+++ b/packages/select/docs/FilterMultiSelect.stories.tsx
@@ -40,7 +40,7 @@ export const DefaultKaizenSiteDemo: ComponentStory<
     new Set(["id-fe"])
   )
 
-  const handleSelectionChange = (keys: Selection) => setSelectedKeys(keys)
+  const handleSelectionChange = (keys: Selection): void => setSelectedKeys(keys)
 
   return (
     <>
@@ -49,7 +49,7 @@ export const DefaultKaizenSiteDemo: ComponentStory<
         onSelectionChange={handleSelectionChange}
         selectedKeys={selectedKeys}
         items={mockItems}
-        trigger={() => (
+        trigger={(): JSX.Element => (
           <FilterMultiSelect.TriggerButton
             selectedOptionLabels={getSelectedOptionLabels(
               selectedKeys,
@@ -59,11 +59,11 @@ export const DefaultKaizenSiteDemo: ComponentStory<
           />
         )}
       >
-        {() => (
+        {(): JSX.Element => (
           <>
             <FilterMultiSelect.SearchInput />
             <FilterMultiSelect.ListBox>
-              {({ allItems, hasNoItems }) => {
+              {({ allItems, hasNoItems }): JSX.Element | JSX.Element[] => {
                 if (hasNoItems) {
                   return (
                     <FilterMultiSelect.NoResults>
@@ -105,14 +105,14 @@ export const Loading: ComponentStory<typeof FilterMultiSelect> = args => (
       isLoading
       isOpen
       loadingSkeleton={<FilterMultiSelect.MenuLoadingSkeleton />}
-      trigger={() => (
+      trigger={(): JSX.Element => (
         <FilterMultiSelect.TriggerButton
           selectedOptionLabels={["Front-End"]}
           label={args.label}
         />
       )}
     >
-      {() => <></>}
+      {(): JSX.Element => <></>}
     </FilterMultiSelect>
   </>
 )
@@ -128,7 +128,7 @@ export const WithSections: ComponentStory<typeof FilterMultiSelect> = () => {
     new Set(["id-fe"])
   )
 
-  const handleSelectionChange = (keys: Selection) => setSelectedKeys(keys)
+  const handleSelectionChange = (keys: Selection): void => setSelectedKeys(keys)
 
   return (
     <>
@@ -137,7 +137,7 @@ export const WithSections: ComponentStory<typeof FilterMultiSelect> = () => {
         selectedKeys={selectedKeys}
         items={mockItems}
         label="Engineer"
-        trigger={() => (
+        trigger={(): JSX.Element => (
           <FilterMultiSelect.TriggerButton
             selectedOptionLabels={getSelectedOptionLabels(
               selectedKeys,
@@ -147,7 +147,7 @@ export const WithSections: ComponentStory<typeof FilterMultiSelect> = () => {
           />
         )}
       >
-        {() => (
+        {(): JSX.Element => (
           <>
             <FilterMultiSelect.SearchInput />
             <FilterMultiSelect.ListBox>
@@ -156,7 +156,7 @@ export const WithSections: ComponentStory<typeof FilterMultiSelect> = () => {
                 unselectedItems,
                 disabledItems,
                 hasNoItems,
-              }) => (
+              }): JSX.Element => (
                 <>
                   {hasNoItems && (
                     <FilterMultiSelect.NoResults>
@@ -167,7 +167,7 @@ export const WithSections: ComponentStory<typeof FilterMultiSelect> = () => {
                     items={selectedItems}
                     sectionName="Selected items"
                   >
-                    {item => (
+                    {(item): JSX.Element => (
                       <FilterMultiSelect.Option key={item.key} item={item} />
                     )}
                   </FilterMultiSelect.ListBoxSection>
@@ -179,7 +179,7 @@ export const WithSections: ComponentStory<typeof FilterMultiSelect> = () => {
                     items={unselectedItems}
                     sectionName="Unselected items"
                   >
-                    {item => (
+                    {(item): JSX.Element => (
                       <FilterMultiSelect.Option key={item.key} item={item} />
                     )}
                   </FilterMultiSelect.ListBoxSection>
@@ -193,7 +193,7 @@ export const WithSections: ComponentStory<typeof FilterMultiSelect> = () => {
                     items={disabledItems}
                     sectionName="Disabled items"
                   >
-                    {item => (
+                    {(item): JSX.Element => (
                       <FilterMultiSelect.Option key={item.key} item={item} />
                     )}
                   </FilterMultiSelect.ListBoxSection>
@@ -224,7 +224,7 @@ export const TruncatedLabels: ComponentStory<typeof FilterMultiSelect> = () => {
   )
   const [characterLimit, setCharacterLimit] = useState<number>(50)
 
-  const handleSelectionChange = (keys: Selection) => setSelectedKeys(keys)
+  const handleSelectionChange = (keys: Selection): void => setSelectedKeys(keys)
 
   const handleCharacterLimitChange: React.ChangeEventHandler<
     HTMLInputElement
@@ -250,7 +250,7 @@ export const TruncatedLabels: ComponentStory<typeof FilterMultiSelect> = () => {
         onSelectionChange={handleSelectionChange}
         selectedKeys={selectedKeys}
         items={mockItems}
-        trigger={() => (
+        trigger={(): JSX.Element => (
           <FilterMultiSelect.TriggerButton
             selectedOptionLabels={getSelectedOptionLabels(
               selectedKeys,
@@ -261,11 +261,11 @@ export const TruncatedLabels: ComponentStory<typeof FilterMultiSelect> = () => {
           />
         )}
       >
-        {() => (
+        {(): JSX.Element => (
           <>
             <FilterMultiSelect.SearchInput />
             <FilterMultiSelect.ListBox>
-              {({ allItems, hasNoItems }) => {
+              {({ allItems, hasNoItems }): JSX.Element | JSX.Element[] => {
                 if (hasNoItems) {
                   return (
                     <FilterMultiSelect.NoResults>
@@ -289,7 +289,7 @@ export const TruncatedLabels: ComponentStory<typeof FilterMultiSelect> = () => {
   )
 }
 
-export const FilterBarDemo = () => {
+export const FilterBarDemo = (): JSX.Element => {
   const {
     groups,
     selectedGroups,
@@ -300,7 +300,7 @@ export const FilterBarDemo = () => {
   } = useDemographicData()
 
   const addFilterButtonRef = React.useRef<ButtonRef>()
-  const focusAddFilter = () => {
+  const focusAddFilter = (): void => {
     addFilterButtonRef.current?.focus()
   }
 
@@ -317,7 +317,7 @@ export const FilterBarDemo = () => {
               label={name}
               selectedKeys={new Set(selectedDemographicValues[id])}
               id={id}
-              onRemove={() => {
+              onRemove={(): void => {
                 focusAddFilter()
 
                 // exclude demographic from both selectedGroups and selectedDemographicValues
@@ -325,7 +325,7 @@ export const FilterBarDemo = () => {
                 const { [id]: omitted, ...rest } = selectedDemographicValues
                 setSelectedDemographicValues(rest)
               }}
-              onSelectionChange={selectedKeys => {
+              onSelectionChange={(selectedKeys): void => {
                 setSelectedDemographicValues({
                   ...selectedDemographicValues,
                   [id]: selectedKeys,
@@ -357,12 +357,12 @@ export const FilterBarDemo = () => {
 
 FilterBarDemo.storyName = "Advanced FilterBar Demo"
 
-export const DefaultKaizenSiteDemoWithoutScrollbar = () => {
+export const DefaultKaizenSiteDemoWithoutScrollbar = (): JSX.Element => {
   const [selectedKeys, setSelectedKeys] = useState<Selection>(
     new Set(["id-fe"])
   )
 
-  const handleSelectionChange = (keys: Selection) => {
+  const handleSelectionChange = (keys: Selection): void => {
     keys && setSelectedKeys(keys)
   }
 
@@ -372,7 +372,7 @@ export const DefaultKaizenSiteDemoWithoutScrollbar = () => {
       onSelectionChange={handleSelectionChange}
       selectedKeys={selectedKeys}
       items={mockItems.slice(0, 3)}
-      trigger={() => (
+      trigger={(): JSX.Element => (
         <FilterMultiSelect.TriggerButton
           selectedOptionLabels={getSelectedOptionLabels(
             selectedKeys,
@@ -382,11 +382,11 @@ export const DefaultKaizenSiteDemoWithoutScrollbar = () => {
         />
       )}
     >
-      {() => (
+      {(): JSX.Element => (
         <>
           <FilterMultiSelect.SearchInput />
           <FilterMultiSelect.ListBox>
-            {({ allItems, hasNoItems }) => {
+            {({ allItems, hasNoItems }): JSX.Element | JSX.Element[] => {
               if (hasNoItems) {
                 return (
                   <FilterMultiSelect.NoResults>
@@ -472,7 +472,7 @@ export const Async: ComponentStory<typeof FilterMultiSelect> = args => {
         isLoading={isLoading}
         loadingSkeleton={<FilterMultiSelect.MenuLoadingSkeleton />}
         items={currentPeople}
-        trigger={() => (
+        trigger={(): JSX.Element => (
           <FilterMultiSelect.TriggerButton
             selectedOptionLabels={getSelectedOptionLabels(
               new Set(selectedPeople),
@@ -481,9 +481,9 @@ export const Async: ComponentStory<typeof FilterMultiSelect> = args => {
             label={"People"}
           />
         )}
-        onSearchInputChange={searchInput => setSearchState(searchInput)}
-        onOpenChange={isOpen => setOpen(isOpen)}
-        onSelectionChange={keys => {
+        onSearchInputChange={setSearchState}
+        onOpenChange={setOpen}
+        onSelectionChange={(keys): void => {
           if (keys === "all") {
             return
           }
@@ -492,13 +492,13 @@ export const Async: ComponentStory<typeof FilterMultiSelect> = args => {
         isOpen={open}
         selectedKeys={new Set(selectedPeople)}
       >
-        {() => (
+        {(): JSX.Element => (
           <>
             <FilterMultiSelect.SearchInput
               isLoading={isRefetching && searchState !== ""}
             />
             <FilterMultiSelect.ListBox>
-              {({ allItems, hasNoItems }) => (
+              {({ allItems, hasNoItems }): JSX.Element => (
                 <>
                   {hasNoItems && (
                     <FilterMultiSelect.NoResults>
@@ -517,7 +517,7 @@ export const Async: ComponentStory<typeof FilterMultiSelect> = args => {
                       label={"View more"}
                       workingLabel={"Loading…"}
                       working={isFetchingNextPage}
-                      onClick={() => fetchNextPage()}
+                      onClick={(): ReturnType<typeof fetchNextPage> => fetchNextPage()}
                     />
                   )}
                 </>

--- a/packages/select/docs/FilterMultiSelect.stories.tsx
+++ b/packages/select/docs/FilterMultiSelect.stories.tsx
@@ -517,7 +517,9 @@ export const Async: ComponentStory<typeof FilterMultiSelect> = args => {
                       label={"View more"}
                       workingLabel={"Loading…"}
                       working={isFetchingNextPage}
-                      onClick={(): ReturnType<typeof fetchNextPage> => fetchNextPage()}
+                      onClick={(): ReturnType<typeof fetchNextPage> =>
+                        fetchNextPage()
+                      }
                     />
                   )}
                 </>

--- a/packages/select/docs/Select.stories.tsx
+++ b/packages/select/docs/Select.stories.tsx
@@ -126,7 +126,7 @@ const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({
           items={singleMockItems}
           description="This is a description"
           selectedKey={"id-sre"}
-          trigger={triggerProps => (
+          trigger={(triggerProps): JSX.Element => (
             <Select.TriggerButton
               {...triggerProps}
               classNameOverride="story__button-selected"
@@ -140,7 +140,7 @@ const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({
           description="This is a description"
           selectedKey={null}
           placeholder="Placeholder"
-          trigger={triggerProps => (
+          trigger={(triggerProps): JSX.Element => (
             <Select.TriggerButton
               {...triggerProps}
               classNameOverride="story__button-hover"
@@ -154,7 +154,7 @@ const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({
           description="This is a description"
           selectedKey={null}
           placeholder="Placeholder"
-          trigger={triggerProps => (
+          trigger={(triggerProps): JSX.Element => (
             <Select.TriggerButton
               {...triggerProps}
               classNameOverride="story__button-focus"

--- a/packages/select/src/FilterMultiSelect/components/MultiSelectOption/MultiSelectOption.spec.tsx
+++ b/packages/select/src/FilterMultiSelect/components/MultiSelectOption/MultiSelectOption.spec.tsx
@@ -8,7 +8,7 @@ import { ItemType } from "../../../types"
 import { MultiSelectOption, MultiSelectOptionProps } from "./MultiSelectOption"
 
 jest.mock("@kaizen/component-library", () => ({
-  Icon: () => <span>icon-mock</span>,
+  Icon: (): JSX.Element => <span>icon-mock</span>,
 }))
 
 jest.mock("@kaizen/draft-badge", () => ({
@@ -20,7 +20,7 @@ jest.mock("@react-aria/listbox", () => ({
 }))
 
 jest.mock("../../provider", () => ({
-  useSelectionContext: () => ({ selectionState: {} }),
+  useSelectionContext: (): { selectionState: Record<string, unknown> } => ({ selectionState: {} }),
 }))
 
 const itemMock: Node<ItemType> = {
@@ -36,7 +36,7 @@ const itemMock: Node<ItemType> = {
 
 const MultiSelectOptionWrapper = ({
   item = itemMock,
-}: Partial<MultiSelectOptionProps>) => <MultiSelectOption item={item} />
+}: Partial<MultiSelectOptionProps>): JSX.Element => <MultiSelectOption item={item} />
 
 describe("<MultiSelectOptionWrapper /> - Visual content", () => {
   describe("Given item is unselected", () => {

--- a/packages/select/src/FilterMultiSelect/components/MultiSelectOption/MultiSelectOption.spec.tsx
+++ b/packages/select/src/FilterMultiSelect/components/MultiSelectOption/MultiSelectOption.spec.tsx
@@ -20,7 +20,9 @@ jest.mock("@react-aria/listbox", () => ({
 }))
 
 jest.mock("../../provider", () => ({
-  useSelectionContext: (): { selectionState: Record<string, unknown> } => ({ selectionState: {} }),
+  useSelectionContext: (): { selectionState: Record<string, unknown> } => ({
+    selectionState: {},
+  }),
 }))
 
 const itemMock: Node<ItemType> = {
@@ -36,7 +38,9 @@ const itemMock: Node<ItemType> = {
 
 const MultiSelectOptionWrapper = ({
   item = itemMock,
-}: Partial<MultiSelectOptionProps>): JSX.Element => <MultiSelectOption item={item} />
+}: Partial<MultiSelectOptionProps>): JSX.Element => (
+  <MultiSelectOption item={item} />
+)
 
 describe("<MultiSelectOptionWrapper /> - Visual content", () => {
   describe("Given item is unselected", () => {

--- a/packages/select/src/FilterMultiSelect/components/SearchInput/SearchInput.spec.tsx
+++ b/packages/select/src/FilterMultiSelect/components/SearchInput/SearchInput.spec.tsx
@@ -9,7 +9,7 @@ jest.mock("../../provider", () => ({
   useSelectionContext: jest.fn(),
 }))
 
-const SearchInputWrapper = () => <SearchInput label="label-mock" />
+const SearchInputWrapper = (): JSX.Element => <SearchInput label="label-mock" />
 
 describe("<SearchInput /> - interaction", () => {
   describe("Given searchQuery is provided", () => {

--- a/packages/select/src/FilterMultiSelect/provider/MenuTriggerProvider/MenuTriggerProvider.spec.tsx
+++ b/packages/select/src/FilterMultiSelect/provider/MenuTriggerProvider/MenuTriggerProvider.spec.tsx
@@ -10,7 +10,7 @@ import {
 
 const MenuTriggerProviderWrapper = (
   props: Partial<MenuTriggerProviderProps>
-) => (
+): JSX.Element => (
   <MenuTriggerProvider {...props}>
     <TriggerButtonBase>trigger-display-label-mock</TriggerButtonBase>
     <MenuPopup>

--- a/packages/select/src/FilterMultiSelect/provider/SelectionProvider/SelectionProvider.spec.tsx
+++ b/packages/select/src/FilterMultiSelect/provider/SelectionProvider/SelectionProvider.spec.tsx
@@ -32,7 +32,7 @@ const SelectionProviderWrapper = ({
   selectedKeys,
   onSelectionChange,
   ...props
-}: Partial<SelectionProviderProps>) => {
+}: Partial<SelectionProviderProps>): JSX.Element => {
   const [selected, setSelected] = useState<Selection>(selectedKeys ?? new Set())
 
   return (
@@ -41,20 +41,20 @@ const SelectionProviderWrapper = ({
       items={items}
       label="selection-label-mock"
       selectedKeys={selected}
-      onSelectionChange={selection => {
+      onSelectionChange={(selection): void => {
         setSelected(selection)
         onSelectionChange && onSelectionChange(selection)
       }}
       {...props}
     >
       <ListBox>
-        {({ selectedItems, unselectedItems, disabledItems }) => (
+        {({ selectedItems, unselectedItems, disabledItems }): JSX.Element => (
           <>
             <FilterMultiSelect.ListBoxSection
               items={selectedItems}
               sectionName="selectedItems"
             >
-              {selectedItem => (
+              {(selectedItem): JSX.Element => (
                 <FilterMultiSelect.Option
                   key={selectedItem.key}
                   item={selectedItem}
@@ -66,7 +66,7 @@ const SelectionProviderWrapper = ({
               items={unselectedItems}
               sectionName="selectedItems"
             >
-              {unselectedItem => (
+              {(unselectedItem): JSX.Element => (
                 <FilterMultiSelect.Option
                   key={unselectedItem.key}
                   item={unselectedItem}
@@ -78,7 +78,7 @@ const SelectionProviderWrapper = ({
               items={disabledItems}
               sectionName="disabledItems"
             >
-              {disabledItem => (
+              {(disabledItem): JSX.Element => (
                 <FilterMultiSelect.Option
                   key={disabledItem.key}
                   item={disabledItem}

--- a/packages/select/src/Select/Select.spec.tsx
+++ b/packages/select/src/Select/Select.spec.tsx
@@ -9,7 +9,7 @@ const SelectWrapper = ({
   selectedKey,
   onSelectionChange,
   ...props
-}: Partial<SelectProps>) => {
+}: Partial<SelectProps>): JSX.Element => {
   const [selected, setSelected] = React.useState<SelectProps["selectedKey"]>(
     selectedKey ?? null
   )
@@ -20,7 +20,7 @@ const SelectWrapper = ({
       items={singleMockItems}
       description="This is a description"
       selectedKey={selected}
-      onSelectionChange={selection => {
+      onSelectionChange={(selection): void => {
         setSelected(selection)
         onSelectionChange?.(selection)
       }}

--- a/packages/split-button/docs/SplitButton.stories.tsx
+++ b/packages/split-button/docs/SplitButton.stories.tsx
@@ -81,7 +81,9 @@ export default {
   decorators: [withDesign],
 } as ComponentMeta<typeof SplitButton>
 
-export const DefaultKaizenSiteDemo: ComponentStory<typeof SplitButton> = args => <SplitButton {...args} />
+export const DefaultKaizenSiteDemo: ComponentStory<
+  typeof SplitButton
+> = args => <SplitButton {...args} />
 DefaultKaizenSiteDemo.storyName = "Split Button"
 DefaultKaizenSiteDemo.args = {
   // @ts-expect-error:next-line - String here is mapped to valid prop value in default controls

--- a/packages/split-button/docs/SplitButton.stories.tsx
+++ b/packages/split-button/docs/SplitButton.stories.tsx
@@ -1,6 +1,6 @@
 import React from "react"
 import { action } from "@storybook/addon-actions"
-import { ComponentMeta, Story } from "@storybook/react"
+import { ComponentMeta, ComponentStory, Story } from "@storybook/react"
 import { withDesign } from "storybook-addon-designs"
 import duplicateIcon from "@kaizen/component-library/icons/duplicate.icon.svg"
 import editIcon from "@kaizen/component-library/icons/edit.icon.svg"
@@ -81,9 +81,10 @@ export default {
   decorators: [withDesign],
 } as ComponentMeta<typeof SplitButton>
 
-export const DefaultKaizenSiteDemo = args => <SplitButton {...args} />
+export const DefaultKaizenSiteDemo: ComponentStory<typeof SplitButton> = args => <SplitButton {...args} />
 DefaultKaizenSiteDemo.storyName = "Split Button"
 DefaultKaizenSiteDemo.args = {
+  // @ts-expect-error:next-line - String here is mapped to valid prop value in default controls
   actionButtonProps: "Button",
   dropdownContent: "MenuList - MenuItems enabled",
 }

--- a/packages/split-button/src/SplitButton/SplitButton.spec.tsx
+++ b/packages/split-button/src/SplitButton/SplitButton.spec.tsx
@@ -1,5 +1,10 @@
 import React from "react"
-import { fireEvent, render, RenderResult, waitFor } from "@testing-library/react"
+import {
+  fireEvent,
+  render,
+  RenderResult,
+  waitFor,
+} from "@testing-library/react"
 import { MenuItem, MenuList } from "@kaizen/draft-menu"
 import { SplitButton, SplitButtonProps } from "./SplitButton"
 
@@ -19,7 +24,9 @@ const DEFAULT_PROPS: SplitButtonProps = {
   ),
 }
 
-const renderSplitButton = (customProps?: Partial<SplitButtonProps>): RenderResult => {
+const renderSplitButton = (
+  customProps?: Partial<SplitButtonProps>
+): RenderResult => {
   const props = { ...DEFAULT_PROPS, ...customProps }
 
   return render(<SplitButton {...props} />)

--- a/packages/split-button/src/SplitButton/SplitButton.spec.tsx
+++ b/packages/split-button/src/SplitButton/SplitButton.spec.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { fireEvent, render, waitFor } from "@testing-library/react"
+import { fireEvent, render, RenderResult, waitFor } from "@testing-library/react"
 import { MenuItem, MenuList } from "@kaizen/draft-menu"
 import { SplitButton, SplitButtonProps } from "./SplitButton"
 
@@ -19,7 +19,7 @@ const DEFAULT_PROPS: SplitButtonProps = {
   ),
 }
 
-const renderSplitButton = (customProps?: Partial<SplitButtonProps>) => {
+const renderSplitButton = (customProps?: Partial<SplitButtonProps>): RenderResult => {
   const props = { ...DEFAULT_PROPS, ...customProps }
 
   return render(<SplitButton {...props} />)

--- a/packages/split-button/src/SplitButton/components/BaseButton/BaseButton.spec.tsx
+++ b/packages/split-button/src/SplitButton/components/BaseButton/BaseButton.spec.tsx
@@ -9,7 +9,9 @@ const DEFAULT_PROPS: BaseButtonProps = {
   label: BUTTON_LABEL,
 }
 
-const renderBaseButton = (customProps?: Partial<BaseButtonProps>): RenderResult => {
+const renderBaseButton = (
+  customProps?: Partial<BaseButtonProps>
+): RenderResult => {
   const props = { ...DEFAULT_PROPS, ...customProps }
 
   return render(<BaseButton {...props} />)

--- a/packages/split-button/src/SplitButton/components/BaseButton/BaseButton.spec.tsx
+++ b/packages/split-button/src/SplitButton/components/BaseButton/BaseButton.spec.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { render } from "@testing-library/react"
+import { render, RenderResult } from "@testing-library/react"
 import { BaseButton, BaseButtonProps } from "./BaseButton"
 import styles from "./BaseButton.scss"
 
@@ -9,7 +9,7 @@ const DEFAULT_PROPS: BaseButtonProps = {
   label: BUTTON_LABEL,
 }
 
-const renderBaseButton = (customProps?: Partial<BaseButtonProps>) => {
+const renderBaseButton = (customProps?: Partial<BaseButtonProps>): RenderResult => {
   const props = { ...DEFAULT_PROPS, ...customProps }
 
   return render(<BaseButton {...props} />)

--- a/packages/split-button/src/SplitButton/components/DropdownButton/DropdownButton.spec.tsx
+++ b/packages/split-button/src/SplitButton/components/DropdownButton/DropdownButton.spec.tsx
@@ -1,8 +1,8 @@
 import React from "react"
-import { render } from "@testing-library/react"
+import { render, RenderResult } from "@testing-library/react"
 import { DropdownButton, DropdownButtonProps } from "./DropdownButton"
 
-const renderDropdownButton = (props?: Partial<DropdownButtonProps>) =>
+const renderDropdownButton = (props?: Partial<DropdownButtonProps>): RenderResult =>
   render(<DropdownButton {...props} />)
 
 describe("<DropdownButton />", () => {

--- a/packages/split-button/src/SplitButton/components/DropdownButton/DropdownButton.spec.tsx
+++ b/packages/split-button/src/SplitButton/components/DropdownButton/DropdownButton.spec.tsx
@@ -2,8 +2,9 @@ import React from "react"
 import { render, RenderResult } from "@testing-library/react"
 import { DropdownButton, DropdownButtonProps } from "./DropdownButton"
 
-const renderDropdownButton = (props?: Partial<DropdownButtonProps>): RenderResult =>
-  render(<DropdownButton {...props} />)
+const renderDropdownButton = (
+  props?: Partial<DropdownButtonProps>
+): RenderResult => render(<DropdownButton {...props} />)
 
 describe("<DropdownButton />", () => {
   it("renders icon with default aria-label", () => {

--- a/packages/tabs/docs/Tabs.stories.tsx
+++ b/packages/tabs/docs/Tabs.stories.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react"
+import { Story } from "@storybook/react"
 import { Button } from "@kaizen/button"
 import { Box } from "@kaizen/component-library"
 import { Card } from "@kaizen/draft-card"
@@ -20,11 +21,11 @@ export default {
   },
 }
 
-export const Uncontrolled = () => (
+export const Uncontrolled: Story = () => (
   <Tabs
     defaultIndex={1}
     // eslint-disable-next-line no-console
-    onChange={index => console.log("Tab changed to ", index)}
+    onChange={(index): void => console.log("Tab changed to ", index)}
   >
     <TabList aria-label="Tabs">
       <Tab>Tab 1</Tab>
@@ -57,13 +58,13 @@ export const Uncontrolled = () => (
 )
 Uncontrolled.parameters = { chromatic: { disable: false } }
 
-export const Controlled = () => {
+export const Controlled: Story = () => {
   const [selectedIndex, setSelectedIndex] = useState<number>(0)
   return (
     <>
       <Tabs
         selectedIndex={selectedIndex}
-        onChange={index => setSelectedIndex(index)}
+        onChange={setSelectedIndex}
       >
         <TabList aria-label="Tabs">
           <Tab>Tab 1</Tab>
@@ -93,12 +94,12 @@ export const Controlled = () => {
         </TabPanels>
       </Tabs>
 
-      <Button label="Switch to tab 2" onClick={() => setSelectedIndex(1)} />
+      <Button label="Switch to tab 2" onClick={(): void => setSelectedIndex(1)} />
     </>
   )
 }
 
-export const ManualKeyboardActivation = () => (
+export const ManualKeyboardActivation: Story = () => (
   <Tabs keyboardActivation="manual">
     <TabList aria-label="Tabs">
       <Tab>Tab 1</Tab>
@@ -135,11 +136,11 @@ export const ManualKeyboardActivation = () => (
   </Tabs>
 )
 
-export const UsageInCard = () => (
+export const UsageInCard: Story = () => (
   <Card>
     <Tabs
       // eslint-disable-next-line no-console
-      onChange={index => console.log("Tab changed to ", index)}
+      onChange={(index): void => console.log("Tab changed to ", index)}
     >
       <TabList aria-label="Tabs">
         <Tab>Tab 1</Tab>

--- a/packages/tabs/docs/Tabs.stories.tsx
+++ b/packages/tabs/docs/Tabs.stories.tsx
@@ -62,10 +62,7 @@ export const Controlled: Story = () => {
   const [selectedIndex, setSelectedIndex] = useState<number>(0)
   return (
     <>
-      <Tabs
-        selectedIndex={selectedIndex}
-        onChange={setSelectedIndex}
-      >
+      <Tabs selectedIndex={selectedIndex} onChange={setSelectedIndex}>
         <TabList aria-label="Tabs">
           <Tab>Tab 1</Tab>
           <Tab>Tab 2</Tab>
@@ -94,7 +91,10 @@ export const Controlled: Story = () => {
         </TabPanels>
       </Tabs>
 
-      <Button label="Switch to tab 2" onClick={(): void => setSelectedIndex(1)} />
+      <Button
+        label="Switch to tab 2"
+        onClick={(): void => setSelectedIndex(1)}
+      />
     </>
   )
 }

--- a/packages/tailwind/docs/ColorTokens.stories.tsx
+++ b/packages/tailwind/docs/ColorTokens.stories.tsx
@@ -20,11 +20,7 @@ export default {
   },
 }
 
-const Padding = ({
-  size = 1,
-}: {
-  size?: React.ComponentProps<typeof Box>["p"]
-}) => <Box p={size}> </Box>
+const Padding = ({ size = 1 }: { size?: React.ComponentProps<typeof Box>["p"] }): JSX.Element => <Box p={size}> </Box>
 
 /**
  * Use this for showing a simple horizontal or vertical stack of elements, with the support of padding/gaps between each of them.
@@ -74,7 +70,7 @@ const Stack = React.memo(
 /**
  * A component to show a simple color block with a name
  */
-const ColorDemo = (props: { color: string; name?: string }) => {
+const ColorDemo = (props: { color: string; name?: string }): JSX.Element => {
   const theme = useTheme()
   const parsedColor = colorString.get(props.color)
   return (
@@ -130,14 +126,8 @@ const ColorDemo = (props: { color: string; name?: string }) => {
 /**
  * A section of components, displayed as a column, with some styles such as a top and left border, a heading/title, and `contain: content` to ensure nothing bleeds out of it such as fixed or absolute positioned elements.
  */
-const ComponentsSection = React.forwardRef(
-  (
-    props: {
-      title: React.ReactNode
-      children: React.ReactNode
-    },
-    ref: React.Ref<HTMLDivElement>
-  ) => (
+const ComponentsSection = React.forwardRef<HTMLDivElement,{ title: React.ReactNode; children: React.ReactNode }>(
+  (props, ref) => (
     <>
       <Heading variant="heading-2">{props.title}</Heading>
       <Padding />

--- a/packages/tailwind/docs/ColorTokens.stories.tsx
+++ b/packages/tailwind/docs/ColorTokens.stories.tsx
@@ -20,7 +20,11 @@ export default {
   },
 }
 
-const Padding = ({ size = 1 }: { size?: React.ComponentProps<typeof Box>["p"] }): JSX.Element => <Box p={size}> </Box>
+const Padding = ({
+  size = 1,
+}: {
+  size?: React.ComponentProps<typeof Box>["p"]
+}): JSX.Element => <Box p={size}> </Box>
 
 /**
  * Use this for showing a simple horizontal or vertical stack of elements, with the support of padding/gaps between each of them.
@@ -126,26 +130,27 @@ const ColorDemo = (props: { color: string; name?: string }): JSX.Element => {
 /**
  * A section of components, displayed as a column, with some styles such as a top and left border, a heading/title, and `contain: content` to ensure nothing bleeds out of it such as fixed or absolute positioned elements.
  */
-const ComponentsSection = React.forwardRef<HTMLDivElement,{ title: React.ReactNode; children: React.ReactNode }>(
-  (props, ref) => (
-    <>
-      <Heading variant="heading-2">{props.title}</Heading>
-      <Padding />
-      <div
-        ref={ref}
-        style={{
-          maxWidth: "100vw",
-          contain: "content",
-          display: "grid",
-          gap: "2rem",
-          gridTemplateColumns: "repeat(auto-fill, 400px)",
-        }}
-      >
-        {props.children}
-      </div>
-    </>
-  )
-)
+const ComponentsSection = React.forwardRef<
+  HTMLDivElement,
+  { title: React.ReactNode; children: React.ReactNode }
+>((props, ref) => (
+  <>
+    <Heading variant="heading-2">{props.title}</Heading>
+    <Padding />
+    <div
+      ref={ref}
+      style={{
+        maxWidth: "100vw",
+        contain: "content",
+        display: "grid",
+        gap: "2rem",
+        gridTemplateColumns: "repeat(auto-fill, 400px)",
+      }}
+    >
+      {props.children}
+    </div>
+  </>
+))
 
 export const ColorTokens: Story = () => {
   const theme = useTheme()

--- a/packages/tailwind/docs/TailwindTokens.stories.tsx
+++ b/packages/tailwind/docs/TailwindTokens.stories.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable jsx-a11y/anchor-is-valid */
 import React from "react"
+import { Story } from "@storybook/react"
 import { withDesign } from "storybook-addon-designs"
 import { Card } from "@kaizen/draft-card"
 import { figmaEmbed } from "../../../storybook/helpers"
@@ -20,7 +21,7 @@ export default {
   decorators: [withDesign],
 }
 
-export const DefaultKaizenSiteDemo = args => (
+export const DefaultKaizenSiteDemo: Story = args => (
   <div className="bg-purple-800 p-12">
     <h1 className="flex flex-col items-center text-heading-1 font-weight-heading font-family-heading text-white ">
       {args.title}
@@ -56,10 +57,10 @@ export const DefaultKaizenSiteDemo = args => (
 DefaultKaizenSiteDemo.storyName = "Default (Kaizen Site Demo)"
 DefaultKaizenSiteDemo.args = { title: "Tailwind title example" }
 
-export const TailwindPsuedoStates = () => (
+export const TailwindPseudoStates: Story = () => (
   <div className="p-12">
     <h1 className="flex flex-col items-center text-heading-1 font-weight-heading font-family-heading text-purple-700">
-      Tailwind Psuedo states
+      Tailwind Pseudo states
     </h1>
     <div className="flex">
       <div className="inline-flex flex-col">
@@ -82,9 +83,9 @@ export const TailwindPsuedoStates = () => (
   </div>
 )
 
-TailwindPsuedoStates.storyName = "Tailwind psuedo selectors"
+TailwindPseudoStates.storyName = "Tailwind pseudo selectors"
 
-export const TailwindMediaQueries = () => (
+export const TailwindMediaQueries: Story = () => (
   <div className="p-12">
     <h1 className="flex flex-col items-center text-heading-1 font-weight-heading font-family-heading text-purple-700">
       Tailwind media queries

--- a/packages/typography/docs/Heading.stories.tsx
+++ b/packages/typography/docs/Heading.stories.tsx
@@ -8,7 +8,7 @@ import {
   Stories,
   PRIMARY_STORY,
 } from "@storybook/addon-docs"
-import { Story } from "@storybook/react"
+import { ComponentStory, Story } from "@storybook/react"
 import { StoryWrapper } from "../../../storybook/components/StoryWrapper"
 import { CATEGORIES, SUB_CATEGORIES } from "../../../storybook/constants"
 import { Heading, Paragraph } from "../"
@@ -20,7 +20,7 @@ export default {
       description: {
         component: 'import { Heading } from "@kaizen/typography"',
       },
-      page: () => (
+      page: (): JSX.Element => (
         <>
           <Title />
           <Subtitle />
@@ -35,13 +35,13 @@ export default {
   },
 }
 
-export const Display0 = args => (
+export const Display0: ComponentStory<typeof Heading> = args => (
   <Heading {...args}>Have the courage to be vulnerable.</Heading>
 )
 Display0.storyName = "Heading"
 Display0.args = { variant: "heading-1", color: "dark" }
 
-const Documentation = () => (
+const Documentation = (): JSX.Element => (
   <Paragraph variant="body">
     <ul>
       <li>

--- a/packages/typography/docs/Paragraph.stories.tsx
+++ b/packages/typography/docs/Paragraph.stories.tsx
@@ -8,7 +8,7 @@ import {
   Stories,
   PRIMARY_STORY,
 } from "@storybook/addon-docs"
-import { Story } from "@storybook/react"
+import { ComponentStory, Story } from "@storybook/react"
 import { withDesign } from "storybook-addon-designs"
 import { StoryWrapper } from "../../../storybook/components/StoryWrapper"
 import { CATEGORIES, SUB_CATEGORIES } from "../../../storybook/constants"
@@ -23,7 +23,7 @@ export default {
       description: {
         component: 'import { Paragraph } from "@kaizen/typography"',
       },
-      page: () => (
+      page: (): JSX.Element => (
         <>
           <Title />
           <Subtitle />
@@ -42,7 +42,7 @@ export default {
   decorators: [withDesign],
 }
 
-const Documentation = () => (
+const Documentation = (): JSX.Element => (
   <Paragraph variant="body">
     <ul>
       <li>
@@ -82,7 +82,7 @@ const Documentation = () => (
   </Paragraph>
 )
 
-export const Body = args => (
+export const Body: ComponentStory<typeof Paragraph> = args => (
   <Paragraph {...args}>The quick brown fox jumps over the lazy dog.</Paragraph>
 )
 Body.storyName = "Paragraph"


### PR DESCRIPTION
## What

Enable linting for explicit return types for stories and tests and fix errors.

Also cleaned up some sticker sheets to use templates rather than duplicate code.

## Note

For existing stories which we haven’t been passing in the args (controls values), I typed them as `Story` as opposed to `ComponentStory<typeof TheComponent>`.

## Why

[KDS-1078](https://cultureamp.atlassian.net/jira/software/projects/KDS/boards/289?selectedIssue=KDS-1078)

[KDS-1078]: https://cultureamp.atlassian.net/browse/KDS-1078?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[KDS-1078]: https://cultureamp.atlassian.net/browse/KDS-1078?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ