### PR TITLE
docs(split-button): use custom controls for actionButtonProps

### DIFF
--- a/packages/split-button/docs/SplitButton.stories.tsx
+++ b/packages/split-button/docs/SplitButton.stories.tsx
@@ -42,20 +42,40 @@ export default {
     dropdownButtonProps: DropdownButton,
   },
   argTypes: {
-    actionButtonProps: {
-      options: ["Button", "Anchor"],
-      control: {
-        type: "select",
-        labels: {
-          Button: '{ label: "Edit Survey", onClick: action("clicked") }',
-          Anchor: '{ label: "Edit Survey", href: "//example.com" }',
-        },
-      },
-      mapping: {
-        Button: ACTION_BUTTON_PROPS__BUTTON,
-        Anchor: ACTION_BUTTON_PROPS__ANCHOR,
-      },
+    actionButtonLabel: {
+      name: "actionButtonProps.label",
+      control: "text",
+      description: "Abc",
+      isRequired: true, // <-- this doesn't work
+      defaultValue: "Edit Survey",
     },
+    actionButtonClickAction: {
+      name: "actionButtonProps.onClick/href",
+      control: { type: "radio" },
+      options: ["onClick", "href"],
+      mapping: {
+        onClick: { onClick: action("clicked") },
+        href: { href: "//example.com" },
+      },
+      defaultValue: "onClick",
+    },
+    actionButtonProps: {
+      control: "disabled"
+    },
+    // actionButtonProps: {
+    //   options: ["Button", "Anchor"],
+    //   control: {
+    //     type: "select",
+    //     labels: {
+    //       Button: '{ label: "Edit Survey", onClick: action("clicked") }',
+    //       Anchor: '{ label: "Edit Survey", href: "//example.com" }',
+    //     },
+    //   },
+    //   mapping: {
+    //     Button: ACTION_BUTTON_PROPS__BUTTON,
+    //     Anchor: ACTION_BUTTON_PROPS__ANCHOR,
+    //   },
+    // },
     dropdownContent: {
       options: [
         "MenuList - MenuItems enabled",
@@ -66,9 +86,11 @@ export default {
         "MenuList - MenuItems enabled": DROPDOWN_CONTENT__ENABLED,
         "MenuList - one MenuItem disabled": DROPDOWN_CONTENT__ONE_DISABLED,
       },
+      defaultValue: "MenuList - MenuItems enabled",
     },
   },
   parameters: {
+    controls: { sort: "alpha" },
     docs: {
       description: {
         component: '`import { SplitButton } from "@kaizen/split-button"`',
@@ -81,15 +103,19 @@ export default {
   decorators: [withDesign],
 } as ComponentMeta<typeof SplitButton>
 
-export const DefaultKaizenSiteDemo: ComponentStory<
-  typeof SplitButton
-> = args => <SplitButton {...args} />
-DefaultKaizenSiteDemo.storyName = "Split Button"
-DefaultKaizenSiteDemo.args = {
-  // @ts-expect-error:next-line - String here is mapped to valid prop value in default controls
-  actionButtonProps: "Button",
-  dropdownContent: "MenuList - MenuItems enabled",
+export const DefaultKaizenSiteDemo: Story<Omit<SplitButtonProps, "actionButtonProps"> & {
+  actionButtonLabel: string,
+  actionButtonClickAction: Record<string, unknown>,
+}> = ({ actionButtonLabel, actionButtonClickAction, ...args}) => {
+  const actionButtonProps = { label: actionButtonLabel, ...actionButtonClickAction }
+  return <SplitButton {...args} actionButtonProps={actionButtonProps} />
 }
+DefaultKaizenSiteDemo.storyName = "Split Button"
+// DefaultKaizenSiteDemo.args = {
+//   // @ts-expect-error:next-line - String here is mapped to valid prop value in default controls
+//   actionButtonProps: "Button",
+//   dropdownContent: "MenuList - MenuItems enabled",
+// }
 
 const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({
   isReversed,


### PR DESCRIPTION
## Why

POC attempt at better Storybook controls.

Inspired by https://github.com/cultureamp/reports-components/blob/307aa00e7ac87b9809cd84e2bd3936aa51b1d396/src/components/QuestionScore/QuestionScore.stories.tsx#L12-L48

## What
<!-- What do your changes do? How do they change/fix the current behavior? -->
<!-- Add screenshots, GIFs or videos to illustrate the changes.  -->

### Existing

|Screenshot|
|---|
|<img width="911" alt="image" src="https://user-images.githubusercontent.com/25891850/210692121-0a8533f1-9459-4268-8489-06aedde47bd0.png">|

|Pros|Cons|
|---|---|
||TypeScript error with mapping confusion|
|Shows structure of how the consumer passes in the prop|Consumer cannot adjust attributes independently|

### New

|Screenshot|
|---|
|<img width="767" alt="image" src="https://user-images.githubusercontent.com/25891850/210692855-bbf3ef26-5463-4e0d-a74a-5cb90c784e80.png">|

|Pros|Cons|
|---|---|
|TypeScript is happy as transforms are done by us|More code required for types and transforms|
|Consumer can adjust attributes independently|Custom controls cannot be marked as required|
||May not be obvious the controls are split out from a single prop|
||Cannot customise sort order (`"alpha"` is likely the best option to group them)|