### PR TITLE
fix(deps): downgrade postcss version to 8.4.19 for causing tsc and jest errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "node-fetch": "^3.3.0",
     "node-sass": "^8.0.0",
     "plop": "^3.1.1",
-    "postcss": "8.4.19",
+    "postcss": "^8.4.19",
     "postcss-flexbugs-fixes": "^5.0.2",
     "postcss-import": "^15.1.0",
     "postcss-loader": "^7.0.2",

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "node-fetch": "^3.3.0",
     "node-sass": "^8.0.0",
     "plop": "^3.1.1",
-    "postcss": "^8.4.20",
+    "postcss": "8.4.19",
     "postcss-flexbugs-fixes": "^5.0.2",
     "postcss-import": "^15.1.0",
     "postcss-loader": "^7.0.2",

--- a/packages/stylelint-plugin/package.json
+++ b/packages/stylelint-plugin/package.json
@@ -19,7 +19,7 @@
     "lodash.flatmap": "^4.5.0",
     "lodash.kebabcase": "^4.1.1",
     "nano-memoize": "^2.0.0",
-    "postcss": "^8.4.20",
+    "postcss": "8.4.19",
     "postcss-less": "^6.0.0",
     "postcss-scss": "^4.0.6",
     "postcss-value-parser": "^4.2.0",

--- a/packages/stylelint-plugin/package.json
+++ b/packages/stylelint-plugin/package.json
@@ -19,7 +19,7 @@
     "lodash.flatmap": "^4.5.0",
     "lodash.kebabcase": "^4.1.1",
     "nano-memoize": "^2.0.0",
-    "postcss": "8.4.19",
+    "postcss": "^8.4.19",
     "postcss-less": "^6.0.0",
     "postcss-scss": "^4.0.6",
     "postcss-value-parser": "^4.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -15721,6 +15721,15 @@ postcss@7.x.x, postcss@^7.0.14, postcss@^7.0.2, postcss@^7.0.21, postcss@^7.0.26
     picocolors "^0.2.1"
     source-map "^0.6.1"
 
+postcss@8.4.19, postcss@^8.1.2, postcss@^8.2.15, postcss@^8.4.18, postcss@^8.4.19:
+  version "8.4.19"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.19.tgz#61178e2add236b17351897c8bcc0b4c8ecab56fc"
+  integrity sha512-h+pbPsyhlYj6N2ozBmHhHrs9DzGmbaarbLvWipMRO7RLS+v4onj26MPFXA5OBYFxyqYhUJK456SwDcY9H2/zsA==
+  dependencies:
+    nanoid "^3.3.4"
+    picocolors "^1.0.0"
+    source-map-js "^1.0.2"
+
 postcss@^5.2.17:
   version "5.2.18"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-5.2.18.tgz#badfa1497d46244f6390f58b319830d9107853c5"
@@ -15730,15 +15739,6 @@ postcss@^5.2.17:
     js-base64 "^2.1.9"
     source-map "^0.5.6"
     supports-color "^3.2.3"
-
-postcss@^8.1.2, postcss@^8.2.15, postcss@^8.4.18, postcss@^8.4.19:
-  version "8.4.19"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.19.tgz#61178e2add236b17351897c8bcc0b4c8ecab56fc"
-  integrity sha512-h+pbPsyhlYj6N2ozBmHhHrs9DzGmbaarbLvWipMRO7RLS+v4onj26MPFXA5OBYFxyqYhUJK456SwDcY9H2/zsA==
-  dependencies:
-    nanoid "^3.3.4"
-    picocolors "^1.0.0"
-    source-map-js "^1.0.2"
 
 postcss@^8.4.20:
   version "8.4.20"

--- a/yarn.lock
+++ b/yarn.lock
@@ -15721,15 +15721,6 @@ postcss@7.x.x, postcss@^7.0.14, postcss@^7.0.2, postcss@^7.0.21, postcss@^7.0.26
     picocolors "^0.2.1"
     source-map "^0.6.1"
 
-postcss@8.4.19, postcss@^8.1.2, postcss@^8.2.15, postcss@^8.4.18, postcss@^8.4.19:
-  version "8.4.19"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.19.tgz#61178e2add236b17351897c8bcc0b4c8ecab56fc"
-  integrity sha512-h+pbPsyhlYj6N2ozBmHhHrs9DzGmbaarbLvWipMRO7RLS+v4onj26MPFXA5OBYFxyqYhUJK456SwDcY9H2/zsA==
-  dependencies:
-    nanoid "^3.3.4"
-    picocolors "^1.0.0"
-    source-map-js "^1.0.2"
-
 postcss@^5.2.17:
   version "5.2.18"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-5.2.18.tgz#badfa1497d46244f6390f58b319830d9107853c5"
@@ -15739,6 +15730,15 @@ postcss@^5.2.17:
     js-base64 "^2.1.9"
     source-map "^0.5.6"
     supports-color "^3.2.3"
+
+postcss@^8.1.2, postcss@^8.2.15, postcss@^8.4.18, postcss@^8.4.19:
+  version "8.4.19"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.19.tgz#61178e2add236b17351897c8bcc0b4c8ecab56fc"
+  integrity sha512-h+pbPsyhlYj6N2ozBmHhHrs9DzGmbaarbLvWipMRO7RLS+v4onj26MPFXA5OBYFxyqYhUJK456SwDcY9H2/zsA==
+  dependencies:
+    nanoid "^3.3.4"
+    picocolors "^1.0.0"
+    source-map-js "^1.0.2"
 
 postcss@^8.4.20:
   version "8.4.20"


### PR DESCRIPTION
## Why
Upgrading postcss to the latest patch causes yarn lock issues which for unknown reasons breaks typescript's ability to parse stylelint-plugin and fails some tests for the rules.

## What
Downgrade the version of postcss to 8.4.19
