### PR TITLE
WIP - Button refactor POC

### DIFF
--- a/packages/button/docs/NewButton.stories.tsx
+++ b/packages/button/docs/NewButton.stories.tsx
@@ -1,0 +1,159 @@
+import React, { ButtonHTMLAttributes } from "react"
+import { ComponentStory, Story } from "@storybook/react"
+import isChromatic from "chromatic"
+import { withDesign } from "storybook-addon-designs"
+import { OverrideClassName } from "@kaizen/component-base"
+import { Icon } from "@kaizen/component-library"
+import addIcon from "@kaizen/component-library/icons/add.icon.svg"
+import arrowRight from "@kaizen/component-library/icons/arrow-right.icon.svg"
+import { StickerSheet } from "../../../storybook/components/StickerSheet"
+import { CATEGORIES, SUB_CATEGORIES } from "../../../storybook/constants"
+import { figmaEmbed } from "../../../storybook/helpers"
+import { NewButton, NewButtonProps } from "../src/StyledButton/NewButton"
+import styles from "./StyledButton.module.scss"
+
+export default {
+  title: `${CATEGORIES.components}/${SUB_CATEGORIES.button}/StyledButton/NewButton`,
+  component: NewButton,
+  parameters: {
+    // actions: {
+    //   argTypesRegex: "^on.*",
+    // },
+    docs: {
+      description: {
+        component:
+          'import { Button, IconButton } from "@kaizen/button". This Button supersedes "@kaizen/draft-button".',
+      },
+    },
+    ...figmaEmbed(
+      "https://www.figma.com/file/eZKEE5kXbEMY3lx84oz8iN/%E2%9D%A4%EF%B8%8F-UI-Kit%3A-Heart?node-id=13555%3A0"
+    ),
+  },
+  decorators: [withDesign],
+}
+
+export const DefaultStory: ComponentStory<typeof NewButton> = args => (
+  <NewButton {...args} />
+)
+DefaultStory.storyName = "NewButton"
+DefaultStory.args = {
+  variant: "default",
+  children: "Click for pancakes",
+}
+
+const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({
+  isReversed,
+}) => {
+  const VARIANTS: Array<NewButtonProps["variant"]> = [
+    "default",
+    "primary",
+    "secondary",
+    "secondaryDestructive",
+  ]
+
+  return (
+    <>
+      <StickerSheet isReversed={isReversed} heading="NewButton">
+        <StickerSheet.Header
+          headings={[
+            "Default / Disabled",
+            "Hover / Working",
+            "Active / classNameOverride",
+            "Focus",
+          ]}
+          hasVerticalHeadings
+        />
+        {VARIANTS.map(variant => (
+          <StickerSheet.Body key={variant}>
+            <StickerSheet.Row rowTitle={variant}>
+              <NewButton isReversed={isReversed} variant={variant}>
+                Pancakes
+              </NewButton>
+
+              <NewButton
+                isReversed={isReversed}
+                variant={variant}
+                classNameOverride="story__NewButton--hover"
+              >
+                Pancakes
+              </NewButton>
+
+              <NewButton
+                isReversed={isReversed}
+                variant={variant}
+                classNameOverride="story__NewButton--active"
+              >
+                Pancakes
+              </NewButton>
+
+              <NewButton
+                isReversed={isReversed}
+                variant={variant}
+                classNameOverride="story__NewButton--focus"
+              >
+                Pancakes
+              </NewButton>
+            </StickerSheet.Row>
+
+            <StickerSheet.Row>
+              <div />
+              <NewButton
+                isReversed={isReversed}
+                variant={variant}
+                disabled
+              >
+                Pancakes
+              </NewButton>
+
+              <NewButton isReversed={isReversed} variant={variant} isWorking>
+                Pancakes
+              </NewButton>
+
+              <NewButton isReversed={isReversed} variant={variant} classNameOverride={styles.red}>
+                Pancakes
+              </NewButton>
+            </StickerSheet.Row>
+
+            {/* <StickerSheet.Row>
+              <div />
+              <NewButton
+                isReversed={isReversed}
+                variant={variant}
+                icon={addIcon}
+              >
+                <button>
+                  Button qwerty qwerty qwerty qwerty qwerty qwerty
+                </button>
+              </NewButton>
+
+              <NewButton
+                isReversed={isReversed}
+                variant={variant}
+                icon={arrowRight}
+                iconPosition="end"
+              >
+                Pancakes
+              </NewButton>
+            </StickerSheet.Row> */}
+          </StickerSheet.Body>
+        ))}
+      </StickerSheet>
+          </>
+  )
+}
+
+export const StickerSheetDefault = StickerSheetTemplate.bind({})
+StickerSheetDefault.storyName = "Sticker Sheet (Default)"
+StickerSheetDefault.parameters = {
+  chromatic: { disable: false },
+  controls: { disable: true },
+}
+
+export const StickerSheetReversed = StickerSheetTemplate.bind({})
+StickerSheetReversed.storyName = "Sticker Sheet (Reversed)"
+StickerSheetReversed.args = { isReversed: true }
+StickerSheetReversed.parameters = {
+  controls: { disable: true },
+  backgrounds: { default: "Purple 700" },
+  chromatic: { disable: false },
+}

--- a/packages/button/docs/NewButton.stories.tsx
+++ b/packages/button/docs/NewButton.stories.tsx
@@ -97,11 +97,7 @@ const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({
 
             <StickerSheet.Row>
               <div />
-              <NewButton
-                isReversed={isReversed}
-                variant={variant}
-                disabled
-              >
+              <NewButton isReversed={isReversed} variant={variant} disabled>
                 Pancakes
               </NewButton>
 
@@ -109,21 +105,23 @@ const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({
                 Pancakes
               </NewButton>
 
-              <NewButton isReversed={isReversed} variant={variant} classNameOverride={styles.red}>
+              <NewButton
+                isReversed={isReversed}
+                variant={variant}
+                classNameOverride={styles.red}
+              >
                 Pancakes
               </NewButton>
             </StickerSheet.Row>
 
-            {/* <StickerSheet.Row>
+            <StickerSheet.Row>
               <div />
               <NewButton
                 isReversed={isReversed}
                 variant={variant}
                 icon={addIcon}
               >
-                <button>
-                  Button qwerty qwerty qwerty qwerty qwerty qwerty
-                </button>
+                Icon start
               </NewButton>
 
               <NewButton
@@ -132,13 +130,13 @@ const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({
                 icon={arrowRight}
                 iconPosition="end"
               >
-                Pancakes
+                Icon end
               </NewButton>
-            </StickerSheet.Row> */}
+            </StickerSheet.Row>
           </StickerSheet.Body>
         ))}
       </StickerSheet>
-          </>
+    </>
   )
 }
 

--- a/packages/button/docs/NewIconButton.stories.tsx
+++ b/packages/button/docs/NewIconButton.stories.tsx
@@ -42,7 +42,7 @@ DefaultStory.storyName = "NewIconButton"
 DefaultStory.args = {
   variant: "default",
   icon: addIcon,
-  "aria-label": "Click for pancakes"
+  "aria-label": "Click for pancakes",
 }
 
 const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({

--- a/packages/button/docs/NewIconButton.stories.tsx
+++ b/packages/button/docs/NewIconButton.stories.tsx
@@ -9,12 +9,15 @@ import arrowRight from "@kaizen/component-library/icons/arrow-right.icon.svg"
 import { StickerSheet } from "../../../storybook/components/StickerSheet"
 import { CATEGORIES, SUB_CATEGORIES } from "../../../storybook/constants"
 import { figmaEmbed } from "../../../storybook/helpers"
-import { NewButton, NewButtonProps } from "../src/StyledButton/NewButton"
+import {
+  NewIconButton,
+  NewIconButtonProps,
+} from "../src/StyledButton/NewIconButton"
 import styles from "./StyledButton.module.scss"
 
 export default {
-  title: `${CATEGORIES.components}/${SUB_CATEGORIES.button}/StyledButton/NewButton`,
-  component: NewButton,
+  title: `${CATEGORIES.components}/${SUB_CATEGORIES.button}/StyledButton/NewIconButton`,
+  component: NewIconButton,
   parameters: {
     // actions: {
     //   argTypesRegex: "^on.*",
@@ -32,19 +35,20 @@ export default {
   decorators: [withDesign],
 }
 
-export const DefaultStory: ComponentStory<typeof NewButton> = args => (
-  <NewButton {...args} />
+export const DefaultStory: ComponentStory<typeof NewIconButton> = args => (
+  <NewIconButton {...args} />
 )
-DefaultStory.storyName = "NewButton"
+DefaultStory.storyName = "NewIconButton"
 DefaultStory.args = {
   variant: "default",
-  children: "Click for pancakes",
+  icon: addIcon,
+  "aria-label": "Click for pancakes"
 }
 
 const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({
   isReversed,
 }) => {
-  const VARIANTS: Array<NewButtonProps["variant"]> = [
+  const VARIANTS: Array<NewIconButtonProps["variant"]> = [
     "default",
     "primary",
     "secondary",
@@ -53,7 +57,7 @@ const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({
 
   return (
     <>
-      <StickerSheet isReversed={isReversed} heading="NewButton">
+      <StickerSheet isReversed={isReversed} heading="NewIconButton">
         <StickerSheet.Header
           headings={[
             "Default / Disabled",
@@ -66,72 +70,63 @@ const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({
         {VARIANTS.map(variant => (
           <StickerSheet.Body key={variant}>
             <StickerSheet.Row rowTitle={variant}>
-              <NewButton isReversed={isReversed} variant={variant}>
-                Pancakes
-              </NewButton>
-
-              <NewButton
-                isReversed={isReversed}
-                variant={variant}
-                classNameOverride="story__StyledButton--hover"
-              >
-                Pancakes
-              </NewButton>
-
-              <NewButton
-                isReversed={isReversed}
-                variant={variant}
-                classNameOverride="story__StyledButton--active"
-              >
-                Pancakes
-              </NewButton>
-
-              <NewButton
-                isReversed={isReversed}
-                variant={variant}
-                classNameOverride="story__StyledButton--focus"
-              >
-                Pancakes
-              </NewButton>
-            </StickerSheet.Row>
-
-            <StickerSheet.Row>
-              <div />
-              <NewButton isReversed={isReversed} variant={variant} disabled>
-                Pancakes
-              </NewButton>
-
-              <NewButton isReversed={isReversed} variant={variant} isWorking>
-                Pancakes
-              </NewButton>
-
-              <NewButton
-                isReversed={isReversed}
-                variant={variant}
-                classNameOverride={styles.red}
-              >
-                Pancakes
-              </NewButton>
-            </StickerSheet.Row>
-
-            <StickerSheet.Row>
-              <div />
-              <NewButton
+              <NewIconButton
                 isReversed={isReversed}
                 variant={variant}
                 icon={addIcon}
-              >
-                Icon start
-              </NewButton>
+                aria-label="Add"
+              />
 
-              <NewButton
+              <NewIconButton
+                icon={addIcon}
+                aria-label="Add"
                 isReversed={isReversed}
                 variant={variant}
-                icon={arrowRight}
-                iconPosition="end"
-              >
-                Icon end
-              </NewButton>
+                classNameOverride="story__StyledButton--hover"
+              />
+
+              <NewIconButton
+                icon={addIcon}
+                aria-label="Add"
+                isReversed={isReversed}
+                variant={variant}
+                classNameOverride="story__StyledButton--active"
+              />
+
+              <NewIconButton
+                icon={addIcon}
+                aria-label="Add"
+                isReversed={isReversed}
+                variant={variant}
+                classNameOverride="story__StyledButton--focus"
+              />
+            </StickerSheet.Row>
+
+            <StickerSheet.Row>
+              <div />
+              <NewIconButton
+                icon={addIcon}
+                aria-label="Add"
+                isReversed={isReversed}
+                variant={variant}
+                disabled
+              />
+
+              <NewIconButton
+                icon={addIcon}
+                aria-label="Add"
+                isReversed={isReversed}
+                variant={variant}
+                isWorking
+              />
+
+              <NewIconButton
+                icon={addIcon}
+                aria-label="Add"
+                isReversed={isReversed}
+                variant={variant}
+                classNameOverride={styles.red}
+              />
             </StickerSheet.Row>
           </StickerSheet.Body>
         ))}

--- a/packages/button/docs/StyledButton.module.scss
+++ b/packages/button/docs/StyledButton.module.scss
@@ -1,0 +1,3 @@
+.red {
+  border-color: red;
+}

--- a/packages/button/docs/StyledButton.module.scss
+++ b/packages/button/docs/StyledButton.module.scss
@@ -1,3 +1,7 @@
+// Does not override combined styles (eg. .default + .isReversed)
+// and not StyledIconButton styles
 .red {
   border-color: red;
+  color: magenta;
+  padding: 2rem;
 }

--- a/packages/button/docs/StyledButton.stories.tsx
+++ b/packages/button/docs/StyledButton.stories.tsx
@@ -68,7 +68,7 @@ const LabelButton: React.VFC<LabelButtonProps> = ({
   </button>
 )
 
-const AddIcon = () => <Icon icon={addIcon} role="presentation" />
+const AddIcon = (): JSX.Element => <Icon icon={addIcon} role="presentation" />
 
 const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({
   isReversed,

--- a/packages/button/docs/StyledButton.stories.tsx
+++ b/packages/button/docs/StyledButton.stories.tsx
@@ -6,12 +6,11 @@ import { OverrideClassName } from "@kaizen/component-base"
 import { Icon } from "@kaizen/component-library"
 import addIcon from "@kaizen/component-library/icons/add.icon.svg"
 import arrowRight from "@kaizen/component-library/icons/arrow-right.icon.svg"
-import { Heading } from "@kaizen/typography"
 import { StickerSheet } from "../../../storybook/components/StickerSheet"
 import { CATEGORIES, SUB_CATEGORIES } from "../../../storybook/constants"
 import { figmaEmbed } from "../../../storybook/helpers"
 import { StyledIconButton } from "../src/StyledButton/StyledIconButton"
-import { StyledButton, StyledButtonProps, StyledButton2 } from ".."
+import { StyledButton, StyledButtonProps, StyledButton2, NewButton } from ".."
 import styles from "./StyledButton.module.scss"
 
 const IS_CHROMATIC = isChromatic()
@@ -83,91 +82,96 @@ const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({
 
   return (
     <>
-    <StickerSheet isReversed={isReversed}  heading="StyledButton">
-      <StickerSheet.Header
-        isReversed={isReversed}
-        headings={[
-          "Default / Disabled",
-          "Hover / Working",
-          "Active / className",
-          "Focus / classNameOverride",
-        ]}
-        hasVerticalHeadings
-        headingsWidth={200}
-      />
-      {VARIANTS.map(variant => (
-        <StickerSheet.Body key={variant}>
-          <StickerSheet.Row isReversed={isReversed} rowTitle={variant}>
-            <StyledButton isReversed={isReversed} variant={variant}>
-              <button>Button</button>
-            </StyledButton>
+      <StickerSheet isReversed={isReversed} heading="StyledButton">
+        <StickerSheet.Header
+          headings={[
+            "Default / Disabled",
+            "Hover / Working",
+            "Active / className",
+            "Focus / classNameOverride",
+          ]}
+          hasVerticalHeadings
+          headingsWidth={250}
+        />
+        {VARIANTS.map(variant => (
+          <StickerSheet.Body key={variant}>
+            <StickerSheet.Row rowTitle={variant}>
+              <StyledButton isReversed={isReversed} variant={variant}>
+                <button>Button</button>
+              </StyledButton>
 
-            <StyledButton
-              isReversed={isReversed}
-              variant={variant}
-              classNameOverride="story__StyledButton--hover"
-            >
-              <button>Button</button>
-            </StyledButton>
+              <StyledButton
+                isReversed={isReversed}
+                variant={variant}
+                classNameOverride="story__StyledButton--hover"
+              >
+                <button>Button</button>
+              </StyledButton>
 
-            <StyledButton
-              isReversed={isReversed}
-              variant={variant}
-              classNameOverride="story__StyledButton--active"
-            >
-              <button>Button</button>
-            </StyledButton>
+              <StyledButton
+                isReversed={isReversed}
+                variant={variant}
+                classNameOverride="story__StyledButton--active"
+              >
+                <button>Button</button>
+              </StyledButton>
 
-            <StyledButton
-              isReversed={isReversed}
-              variant={variant}
-              classNameOverride="story__StyledButton--focus"
-            >
-              <button>Button</button>
-            </StyledButton>
-          </StickerSheet.Row>
+              <StyledButton
+                isReversed={isReversed}
+                variant={variant}
+                classNameOverride="story__StyledButton--focus"
+              >
+                <button>Button</button>
+              </StyledButton>
+            </StickerSheet.Row>
 
-          <StickerSheet.Row isReversed={isReversed}>
-            <div />
-            <StyledButton isReversed={isReversed} variant={variant} isDisabled>
-              <button disabled>Button</button>
-            </StyledButton>
+            <StickerSheet.Row>
+              <div />
+              <StyledButton
+                isReversed={isReversed}
+                variant={variant}
+                isDisabled
+              >
+                <button disabled>Button</button>
+              </StyledButton>
 
-            <StyledButton isReversed={isReversed} variant={variant} isWorking>
-              <button>Button</button>
-            </StyledButton>
+              <StyledButton isReversed={isReversed} variant={variant} isWorking>
+                <button>Button</button>
+              </StyledButton>
 
-            <StyledButton isReversed={isReversed} variant={variant}>
-              <button className={styles.red}>Button</button>
-            </StyledButton>
+              <StyledButton isReversed={isReversed} variant={variant}>
+                <button className={styles.red}>Button</button>
+              </StyledButton>
 
-            <StyledButton isReversed={isReversed} variant={variant}>
-              <CustomButton classNameOverride={styles.red}>Button</CustomButton>
-            </StyledButton>
-          </StickerSheet.Row>
+              <StyledButton isReversed={isReversed} variant={variant}>
+                <CustomButton classNameOverride={styles.red}>
+                  Button
+                </CustomButton>
+              </StyledButton>
+            </StickerSheet.Row>
 
-          <StickerSheet.Row isReversed={isReversed}>
-            <div />
-            <StyledButton
-              isReversed={isReversed}
-              variant={variant}
-              contentsPropName="label"
-            >
-              <LabelButton label="Label" />
-            </StyledButton>
+            <StickerSheet.Row>
+              <div />
+              <StyledButton
+                isReversed={isReversed}
+                variant={variant}
+                contentsPropName="label"
+              >
+                <LabelButton label="Label" />
+              </StyledButton>
 
-            <StyledButton
-              isReversed={isReversed}
-              variant={variant}
-              contentsPropName="label"
-              isWorking
-            >
-              <LabelButton label="Label" />
-            </StyledButton>
-          </StickerSheet.Row>
+              <StyledButton
+                isReversed={isReversed}
+                variant={variant}
+                contentsPropName="label"
+                isWorking
+              >
+                <LabelButton label="Label" />
+              </StyledButton>
+            </StickerSheet.Row>
 
-          <StickerSheet.Row isReversed={isReversed}>
-            <div />
+            <StickerSheet.Row>
+              <div />
               <StyledButton
                 isReversed={isReversed}
                 variant={variant}
@@ -186,228 +190,230 @@ const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({
               >
                 <button>Button</button>
               </StyledButton>
-          </StickerSheet.Row>
-        </StickerSheet.Body>
-      ))}
+            </StickerSheet.Row>
+          </StickerSheet.Body>
+        ))}
       </StickerSheet>
 
-      <StickerSheet heading="StyledButton2">
-      <StickerSheet.Header
-        isReversed={isReversed}
-        headings={[
-          "Default / Disabled",
-          "Hover / Working",
-          "Active / className",
-          "Focus / classNameOverride",
-        ]}
-        hasVerticalHeadings
-        headingsWidth={200}
-      />
-      {VARIANTS.map(variant => (
-        <StickerSheet.Body key={variant}>
-          <StickerSheet.Row isReversed={isReversed} rowTitle={variant}>
-            <StyledButton2
-              isReversed={isReversed}
-              element={<button>Button</button>}
-              variant={variant}
-            />
+      <StickerSheet isReversed={isReversed} heading="StyledButton2">
+        <StickerSheet.Header
+          headings={[
+            "Default / Disabled",
+            "Hover / Working",
+            "Active / className",
+            "Focus / classNameOverride",
+          ]}
+          hasVerticalHeadings
+          headingsWidth={250}
+        />
+        {VARIANTS.map(variant => (
+          <StickerSheet.Body key={variant}>
+            <StickerSheet.Row rowTitle={variant}>
+              <StyledButton2
+                isReversed={isReversed}
+                element={<button>Button</button>}
+                variant={variant}
+              />
 
-            <StyledButton2
-              isReversed={isReversed}
-              element={<button>Button</button>}
-              variant={variant}
-              classNameOverride="story__StyledButton--hover"
-            />
+              <StyledButton2
+                isReversed={isReversed}
+                element={<button>Button</button>}
+                variant={variant}
+                classNameOverride="story__StyledButton--hover"
+              />
 
-            <StyledButton2
-              isReversed={isReversed}
-              element={<button>Button</button>}
-              variant={variant}
-              classNameOverride="story__StyledButton--active"
-            />
+              <StyledButton2
+                isReversed={isReversed}
+                element={<button>Button</button>}
+                variant={variant}
+                classNameOverride="story__StyledButton--active"
+              />
 
-            <StyledButton2
-              isReversed={isReversed}
-              element={<button>Button</button>}
-              variant={variant}
-              classNameOverride="story__StyledButton--focus"
-            />
-          </StickerSheet.Row>
+              <StyledButton2
+                isReversed={isReversed}
+                element={<button>Button</button>}
+                variant={variant}
+                classNameOverride="story__StyledButton--focus"
+              />
+            </StickerSheet.Row>
 
-          <StickerSheet.Row isReversed={isReversed} rowTitle="">
-            <StyledButton2
-              isReversed={isReversed}
-              element={<button disabled>Button</button>}
-              variant={variant}
-              isDisabled
-            />
+            <StickerSheet.Row>
+              <div />
+              <StyledButton2
+                isReversed={isReversed}
+                element={<button disabled>Button</button>}
+                variant={variant}
+                isDisabled
+              />
 
-            <StyledButton2
-              isReversed={isReversed}
-              element={<button disabled>Button</button>}
-              variant={variant}
-              isWorking
-            />
+              <StyledButton2
+                isReversed={isReversed}
+                element={<button disabled>Button</button>}
+                variant={variant}
+                isWorking
+              />
 
-            <StyledButton2
-              isReversed={isReversed}
-              element={<button className={styles.red}>Button</button>}
-              variant={variant}
-            />
+              <StyledButton2
+                isReversed={isReversed}
+                element={<button className={styles.red}>Button</button>}
+                variant={variant}
+              />
 
-            <StyledButton2
-              isReversed={isReversed}
-              element={
-                <CustomButton classNameOverride={styles.red}>
-                  Button
-                </CustomButton>
-              }
-              variant={variant}
-            />
-          </StickerSheet.Row>
+              <StyledButton2
+                isReversed={isReversed}
+                element={
+                  <CustomButton classNameOverride={styles.red}>
+                    Button
+                  </CustomButton>
+                }
+                variant={variant}
+              />
+            </StickerSheet.Row>
 
-          <StickerSheet.Row isReversed={isReversed} rowTitle="">
-            <StyledButton2
-              isReversed={isReversed}
-              variant={variant}
-              contentsPropName="label"
-              element={<LabelButton label="Label" />}
-            />
+            <StickerSheet.Row>
+              <div />
+              <StyledButton2
+                isReversed={isReversed}
+                variant={variant}
+                contentsPropName="label"
+                element={<LabelButton label="Label" />}
+              />
 
-            <StyledButton2
-              isReversed={isReversed}
-              variant={variant}
-              contentsPropName="label"
-              element={<LabelButton label="Label" />}
-              isWorking
-            />
-          </StickerSheet.Row>
-        </StickerSheet.Body>
-      ))}
+              <StyledButton2
+                isReversed={isReversed}
+                variant={variant}
+                contentsPropName="label"
+                element={<LabelButton label="Label" />}
+                isWorking
+              />
+            </StickerSheet.Row>
+          </StickerSheet.Body>
+        ))}
       </StickerSheet>
 
-      <StickerSheet heading="StyledIconButton">
-      <StickerSheet.Header
-        isReversed={isReversed}
-        headings={[
-          "Default / Disabled",
-          "Hover / Working",
-          "Active / className",
-          "Focus / classNameOverride",
-        ]}
-        hasVerticalHeadings
-        headingsWidth={200}
-      />
-      {VARIANTS.map(variant => (
-        <StickerSheet.Body key={variant}>
-          <StickerSheet.Row isReversed={isReversed} rowTitle={variant}>
-            <StyledIconButton
-              isReversed={isReversed}
-              element={
-                <button>
-                  <AddIcon />
-                </button>
-              }
-              variant={variant}
-            />
+      <StickerSheet isReversed={isReversed} heading="StyledIconButton">
+        <StickerSheet.Header
+          headings={[
+            "Default / Disabled",
+            "Hover / Working",
+            "Active / className",
+            "Focus / classNameOverride",
+          ]}
+          hasVerticalHeadings
+          headingsWidth={250}
+        />
+        {VARIANTS.map(variant => (
+          <StickerSheet.Body key={variant}>
+            <StickerSheet.Row rowTitle={variant}>
+              <StyledIconButton
+                isReversed={isReversed}
+                element={
+                  <button>
+                    <AddIcon />
+                  </button>
+                }
+                variant={variant}
+              />
 
-            <StyledIconButton
-              isReversed={isReversed}
-              element={
-                <button>
-                  <AddIcon />
-                </button>
-              }
-              variant={variant}
-              classNameOverride="story__StyledButton--hover"
-            />
+              <StyledIconButton
+                isReversed={isReversed}
+                element={
+                  <button>
+                    <AddIcon />
+                  </button>
+                }
+                variant={variant}
+                classNameOverride="story__StyledButton--hover"
+              />
 
-            <StyledIconButton
-              isReversed={isReversed}
-              element={
-                <button>
-                  <AddIcon />
-                </button>
-              }
-              variant={variant}
-              classNameOverride="story__StyledButton--active"
-            />
+              <StyledIconButton
+                isReversed={isReversed}
+                element={
+                  <button>
+                    <AddIcon />
+                  </button>
+                }
+                variant={variant}
+                classNameOverride="story__StyledButton--active"
+              />
 
-            <StyledIconButton
-              isReversed={isReversed}
-              element={
-                <button>
-                  <AddIcon />
-                </button>
-              }
-              variant={variant}
-              classNameOverride="story__StyledButton--focus"
-            />
-          </StickerSheet.Row>
+              <StyledIconButton
+                isReversed={isReversed}
+                element={
+                  <button>
+                    <AddIcon />
+                  </button>
+                }
+                variant={variant}
+                classNameOverride="story__StyledButton--focus"
+              />
+            </StickerSheet.Row>
 
-          <StickerSheet.Row isReversed={isReversed} rowTitle="">
-            <StyledIconButton
-              isReversed={isReversed}
-              element={
-                <button disabled>
-                  <AddIcon />
-                </button>
-              }
-              variant={variant}
-              isDisabled
-            />
+            <StickerSheet.Row>
+              <div />
+              <StyledIconButton
+                isReversed={isReversed}
+                element={
+                  <button disabled>
+                    <AddIcon />
+                  </button>
+                }
+                variant={variant}
+                isDisabled
+              />
 
-            <StyledIconButton
-              isReversed={isReversed}
-              element={
-                <button>
-                  <AddIcon />
-                </button>
-              }
-              variant={variant}
-              isWorking
-            />
+              <StyledIconButton
+                isReversed={isReversed}
+                element={
+                  <button>
+                    <AddIcon />
+                  </button>
+                }
+                variant={variant}
+                isWorking
+              />
 
-            <StyledIconButton
-              isReversed={isReversed}
-              element={
-                <button className={styles.red}>
-                  <AddIcon />
-                </button>
-              }
-              variant={variant}
-            />
+              <StyledIconButton
+                isReversed={isReversed}
+                element={
+                  <button className={styles.red}>
+                    <AddIcon />
+                  </button>
+                }
+                variant={variant}
+              />
 
-            <StyledIconButton
-              isReversed={isReversed}
-              element={
-                <CustomButton classNameOverride={styles.red}>
-                  <AddIcon />
-                </CustomButton>
-              }
-              variant={variant}
-            />
-          </StickerSheet.Row>
+              <StyledIconButton
+                isReversed={isReversed}
+                element={
+                  <CustomButton classNameOverride={styles.red}>
+                    <AddIcon />
+                  </CustomButton>
+                }
+                variant={variant}
+              />
+            </StickerSheet.Row>
 
-          <StickerSheet.Row isReversed={isReversed} rowTitle="">
-            <StyledIconButton
-              isReversed={isReversed}
-              variant={variant}
-              contentsPropName="label"
-              element={<LabelButton label={<AddIcon />} />}
-            />
+            <StickerSheet.Row>
+              <div />
+              <StyledIconButton
+                isReversed={isReversed}
+                variant={variant}
+                contentsPropName="label"
+                element={<LabelButton label={<AddIcon />} />}
+              />
 
-            <StyledIconButton
-              isReversed={isReversed}
-              variant={variant}
-              contentsPropName="label"
-              element={<LabelButton label={<AddIcon />} />}
-              isWorking
-            />
-          </StickerSheet.Row>
-        </StickerSheet.Body>
-      ))}
-    </StickerSheet>
+              <StyledIconButton
+                isReversed={isReversed}
+                variant={variant}
+                contentsPropName="label"
+                element={<LabelButton label={<AddIcon />} />}
+                isWorking
+              />
+            </StickerSheet.Row>
+          </StickerSheet.Body>
+        ))}
+      </StickerSheet>
     </>
   )
 }

--- a/packages/button/docs/StyledButton.stories.tsx
+++ b/packages/button/docs/StyledButton.stories.tsx
@@ -133,8 +133,7 @@ const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({
 
           <StoryWrapper.Row isReversed={isReversed} rowTitle="">
             <StyledButton isReversed={isReversed} variant={variant} isDisabled>
-              <button>Button</button>
-              {/* <button disabled>Button</button> */}
+              <button disabled>Button</button>
             </StyledButton>
 
             <StyledButton isReversed={isReversed} variant={variant} isWorking>

--- a/packages/button/docs/StyledButton.stories.tsx
+++ b/packages/button/docs/StyledButton.stories.tsx
@@ -1,0 +1,236 @@
+import React, { ButtonHTMLAttributes } from "react"
+import { ComponentStory, Story } from "@storybook/react"
+import isChromatic from "chromatic"
+import { withDesign } from "storybook-addon-designs"
+import { OverrideClassName } from "@kaizen/component-base"
+import { Icon } from "@kaizen/component-library"
+import addIcon from "@kaizen/component-library/icons/add.icon.svg"
+import arrowRight from "@kaizen/component-library/icons/arrow-right.icon.svg"
+import { Heading } from "@kaizen/typography"
+import { StoryWrapper } from "../../../storybook/components/StoryWrapper"
+import { CATEGORIES, SUB_CATEGORIES } from "../../../storybook/constants"
+import { figmaEmbed } from "../../../storybook/helpers"
+import { StyledIconButton } from "../src/StyledButton/StyledIconButton"
+import { StyledButton, StyledButtonProps, StyledButton2 } from ".."
+import styles from "./StyledButton.module.scss"
+
+const IS_CHROMATIC = isChromatic()
+
+export default {
+  title: `${CATEGORIES.components}/${SUB_CATEGORIES.button}/StyledButton`,
+  component: StyledButton2,
+  parameters: {
+    // actions: {
+    //   argTypesRegex: "^on.*",
+    // },
+    docs: {
+      description: {
+        component:
+          'import { Button, IconButton } from "@kaizen/button". This Button supersedes "@kaizen/draft-button".',
+      },
+    },
+    ...figmaEmbed(
+      "https://www.figma.com/file/eZKEE5kXbEMY3lx84oz8iN/%E2%9D%A4%EF%B8%8F-UI-Kit%3A-Heart?node-id=13555%3A0"
+    ),
+  },
+  decorators: [withDesign],
+}
+
+export const DefaultStory: ComponentStory<typeof StyledButton2> = args => <StyledButton2 {...args} />
+DefaultStory.storyName = "StyledButton2"
+DefaultStory.args = {
+  variant: "default",
+  element: <button>Button</button>
+}
+
+type CustomButtonProps = OverrideClassName<ButtonHTMLAttributes<HTMLButtonElement>>
+
+const CustomButton: React.VFC<CustomButtonProps> = ({
+  classNameOverride,
+  ...restProps
+}) => (
+  <button className={classNameOverride} {...restProps} />
+)
+
+const AddIcon = () => (
+  <Icon icon={addIcon} title="Add" />
+)
+
+const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({
+  isReversed,
+}) => {
+  const VARIANTS: Array<StyledButtonProps["variant"]> = [
+    "default",
+    "primary",
+    "secondary",
+    "secondaryDestructive",
+  ]
+
+  const SectionHeading: React.VFC<{ heading: string }> = ({ heading }) => (
+    <Heading variant="heading-3" tag="h1" color={isReversed ? "white" : "dark"}>
+      {heading}
+    </Heading>
+  )
+
+  return (
+    <StoryWrapper isReversed={isReversed}>
+      <SectionHeading heading="StyledButton" />
+      <StoryWrapper.RowHeader
+        headings={["Default", "Hover", "Active", "Focus", "Disabled", "className", "classNameOverride"]}
+      />
+      {VARIANTS.map(variant => (
+        <React.Fragment key={variant}>
+        <StoryWrapper.Row rowTitle={variant}>
+          <StyledButton variant={variant}>
+            <button>Button</button>
+          </StyledButton>
+
+          <StyledButton variant={variant} classNameOverride="story__StyledButton--hover">
+            <button>Button</button>
+          </StyledButton>
+
+          <StyledButton variant={variant} classNameOverride="story__StyledButton--active">
+            <button>Button</button>
+          </StyledButton>
+
+          <StyledButton variant={variant} classNameOverride="story__StyledButton--focus">
+            <button>Button</button>
+          </StyledButton>
+
+          <StyledButton variant={variant}>
+            <button disabled>Button</button>
+          </StyledButton>
+
+          <StyledButton variant={variant}>
+            <button className={styles.red}>Button</button>
+          </StyledButton>
+
+          <StyledButton variant={variant}>
+            <CustomButton classNameOverride={styles.red}>Button</CustomButton>
+          </StyledButton>
+        </StoryWrapper.Row>
+        </React.Fragment>
+      ))}
+
+      <SectionHeading heading="StyledButton2" />
+      <StoryWrapper.RowHeader
+        headings={["Default", "Hover", "Active", "Focus", "Disabled", "className", "classNameOverride"]}
+      />
+      {VARIANTS.map(variant => (
+        <React.Fragment key={variant}>
+        <StoryWrapper.Row rowTitle={variant}>
+          <StyledButton2
+            element={<button>Button</button>}
+            variant={variant}
+          />
+
+          <StyledButton2
+            element={<button>Button</button>}
+            variant={variant}
+            classNameOverride="story__StyledButton--hover"
+          />
+
+          <StyledButton2
+            element={<button>Button</button>}
+            variant={variant}
+            classNameOverride="story__StyledButton--active"
+          />
+
+          <StyledButton2
+            element={<button>Button</button>}
+            variant={variant}
+            classNameOverride="story__StyledButton--focus"
+          />
+
+          <StyledButton2
+            element={<button disabled>Button</button>}
+            variant={variant}
+          />
+
+          <StyledButton2
+            element={<button className={styles.red}>Button</button>}
+            variant={variant}
+          />
+
+          <StyledButton2
+            element={<CustomButton classNameOverride={styles.red}>Button</CustomButton>}
+            variant={variant}
+          />
+        </StoryWrapper.Row>
+        </React.Fragment>
+      ))}
+
+      <SectionHeading heading="StyledIconButton" />
+      <StoryWrapper.RowHeader
+        headings={["Default", "Hover", "Active", "Focus", "Disabled", "className", "classNameOverride"]}
+      />
+      {VARIANTS.map(variant => (
+        <React.Fragment key={variant}>
+        <StoryWrapper.Row rowTitle={variant}>
+          <StyledIconButton
+            element={<button><AddIcon /></button>}
+            variant={variant}
+          />
+
+          <StyledIconButton
+            element={<button><AddIcon /></button>}
+            variant={variant}
+            classNameOverride="story__StyledButton--hover"
+          />
+
+          <StyledIconButton
+            element={<button><AddIcon /></button>}
+            variant={variant}
+            classNameOverride="story__StyledButton--active"
+          />
+
+          <StyledIconButton
+            element={<button><AddIcon /></button>}
+            variant={variant}
+            classNameOverride="story__StyledButton--focus"
+          />
+
+          <StyledIconButton
+            element={<button disabled><AddIcon /></button>}
+            variant={variant}
+          />
+
+          <StyledIconButton
+            element={
+            <button className={styles.red}>
+              <AddIcon />
+            </button>
+            }
+            variant={variant}
+          />
+
+          <StyledIconButton
+            element={
+            <CustomButton classNameOverride={styles.red}>
+              <AddIcon />
+            </CustomButton>
+            }
+            variant={variant}
+          />
+        </StoryWrapper.Row>
+        </React.Fragment>
+      ))}
+    </StoryWrapper>
+  )
+}
+
+export const StickerSheetDefault = StickerSheetTemplate.bind({})
+StickerSheetDefault.storyName = "Sticker Sheet (Default)"
+StickerSheetDefault.parameters = {
+  chromatic: { disable: false },
+  controls: { disable: true },
+}
+
+// export const StickerSheetReversed = StickerSheetTemplate.bind({})
+// StickerSheetReversed.storyName = "Sticker Sheet (Reversed)"
+// StickerSheetReversed.args = { isReversed: true }
+// StickerSheetReversed.parameters = {
+//   controls: { disable: true },
+//   backgrounds: { default: "Purple 700" },
+//   chromatic: { disable: false },
+// }

--- a/packages/button/docs/StyledButton.stories.tsx
+++ b/packages/button/docs/StyledButton.stories.tsx
@@ -167,6 +167,31 @@ const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({
               <LabelButton label="Label" />
             </StyledButton>
           </StoryWrapper.Row>
+
+          <StoryWrapper.Row isReversed={isReversed} rowTitle="" gridColumns={4}>
+            <div>
+              <StyledButton
+                isReversed={isReversed}
+                variant={variant}
+                icon={addIcon}
+              >
+                <button>
+                  Button qwerty qwerty qwerty qwerty qwerty qwerty
+                </button>
+              </StyledButton>
+            </div>
+
+            <div>
+              <StyledButton
+                isReversed={isReversed}
+                variant={variant}
+                icon={arrowRight}
+                iconPosition="end"
+              >
+                <button>Button</button>
+              </StyledButton>
+            </div>
+          </StoryWrapper.Row>
         </React.Fragment>
       ))}
 

--- a/packages/button/docs/StyledButton.stories.tsx
+++ b/packages/button/docs/StyledButton.stories.tsx
@@ -36,25 +36,25 @@ export default {
   decorators: [withDesign],
 }
 
-export const DefaultStory: ComponentStory<typeof StyledButton2> = args => <StyledButton2 {...args} />
+export const DefaultStory: ComponentStory<typeof StyledButton2> = args => (
+  <StyledButton2 {...args} />
+)
 DefaultStory.storyName = "StyledButton2"
 DefaultStory.args = {
   variant: "default",
-  element: <button>Button</button>
+  element: <button>Button</button>,
 }
 
-type CustomButtonProps = OverrideClassName<ButtonHTMLAttributes<HTMLButtonElement>>
+type CustomButtonProps = OverrideClassName<
+  ButtonHTMLAttributes<HTMLButtonElement>
+>
 
 const CustomButton: React.VFC<CustomButtonProps> = ({
   classNameOverride,
   ...restProps
-}) => (
-  <button className={classNameOverride} {...restProps} />
-)
+}) => <button className={classNameOverride} {...restProps} />
 
-const AddIcon = () => (
-  <Icon icon={addIcon} title="Add" />
-)
+const AddIcon = () => <Icon icon={addIcon} title="Add" />
 
 const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({
   isReversed,
@@ -76,143 +76,220 @@ const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({
     <StoryWrapper isReversed={isReversed}>
       <SectionHeading heading="StyledButton" />
       <StoryWrapper.RowHeader
-        headings={["Default", "Hover", "Active", "Focus", "Disabled", "className", "classNameOverride"]}
+        isReversed={isReversed}
+        headings={[
+          "Default",
+          "Hover",
+          "Active",
+          "Focus",
+          "Disabled",
+          "className",
+          "classNameOverride",
+        ]}
       />
       {VARIANTS.map(variant => (
         <React.Fragment key={variant}>
-        <StoryWrapper.Row rowTitle={variant}>
-          <StyledButton variant={variant}>
-            <button>Button</button>
-          </StyledButton>
+          <StoryWrapper.Row isReversed={isReversed} rowTitle={variant}>
+            <StyledButton isReversed={isReversed} variant={variant}>
+              <button>Button</button>
+            </StyledButton>
 
-          <StyledButton variant={variant} classNameOverride="story__StyledButton--hover">
-            <button>Button</button>
-          </StyledButton>
+            <StyledButton
+              isReversed={isReversed}
+              variant={variant}
+              classNameOverride="story__StyledButton--hover"
+            >
+              <button>Button</button>
+            </StyledButton>
 
-          <StyledButton variant={variant} classNameOverride="story__StyledButton--active">
-            <button>Button</button>
-          </StyledButton>
+            <StyledButton
+              isReversed={isReversed}
+              variant={variant}
+              classNameOverride="story__StyledButton--active"
+            >
+              <button>Button</button>
+            </StyledButton>
 
-          <StyledButton variant={variant} classNameOverride="story__StyledButton--focus">
-            <button>Button</button>
-          </StyledButton>
+            <StyledButton
+              isReversed={isReversed}
+              variant={variant}
+              classNameOverride="story__StyledButton--focus"
+            >
+              <button>Button</button>
+            </StyledButton>
 
-          <StyledButton variant={variant}>
-            <button disabled>Button</button>
-          </StyledButton>
+            <StyledButton isReversed={isReversed} variant={variant}>
+              <button disabled>Button</button>
+            </StyledButton>
 
-          <StyledButton variant={variant}>
-            <button className={styles.red}>Button</button>
-          </StyledButton>
+            <StyledButton isReversed={isReversed} variant={variant}>
+              <button className={styles.red}>Button</button>
+            </StyledButton>
 
-          <StyledButton variant={variant}>
-            <CustomButton classNameOverride={styles.red}>Button</CustomButton>
-          </StyledButton>
-        </StoryWrapper.Row>
+            <StyledButton isReversed={isReversed} variant={variant}>
+              <CustomButton classNameOverride={styles.red}>Button</CustomButton>
+            </StyledButton>
+          </StoryWrapper.Row>
         </React.Fragment>
       ))}
 
       <SectionHeading heading="StyledButton2" />
       <StoryWrapper.RowHeader
-        headings={["Default", "Hover", "Active", "Focus", "Disabled", "className", "classNameOverride"]}
+        isReversed={isReversed}
+        headings={[
+          "Default",
+          "Hover",
+          "Active",
+          "Focus",
+          "Disabled",
+          "className",
+          "classNameOverride",
+        ]}
       />
       {VARIANTS.map(variant => (
         <React.Fragment key={variant}>
-        <StoryWrapper.Row rowTitle={variant}>
-          <StyledButton2
-            element={<button>Button</button>}
-            variant={variant}
-          />
+          <StoryWrapper.Row isReversed={isReversed} rowTitle={variant}>
+            <StyledButton2
+              isReversed={isReversed}
+              element={<button>Button</button>}
+              variant={variant}
+            />
 
-          <StyledButton2
-            element={<button>Button</button>}
-            variant={variant}
-            classNameOverride="story__StyledButton--hover"
-          />
+            <StyledButton2
+              isReversed={isReversed}
+              element={<button>Button</button>}
+              variant={variant}
+              classNameOverride="story__StyledButton--hover"
+            />
 
-          <StyledButton2
-            element={<button>Button</button>}
-            variant={variant}
-            classNameOverride="story__StyledButton--active"
-          />
+            <StyledButton2
+              isReversed={isReversed}
+              element={<button>Button</button>}
+              variant={variant}
+              classNameOverride="story__StyledButton--active"
+            />
 
-          <StyledButton2
-            element={<button>Button</button>}
-            variant={variant}
-            classNameOverride="story__StyledButton--focus"
-          />
+            <StyledButton2
+              isReversed={isReversed}
+              element={<button>Button</button>}
+              variant={variant}
+              classNameOverride="story__StyledButton--focus"
+            />
 
-          <StyledButton2
-            element={<button disabled>Button</button>}
-            variant={variant}
-          />
+            <StyledButton2
+              isReversed={isReversed}
+              element={<button disabled>Button</button>}
+              variant={variant}
+            />
 
-          <StyledButton2
-            element={<button className={styles.red}>Button</button>}
-            variant={variant}
-          />
+            <StyledButton2
+              isReversed={isReversed}
+              element={<button className={styles.red}>Button</button>}
+              variant={variant}
+            />
 
-          <StyledButton2
-            element={<CustomButton classNameOverride={styles.red}>Button</CustomButton>}
-            variant={variant}
-          />
-        </StoryWrapper.Row>
+            <StyledButton2
+              isReversed={isReversed}
+              element={
+                <CustomButton classNameOverride={styles.red}>
+                  Button
+                </CustomButton>
+              }
+              variant={variant}
+            />
+          </StoryWrapper.Row>
         </React.Fragment>
       ))}
 
       <SectionHeading heading="StyledIconButton" />
       <StoryWrapper.RowHeader
-        headings={["Default", "Hover", "Active", "Focus", "Disabled", "className", "classNameOverride"]}
+        isReversed={isReversed}
+        headings={[
+          "Default",
+          "Hover",
+          "Active",
+          "Focus",
+          "Disabled",
+          "className",
+          "classNameOverride",
+        ]}
       />
       {VARIANTS.map(variant => (
         <React.Fragment key={variant}>
-        <StoryWrapper.Row rowTitle={variant}>
-          <StyledIconButton
-            element={<button><AddIcon /></button>}
-            variant={variant}
-          />
+          <StoryWrapper.Row isReversed={isReversed} rowTitle={variant}>
+            <StyledIconButton
+              isReversed={isReversed}
+              element={
+                <button>
+                  <AddIcon />
+                </button>
+              }
+              variant={variant}
+            />
 
-          <StyledIconButton
-            element={<button><AddIcon /></button>}
-            variant={variant}
-            classNameOverride="story__StyledButton--hover"
-          />
+            <StyledIconButton
+              isReversed={isReversed}
+              element={
+                <button>
+                  <AddIcon />
+                </button>
+              }
+              variant={variant}
+              classNameOverride="story__StyledButton--hover"
+            />
 
-          <StyledIconButton
-            element={<button><AddIcon /></button>}
-            variant={variant}
-            classNameOverride="story__StyledButton--active"
-          />
+            <StyledIconButton
+              isReversed={isReversed}
+              element={
+                <button>
+                  <AddIcon />
+                </button>
+              }
+              variant={variant}
+              classNameOverride="story__StyledButton--active"
+            />
 
-          <StyledIconButton
-            element={<button><AddIcon /></button>}
-            variant={variant}
-            classNameOverride="story__StyledButton--focus"
-          />
+            <StyledIconButton
+              isReversed={isReversed}
+              element={
+                <button>
+                  <AddIcon />
+                </button>
+              }
+              variant={variant}
+              classNameOverride="story__StyledButton--focus"
+            />
 
-          <StyledIconButton
-            element={<button disabled><AddIcon /></button>}
-            variant={variant}
-          />
+            <StyledIconButton
+              isReversed={isReversed}
+              element={
+                <button disabled>
+                  <AddIcon />
+                </button>
+              }
+              variant={variant}
+            />
 
-          <StyledIconButton
-            element={
-            <button className={styles.red}>
-              <AddIcon />
-            </button>
-            }
-            variant={variant}
-          />
+            <StyledIconButton
+              isReversed={isReversed}
+              element={
+                <button className={styles.red}>
+                  <AddIcon />
+                </button>
+              }
+              variant={variant}
+            />
 
-          <StyledIconButton
-            element={
-            <CustomButton classNameOverride={styles.red}>
-              <AddIcon />
-            </CustomButton>
-            }
-            variant={variant}
-          />
-        </StoryWrapper.Row>
+            <StyledIconButton
+              isReversed={isReversed}
+              element={
+                <CustomButton classNameOverride={styles.red}>
+                  <AddIcon />
+                </CustomButton>
+              }
+              variant={variant}
+            />
+          </StoryWrapper.Row>
         </React.Fragment>
       ))}
     </StoryWrapper>
@@ -226,11 +303,11 @@ StickerSheetDefault.parameters = {
   controls: { disable: true },
 }
 
-// export const StickerSheetReversed = StickerSheetTemplate.bind({})
-// StickerSheetReversed.storyName = "Sticker Sheet (Reversed)"
-// StickerSheetReversed.args = { isReversed: true }
-// StickerSheetReversed.parameters = {
-//   controls: { disable: true },
-//   backgrounds: { default: "Purple 700" },
-//   chromatic: { disable: false },
-// }
+export const StickerSheetReversed = StickerSheetTemplate.bind({})
+StickerSheetReversed.storyName = "Sticker Sheet (Reversed)"
+StickerSheetReversed.args = { isReversed: true }
+StickerSheetReversed.parameters = {
+  controls: { disable: true },
+  backgrounds: { default: "Purple 700" },
+  chromatic: { disable: false },
+}

--- a/packages/button/docs/StyledButton.stories.tsx
+++ b/packages/button/docs/StyledButton.stories.tsx
@@ -132,8 +132,9 @@ const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({
           </StoryWrapper.Row>
 
           <StoryWrapper.Row isReversed={isReversed} rowTitle="">
-            <StyledButton isReversed={isReversed} variant={variant}>
-              <button disabled>Button</button>
+            <StyledButton isReversed={isReversed} variant={variant} isDisabled>
+              <button>Button</button>
+              {/* <button disabled>Button</button> */}
             </StyledButton>
 
             <StyledButton isReversed={isReversed} variant={variant} isWorking>
@@ -216,6 +217,7 @@ const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({
               isReversed={isReversed}
               element={<button disabled>Button</button>}
               variant={variant}
+              isDisabled
             />
 
             <StyledButton2
@@ -327,6 +329,7 @@ const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({
                 </button>
               }
               variant={variant}
+              isDisabled
             />
 
             <StyledIconButton

--- a/packages/button/docs/StyledButton.stories.tsx
+++ b/packages/button/docs/StyledButton.stories.tsx
@@ -7,7 +7,7 @@ import { Icon } from "@kaizen/component-library"
 import addIcon from "@kaizen/component-library/icons/add.icon.svg"
 import arrowRight from "@kaizen/component-library/icons/arrow-right.icon.svg"
 import { Heading } from "@kaizen/typography"
-import { StoryWrapper } from "../../../storybook/components/StoryWrapper"
+import { StickerSheet } from "../../../storybook/components/StickerSheet"
 import { CATEGORIES, SUB_CATEGORIES } from "../../../storybook/constants"
 import { figmaEmbed } from "../../../storybook/helpers"
 import { StyledIconButton } from "../src/StyledButton/StyledIconButton"
@@ -81,16 +81,10 @@ const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({
     "secondaryDestructive",
   ]
 
-  const SectionHeading: React.VFC<{ heading: string }> = ({ heading }) => (
-    <Heading variant="heading-3" tag="h1" color={isReversed ? "white" : "dark"}>
-      {heading}
-    </Heading>
-  )
-
   return (
-    <StoryWrapper isReversed={isReversed}>
-      <SectionHeading heading="StyledButton" />
-      <StoryWrapper.RowHeader
+    <>
+    <StickerSheet isReversed={isReversed}  heading="StyledButton">
+      <StickerSheet.Header
         isReversed={isReversed}
         headings={[
           "Default / Disabled",
@@ -98,10 +92,12 @@ const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({
           "Active / className",
           "Focus / classNameOverride",
         ]}
+        hasVerticalHeadings
+        headingsWidth={200}
       />
       {VARIANTS.map(variant => (
-        <React.Fragment key={variant}>
-          <StoryWrapper.Row isReversed={isReversed} rowTitle={variant}>
+        <StickerSheet.Body key={variant}>
+          <StickerSheet.Row isReversed={isReversed} rowTitle={variant}>
             <StyledButton isReversed={isReversed} variant={variant}>
               <button>Button</button>
             </StyledButton>
@@ -129,9 +125,10 @@ const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({
             >
               <button>Button</button>
             </StyledButton>
-          </StoryWrapper.Row>
+          </StickerSheet.Row>
 
-          <StoryWrapper.Row isReversed={isReversed} rowTitle="">
+          <StickerSheet.Row isReversed={isReversed}>
+            <div />
             <StyledButton isReversed={isReversed} variant={variant} isDisabled>
               <button disabled>Button</button>
             </StyledButton>
@@ -147,9 +144,10 @@ const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({
             <StyledButton isReversed={isReversed} variant={variant}>
               <CustomButton classNameOverride={styles.red}>Button</CustomButton>
             </StyledButton>
-          </StoryWrapper.Row>
+          </StickerSheet.Row>
 
-          <StoryWrapper.Row isReversed={isReversed} rowTitle="" gridColumns={4}>
+          <StickerSheet.Row isReversed={isReversed}>
+            <div />
             <StyledButton
               isReversed={isReversed}
               variant={variant}
@@ -166,10 +164,10 @@ const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({
             >
               <LabelButton label="Label" />
             </StyledButton>
-          </StoryWrapper.Row>
+          </StickerSheet.Row>
 
-          <StoryWrapper.Row isReversed={isReversed} rowTitle="" gridColumns={4}>
-            <div>
+          <StickerSheet.Row isReversed={isReversed}>
+            <div />
               <StyledButton
                 isReversed={isReversed}
                 variant={variant}
@@ -179,9 +177,7 @@ const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({
                   Button qwerty qwerty qwerty qwerty qwerty qwerty
                 </button>
               </StyledButton>
-            </div>
 
-            <div>
               <StyledButton
                 isReversed={isReversed}
                 variant={variant}
@@ -190,13 +186,13 @@ const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({
               >
                 <button>Button</button>
               </StyledButton>
-            </div>
-          </StoryWrapper.Row>
-        </React.Fragment>
+          </StickerSheet.Row>
+        </StickerSheet.Body>
       ))}
+      </StickerSheet>
 
-      <SectionHeading heading="StyledButton2" />
-      <StoryWrapper.RowHeader
+      <StickerSheet heading="StyledButton2">
+      <StickerSheet.Header
         isReversed={isReversed}
         headings={[
           "Default / Disabled",
@@ -204,10 +200,12 @@ const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({
           "Active / className",
           "Focus / classNameOverride",
         ]}
+        hasVerticalHeadings
+        headingsWidth={200}
       />
       {VARIANTS.map(variant => (
-        <React.Fragment key={variant}>
-          <StoryWrapper.Row isReversed={isReversed} rowTitle={variant}>
+        <StickerSheet.Body key={variant}>
+          <StickerSheet.Row isReversed={isReversed} rowTitle={variant}>
             <StyledButton2
               isReversed={isReversed}
               element={<button>Button</button>}
@@ -234,9 +232,9 @@ const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({
               variant={variant}
               classNameOverride="story__StyledButton--focus"
             />
-          </StoryWrapper.Row>
+          </StickerSheet.Row>
 
-          <StoryWrapper.Row isReversed={isReversed} rowTitle="">
+          <StickerSheet.Row isReversed={isReversed} rowTitle="">
             <StyledButton2
               isReversed={isReversed}
               element={<button disabled>Button</button>}
@@ -266,9 +264,9 @@ const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({
               }
               variant={variant}
             />
-          </StoryWrapper.Row>
+          </StickerSheet.Row>
 
-          <StoryWrapper.Row isReversed={isReversed} rowTitle="" gridColumns={4}>
+          <StickerSheet.Row isReversed={isReversed} rowTitle="">
             <StyledButton2
               isReversed={isReversed}
               variant={variant}
@@ -283,12 +281,13 @@ const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({
               element={<LabelButton label="Label" />}
               isWorking
             />
-          </StoryWrapper.Row>
-        </React.Fragment>
+          </StickerSheet.Row>
+        </StickerSheet.Body>
       ))}
+      </StickerSheet>
 
-      <SectionHeading heading="StyledIconButton" />
-      <StoryWrapper.RowHeader
+      <StickerSheet heading="StyledIconButton">
+      <StickerSheet.Header
         isReversed={isReversed}
         headings={[
           "Default / Disabled",
@@ -296,10 +295,12 @@ const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({
           "Active / className",
           "Focus / classNameOverride",
         ]}
+        hasVerticalHeadings
+        headingsWidth={200}
       />
       {VARIANTS.map(variant => (
-        <React.Fragment key={variant}>
-          <StoryWrapper.Row isReversed={isReversed} rowTitle={variant}>
+        <StickerSheet.Body key={variant}>
+          <StickerSheet.Row isReversed={isReversed} rowTitle={variant}>
             <StyledIconButton
               isReversed={isReversed}
               element={
@@ -342,9 +343,9 @@ const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({
               variant={variant}
               classNameOverride="story__StyledButton--focus"
             />
-          </StoryWrapper.Row>
+          </StickerSheet.Row>
 
-          <StoryWrapper.Row isReversed={isReversed} rowTitle="">
+          <StickerSheet.Row isReversed={isReversed} rowTitle="">
             <StyledIconButton
               isReversed={isReversed}
               element={
@@ -386,9 +387,9 @@ const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({
               }
               variant={variant}
             />
-          </StoryWrapper.Row>
+          </StickerSheet.Row>
 
-          <StoryWrapper.Row isReversed={isReversed} rowTitle="" gridColumns={4}>
+          <StickerSheet.Row isReversed={isReversed} rowTitle="">
             <StyledIconButton
               isReversed={isReversed}
               variant={variant}
@@ -403,10 +404,11 @@ const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({
               element={<LabelButton label={<AddIcon />} />}
               isWorking
             />
-          </StoryWrapper.Row>
-        </React.Fragment>
+          </StickerSheet.Row>
+        </StickerSheet.Body>
       ))}
-    </StoryWrapper>
+    </StickerSheet>
+    </>
   )
 }
 

--- a/packages/button/docs/StyledButton.stories.tsx
+++ b/packages/button/docs/StyledButton.stories.tsx
@@ -287,6 +287,28 @@ const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({
                 isWorking
               />
             </StickerSheet.Row>
+
+            <StickerSheet.Row>
+              <div />
+              <StyledButton2
+                isReversed={isReversed}
+                variant={variant}
+                icon={addIcon}
+                element={
+                  <button>
+                    Button qwerty qwerty qwerty qwerty qwerty qwerty
+                  </button>
+                }
+              />
+
+              <StyledButton2
+                isReversed={isReversed}
+                variant={variant}
+                icon={arrowRight}
+                iconPosition="end"
+                element={<button>Button</button>}
+              />
+            </StickerSheet.Row>
           </StickerSheet.Body>
         ))}
       </StickerSheet>

--- a/packages/button/docs/StyledButton.stories.tsx
+++ b/packages/button/docs/StyledButton.stories.tsx
@@ -68,7 +68,7 @@ const LabelButton: React.VFC<LabelButtonProps> = ({
   </button>
 )
 
-const AddIcon = () => <Icon icon={addIcon} title="Add" />
+const AddIcon = () => <Icon icon={addIcon} role="presentation" />
 
 const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({
   isReversed,
@@ -308,7 +308,7 @@ const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({
               <StyledIconButton
                 isReversed={isReversed}
                 element={
-                  <button>
+                  <button aria-label="Add">
                     <AddIcon />
                   </button>
                 }
@@ -318,7 +318,7 @@ const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({
               <StyledIconButton
                 isReversed={isReversed}
                 element={
-                  <button>
+                  <button aria-label="Add">
                     <AddIcon />
                   </button>
                 }
@@ -329,7 +329,7 @@ const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({
               <StyledIconButton
                 isReversed={isReversed}
                 element={
-                  <button>
+                  <button aria-label="Add">
                     <AddIcon />
                   </button>
                 }
@@ -340,7 +340,7 @@ const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({
               <StyledIconButton
                 isReversed={isReversed}
                 element={
-                  <button>
+                  <button aria-label="Add">
                     <AddIcon />
                   </button>
                 }
@@ -354,7 +354,7 @@ const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({
               <StyledIconButton
                 isReversed={isReversed}
                 element={
-                  <button disabled>
+                  <button aria-label="Add" disabled>
                     <AddIcon />
                   </button>
                 }
@@ -365,7 +365,7 @@ const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({
               <StyledIconButton
                 isReversed={isReversed}
                 element={
-                  <button>
+                  <button aria-label="Add">
                     <AddIcon />
                   </button>
                 }
@@ -376,7 +376,7 @@ const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({
               <StyledIconButton
                 isReversed={isReversed}
                 element={
-                  <button className={styles.red}>
+                  <button aria-label="Add" className={styles.red}>
                     <AddIcon />
                   </button>
                 }
@@ -386,7 +386,7 @@ const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({
               <StyledIconButton
                 isReversed={isReversed}
                 element={
-                  <CustomButton classNameOverride={styles.red}>
+                  <CustomButton aria-label="Add" classNameOverride={styles.red}>
                     <AddIcon />
                   </CustomButton>
                 }
@@ -400,14 +400,14 @@ const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({
                 isReversed={isReversed}
                 variant={variant}
                 contentsPropName="label"
-                element={<LabelButton label={<AddIcon />} />}
+                element={<LabelButton label={<AddIcon />} aria-label="Add" />}
               />
 
               <StyledIconButton
                 isReversed={isReversed}
                 variant={variant}
                 contentsPropName="label"
-                element={<LabelButton label={<AddIcon />} />}
+                element={<LabelButton label={<AddIcon />} aria-label="Add" />}
                 isWorking
               />
             </StickerSheet.Row>

--- a/packages/button/docs/StyledButton.stories.tsx
+++ b/packages/button/docs/StyledButton.stories.tsx
@@ -54,6 +54,21 @@ const CustomButton: React.VFC<CustomButtonProps> = ({
   ...restProps
 }) => <button className={classNameOverride} {...restProps} />
 
+type LabelButtonProps = Omit<
+  OverrideClassName<ButtonHTMLAttributes<HTMLButtonElement>>,
+  "children"
+> & { label: React.ReactNode }
+
+const LabelButton: React.VFC<LabelButtonProps> = ({
+  label,
+  classNameOverride,
+  ...restProps
+}) => (
+  <button className={classNameOverride} {...restProps}>
+    {label}
+  </button>
+)
+
 const AddIcon = () => <Icon icon={addIcon} title="Add" />
 
 const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({
@@ -78,13 +93,10 @@ const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({
       <StoryWrapper.RowHeader
         isReversed={isReversed}
         headings={[
-          "Default",
-          "Hover",
-          "Active",
-          "Focus",
-          "Disabled",
-          "className",
-          "classNameOverride",
+          "Default / Disabled",
+          "Hover / Working",
+          "Active / className",
+          "Focus / classNameOverride",
         ]}
       />
       {VARIANTS.map(variant => (
@@ -117,9 +129,15 @@ const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({
             >
               <button>Button</button>
             </StyledButton>
+          </StoryWrapper.Row>
 
+          <StoryWrapper.Row isReversed={isReversed} rowTitle="">
             <StyledButton isReversed={isReversed} variant={variant}>
               <button disabled>Button</button>
+            </StyledButton>
+
+            <StyledButton isReversed={isReversed} variant={variant} isWorking>
+              <button>Button</button>
             </StyledButton>
 
             <StyledButton isReversed={isReversed} variant={variant}>
@@ -130,6 +148,25 @@ const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({
               <CustomButton classNameOverride={styles.red}>Button</CustomButton>
             </StyledButton>
           </StoryWrapper.Row>
+
+          <StoryWrapper.Row isReversed={isReversed} rowTitle="" gridColumns={4}>
+            <StyledButton
+              isReversed={isReversed}
+              variant={variant}
+              contentsPropName="label"
+            >
+              <LabelButton label="Label" />
+            </StyledButton>
+
+            <StyledButton
+              isReversed={isReversed}
+              variant={variant}
+              contentsPropName="label"
+              isWorking
+            >
+              <LabelButton label="Label" />
+            </StyledButton>
+          </StoryWrapper.Row>
         </React.Fragment>
       ))}
 
@@ -137,13 +174,10 @@ const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({
       <StoryWrapper.RowHeader
         isReversed={isReversed}
         headings={[
-          "Default",
-          "Hover",
-          "Active",
-          "Focus",
-          "Disabled",
-          "className",
-          "classNameOverride",
+          "Default / Disabled",
+          "Hover / Working",
+          "Active / className",
+          "Focus / classNameOverride",
         ]}
       />
       {VARIANTS.map(variant => (
@@ -175,11 +209,20 @@ const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({
               variant={variant}
               classNameOverride="story__StyledButton--focus"
             />
+          </StoryWrapper.Row>
+
+          <StoryWrapper.Row isReversed={isReversed} rowTitle="">
+            <StyledButton2
+              isReversed={isReversed}
+              element={<button disabled>Button</button>}
+              variant={variant}
+            />
 
             <StyledButton2
               isReversed={isReversed}
               element={<button disabled>Button</button>}
               variant={variant}
+              isWorking
             />
 
             <StyledButton2
@@ -198,6 +241,23 @@ const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({
               variant={variant}
             />
           </StoryWrapper.Row>
+
+          <StoryWrapper.Row isReversed={isReversed} rowTitle="" gridColumns={4}>
+            <StyledButton2
+              isReversed={isReversed}
+              variant={variant}
+              contentsPropName="label"
+              element={<LabelButton label="Label" />}
+            />
+
+            <StyledButton2
+              isReversed={isReversed}
+              variant={variant}
+              contentsPropName="label"
+              element={<LabelButton label="Label" />}
+              isWorking
+            />
+          </StoryWrapper.Row>
         </React.Fragment>
       ))}
 
@@ -205,13 +265,10 @@ const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({
       <StoryWrapper.RowHeader
         isReversed={isReversed}
         headings={[
-          "Default",
-          "Hover",
-          "Active",
-          "Focus",
-          "Disabled",
-          "className",
-          "classNameOverride",
+          "Default / Disabled",
+          "Hover / Working",
+          "Active / className",
+          "Focus / classNameOverride",
         ]}
       />
       {VARIANTS.map(variant => (
@@ -259,7 +316,9 @@ const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({
               variant={variant}
               classNameOverride="story__StyledButton--focus"
             />
+          </StoryWrapper.Row>
 
+          <StoryWrapper.Row isReversed={isReversed} rowTitle="">
             <StyledIconButton
               isReversed={isReversed}
               element={
@@ -268,6 +327,17 @@ const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({
                 </button>
               }
               variant={variant}
+            />
+
+            <StyledIconButton
+              isReversed={isReversed}
+              element={
+                <button>
+                  <AddIcon />
+                </button>
+              }
+              variant={variant}
+              isWorking
             />
 
             <StyledIconButton
@@ -288,6 +358,23 @@ const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({
                 </CustomButton>
               }
               variant={variant}
+            />
+          </StoryWrapper.Row>
+
+          <StoryWrapper.Row isReversed={isReversed} rowTitle="" gridColumns={4}>
+            <StyledIconButton
+              isReversed={isReversed}
+              variant={variant}
+              contentsPropName="label"
+              element={<LabelButton label={<AddIcon />} />}
+            />
+
+            <StyledIconButton
+              isReversed={isReversed}
+              variant={variant}
+              contentsPropName="label"
+              element={<LabelButton label={<AddIcon />} />}
+              isWorking
             />
           </StoryWrapper.Row>
         </React.Fragment>

--- a/packages/button/index.ts
+++ b/packages/button/index.ts
@@ -8,5 +8,4 @@ export type {
 } from "./src/Button/components/GenericButton"
 export type { ButtonProps } from "./src/Button/Button"
 
-
 export * from "./src/StyledButton"

--- a/packages/button/index.ts
+++ b/packages/button/index.ts
@@ -7,3 +7,6 @@ export type {
   CustomButtonProps,
 } from "./src/Button/components/GenericButton"
 export type { ButtonProps } from "./src/Button/Button"
+
+
+export * from "./src/StyledButton"

--- a/packages/button/package.json
+++ b/packages/button/package.json
@@ -29,6 +29,7 @@
   "private": false,
   "license": "MIT",
   "dependencies": {
+    "@kaizen/component-base": "^1.1.1",
     "@kaizen/component-library": "^16.1.14",
     "@kaizen/draft-badge": "^1.13.4",
     "@kaizen/loading-spinner": "^2.3.4",

--- a/packages/button/src/StyledButton/NewButton.tsx
+++ b/packages/button/src/StyledButton/NewButton.tsx
@@ -1,0 +1,12 @@
+import React, { ButtonHTMLAttributes } from "react"
+import { OverrideClassName } from "@kaizen/component-base"
+
+export interface NewButtonProps extends OverrideClassName<ButtonHTMLAttributes<HTMLButtonElement>> {
+  test?: boolean
+}
+
+export const NewButton: React.VFC<NewButtonProps> = ({
+  children
+}) => (
+  <button>{children}</button>
+)

--- a/packages/button/src/StyledButton/NewButton.tsx
+++ b/packages/button/src/StyledButton/NewButton.tsx
@@ -1,11 +1,27 @@
 import React, { ButtonHTMLAttributes } from "react"
 import { OverrideClassName } from "@kaizen/component-base"
+import { StyledButton, StyledButtonProps } from "./StyledButton"
 
 export interface NewButtonProps
   extends OverrideClassName<ButtonHTMLAttributes<HTMLButtonElement>> {
-  test?: boolean
+  variant: StyledButtonProps["variant"]
+  isReversed?: StyledButtonProps["isReversed"]
+  isWorking?: StyledButtonProps["isWorking"]
 }
 
-export const NewButton: React.VFC<NewButtonProps> = ({ children }) => (
-  <button>{children}</button>
+export const NewButton: React.VFC<NewButtonProps> = ({
+  children,
+  variant,
+  isReversed = false,
+  isWorking = false,
+  ...buttonAttributes // maybe this is clearer than `restProps`?
+}) => (
+  <StyledButton
+    variant={variant}
+    isReversed={isReversed}
+    isWorking={isWorking}
+    isDisabled={buttonAttributes.disabled}
+  >
+    <button {...buttonAttributes}>{children}</button>
+  </StyledButton>
 )

--- a/packages/button/src/StyledButton/NewButton.tsx
+++ b/packages/button/src/StyledButton/NewButton.tsx
@@ -7,6 +7,8 @@ export interface NewButtonProps
   variant: StyledButtonProps["variant"]
   isReversed?: StyledButtonProps["isReversed"]
   isWorking?: StyledButtonProps["isWorking"]
+  icon?: StyledButtonProps["icon"]
+  iconPosition?: StyledButtonProps["iconPosition"]
 }
 
 export const NewButton: React.VFC<NewButtonProps> = ({
@@ -14,6 +16,9 @@ export const NewButton: React.VFC<NewButtonProps> = ({
   variant,
   isReversed = false,
   isWorking = false,
+  icon,
+  iconPosition,
+  classNameOverride,
   ...buttonAttributes // maybe this is clearer than `restProps`?
 }) => (
   <StyledButton
@@ -21,6 +26,9 @@ export const NewButton: React.VFC<NewButtonProps> = ({
     isReversed={isReversed}
     isWorking={isWorking}
     isDisabled={buttonAttributes.disabled}
+    icon={icon}
+    iconPosition={iconPosition}
+    classNameOverride={classNameOverride}
   >
     <button {...buttonAttributes}>{children}</button>
   </StyledButton>

--- a/packages/button/src/StyledButton/NewButton.tsx
+++ b/packages/button/src/StyledButton/NewButton.tsx
@@ -12,7 +12,7 @@ export interface NewButtonProps
 }
 
 export const NewButton: React.VFC<NewButtonProps> = ({
-  children,
+  children, // or maybe use `label` or similar instead if we want?
   variant,
   isReversed = false,
   isWorking = false,

--- a/packages/button/src/StyledButton/NewButton.tsx
+++ b/packages/button/src/StyledButton/NewButton.tsx
@@ -1,12 +1,11 @@
 import React, { ButtonHTMLAttributes } from "react"
 import { OverrideClassName } from "@kaizen/component-base"
 
-export interface NewButtonProps extends OverrideClassName<ButtonHTMLAttributes<HTMLButtonElement>> {
+export interface NewButtonProps
+  extends OverrideClassName<ButtonHTMLAttributes<HTMLButtonElement>> {
   test?: boolean
 }
 
-export const NewButton: React.VFC<NewButtonProps> = ({
-  children
-}) => (
+export const NewButton: React.VFC<NewButtonProps> = ({ children }) => (
   <button>{children}</button>
 )

--- a/packages/button/src/StyledButton/NewIconButton.tsx
+++ b/packages/button/src/StyledButton/NewIconButton.tsx
@@ -1,0 +1,41 @@
+import React, { ButtonHTMLAttributes } from "react"
+import { OverrideClassName } from "@kaizen/component-base"
+import { Icon, IconProps } from "@kaizen/component-library"
+import { StyledButton, StyledButtonProps } from "./StyledButton"
+import { StyledIconButton, StyledIconButtonProps } from "./StyledIconButton"
+
+interface NewIconButtonAttributes
+  extends OverrideClassName<
+    Omit<ButtonHTMLAttributes<HTMLButtonElement>, "children">
+  > {
+  "aria-label": string
+}
+
+export interface NewIconButtonProps extends NewIconButtonAttributes {
+  icon: IconProps["icon"]
+  variant: StyledIconButtonProps["variant"]
+  isReversed?: StyledIconButtonProps["isReversed"]
+  isWorking?: StyledIconButtonProps["isWorking"]
+}
+
+export const NewIconButton: React.VFC<NewIconButtonProps> = ({
+  icon,
+  variant,
+  isReversed = false,
+  isWorking = false,
+  classNameOverride,
+  ...buttonAttributes // maybe this is clearer than `restProps`?
+}) => (
+  <StyledIconButton
+    variant={variant}
+    isReversed={isReversed}
+    isWorking={isWorking}
+    isDisabled={buttonAttributes.disabled}
+    classNameOverride={classNameOverride}
+    element={
+      <button {...buttonAttributes}>
+        <Icon icon={icon} role="presentation" />
+      </button>
+    }
+  />
+)

--- a/packages/button/src/StyledButton/StyledButton.module.scss
+++ b/packages/button/src/StyledButton/StyledButton.module.scss
@@ -1,0 +1,95 @@
+@import "~@kaizen/design-tokens/sass/border";
+@import "~@kaizen/design-tokens/sass/color";
+@import "~@kaizen/design-tokens/sass/spacing";
+@import "~@kaizen/design-tokens/sass/typography";
+@import "mixins";
+@import "variables";
+
+.styledButton {
+  @include button-reset;
+
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+
+  display: inline-flex;
+  align-items: center;
+  width: fit-content;
+
+  text-align: left;
+
+  border-width: $border-solid-border-width;
+  border-style: $border-solid-border-style;
+  border-radius: 7px;
+
+  #{$selectors--button-active} {
+    transform: translateY(1px);
+  }
+
+  #{$selectors--button-focus} {
+    outline-width: $border-solid-border-width;
+    outline-style: $border-solid-border-style;
+    outline-color: $color-blue-500;
+    outline-offset: 1px;
+  }
+}
+
+%button-base--primary {
+  padding: calc(#{$spacing-sm} - #{$border-solid-border-width}) calc(#{$spacing-md} - #{$border-solid-border-width});
+  font-family: $typography-button-primary-font-family;
+  font-weight: $typography-button-primary-font-weight;
+  font-size: $typography-button-primary-font-size;
+  line-height: $typography-button-primary-line-height;
+  letter-spacing: $typography-button-primary-letter-spacing;
+}
+
+.default {
+  @extend %button-base--primary;
+  border-color: $color-gray-500;
+  background-color: $color-white;
+  color: $color-purple-800;
+
+  @include enabled-pseudo-states-variant(
+    $background-color: $color-gray-200, 
+    $border-color: $color-gray-600
+  );
+}
+
+.primary {
+  @extend %button-base--primary;
+  border-color: $border-borderless-border-color;
+  background-color: $color-blue-500;
+  color: $color-white;
+
+  @include enabled-pseudo-states-variant(
+    $background-color: $color-blue-600, 
+  );
+}
+
+%button-base--secondary {
+  padding: calc(#{$spacing-sm} - #{$border-solid-border-width});
+  font-family: $typography-button-secondary-font-family;
+  font-weight: $typography-button-secondary-font-weight;
+  font-size: $typography-button-secondary-font-size;
+  line-height: $typography-button-secondary-line-height;
+  letter-spacing: $typography-button-secondary-letter-spacing;
+  border-color: $border-borderless-border-color;
+  background-color: transparent;
+}
+
+.secondary {
+  @extend %button-base--secondary;
+  color: $color-blue-500;
+
+  @include enabled-pseudo-states-variant(
+    $background-color: $color-blue-100, 
+  );
+}
+
+.secondaryDestructive {
+  @extend %button-base--secondary;
+  color: $color-red-600;
+
+  @include enabled-pseudo-states-variant(
+    $background-color: $color-red-100, 
+  );
+}

--- a/packages/button/src/StyledButton/StyledButton.module.scss
+++ b/packages/button/src/StyledButton/StyledButton.module.scss
@@ -66,6 +66,20 @@
   left: calc(50% - 12px);
 }
 
+.buttonContents {
+  display: flex;
+  align-items: center; // I can't make this at the top, otherwise single-line is not centred
+  gap: 0.5rem; // We don't have a token for this :')
+}
+
+.iconPositionEnd {
+  flex-direction: row-reverse;
+}
+
+.iconContainer {
+  display: flex;
+}
+
 %button-base--primary {
   padding: calc(#{$spacing-sm} - #{$border-solid-border-width})
     calc(#{$spacing-md} - #{$border-solid-border-width});

--- a/packages/button/src/StyledButton/StyledButton.module.scss
+++ b/packages/button/src/StyledButton/StyledButton.module.scss
@@ -48,16 +48,21 @@
       border-color: $color-blue-500;
     }
   }
-
-  &:disabled {
-    pointer-events: none;
-    opacity: 0.3;
-  }
 }
 
 .isWorking {
   pointer-events: none;
   opacity: 0.3;
+}
+
+.hidden {
+  display: contents;
+  visibility: hidden;
+}
+
+.loadingSpinner {
+  position: absolute;
+  left: calc(50% - 12px);
 }
 
 %button-base--primary {

--- a/packages/button/src/StyledButton/StyledButton.module.scss
+++ b/packages/button/src/StyledButton/StyledButton.module.scss
@@ -56,7 +56,8 @@
 }
 
 %button-base--primary {
-  padding: calc(#{$spacing-sm} - #{$border-solid-border-width}) calc(#{$spacing-md} - #{$border-solid-border-width});
+  padding: calc(#{$spacing-sm} - #{$border-solid-border-width})
+    calc(#{$spacing-md} - #{$border-solid-border-width});
   font-family: $typography-button-primary-font-family;
   font-weight: $typography-button-primary-font-weight;
   font-size: $typography-button-primary-font-size;
@@ -71,9 +72,20 @@
   color: $color-purple-800;
 
   @include enabled-pseudo-states-variant(
-    $background-color: $color-gray-200, 
+    $background-color: $color-gray-200,
     $border-color: $color-gray-600
   );
+
+  &.isReversed {
+    background-color: transparent;
+    border-color: rgba($color-white-rgb, 0.65);
+    color: $color-white;
+
+    @include enabled-pseudo-states-variant(
+      rgba($color-white-rgb, 0.1),
+      $color-white
+    );
+  }
 }
 
 .primary {
@@ -82,9 +94,18 @@
   background-color: $color-blue-500;
   color: $color-white;
 
-  @include enabled-pseudo-states-variant(
-    $background-color: $color-blue-600, 
-  );
+  @include enabled-pseudo-states-variant($background-color: $color-blue-600);
+
+  &.isReversed {
+    border-color: $border-borderless-border-color;
+    background-color: $color-green-300;
+    color: $color-purple-800;
+
+    @include enabled-pseudo-states-variant(
+      $color-green-400,
+      $border-borderless-border-color
+    );
+  }
 }
 
 %button-base--secondary {
@@ -102,16 +123,22 @@
   @extend %button-base--secondary;
   color: $color-blue-500;
 
-  @include enabled-pseudo-states-variant(
-    $background-color: $color-blue-100, 
-  );
+  @include enabled-pseudo-states-variant($background-color: $color-blue-100);
+
+  &.isReversed {
+    border-color: $border-borderless-border-color;
+    color: $color-white;
+
+    @include enabled-pseudo-states-variant(
+      rgba($color-white-rgb, 0.2),
+      $border-borderless-border-color
+    );
+  }
 }
 
 .secondaryDestructive {
   @extend %button-base--secondary;
   color: $color-red-600;
 
-  @include enabled-pseudo-states-variant(
-    $background-color: $color-red-100, 
-  );
+  @include enabled-pseudo-states-variant($background-color: $color-red-100);
 }

--- a/packages/button/src/StyledButton/StyledButton.module.scss
+++ b/packages/button/src/StyledButton/StyledButton.module.scss
@@ -55,6 +55,11 @@
   }
 }
 
+.isWorking {
+  pointer-events: none;
+  opacity: 0.3;
+}
+
 %button-base--primary {
   padding: calc(#{$spacing-sm} - #{$border-solid-border-width})
     calc(#{$spacing-md} - #{$border-solid-border-width});

--- a/packages/button/src/StyledButton/StyledButton.module.scss
+++ b/packages/button/src/StyledButton/StyledButton.module.scss
@@ -50,7 +50,8 @@
   }
 }
 
-.isWorking {
+.isWorking,
+.isDisabled {
   pointer-events: none;
   opacity: 0.3;
 }

--- a/packages/button/src/StyledButton/StyledButton.module.scss
+++ b/packages/button/src/StyledButton/StyledButton.module.scss
@@ -11,6 +11,7 @@
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 
+  position: relative;
   display: inline-flex;
   align-items: center;
   width: fit-content;
@@ -19,17 +20,38 @@
 
   border-width: $border-solid-border-width;
   border-style: $border-solid-border-style;
-  border-radius: 7px;
+  border-radius: $border-solid-border-radius;
 
   #{$selectors--button-active} {
     transform: translateY(1px);
   }
 
+  &:focus,
+  &:focus-visible {
+    outline: none;
+  }
+
   #{$selectors--button-focus} {
-    outline-width: $border-solid-border-width;
-    outline-style: $border-solid-border-style;
-    outline-color: $color-blue-500;
-    outline-offset: 1px;
+    &::after {
+      $focus-ring-offset: calc(
+        -1 * calc((#{$border-solid-border-width} * 2) + 1px)
+      );
+      position: absolute;
+      content: "";
+      top: $focus-ring-offset;
+      bottom: $focus-ring-offset;
+      left: $focus-ring-offset;
+      right: $focus-ring-offset;
+      border-width: $border-focus-ring-border-width;
+      border-style: $border-focus-ring-border-style;
+      border-radius: $border-focus-ring-border-radius;
+      border-color: $color-blue-500;
+    }
+  }
+
+  &:disabled {
+    pointer-events: none;
+    opacity: 0.3;
   }
 }
 

--- a/packages/button/src/StyledButton/StyledButton.module.scss
+++ b/packages/button/src/StyledButton/StyledButton.module.scss
@@ -67,8 +67,8 @@
 }
 
 .buttonContents {
+  position: relative;
   display: flex;
-  align-items: center; // I can't make this at the top, otherwise single-line is not centred
   gap: 0.5rem; // We don't have a token for this :')
 }
 
@@ -77,7 +77,9 @@
 }
 
 .iconContainer {
-  display: flex;
+  position: relative;
+  top: 2px;
+  margin-bottom: -2px;
 }
 
 %button-base--primary {

--- a/packages/button/src/StyledButton/StyledButton.tsx
+++ b/packages/button/src/StyledButton/StyledButton.tsx
@@ -5,16 +5,20 @@ import styles from "./StyledButton.module.scss"
 
 interface BaseStyledButtonProps extends OverrideClassName<unknown> {
   variant: "default" | "primary" | "secondary" | "secondaryDestructive"
+  isReversed?: boolean
 }
 
 export const getStyledButtonClassNames = ({
   variant,
+  isReversed,
   classNameOverride,
-}: BaseStyledButtonProps) => classnames(
-  styles.styledButton,
-  styles[variant],
-  classNameOverride,
-)
+}: BaseStyledButtonProps) =>
+  classnames(
+    styles.styledButton,
+    styles[variant],
+    isReversed && styles.isReversed,
+    classNameOverride
+  )
 
 // V1: Using children
 export interface StyledButtonProps extends BaseStyledButtonProps {
@@ -26,7 +30,7 @@ export const StyledButton: React.VFC<StyledButtonProps> = ({
   ...restProps
 }) => {
   const className = getStyledButtonClassNames({
-    ...restProps
+    ...restProps,
   })
 
   return React.Children.only(
@@ -36,7 +40,7 @@ export const StyledButton: React.VFC<StyledButtonProps> = ({
         className,
         children.props.className,
         children.props.classNameOverride
-      )
+      ),
     })
   )
 }
@@ -51,7 +55,7 @@ export const StyledButton2: React.VFC<StyledButtonProps2> = ({
   ...restProps
 }) => {
   const className = getStyledButtonClassNames({
-    ...restProps
+    ...restProps,
   })
 
   return React.cloneElement(element, {
@@ -60,6 +64,6 @@ export const StyledButton2: React.VFC<StyledButtonProps2> = ({
       className,
       element.props.className,
       element.props.classNameOverride
-    )
+    ),
   })
 }

--- a/packages/button/src/StyledButton/StyledButton.tsx
+++ b/packages/button/src/StyledButton/StyledButton.tsx
@@ -1,12 +1,26 @@
 import React from "react"
 import classnames from "classnames"
 import { OverrideClassName } from "@kaizen/component-base"
+import { LoadingSpinner } from "@kaizen/loading-spinner"
 import styles from "./StyledButton.module.scss"
 
+const WorkingContents = ({ contents }: { contents: React.ReactNode }) => (
+  <>
+    <div className={styles.hidden} aria-hidden="true">
+      {contents}
+    </div>
+    <LoadingSpinner
+      accessibilityLabel=""
+      size="sm"
+      classNameOverride={styles.loadingSpinner}
+    />
+  </>
+)
 interface BaseStyledButtonProps extends OverrideClassName<unknown> {
   variant: "default" | "primary" | "secondary" | "secondaryDestructive"
   isReversed?: boolean
   isWorking?: boolean
+  contentsPropName?: string
 }
 
 export const getStyledButtonClassNames = ({
@@ -30,15 +44,23 @@ export interface StyledButtonProps extends BaseStyledButtonProps {
 
 export const StyledButton: React.VFC<StyledButtonProps> = ({
   children,
+  isWorking,
+  contentsPropName = "children",
   ...restProps
 }) => {
   const className = getStyledButtonClassNames({
+    isWorking,
     ...restProps,
   })
 
   return React.Children.only(
     React.cloneElement(children, {
       ...children.props,
+      [contentsPropName]: isWorking ? (
+        <WorkingContents contents={children.props[contentsPropName]} />
+      ) : (
+        children.props[contentsPropName]
+      ),
       className: classnames(
         className,
         children.props.className,
@@ -55,14 +77,22 @@ export interface StyledButtonProps2 extends BaseStyledButtonProps {
 
 export const StyledButton2: React.VFC<StyledButtonProps2> = ({
   element,
+  isWorking,
+  contentsPropName = "children",
   ...restProps
 }) => {
   const className = getStyledButtonClassNames({
+    isWorking,
     ...restProps,
   })
 
   return React.cloneElement(element, {
     ...element.props,
+    [contentsPropName]: isWorking ? (
+      <WorkingContents contents={element.props[contentsPropName]} />
+    ) : (
+      element.props[contentsPropName]
+    ),
     className: classnames(
       className,
       element.props.className,

--- a/packages/button/src/StyledButton/StyledButton.tsx
+++ b/packages/button/src/StyledButton/StyledButton.tsx
@@ -21,12 +21,14 @@ interface BaseStyledButtonProps extends OverrideClassName<unknown> {
   isReversed?: boolean
   isWorking?: boolean
   contentsPropName?: string
+  isDisabled?: boolean
 }
 
 export const getStyledButtonClassNames = ({
   variant,
   isReversed,
   isWorking,
+  isDisabled,
   classNameOverride,
 }: BaseStyledButtonProps) =>
   classnames(
@@ -34,6 +36,7 @@ export const getStyledButtonClassNames = ({
     styles[variant],
     isReversed && styles.isReversed,
     isWorking && styles.isWorking,
+    isDisabled && styles.isDisabled,
     classNameOverride
   )
 

--- a/packages/button/src/StyledButton/StyledButton.tsx
+++ b/packages/button/src/StyledButton/StyledButton.tsx
@@ -6,17 +6,20 @@ import styles from "./StyledButton.module.scss"
 interface BaseStyledButtonProps extends OverrideClassName<unknown> {
   variant: "default" | "primary" | "secondary" | "secondaryDestructive"
   isReversed?: boolean
+  isWorking?: boolean
 }
 
 export const getStyledButtonClassNames = ({
   variant,
   isReversed,
+  isWorking,
   classNameOverride,
 }: BaseStyledButtonProps) =>
   classnames(
     styles.styledButton,
     styles[variant],
     isReversed && styles.isReversed,
+    isWorking && styles.isWorking,
     classNameOverride
   )
 

--- a/packages/button/src/StyledButton/StyledButton.tsx
+++ b/packages/button/src/StyledButton/StyledButton.tsx
@@ -1,0 +1,11 @@
+import React from "react"
+
+export interface StyledButtonProps {
+  children: React.ReactNode
+}
+
+export const StyledButton: React.VFC<StyledButtonProps> = ({ children }) => {
+  {React.Children.only(children, () => {
+
+  })}
+}

--- a/packages/button/src/StyledButton/StyledButton.tsx
+++ b/packages/button/src/StyledButton/StyledButton.tsx
@@ -5,7 +5,7 @@ import { Icon } from "@kaizen/component-library"
 import { LoadingSpinner } from "@kaizen/loading-spinner"
 import styles from "./StyledButton.module.scss"
 
-const WorkingContents = ({ contents }: { contents: React.ReactNode }) => (
+const WorkingContents = ({ contents }: { contents: React.ReactNode }): JSX.Element => (
   <>
     <span className={styles.hidden} aria-hidden="true">
       {contents}
@@ -65,7 +65,7 @@ export const getStyledButtonClassNames = ({
   isWorking,
   isDisabled,
   classNameOverride,
-}: BaseStyledButtonProps) =>
+}: BaseStyledButtonProps): string =>
   classnames(
     styles.styledButton,
     styles[variant],

--- a/packages/button/src/StyledButton/StyledButton.tsx
+++ b/packages/button/src/StyledButton/StyledButton.tsx
@@ -1,11 +1,65 @@
 import React from "react"
+import classnames from "classnames"
+import { OverrideClassName } from "@kaizen/component-base"
+import styles from "./StyledButton.module.scss"
 
-export interface StyledButtonProps {
-  children: React.ReactNode
+interface BaseStyledButtonProps extends OverrideClassName<unknown> {
+  variant: "default" | "primary" | "secondary" | "secondaryDestructive"
 }
 
-export const StyledButton: React.VFC<StyledButtonProps> = ({ children }) => {
-  {React.Children.only(children, () => {
+export const getStyledButtonClassNames = ({
+  variant,
+  classNameOverride,
+}: BaseStyledButtonProps) => classnames(
+  styles.styledButton,
+  styles[variant],
+  classNameOverride,
+)
 
-  })}
+// V1: Using children
+export interface StyledButtonProps extends BaseStyledButtonProps {
+  children: React.ReactElement
+}
+
+export const StyledButton: React.VFC<StyledButtonProps> = ({
+  children,
+  ...restProps
+}) => {
+  const className = getStyledButtonClassNames({
+    ...restProps
+  })
+
+  return React.Children.only(
+    React.cloneElement(children, {
+      ...children.props,
+      className: classnames(
+        className,
+        children.props.className,
+        children.props.classNameOverride
+      )
+    })
+  )
+}
+
+// V2: Using prop
+export interface StyledButtonProps2 extends BaseStyledButtonProps {
+  element: React.ReactElement
+}
+
+export const StyledButton2: React.VFC<StyledButtonProps2> = ({
+  element,
+  ...restProps
+}) => {
+  const className = getStyledButtonClassNames({
+    ...restProps
+  })
+
+  return React.cloneElement(element, {
+    ...element.props,
+    className: classnames(
+      className,
+      element.props.className,
+      element.props.classNameOverride
+    )
+  })
 }

--- a/packages/button/src/StyledButton/StyledButton.tsx
+++ b/packages/button/src/StyledButton/StyledButton.tsx
@@ -6,9 +6,9 @@ import styles from "./StyledButton.module.scss"
 
 const WorkingContents = ({ contents }: { contents: React.ReactNode }) => (
   <>
-    <div className={styles.hidden} aria-hidden="true">
+    <span className={styles.hidden} aria-hidden="true">
       {contents}
-    </div>
+    </span>
     <LoadingSpinner
       accessibilityLabel=""
       size="sm"

--- a/packages/button/src/StyledButton/StyledButton.tsx
+++ b/packages/button/src/StyledButton/StyledButton.tsx
@@ -5,7 +5,11 @@ import { Icon } from "@kaizen/component-library"
 import { LoadingSpinner } from "@kaizen/loading-spinner"
 import styles from "./StyledButton.module.scss"
 
-const WorkingContents = ({ contents }: { contents: React.ReactNode }): JSX.Element => (
+const WorkingContents = ({
+  contents,
+}: {
+  contents: React.ReactNode
+}): JSX.Element => (
   <>
     <span className={styles.hidden} aria-hidden="true">
       {contents}
@@ -127,6 +131,8 @@ export const StyledButton2: React.VFC<StyledButtonProps2> = ({
   element,
   isWorking,
   contentsPropName = "children",
+  icon,
+  iconPosition = "start",
   ...restProps
 }) => {
   const className = getStyledButtonClassNames({
@@ -134,12 +140,20 @@ export const StyledButton2: React.VFC<StyledButtonProps2> = ({
     ...restProps,
   })
 
+  const buttonContents = (
+    <ButtonContents
+      contents={element.props[contentsPropName]}
+      icon={icon}
+      iconPosition={iconPosition}
+    />
+  )
+
   return React.cloneElement(element, {
     ...element.props,
     [contentsPropName]: isWorking ? (
       <WorkingContents contents={element.props[contentsPropName]} />
     ) : (
-      element.props[contentsPropName]
+      buttonContents
     ),
     className: classnames(
       className,

--- a/packages/button/src/StyledButton/StyledButton.tsx
+++ b/packages/button/src/StyledButton/StyledButton.tsx
@@ -1,6 +1,7 @@
 import React from "react"
 import classnames from "classnames"
 import { OverrideClassName } from "@kaizen/component-base"
+import { Icon } from "@kaizen/component-library"
 import { LoadingSpinner } from "@kaizen/loading-spinner"
 import styles from "./StyledButton.module.scss"
 
@@ -16,7 +17,41 @@ const WorkingContents = ({ contents }: { contents: React.ReactNode }) => (
     />
   </>
 )
-interface BaseStyledButtonProps extends OverrideClassName<unknown> {
+
+interface ButtonIconProps {
+  icon?: React.SVGAttributes<SVGSymbolElement>
+  iconPosition?: "start" | "end"
+}
+
+interface ButtonContentsProps extends ButtonIconProps {
+  contents: React.ReactNode
+}
+
+const ButtonContents: React.VFC<ButtonContentsProps> = ({
+  contents,
+  icon,
+  iconPosition = "start",
+}) => {
+  if (!icon) return <>{contents}</>
+
+  return (
+    <span
+      className={classnames(
+        styles.buttonContents,
+        iconPosition === "end" && styles.iconPositionEnd
+      )}
+    >
+      <span className={styles.iconContainer}>
+        <Icon icon={icon} role="presentation" />
+      </span>
+      <span>{contents}</span>
+    </span>
+  )
+}
+
+interface BaseStyledButtonProps
+  extends ButtonIconProps,
+    OverrideClassName<unknown> {
   variant: "default" | "primary" | "secondary" | "secondaryDestructive"
   isReversed?: boolean
   isWorking?: boolean
@@ -49,6 +84,8 @@ export const StyledButton: React.VFC<StyledButtonProps> = ({
   children,
   isWorking,
   contentsPropName = "children",
+  icon,
+  iconPosition = "start",
   ...restProps
 }) => {
   const className = getStyledButtonClassNames({
@@ -56,13 +93,21 @@ export const StyledButton: React.VFC<StyledButtonProps> = ({
     ...restProps,
   })
 
+  const buttonContents = (
+    <ButtonContents
+      contents={children.props[contentsPropName]}
+      icon={icon}
+      iconPosition={iconPosition}
+    />
+  )
+
   return React.Children.only(
     React.cloneElement(children, {
       ...children.props,
       [contentsPropName]: isWorking ? (
-        <WorkingContents contents={children.props[contentsPropName]} />
+        <WorkingContents contents={buttonContents} />
       ) : (
-        children.props[contentsPropName]
+        buttonContents
       ),
       className: classnames(
         className,

--- a/packages/button/src/StyledButton/StyledIconButton.module.scss
+++ b/packages/button/src/StyledButton/StyledIconButton.module.scss
@@ -1,0 +1,12 @@
+$button-height: 48px;
+
+.styledIconButton {
+  height: $button-height;
+  width: $button-height;
+  justify-content: center;
+  padding: unset;
+}
+
+.default {
+  border-color: transparent;
+}

--- a/packages/button/src/StyledButton/StyledIconButton.module.scss
+++ b/packages/button/src/StyledButton/StyledIconButton.module.scss
@@ -6,11 +6,14 @@ $button-size: 48px;
   height: $button-size;
   width: $button-size;
   justify-content: center;
-  padding: unset;
+  padding: 0;
 }
 
 .default {
-  border-color: transparent;
+  &,
+  &.isReversed {
+    border-color: transparent;
 
-  @include enabled-pseudo-states-variant($border-color: transparent);
+    @include enabled-pseudo-states-variant($border-color: transparent);
+  }
 }

--- a/packages/button/src/StyledButton/StyledIconButton.module.scss
+++ b/packages/button/src/StyledButton/StyledIconButton.module.scss
@@ -1,12 +1,16 @@
-$button-height: 48px;
+@import "./mixins";
+
+$button-size: 48px;
 
 .styledIconButton {
-  height: $button-height;
-  width: $button-height;
+  height: $button-size;
+  width: $button-size;
   justify-content: center;
   padding: unset;
 }
 
 .default {
   border-color: transparent;
+
+  @include enabled-pseudo-states-variant($border-color: transparent);
 }

--- a/packages/button/src/StyledButton/StyledIconButton.tsx
+++ b/packages/button/src/StyledButton/StyledIconButton.tsx
@@ -9,19 +9,19 @@ export const StyledIconButton: React.VFC<StyledIconButtonProps> = ({
   variant,
   classNameOverride,
   ...restProps
-}) =>
-
-   <StyledButton2
+}) => (
+  <StyledButton2
     variant={variant}
     classNameOverride={classnames(
       styles.styledIconButton,
       variant === "default" && styles.default,
-      classNameOverride,
+      classNameOverride
     )}
     {...restProps}
   />
+)
 
-  // return React.cloneElement(element, {
-  //   ...element.props,
-  //   className
-  // })
+// return React.cloneElement(element, {
+//   ...element.props,
+//   className
+// })

--- a/packages/button/src/StyledButton/StyledIconButton.tsx
+++ b/packages/button/src/StyledButton/StyledIconButton.tsx
@@ -1,0 +1,27 @@
+import React from "react"
+import classnames from "classnames"
+import { StyledButton2, StyledButtonProps2 } from "./StyledButton"
+import styles from "./StyledIconButton.module.scss"
+
+export type StyledIconButtonProps = StyledButtonProps2
+
+export const StyledIconButton: React.VFC<StyledIconButtonProps> = ({
+  variant,
+  classNameOverride,
+  ...restProps
+}) =>
+
+   <StyledButton2
+    variant={variant}
+    classNameOverride={classnames(
+      styles.styledIconButton,
+      variant === "default" && styles.default,
+      classNameOverride,
+    )}
+    {...restProps}
+  />
+
+  // return React.cloneElement(element, {
+  //   ...element.props,
+  //   className
+  // })

--- a/packages/button/src/StyledButton/StyledIconButton.tsx
+++ b/packages/button/src/StyledButton/StyledIconButton.tsx
@@ -3,7 +3,10 @@ import classnames from "classnames"
 import { StyledButton2, StyledButtonProps2 } from "./StyledButton"
 import styles from "./StyledIconButton.module.scss"
 
-export type StyledIconButtonProps = StyledButtonProps2
+export type StyledIconButtonProps = Omit<
+  StyledButtonProps2,
+  "icon" | "iconPosition"
+>
 
 export const StyledIconButton: React.VFC<StyledIconButtonProps> = ({
   variant,

--- a/packages/button/src/StyledButton/StyledIconButton.tsx
+++ b/packages/button/src/StyledButton/StyledIconButton.tsx
@@ -20,7 +20,7 @@ export const StyledIconButton: React.VFC<StyledIconButtonProps> = ({
     classNameOverride={classnames(
       styles.styledIconButton,
       variant === "default" && styles.default,
-      (variant === "default" && isReversed) && styles.isReversed,
+      variant === "default" && isReversed && styles.isReversed,
       classNameOverride
     )}
     {...restProps}

--- a/packages/button/src/StyledButton/StyledIconButton.tsx
+++ b/packages/button/src/StyledButton/StyledIconButton.tsx
@@ -10,21 +10,19 @@ export type StyledIconButtonProps = Omit<
 
 export const StyledIconButton: React.VFC<StyledIconButtonProps> = ({
   variant,
+  isReversed,
   classNameOverride,
   ...restProps
 }) => (
   <StyledButton2
     variant={variant}
+    isReversed={isReversed}
     classNameOverride={classnames(
       styles.styledIconButton,
       variant === "default" && styles.default,
+      (variant === "default" && isReversed) && styles.isReversed,
       classNameOverride
     )}
     {...restProps}
   />
 )
-
-// return React.cloneElement(element, {
-//   ...element.props,
-//   className
-// })

--- a/packages/button/src/StyledButton/_mixins.scss
+++ b/packages/button/src/StyledButton/_mixins.scss
@@ -1,0 +1,29 @@
+@import "variables";
+
+// reset user agent styles for button element type
+@mixin button-reset {
+  appearance: none;
+  background: transparent;
+  border: none;
+  font: inherit;
+  margin: 0;
+  padding: 0;
+  transition: none; // override Murmur global styles :(
+}
+
+@mixin enabled-pseudo-states-variant(
+  $background-color: undefined,
+  $border-color: undefined
+) {
+  #{$selectors--button-hover},
+  #{$selectors--button-active},
+  #{$selectors--button-focus} {
+    @if ($background-color != undefined) {
+      background-color: $background-color;
+    }
+
+    @if ($border-color != undefined) {
+      border-color: $border-color;
+    }
+  }
+}

--- a/packages/button/src/StyledButton/_variables.scss
+++ b/packages/button/src/StyledButton/_variables.scss
@@ -1,0 +1,12 @@
+// Polyfill
+$polyfill--focus-visible: ":global(.js-focus-visible) &:global(.focus-visible)";
+
+// Classnames to simulate pseudo states in storybook
+$story-className--button-hover: ":global(.story__StyledButton--hover)";
+$story-className--button-active: ":global(.story__StyledButton--active)";
+$story-className--button-focus: ":global(.story__StyledButton--focus)";
+
+// Combined pseudo state classes
+$selectors--button-hover: "&:hover, &#{$story-className--button-hover}";
+$selectors--button-active: "&:active, &#{$story-className--button-active}";
+$selectors--button-focus: "&:focus-visible, #{$polyfill--focus-visible}, &#{$story-className--button-focus}";

--- a/packages/button/src/StyledButton/index.ts
+++ b/packages/button/src/StyledButton/index.ts
@@ -1,0 +1,2 @@
+export * from "./StyledButton"
+export * from "./NewButton"


### PR DESCRIPTION
## What

Solution preview POC for new Kaizen Button/Link components.

---

New abstraction method where the base is a Styled[Button/Link] component that adds styles to the child element.

More specific components supplied by Kaizen in this concept:
- Button (looks like a button, semantically a `button`)
- IconButton (looks like a button, semantically a `button`)
- Link (looks like a link, semantically an `a`)

All other variations (eg. looks like a button, semantically an `a`) would require the consumer to use `StyledButton` and supply the underlying element.

---

- StyledButton pattern would be the same for creating a StyledLink component
- Not all variants are added in this POC
- May be missing some a11y?
- Unsure if we need a Working state with the label showing or not (UI Kit does not show it, but there is code in the old one)
- Badge has not been added in this POC, but it should be rather straightforward to add

---

There are two proposals for abstraction in this POC:
1. Underlying element is supplied in `children`
2. Underlying element is supplied in an `element` prop