### PR TITLE
refactor(date-picker): remove Calendar disabled focus ring styles

### DIFF
--- a/packages/date-picker/docs/Calendars.stories.tsx
+++ b/packages/date-picker/docs/Calendars.stories.tsx
@@ -1,7 +1,7 @@
 import React from "react"
 import { Story } from "@storybook/react"
 import { within } from "@storybook/testing-library"
-import { StoryWrapper } from "../../../storybook/components/StoryWrapper"
+import { StickerSheet } from "../../../storybook/components/StickerSheet"
 import {
   CATEGORIES,
   SUB_CATEGORIES,
@@ -37,91 +37,102 @@ const CalendarSingleExample = (
   </div>
 )
 
-const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({
-  isReversed,
-}) => (
+const StickerSheetTemplate: Story = () => (
   <>
-    <StoryWrapper isReversed={isReversed}>
-      <StoryWrapper.RowHeader headings={["Hover", "Focus"]} gridColumns={3} />
-      <StoryWrapper.Row rowTitle="Default" gridColumns={3}>
-        <CalendarSingleExample id="default-hover" />
-        <CalendarSingleExample id="default-focus" />
-      </StoryWrapper.Row>
+    <StickerSheet heading="Calendars - Day">
+      <StickerSheet.Header headings={["Hover", "Focus", "Disabled"]} />
+      <StickerSheet.Body>
+        <StickerSheet.Row>
+          <CalendarSingleExample id="default-hover" />
+          <CalendarSingleExample id="default-focus" />
+          <CalendarSingleExample
+            disabled={[
+              new Date("2021-09-15"),
+              { after: new Date("2021-09-17") },
+            ]}
+            id="disabled-default"
+          />
+        </StickerSheet.Row>
+      </StickerSheet.Body>
+    </StickerSheet>
 
-      <StoryWrapper.RowHeader headings={["Default", "Focus"]} gridColumns={3} />
-      <StoryWrapper.Row rowTitle="Disabled" gridColumns={3}>
-        <CalendarSingleExample
-          disabled={[new Date("2021-09-15"), { after: new Date("2021-09-17") }]}
-          id="disabled-default"
-        />
-        <CalendarSingleExample
-          disabled={[new Date("2021-09-15"), { after: new Date("2021-09-17") }]}
-          id="disabled-focus"
-        />
-      </StoryWrapper.Row>
+    <StickerSheet heading="Calendars - Selected Day">
+      <StickerSheet.Header headings={["Default", "Hover", "Focus"]} />
+      <StickerSheet.Body>
+        <StickerSheet.Row>
+          <CalendarSingleExample
+            selected={new Date("2021-09-05")}
+            id="selected-default"
+          />
+          <CalendarSingleExample
+            selected={new Date("2021-09-05")}
+            id="selected-hover"
+          />
+          <CalendarSingleExample
+            selected={new Date("2021-09-05")}
+            id="selected-focus"
+          />
+        </StickerSheet.Row>
+      </StickerSheet.Body>
+    </StickerSheet>
 
-      <StoryWrapper.RowHeader headings={["Default", "Hover", "Focus"]} />
-      <StoryWrapper.Row rowTitle="Selected">
-        <CalendarSingleExample
-          selected={new Date("2021-09-05")}
-          id="selected-default"
-        />
-        <CalendarSingleExample
-          selected={new Date("2021-09-05")}
-          id="selected-hover"
-        />
-        <CalendarSingleExample
-          selected={new Date("2021-09-05")}
-          id="selected-focus"
-        />
-      </StoryWrapper.Row>
+    <StickerSheet heading="Calendars - Today">
+      <StickerSheet.Header headings={["Default", "Selected", "Disabled"]} />
+      <StickerSheet.Body>
+        <StickerSheet.Row>
+          <CalendarSingleExample
+            defaultMonth={new Date("2022-05-01")}
+            id="today-default"
+          />
+          <CalendarSingleExample
+            defaultMonth={new Date("2022-05-01")}
+            id="today-selected"
+            selected={new Date("2022-05-01")}
+          />
+          <CalendarSingleExample
+            defaultMonth={new Date("2022-05-01")}
+            id="today-disabled"
+            selected={new Date("2022-05-01")}
+            disabled={[new Date("2022-05-01")]}
+          />
+        </StickerSheet.Row>
+      </StickerSheet.Body>
+    </StickerSheet>
 
-      <StoryWrapper.RowHeader headings={["Default", "Selected", "Disabled"]} />
-      <StoryWrapper.Row rowTitle="Today">
-        <CalendarSingleExample
-          defaultMonth={new Date("2022-05-01")}
-          id="today-default"
-        />
-        <CalendarSingleExample
-          defaultMonth={new Date("2022-05-01")}
-          id="today-selected"
-          selected={new Date("2022-05-01")}
-        />
-        <CalendarSingleExample
-          defaultMonth={new Date("2022-05-01")}
-          id="today-disabled"
-          selected={new Date("2022-05-01")}
-          disabled={[new Date("2022-05-01")]}
-        />
-      </StoryWrapper.Row>
+    <StickerSheet heading="Calendars - Navigation Buttons">
+      <StickerSheet.Header headings={["Hover", "Focus"]} />
+      <StickerSheet.Body>
+        <StickerSheet.Row>
+          <CalendarSingleExample id="navigation-hover" />
+          <CalendarSingleExample id="navigation-focus" />
+        </StickerSheet.Row>
+      </StickerSheet.Body>
+    </StickerSheet>
 
-      <StoryWrapper.RowHeader headings={["Hover", "Focus"]} gridColumns={3} />
-      <StoryWrapper.Row rowTitle="Navigation Buttons" gridColumns={3}>
-        <CalendarSingleExample id="navigation-hover" />
-        <CalendarSingleExample id="navigation-focus" />
-      </StoryWrapper.Row>
+    <StickerSheet heading="Calendar Range">
+      <StickerSheet.Body>
+        <StickerSheet.Row rowTitle="Default">
+          <CalendarRange
+            selected={{
+              from: new Date("2022-02-19"),
+              to: new Date("2022-03-04"),
+            }}
+          />
+        </StickerSheet.Row>
 
-      <StoryWrapper.RowHeader headings={["Default"]} gridColumns={3} />
-      <StoryWrapper.Row rowTitle="Range" gridColumns={3}>
-        <CalendarRange
-          selected={{
-            from: new Date("2022-02-19"),
-            to: new Date("2022-03-04"),
-          }}
-        />
-      </StoryWrapper.Row>
-
-      <StoryWrapper.RowHeader headings={["Default"]} gridColumns={3} />
-      <StoryWrapper.Row rowTitle="Range with divider" gridColumns={3}>
-        <CalendarRange
-          selected={{
-            from: new Date("2022-02-19"),
-            to: new Date("2022-03-04"),
-          }}
-          hasDivider
-        />
-      </StoryWrapper.Row>
-    </StoryWrapper>
+        <StickerSheet.Row rowTitle="With divider">
+          <div style={{ padding: "1.5rem 0" }}>
+            <CalendarRange
+              selected={{
+                from: new Date("2022-02-19"),
+                to: new Date("2022-03-04"),
+              }}
+              hasDivider
+            />
+          </div>
+        </StickerSheet.Row>
+      </StickerSheet.Body>
+    </StickerSheet>
   </>
 )
 
@@ -164,9 +175,4 @@ StickerSheetDefault.play = ({ canvasElement }): void => {
       "focus-visible"
     )
   })
-
-  getElementWithinCalendar(
-    "disabled-focus",
-    "15th September (Wednesday)"
-  ).classList.add("focus-visible")
 }

--- a/packages/date-picker/src/_subcomponents/Calendar/Calendar.module.scss
+++ b/packages/date-picker/src/_subcomponents/Calendar/Calendar.module.scss
@@ -45,6 +45,11 @@ $selectors--button-focus: "&:focus-visible, #{$polyfill--focus-visible}";
   }
 }
 
+// UX has been updated such that disabled days do not receive focus,
+// and keyboard navigation only lands on available days.
+// If this changes at some point again, these styles are available for use.
+// https://github.com/gpbl/react-day-picker/pull/1519
+// https://github.com/gpbl/react-day-picker/issues/1449#issuecomment-1149942033
 %focus-ring--disabled {
   @extend %focus-ring;
 
@@ -197,6 +202,8 @@ $selectors--button-focus: "&:focus-visible, #{$polyfill--focus-visible}";
 }
 
 .dayDisabled {
+  // Library currently prevents you from ever seeing these styles.
+  // See comment for this silent class for more details.
   @extend %focus-ring--disabled;
 
   background: none;

--- a/packages/date-picker/src/_subcomponents/Calendar/Calendar.module.scss
+++ b/packages/date-picker/src/_subcomponents/Calendar/Calendar.module.scss
@@ -45,22 +45,6 @@ $selectors--button-focus: "&:focus-visible, #{$polyfill--focus-visible}";
   }
 }
 
-// UX has been updated such that disabled days do not receive focus,
-// and keyboard navigation only lands on available days.
-// If this changes at some point again, these styles are available for use.
-// https://github.com/gpbl/react-day-picker/pull/1519
-// https://github.com/gpbl/react-day-picker/issues/1449#issuecomment-1149942033
-%focus-ring--disabled {
-  @extend %focus-ring;
-
-  #{$selectors--button-focus} {
-    &::after {
-      border: $border-focus-ring-border-width $border-dashed-border-style
-        $color-gray-300;
-    }
-  }
-}
-
 .root {
   display: inline-flex;
 }
@@ -202,9 +186,10 @@ $selectors--button-focus: "&:focus-visible, #{$polyfill--focus-visible}";
 }
 
 .dayDisabled {
-  // Library currently prevents you from ever seeing these styles.
-  // See comment for this silent class for more details.
-  @extend %focus-ring--disabled;
+  // Focus ring styles have been removed as react-day-picker has been updated such that
+  // disabled days do not receive focus, and keyboard navigation only lands on available days.
+  // https://github.com/gpbl/react-day-picker/pull/1519
+  // https://github.com/gpbl/react-day-picker/issues/1449#issuecomment-1149942033
 
   background: none;
   pointer-events: none;


### PR DESCRIPTION
## What

Remove disabled focus ring stories for Calendars.
Remove Calendar disabled focus ring styles.

## Why

[KDS-1062](https://cultureamp.atlassian.net/jira/software/projects/KDS/boards/289?selectedIssue=KDS-1062)

An update in `react-day-picker` changed the UX for disabled days to not be focusable via the keyboard. This was a feature to make it easier for users to not be stuck on disabled days without knowing where the next available day is.
- https://github.com/gpbl/react-day-picker/pull/1519
- https://github.com/gpbl/react-day-picker/issues/1449#issuecomment-1149942033

~~Keeping the styles around in the case the UX decision is reverted.~~

[KDS-1062]: https://cultureamp.atlassian.net/browse/KDS-1062?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ