### PR TITLE
feat(date-picker): allow custom description for FilterDRP

### DIFF
--- a/packages/date-picker/docs/FilterDateRangePicker.stories.tsx
+++ b/packages/date-picker/docs/FilterDateRangePicker.stories.tsx
@@ -167,6 +167,7 @@ const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({
               locale="en-AU"
               selectedRange={rangeOpen}
               onRangeChange={setRangeOpen}
+              description="This is a custom description"
             />
           </div>
         </StoryWrapper.Row>

--- a/packages/date-picker/src/FilterDateRangePicker/FilterDateRangePicker.tsx
+++ b/packages/date-picker/src/FilterDateRangePicker/FilterDateRangePicker.tsx
@@ -54,6 +54,10 @@ export interface FilterDateRangePickerProps
   onRemoveFilter?: () => void
   inputRangeStartProps?: FilterInputProps<InputRangeStartProps>
   inputRangeEndProps?: FilterInputProps<InputRangeEndProps>
+  /**
+   * Custom description to provide extra context (input format help text remains).
+   */
+  description?: DateRangeInputFieldProps["description"]
 }
 
 export const FilterDateRangePicker = ({
@@ -72,6 +76,7 @@ export const FilterDateRangePicker = ({
   onRemoveFilter,
   inputRangeStartProps,
   inputRangeEndProps,
+  description,
   classNameOverride,
   ...restProps
 }: FilterDateRangePickerProps): JSX.Element => {
@@ -190,6 +195,7 @@ export const FilterDateRangePicker = ({
                 ...inputRangeEndHandlers,
               }}
               locale={locale}
+              description={description}
             />
             <CalendarRange
               defaultMonth={defaultMonth}


### PR DESCRIPTION
## What

Expose `description` prop for FilterDRP.

## Why

[KDS-1100](https://cultureamp.atlassian.net/jira/software/projects/KDS/boards/289?selectedIssue=KDS-1100)

Allow consumers to add a custom description.

[KDS-1100]: https://cultureamp.atlassian.net/browse/KDS-1100?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ