### PR TITLE
fix(deps): ignore stylelint upgrade

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -11,6 +11,8 @@
     "react-dom-17",
     "@testing-library/react-12",
     "react-test-renderer-17",
+    // Codemods only work for stylelint v13
+    "stylelint"
   ],
   "packageRules": [
     {


### PR DESCRIPTION
## Why
Test fail for `stylelint-plugin` when upgrading stylelint to v14, https://github.com/cultureamp/kaizen-design-system/pull/3204

Seems our codemods aren't suited for v14

## What
Lock our stylelint version to v13
