### PR TITLE
chore(deps): ignore postcss version which breaks types

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -13,6 +13,8 @@
     "react-test-renderer-17",
     // Codemods only work for stylelint v13
     "stylelint"
+    // the 8.4.19 -> 8.4.21 patch causes typescript issues
+    "postcss"
   ],
   "packageRules": [
     {


### PR DESCRIPTION
## Why
The postcss 8.4.19 -> 8.4.21 patch causes typescript issues with the stylelint-plugin. Instead of ignoring the types, I've chosen to freeze the version as it wouldn't make sense to have the plugin incompatible with it's own dependencies.


## What
Have Renovate ignore this dependency until we revisit stylelint-plugin's architecture