### PR TITLE
fix(date-picker): fix function wiring to onRemove

### DIFF
--- a/packages/date-picker/src/FilterDateRangePicker/FilterDateRangePicker.tsx
+++ b/packages/date-picker/src/FilterDateRangePicker/FilterDateRangePicker.tsx
@@ -163,7 +163,7 @@ export const FilterDateRangePicker = ({
           ref={removableButtonRefs}
           triggerButtonProps={triggerButtonProps}
           removeButtonProps={{
-            onClick: () => undefined,
+            onClick: onRemoveFilter,
           }}
         />
       ) : (


### PR DESCRIPTION
Component filterdaterangepicker `onRemove` prop function is not getting triggered as the internal wiring for the function is not in place

## Why
[Fix onRemove bug](https://cultureamp.slack.com/archives/C0189KBPM4Y/p1674170621930549?thread_ts=1674105839.497259&cid=C0189KBPM4Y)


## What
Wire function correctly
