### PR TITLE
fix: update Slider story argTypes to allow text input

### DIFF
--- a/draft-packages/form/docs/Slider.stories.tsx
+++ b/draft-packages/form/docs/Slider.stories.tsx
@@ -14,6 +14,14 @@ export default {
       },
     },
   },
+  argTypes: {
+    readOnlyMessage: {
+      control: "text",
+    },
+    description: {
+      control: "text",
+    },
+  },
 } as ComponentMeta<typeof Slider>
 
 export const DefaultKaizenSiteDemo: ComponentStory<typeof Slider> = args => (


### PR DESCRIPTION
## Why
Elliot raised this a while back but the input in the controls was break the component when attempting to input new text.


## What
- update story args type to allow for text input (in place of the ReactNode) to allow consumers to use the control input
