### PR TITLE
fix: update 1.25 padding prop to correct rem value

### DIFF
--- a/draft-packages/form/docs/Slider.stories.tsx
+++ b/draft-packages/form/docs/Slider.stories.tsx
@@ -14,6 +14,14 @@ export default {
       },
     },
   },
+  argTypes: {
+    readOnlyMessage: {
+      control: "text",
+    },
+    description: {
+      control: "text",
+    },
+  },
 } as ComponentMeta<typeof Slider>
 
 export const DefaultKaizenSiteDemo: ComponentStory<typeof Slider> = args => (

--- a/packages/component-library/components/Spacing/Base.module.scss
+++ b/packages/component-library/components/Spacing/Base.module.scss
@@ -1,19 +1,19 @@
 @import "~@kaizen/component-library/styles/fonts";
-@import "~@kaizen/deprecated-component-library-helpers/styles/type"; // just for the grid unit @TODO - update when we move to dart-sass
+@import "~@kaizen/design-tokens/sass/spacing";
 
 // this should always be parity with util.ts
 $spacing-list: (
   ("0", 0),
-  ("0-point-25", 0.25 * $ca-grid),
-  ("0-point-5", 0.5 * $ca-grid),
-  ("0-point-75", 0.75 * $ca-grid),
-  ("1", $ca-grid),
-  ("1-point-25", calc(1.25 * calc(#{$ca-grid}/ 4))),
-  ("1-point-5", 1.5 * $ca-grid),
-  ("1-point-75", 1.75 * $ca-grid),
-  ("2", $ca-grid * 2),
-  ("2-point-5", 2.5 * $ca-grid),
-  ("3", 3 * $ca-grid),
-  ("3-point-5", 3.5 * $ca-grid),
-  ("4", $ca-grid * 4)
+  ("0-point-25", calc(0.25 * #{$spacing-md})),
+  ("0-point-5", calc(0.5 * #{$spacing-md})),
+  ("0-point-75", calc(0.75 * #{$spacing-md})),
+  ("1", $spacing-md),
+  ("1-point-25", calc(1.25 * #{$spacing-md})),
+  ("1-point-5", calc(1.5 * #{$spacing-md})),
+  ("1-point-75", calc(1.75 * #{$spacing-md})),
+  ("2", calc(2 * #{$spacing-md})),
+  ("2-point-5", calc(2.5 * #{$spacing-md})),
+  ("3", calc(3 * #{$spacing-md})),
+  ("3-point-5", calc(3.5 * #{$spacing-md})),
+  ("4", calc(4 * #{$spacing-md}))
 );

--- a/packages/component-library/components/Spacing/util.ts
+++ b/packages/component-library/components/Spacing/util.ts
@@ -14,7 +14,7 @@ export const convertFractionToString = (fraction: GridFractions): string => {
     case 1:
       return "1"
     case 1.25:
-      return "0-point-25"
+      return "1-point-25"
     case 1.5:
       return "1-point-5"
     case 1.75:


### PR DESCRIPTION
## Why
The value output for the 1.25 prop for the box component has incorrectly been rendering this as the `"0-point-25"` rem value.


## What
- corrects the utili on ln18 to `"1-point-25"`
- remove dependence on the deprecated component lib helper for ca-grid
- cleans up and adds calc value on the sass calculations
