### PR TITLE
fix(date-picker): remove Calendar global class for dayToday

### DIFF
--- a/packages/date-picker/docs/Calendars.stories.tsx
+++ b/packages/date-picker/docs/Calendars.stories.tsx
@@ -12,6 +12,7 @@ import {
   CalendarSingle,
   CalendarSingleProps,
 } from "../src/_subcomponents/Calendar"
+import styles from "../src/_subcomponents/Calendar/Calendar.module.scss"
 
 export default {
   title: `${CATEGORIES.components}/${SUB_CATEGORIES.datePicker}/${SUB_COMPONENTS_FOLDER_NAME}/Calendars`,
@@ -150,7 +151,7 @@ const applyStickerSheetStyles = (canvasElement: HTMLElement): void => {
 
   todayCalendarIds.forEach(id => {
     getElementWithinCalendar(id, "1st May (Sunday)").classList.add(
-      "story__datepicker__calendar--day-today"
+      styles.dayToday
     )
   })
 

--- a/packages/date-picker/src/_subcomponents/Calendar/Calendar.module.scss
+++ b/packages/date-picker/src/_subcomponents/Calendar/Calendar.module.scss
@@ -172,7 +172,7 @@ $selectors--button-focus: "&:focus-visible, #{$polyfill--focus-visible}";
 }
 
 .dayToday,
-:global(.story__datepicker__calendar--day-today) {
+.dayToday:global(.story__datepicker__calendar--day-today) {
   color: $color-blue-500;
   font-weight: bold;
 }

--- a/packages/date-picker/src/_subcomponents/Calendar/Calendar.module.scss
+++ b/packages/date-picker/src/_subcomponents/Calendar/Calendar.module.scss
@@ -171,8 +171,7 @@ $selectors--button-focus: "&:focus-visible, #{$polyfill--focus-visible}";
   }
 }
 
-.dayToday,
-.dayToday:global(.story__datepicker__calendar--day-today) {
+.dayToday {
   color: $color-blue-500;
   font-weight: bold;
 }


### PR DESCRIPTION
## Why
bug: Global Selector not compilable by NextJS project
https://cultureamp.atlassian.net/browse/KDS-1160


## What
~~fix: Change Global selector to be "accepted" by NextJS projects~~
Delete the global class and find another way to make the story work