### PR TITLE
feat: add renderSectionTitle render prop

### DIFF
--- a/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/TitleBlockZen.spec.tsx
+++ b/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/TitleBlockZen.spec.tsx
@@ -1,7 +1,11 @@
 import React from "react"
 import { configure, fireEvent } from "@testing-library/dom"
 import { render, waitFor, screen } from "@testing-library/react"
-import { TitleBlockZen, CustomBreadcrumbProps } from "./index"
+import {
+  TitleBlockZen,
+  CustomBreadcrumbProps,
+  SectionTitleRenderProps,
+} from "./index"
 import "@testing-library/jest-dom"
 import "./matchMedia.mock"
 
@@ -527,6 +531,31 @@ describe("<TitleBlockZen />", () => {
       fireEvent.click(btn[0])
       expect(testOnClickFn).toHaveBeenCalled()
       spy.mockRestore()
+    })
+  })
+
+  describe("when a custom compent is provided for section title", () => {
+    it("renders a custom element in section title", async () => {
+      const expectedText = "This is a button"
+      const CustomComponent = (props: SectionTitleRenderProps): JSX.Element => (
+        <button>{props.sectionTitle}</button>
+      )
+      render(
+        <TitleBlockZen
+          title="Test title"
+          sectionTitle={expectedText}
+          renderSectionTitle={CustomComponent}
+        />
+      )
+      const el = await screen.findByRole("button")
+      expect(el.textContent).toBe(expectedText)
+    })
+
+    it("renders a heading when no render prop is provided", async () => {
+      const expectedText = "My expected text"
+      render(<TitleBlockZen title="Test title" sectionTitle={expectedText} />)
+      const el = await screen.findByRole("heading", { level: 2 })
+      expect(el.textContent).toBe(expectedText)
     })
   })
 

--- a/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/TitleBlockZen.tsx
+++ b/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/TitleBlockZen.tsx
@@ -557,7 +557,7 @@ const TitleBlockZen = ({
           [styles.adminVariant]: variant === "admin",
           [styles.collapseNavigationArea]:
             collapseNavigationArea &&
-            !(sectionTitle || sectionTitleDescription),
+            !(sectionTitle || sectionTitleDescription || renderSectionTitle),
           [styles.hasLongTitle]: title && title.length >= 30,
           [styles.hasLongSubtitle]:
             subtitle && typeof subtitle === "string" && subtitle.length >= 18,

--- a/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/TitleBlockZen.tsx
+++ b/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/TitleBlockZen.tsx
@@ -266,14 +266,14 @@ const renderSubtitle = (
 )
 
 const defaultRenderSectionTitle = (
-  sectionTitle?: React.ReactNode,
+  sectionTitle?: string,
   sectionTitleDescription?: string,
   variant?: Variant,
   sectionTitleAutomationId?: string,
   sectionTitleDescriptionAutomationId?: string
 ): JSX.Element => (
   <>
-    {sectionTitle && typeof sectionTitle === "string" && (
+    {sectionTitle && (
       <div className={styles.sectionTitle}>
         <Heading
           variant="heading-2"
@@ -284,9 +284,6 @@ const defaultRenderSectionTitle = (
           {sectionTitle}
         </Heading>
       </div>
-    )}
-    {sectionTitle && typeof sectionTitle !== "string" && (
-      <div className={styles.sectionTitle}>{sectionTitle}</div>
     )}
     {sectionTitleDescription && (
       <div

--- a/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/TitleBlockZen.tsx
+++ b/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/TitleBlockZen.tsx
@@ -38,6 +38,14 @@ type AvatarProps =
 
 export const NON_REVERSED_VARIANTS = ["education", "admin"]
 
+export type SectionTitleRenderProps = Pick<
+  TitleBlockProps,
+  | "sectionTitle"
+  | "sectionTitleAutomationId"
+  | "sectionTitleDescription"
+  | "sectionTitleDescriptionAutomationId"
+>
+
 /**
  * @param TitleBlockProps ### Accessing internal types of TitleBlockProps
  * If you want access to types like `PrimaryActionProps` (for example, in the scenario
@@ -57,6 +65,7 @@ export interface TitleBlockProps {
   subtitle?: React.ReactNode
   sectionTitle?: string
   sectionTitleDescription?: string
+  renderSectionTitle?: (renderProps: SectionTitleRenderProps) => React.ReactNode
   pageSwitcherSelect?: SelectProps
   handleHamburgerClick?: (event: React.MouseEvent) => void
   primaryAction?: PrimaryActionProps
@@ -256,39 +265,40 @@ const renderSubtitle = (
   </div>
 )
 
-const renderSectionTitle = (
-  sectionTitle?: string,
+const defaultRenderSectionTitle = (
+  sectionTitle?: React.ReactNode,
   sectionTitleDescription?: string,
   variant?: Variant,
   sectionTitleAutomationId?: string,
   sectionTitleDescriptionAutomationId?: string
 ): JSX.Element => (
-  <div className={styles.sectionTitleContainer}>
-    <div className={styles.sectionTitleInner}>
-      {sectionTitle && (
-        <div className={styles.sectionTitle}>
-          <Heading
-            variant="heading-2"
-            color={isReversed(variant) ? "white" : "dark"}
-            classNameOverride={styles.sectionTitleOverride}
-            data-automation-id={sectionTitleAutomationId}
-          >
-            {sectionTitle}
-          </Heading>
-        </div>
-      )}
-      {sectionTitleDescription && (
-        <div
-          data-automation-id={sectionTitleDescriptionAutomationId}
-          className={classNames(styles.sectionTitleDescription, {
-            [styles.dark]: !isReversed(variant),
-          })}
+  <>
+    {sectionTitle && typeof sectionTitle === "string" && (
+      <div className={styles.sectionTitle}>
+        <Heading
+          variant="heading-2"
+          color={isReversed(variant) ? "white" : "dark"}
+          classNameOverride={styles.sectionTitleOverride}
+          data-automation-id={sectionTitleAutomationId}
         >
-          {sectionTitleDescription}
-        </div>
-      )}
-    </div>
-  </div>
+          {sectionTitle}
+        </Heading>
+      </div>
+    )}
+    {sectionTitle && typeof sectionTitle !== "string" && (
+      <div className={styles.sectionTitle}>{sectionTitle}</div>
+    )}
+    {sectionTitleDescription && (
+      <div
+        data-automation-id={sectionTitleDescriptionAutomationId}
+        className={classNames(styles.sectionTitleDescription, {
+          [styles.dark]: !isReversed(variant),
+        })}
+      >
+        {sectionTitleDescription}
+      </div>
+    )}
+  </>
 )
 
 type BreadcrumbType = {
@@ -511,6 +521,7 @@ const TitleBlockZen = ({
   subtitle,
   sectionTitle,
   sectionTitleDescription,
+  renderSectionTitle,
   pageSwitcherSelect,
   handleHamburgerClick,
   primaryAction,
@@ -643,14 +654,28 @@ const TitleBlockZen = ({
         <div className={styles.rowBelowSeparator}>
           <div className={styles.rowBelowSeparatorInner}>
             <div className={styles.rowBelowSeparatorInnerContent}>
-              {(sectionTitle || sectionTitleDescription) &&
-                renderSectionTitle(
-                  sectionTitle,
-                  sectionTitleDescription,
-                  variant,
-                  sectionTitleAutomationId,
-                  sectionTitleDescriptionAutomationId
-                )}
+              {(sectionTitle ||
+                sectionTitleDescription ||
+                renderSectionTitle) && (
+                <div className={styles.sectionTitleContainer}>
+                  <div className={styles.sectionTitleInner}>
+                    {!!renderSectionTitle
+                      ? renderSectionTitle({
+                          sectionTitle,
+                          sectionTitleAutomationId,
+                          sectionTitleDescription,
+                          sectionTitleDescriptionAutomationId,
+                        })
+                      : defaultRenderSectionTitle(
+                          sectionTitle,
+                          sectionTitleDescription,
+                          variant,
+                          sectionTitleAutomationId,
+                          sectionTitleDescriptionAutomationId
+                        )}
+                  </div>
+                </div>
+              )}
               {renderNavigationTabs(navigationTabs, collapseNavigationArea)}
               {(secondaryActions || secondaryOverflowMenuItems) && (
                 <SecondaryActions

--- a/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/index.ts
+++ b/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/index.ts
@@ -1,6 +1,7 @@
 export {
   default as TitleBlockZen,
   CustomBreadcrumbProps,
+  SectionTitleRenderProps,
 } from "./TitleBlockZen"
 export { NavigationTab, NavigationTabProps } from "./TitleBlockZen"
 export { TitleBlockProps } from "./TitleBlockZen"

--- a/draft-packages/title-block-zen/docs/TitleBlockZen.stories.module.scss
+++ b/draft-packages/title-block-zen/docs/TitleBlockZen.stories.module.scss
@@ -1,3 +1,10 @@
 .contentContainer {
   background: #eee;
 }
+
+.flex-wrapper {
+  align-items: center;
+  display: flex;
+  flex-direction: row;
+  gap: 1rem;
+}

--- a/draft-packages/title-block-zen/docs/TitleBlockZen.stories.tsx
+++ b/draft-packages/title-block-zen/docs/TitleBlockZen.stories.tsx
@@ -8,11 +8,12 @@ import commentIcon from "@kaizen/component-library/icons/comment.icon.svg"
 import reportSharingIcon from "@kaizen/component-library/icons/report-sharing.icon.svg"
 import starIcon from "@kaizen/component-library/icons/star-on.icon.svg"
 import { Container, Content, Skirt, SkirtCard } from "@kaizen/draft-page-layout"
+import { Tag } from "@kaizen/draft-tag"
 import { assetUrl } from "@kaizen/hosted-assets"
 import { Heading, Paragraph } from "@kaizen/typography"
 import { CATEGORIES } from "../../../storybook/constants"
 import { figmaEmbed } from "../../../storybook/helpers"
-import { NavigationTab, TitleBlockZen } from ".."
+import { NavigationTab, SectionTitleRenderProps, TitleBlockZen } from ".."
 import styles from "./TitleBlockZen.stories.module.scss"
 
 const TESTING_VIEWPORTS = [320, 768, 1200]
@@ -1117,3 +1118,34 @@ export const RenderProps: Story = () => {
     </OffsetPadding>
   )
 }
+
+export const WithCustomSectionTitle: Story = () => {
+  const CustomComponent = (props: SectionTitleRenderProps): JSX.Element => (
+    <div className={styles["flex-wrapper"]}>
+      <Heading color="white" variant="heading-3">
+        {props.sectionTitle}
+      </Heading>
+      <Tag variant="statusAction">My custom element</Tag>
+    </div>
+  )
+  return (
+    <OffsetPadding>
+      <TitleBlockZen
+        title="Page title"
+        primaryAction={{
+          label: "Primary action",
+          onClick: () => alert("primary action clicked"),
+        }}
+        subtitle="Subtitle"
+        sectionTitle="Section title"
+        renderSectionTitle={CustomComponent}
+        breadcrumb={{
+          text: "Back",
+          handleClick: () => undefined,
+        }}
+      />
+    </OffsetPadding>
+  )
+}
+WithCustomSectionTitle.storyName = "With custom section title"
+WithCustomSectionTitle.parameters = { chromatic: { disable: false } }


### PR DESCRIPTION
to title block zen

## Why

Our team has a design to have a status Pill (Tag) in the section title area of the title block component.
See [discussion here](https://cultureamp.slack.com/archives/C0189KBPM4Y/p1669611247289339).


## What
This PR adds a render prop, that, if provided, renders the provided component in the space where the section title is normally rendered.  All relevant section title props are provided through the callback (`sectionTitle`, `sectionDescription`, and the `data-*` attributes).

## Screenshots
<img width="1491" alt="Screen Shot 2023-01-24 at 2 35 06 pm" src="https://user-images.githubusercontent.com/1703264/214207138-5de82d98-5e5d-4e1f-8d3c-853153126c4c.png">

## Thoughts
This implementation was a tougher decision than I thought.  Initially, I was just going to change the `sectionTitle` prop type from a `string` to `ReactNode`.  The issue I came across was, if the `{sectionTitle}` section is rendered in a heading, which has style and accessibility implications.  

If we split the render conditionally, for example just rendering`{sectionTitle}` if the prop is a function, and the normal heading if it's a string, then we ignore the other props related to `sectionTitle`, such as `sectionDescription`.

I'm happy to switch back to the `React.Node`, but the render prop seemed the simplest solution that:
- Did not just fix my particular problem, but would allow future designs without another PR
- Continued to use all the available props
- Is opt in, and backwards compatible
- Fixes my issue ;)

We can discuss more in the PR.
