### PR TITLE
feat: reset filter when open

### DIFF
--- a/packages/select/src/FilterMultiSelect/provider/SelectionProvider/SelectionProvider.spec.tsx
+++ b/packages/select/src/FilterMultiSelect/provider/SelectionProvider/SelectionProvider.spec.tsx
@@ -500,7 +500,7 @@ describe("<SelectionProviderWrapper /> - Search Filtering", () => {
       const searchString = "1"
       await userEvent.type(searchInput, searchString)
 
-      expect(onSearchInputChange).toBeCalledTimes(1)
+      expect(onSearchInputChange).toBeCalledTimes(2)
       expect(onSearchInputChange).toBeCalledWith(searchString)
     })
   })

--- a/packages/select/src/FilterMultiSelect/provider/SelectionProvider/SelectionProvider.tsx
+++ b/packages/select/src/FilterMultiSelect/provider/SelectionProvider/SelectionProvider.tsx
@@ -34,7 +34,6 @@ export const SelectionProvider = (
   props: SelectionProviderProps
 ): JSX.Element => {
   const { onSearchInputChange, ...otherProps } = props
-  const isFirstRender = React.useRef(true)
   const [searchQuery, setSearchQuery] = useState<string>("")
 
   /**
@@ -42,11 +41,8 @@ export const SelectionProvider = (
    * If the search input state becomes controlled, this useEffect could cause synchronisation
    * issues and should be replaced.
    */
+
   React.useEffect(() => {
-    if (isFirstRender.current) {
-      isFirstRender.current = false
-      return
-    }
     if (onSearchInputChange) {
       onSearchInputChange(searchQuery)
     }


### PR DESCRIPTION
## Why
<!-- Why have you created this PR? - Is it a new feature, or a bug fix? Or something else? -->
<!-- Reference any relevant Jira tickets so your reviewer can find more context if needed. -->
<!-- Fixing a GitHub issue? Add "Fixes [issue URL]". -->
- The filter remained within the options when open and closed but the SearchInput gets reset when unmounted.
https://cultureamp.atlassian.net/jira/software/projects/KDS/boards/289?selectedIssue=KDS-960

This JIra card number 2 on the list

## What
<!-- What do your changes do? How do they change/fix the current behavior? -->
<!-- Add screenshots, GIFs or videos to illustrate the changes.  -->
- Match the normal filterMultiSelect UX and reset the filter when opened/first rendered