### PR TITLE
feat: update max-height of filterSelect listbox

### DIFF
--- a/packages/select/src/FilterMultiSelect/components/ListBox/ListBox.module.scss
+++ b/packages/select/src/FilterMultiSelect/components/ListBox/ListBox.module.scss
@@ -5,7 +5,7 @@
   padding: $spacing-sm;
   margin: 0 $spacing-sm 0 0;
   display: grid;
-  max-height: 210px;
+  max-height: 22rem;
   overflow-y: auto;
 }
 


### PR DESCRIPTION
## Why
<!-- Why have you created this PR? - Is it a new feature, or a bug fix? Or something else? -->
<!-- Reference any relevant Jira tickets so your reviewer can find more context if needed. -->
<!-- Fixing a GitHub issue? Add "Fixes [issue URL]". -->
The listbox max-height had been updated when doing the Select rebuild

## What
<!-- What do your changes do? How do they change/fix the current behavior? -->
<!-- Add screenshots, GIFs or videos to illustrate the changes.  -->
Match the Select ListBox styles

NEW:
<img width="424" alt="image" src="https://user-images.githubusercontent.com/48232362/214472446-bc9776fd-f6e0-4f2e-8f7a-b7df2ea09ed3.png">

OLD:
<img width="428" alt="image" src="https://user-images.githubusercontent.com/48232362/214472474-366df440-2f48-4261-80a9-a0b86eaee228.png">
