### PR TITLE
feat: add isContentFullWidth boolean

### DIFF
--- a/draft-packages/modal/KaizenDraft/Modal/Presets/ConfirmationModal.module.scss
+++ b/draft-packages/modal/KaizenDraft/Modal/Presets/ConfirmationModal.module.scss
@@ -72,6 +72,14 @@ $dt-assertive-header-background: $color-orange-100;
         height: 86px;
       }
     }
+    &.contentFullWidth {
+      grid-template-columns: 0.9fr 2fr;
+      .spotIcon,
+      .svgIcon > svg {
+        width: 130px;
+        height: 130px;
+      }
+    }
   }
   .iconContainer {
     align-self: flex-start;
@@ -142,6 +150,11 @@ $dt-assertive-header-background: $color-orange-100;
   align-items: center;
   @media (max-width: $layout-breakpoints-medium) {
     grid-template-columns: 1fr;
+  }
+
+  &.contentFullWidthBody {
+    grid-template-columns: 1fr;
+    padding-top: $spacing-xl;
   }
 }
 

--- a/draft-packages/modal/KaizenDraft/Modal/Presets/ConfirmationModal.tsx
+++ b/draft-packages/modal/KaizenDraft/Modal/Presets/ConfirmationModal.tsx
@@ -24,6 +24,10 @@ import {
 import styles from "./ConfirmationModal.module.scss"
 
 export interface ConfirmationModalProps {
+  /**
+   * Gives the modal content full width if needed
+   */
+  readonly isContentFullWidth?: boolean
   readonly isOpen: boolean
   readonly unpadded?: boolean
   /**
@@ -87,6 +91,7 @@ const getIcon = (mood: Mood, isProminent: boolean): JSX.Element => {
  * {@link https://cultureamp.design/storybook/?path=/docs/components-modal--confirmation-modal-example Storybook}
  */
 const ConfirmationModal = ({
+  isContentFullWidth = false,
   isOpen,
   isProminent = false,
   unpadded = false,
@@ -140,6 +145,7 @@ const ConfirmationModal = ({
               [styles.negativeHeader]: mood === "negative",
               [styles.positiveHeader]: mood === "positive",
               [styles.assertiveHeader]: mood === "assertive",
+              [styles.contentFullWidth]: isContentFullWidth,
               [styles.prominent]: isProminent,
               [styles.padded]: !unpadded,
             })}
@@ -163,6 +169,7 @@ const ConfirmationModal = ({
         <ModalBody>
           <div
             className={classnames({
+              [styles.contentFullWidthBody]: isContentFullWidth,
               [styles.prominent]: isProminent,
               [styles.padded]: !unpadded,
             })}

--- a/draft-packages/modal/KaizenDraft/Modal/Presets/ConfirmationModal.tsx
+++ b/draft-packages/modal/KaizenDraft/Modal/Presets/ConfirmationModal.tsx
@@ -25,7 +25,7 @@ import styles from "./ConfirmationModal.module.scss"
 
 export interface ConfirmationModalProps {
   /**
-   * Gives the modal content full width if needed
+   * Gives the modal body full width
    */
   readonly isContentFullWidth?: boolean
   readonly isOpen: boolean


### PR DESCRIPTION
## Why
Given a modal has the isProminent boolean, 
then the Modal Body does not appear as full width. 

This new boolean allows content to be full width which is handy for Modal Body's with a lot of content. https://cultureamp.atlassian.net/browse/KDS-1156


## What
**An example without isContentFullWidth**
<img width="1283" alt="image" src="https://user-images.githubusercontent.com/115598563/214475400-bc62eda1-2fc9-43c7-8434-c4b5529ff4ff.png">


**An example with isContentFullWidth**
- Icon is slightly smaller (130px), 
- Content is full width, 
- Modal title is moved to the left
- Modal body top padding has been increased (xl)
<img width="537" alt="image" src="https://user-images.githubusercontent.com/115598563/214475256-9e156374-d3b8-4ee4-8928-ad2ab09a90f3.png">

