### PR TITLE
feat: add alignment prop to filter multi select

### DIFF
--- a/packages/select/src/FilterMultiSelect/components/MenuPopup/MenuPopup.module.scss
+++ b/packages/select/src/FilterMultiSelect/components/MenuPopup/MenuPopup.module.scss
@@ -25,3 +25,8 @@ $menu-container-max-height: 312px;
     text-align: right;
   }
 }
+
+.menuPopupRight {
+  @extend .menuPopup;
+  right: 0;
+}

--- a/packages/select/src/FilterMultiSelect/components/MenuPopup/MenuPopup.tsx
+++ b/packages/select/src/FilterMultiSelect/components/MenuPopup/MenuPopup.tsx
@@ -8,12 +8,14 @@ import styles from "./MenuPopup.module.scss"
 export interface MenuPopupProps {
   isLoading?: boolean
   loadingSkeleton?: React.ReactNode
+  alignPopup?: "left" | "right"
   children: React.ReactNode
 }
 
 export const MenuPopup = ({
   isLoading,
   loadingSkeleton,
+  alignPopup,
   children,
 }: MenuPopupProps): JSX.Element => {
   const { menuTriggerState, menuProps } = useMenuTriggerContext()
@@ -40,7 +42,9 @@ export const MenuPopup = ({
     <div
       {...mergeProps(overlayProps, menuProps)}
       ref={overlayRef}
-      className={styles.menuPopup}
+      className={
+        alignPopup === "right" ? styles.menuPopupRight : styles.menuPopup
+      }
     >
       {isLoading && loadingSkeleton ? (
         <>

--- a/packages/select/src/FilterMultiSelect/components/Root/Root.tsx
+++ b/packages/select/src/FilterMultiSelect/components/Root/Root.tsx
@@ -12,22 +12,17 @@ import {
   SelectionProvider,
   SelectionProviderContextType,
 } from "../../provider/SelectionProvider"
-import { MenuPopup } from "../MenuPopup/MenuPopup"
+import { MenuPopup, MenuPopupProps } from "../MenuPopup/MenuPopup"
 
 export interface RootProps
-  extends MenuPopupProps,
+  extends Omit<MenuPopupProps, "children">,
     MenuTriggerProps,
     SelectionProps {
-  trigger: (value?: MenuTriggerProviderContextType) => React.ReactNode
   children: (value?: SelectionProviderContextType) => React.ReactNode // the content of the menu
+  trigger: (value?: MenuTriggerProviderContextType) => React.ReactNode
 }
 
 type MenuTriggerProps = Omit<MenuTriggerProviderProps, "children">
-
-interface MenuPopupProps {
-  isLoading?: boolean
-  loadingSkeleton?: React.ReactNode
-}
 
 interface SelectionProps {
   label: string // provide A11y context for listbox
@@ -48,6 +43,7 @@ export const Root = ({
   onOpenChange,
   isLoading,
   loadingSkeleton,
+  alignPopup,
 
   label,
   items,
@@ -57,7 +53,7 @@ export const Root = ({
   onSearchInputChange,
 }: RootProps): JSX.Element => {
   const menuTriggerProps = { isOpen, defaultOpen, onOpenChange }
-  const menuPopupProps = { isLoading, loadingSkeleton }
+  const menuPopupProps = { isLoading, loadingSkeleton, alignPopup }
   const disabledKeys: Selection = new Set(
     items
       ?.filter(item => item.isDisabled === true)
@@ -75,7 +71,7 @@ export const Root = ({
 
   return (
     <MenuTriggerProvider {...menuTriggerProps}>
-      <div>
+      <div className="relative">
         <MenuTriggerConsumer>{trigger}</MenuTriggerConsumer>
         <MenuPopup {...menuPopupProps}>
           <SelectionProvider {...selectionProps}>


### PR DESCRIPTION
## Why
When the `<FilterMultiSelect />` is located on the right hand side of the window the `<MenuPopup />` overflows.

## What
A new prop `alignPopup: "left" | "right"` allows alignment for the popup, useful when the FilterMultiSelect component is on the right hand side of the screen to stop overflowing the window. 

### Left
![Screen Shot 2023-01-30 at 4 32 24 pm](https://user-images.githubusercontent.com/5242169/215395954-7d6e1b1d-07bd-438c-ae92-a4e85be50bcd.png)

### Right Before
![Screen Shot 2023-01-30 at 4 34 20 pm](https://user-images.githubusercontent.com/5242169/215395981-e307e973-5736-4004-9bf3-8933b9a9e8a4.png)

### Right After
![Screen Shot 2023-01-30 at 4 34 28 pm](https://user-images.githubusercontent.com/5242169/215396007-d645a04a-2836-41c4-99dc-3f745a7f8bdb.png)

