### PR TITLE
fix: add box-sizing:content-box to modal to prevent incorrect sizing in environments that use a border-box default

### DIFF
--- a/draft-packages/modal/KaizenDraft/Modal/Presets/ContextModal.module.scss
+++ b/draft-packages/modal/KaizenDraft/Modal/Presets/ContextModal.module.scss
@@ -42,6 +42,7 @@
 .portraitContentlayout {
   padding: $spacing-md;
   display: block;
+  box-sizing: content-box;
   @media (min-width: $layout-breakpoints-medium) {
     display: grid;
     max-width: 800px;


### PR DESCRIPTION
fix: add box-sizing:content-box to modal to prevent incorrect sizing in environments that use a border-box default

## Why
<!-- Why have you created this PR? - Is it a new feature, or a bug fix? Or something else? -->
<!-- Reference any relevant Jira tickets so your reviewer can find more context if needed. -->
<!-- Fixing a GitHub issue? Add "Fixes [issue URL]". -->
Murmur has a style rule of
`*, :before, :after { box-sizing: border-box; }` which breaks the modal's width calculations as it assumes a default of content-box.

## What
<!-- What do your changes do? How do they change/fix the current behavior? -->
<!-- Add screenshots, GIFs or videos to illustrate the changes.  -->
I've added a default of content-box to the element with the width calculations.
