### PR TITLE
feat: remove max-width in form groups

### DIFF
--- a/draft-packages/form/KaizenDraft/Form/CheckboxGroup/CheckboxGroup.module.scss
+++ b/draft-packages/form/KaizenDraft/Form/CheckboxGroup/CheckboxGroup.module.scss
@@ -10,8 +10,4 @@
   &.noBottomMargin {
     margin-bottom: 0;
   }
-
-  label {
-    width: 400px;
-  }
 }

--- a/draft-packages/form/KaizenDraft/Form/RadioGroup/RadioGroup.module.scss
+++ b/draft-packages/form/KaizenDraft/Form/RadioGroup/RadioGroup.module.scss
@@ -20,8 +20,4 @@
   &.noBottomMargin {
     margin-bottom: 0;
   }
-
-  label {
-    max-width: 400px;
-  }
 }


### PR DESCRIPTION
BREAKING CHANGE: Layouts that rely on a `max-width: 400px` checkbox or radio groups may be affected

## Why
The radio group has a css rule that all labels have a max-width of `400`.  Something like:

```
.radio-group {
  label {
    max-width: 400px;
  }
}
```

This number seems arbitrary and we have needed to add special css overrides in our app in order to have full width radio buttons.


## What
This change removes the max-width css rule.

### Before
<img width="841" alt="Screen Shot 2023-02-03 at 3 08 58 pm" src="https://user-images.githubusercontent.com/1703264/216510504-a6f93376-85b9-4bb7-84d0-ada4d859c5d5.png">

### After
<img width="831" alt="Screen Shot 2023-02-03 at 3 09 16 pm" src="https://user-images.githubusercontent.com/1703264/216510484-f6d23ecf-cdff-40c8-ab0e-ac061ce7f0d9.png">

## Notes
We don't have any issues with the checkbox group, but I noticed that has a `width: 400px` css rule for the label.  I'm happy to remove that as part of this PR.
