### PR TITLE
fix(filtermultiselect): trigger button tooltip consistency

### DIFF
--- a/packages/select/src/FilterMultiSelect/components/Trigger/RemovableFilterTrigger/RemovableFilterTrigger.tsx
+++ b/packages/select/src/FilterMultiSelect/components/Trigger/RemovableFilterTrigger/RemovableFilterTrigger.tsx
@@ -16,7 +16,7 @@ export const RemovableFilterTrigger = ({
   onRemove,
   ...filterTriggerProps
 }: RemovableFilterTriggerProps): JSX.Element => {
-  const removeButtonLabel = `Remove ${filterTriggerProps.label} filter`
+  const removeButtonLabel = `Remove filter - ${filterTriggerProps.label}`
   return (
     <div className={styles.trigger}>
       <FilterTriggerButton


### PR DESCRIPTION
## Why
Update component tooltip to match others filters tooltips as per:

https://github.com/cultureamp/kaizen-design-system/blob/main/packages/date-picker/src/FilterDateRangePicker/components/Trigger/RemovableFilterTriggerButton/RemovableFilterTriggerButton.tsx#L38

Ticket: https://cultureamp.atlassian.net/browse/KZN-962

## What
Update tooltip interpolation
