### PR TITLE
feat(tailwind): Add spacing token for 6px/.375 rem

### DIFF
--- a/packages/tailwind/src/kz-spacing.ts
+++ b/packages/tailwind/src/kz-spacing.ts
@@ -5,6 +5,7 @@ export const kzSpacing = {
   1: ".0625rem",
   2: ".125rem",
   4: ".25rem",
+  6: ".375rem",
   8: ".5rem",
   12: ".75rem",
   16: "1rem",


### PR DESCRIPTION
## Why
6px is a spacing value that comes up a lot in designs.


## What
Adds a 6px spacing token to the Tailwind package.

