### PR TITLE
fix: increase timeout for filter DRP long test

### DIFF
--- a/packages/date-picker/src/FilterDateRangePicker/FilterDateRangePicker.spec.tsx
+++ b/packages/date-picker/src/FilterDateRangePicker/FilterDateRangePicker.spec.tsx
@@ -293,7 +293,7 @@ describe("<FilterDateRangePicker />", () => {
       const inputRangeAfterEnd = screen.getByLabelText("Date to")
       expect(inputRangeAfterStart).toHaveValue("")
       expect(inputRangeAfterEnd).toHaveValue("")
-    })
+    }, 10000)
   })
 
   describe("Calendar", () => {


### PR DESCRIPTION
## Why
The "resets the input values if cleared from the outside" test for the Filter DRP is throwing a timeout in CI. The test itself is functioning as expected but due to its asynchronous interaction with a complex component, it sometimes breaks in CI.

If this is a recurring issue In the future we may want to either revisit our CI to see if a larger agent will more reliably run this test or explore alternatives such as playwright.

## What
- increases jest timeout to 10000
