### PR TITLE
feat: Update the useEffect only trigger when defaultOpen

### DIFF
--- a/packages/select/src/Select/Select.spec.tsx
+++ b/packages/select/src/Select/Select.spec.tsx
@@ -156,7 +156,11 @@ describe("<Select>", () => {
           const trigger = screen.getByRole("button", {
             name: "Mock Label SRE",
           })
-          trigger.focus()
+          userEvent.tab()
+          userEvent.tab()
+          await waitFor(() => {
+            expect(trigger).toHaveFocus()
+          })
           userEvent.keyboard("{Enter}")
           await waitFor(() => {
             expect(screen.queryByRole("listbox")).toBeVisible()
@@ -266,7 +270,6 @@ describe("<Select>", () => {
         it("focuses on the first option when tabs onto the list", async () => {
           render(<SelectWrapper />)
           await userEvent.tab()
-          await userEvent.tab()
           await userEvent.keyboard("{Enter}")
           await waitFor(() => {
             expect(
@@ -280,7 +283,6 @@ describe("<Select>", () => {
         it("focuses the first selected option when tabs onto the list", async () => {
           render(<SelectWrapper selectedKey="id-sre" />)
           await userEvent.tab()
-          await userEvent.tab()
           await userEvent.keyboard("{Enter}")
           await waitFor(() => {
             expect(screen.getByRole("option", { name: "SRE" })).toHaveFocus()
@@ -290,9 +292,8 @@ describe("<Select>", () => {
 
       it("keeps the focus ring at the first element when hits arrow up key on it", async () => {
         render(<SelectWrapper />)
-        await userEvent.tab()
-        await userEvent.tab()
-        await userEvent.keyboard("{ArrowUp}")
+        userEvent.tab()
+        userEvent.keyboard("{ArrowUp}")
         await waitFor(() => {
           expect(
             screen.getByRole("option", { name: "Front-End" })

--- a/packages/select/src/Select/Select.tsx
+++ b/packages/select/src/Select/Select.tsx
@@ -137,7 +137,7 @@ export const Select = ({
 
   // Fix the issue when default open and close by keyboard, then focus is lost
   useEffect(() => {
-    if (state.isOpen === false) {
+    if (state.isOpen === false && defaultOpen) {
       buttonRef.current?.focus()
     }
   }, [state.isOpen])


### PR DESCRIPTION
## Why
<!-- Why have you created this PR? - Is it a new feature, or a bug fix? Or something else? -->
<!-- Reference any relevant Jira tickets so your reviewer can find more context if needed. -->
<!-- Fixing a GitHub issue? Add "Fixes [issue URL]". -->
- Only force focus when the `defaultOpen` is set
- useEffect was created as a solution to force the focus back to the button when defaultOpen was set

## What
<!-- What do your changes do? How do they change/fix the current behavior? -->
<!-- Add screenshots, GIFs or videos to illustrate the changes.  -->
- Update useEffect within Select to only force focus after close when `defaultOpen` is true