### PR TITLE
fix: add prepublish to design-tokens and tailwind

### DIFF
--- a/.buildkite/scripts/build-storybook.sh
+++ b/.buildkite/scripts/build-storybook.sh
@@ -5,5 +5,7 @@ set -e
 . ".buildkite/scripts/helpers/setup-registry.sh"
 
 yarn install --frozen-lockfile
+yarn workspace @kaizen/design-tokens prepublish
+yarn workspace @kaizen/tailwind prepublish
 yarn storybook:build
 tar -czf ./storybook.tar.gz ./storybook/public

--- a/.buildkite/scripts/release.sh
+++ b/.buildkite/scripts/release.sh
@@ -49,6 +49,9 @@ release() {
 
   yarn install --frozen-lockfile
 
+  yarn workspace @kaizen/design-tokens prepublish
+  yarn workspace @kaizen/tailwind prepublish
+
   # Bump packages, push and tag a release commit, and update release notes
   yarn lerna version --conventional-commits --create-release=github --yes \
     --message "chore: release [skip ci]"


### PR DESCRIPTION
Errors of missing packages on build time, so I added commands to prepublish  design-tokens and tailwind.