### PR TITLE
feat: add caption to table

### DIFF
--- a/draft-packages/table/KaizenDraft/Table/Table.tsx
+++ b/draft-packages/table/KaizenDraft/Table/Table.tsx
@@ -11,6 +11,7 @@ import { Heading } from "@kaizen/typography"
 import styles from "./Table.module.scss"
 
 type TableContainerProps = {
+  caption?: string
   children?: React.ReactNode
   variant?: "compact" | "default" | "data"
 }
@@ -20,19 +21,20 @@ type TableContainerProps = {
  */
 export const TableContainer = ({
   variant = "compact",
+  caption,
   children,
   ...otherProps
 }: TableContainerProps): JSX.Element => (
-  <div
-    role="table"
+  <table
     className={classNames(styles.container, {
       [styles.defaultSpacing]: variant === "default",
       [styles.dataVariant]: variant === "data",
     })}
     {...otherProps}
   >
+    {caption && <caption className="sr-only">{caption}</caption>}
     {children}
-  </div>
+  </table>
 )
 
 /**
@@ -350,6 +352,7 @@ export const TableCard = ({
       href={href}
       className={className}
       onClick={onClick as AnchorClickEvent}
+      role="button"
       {...otherProps}
     >
       {children}

--- a/draft-packages/table/docs/Table.stories.tsx
+++ b/draft-packages/table/docs/Table.stories.tsx
@@ -184,7 +184,7 @@ const Multiline = ({ isReversed }: { isReversed: boolean }): JSX.Element => (
 
 export const DataVariant: Story = () => (
   <Container>
-    <TableContainer variant="data">
+    <TableContainer caption="A data variant table example." variant="data">
       <TableHeader>
         <ExampleTableHeaderRow reversed={false} />
       </TableHeader>
@@ -204,7 +204,7 @@ DataVariant.parameters = { chromatic: { disable: false } }
 
 export const IconVariant: Story = () => (
   <Container>
-    <TableContainer>
+    <TableContainer caption="An icon variant table example.">
       <TableHeader>
         <TableHeaderRow>
           <TableHeaderRowCell
@@ -266,7 +266,7 @@ IconVariant.parameters = { chromatic: { disable: false } }
 
 export const LinkVariant: Story = () => (
   <Container>
-    <TableContainer>
+    <TableContainer caption="A link variant table example.">
       <TableHeader>
         <TableHeaderRow>
           <TableHeaderRowCell labelText="Header A" width={1 / 3} />
@@ -291,6 +291,19 @@ export const LinkVariant: Story = () => (
         <TableRow>
           <TableRowCell width={1 / 3}>
             <Paragraph variant="body">This row has a href</Paragraph>
+          </TableRowCell>
+          <TableRowCell width={1 / 3}>
+            <Paragraph variant="body">24</Paragraph>
+          </TableRowCell>
+          <TableRowCell width={1 / 3}>
+            <Paragraph variant="body">48</Paragraph>
+          </TableRowCell>
+        </TableRow>
+      </TableCard>
+      <TableCard>
+        <TableRow>
+          <TableRowCell width={1 / 3}>
+            <Paragraph variant="body">This is a default row</Paragraph>
           </TableRowCell>
           <TableRowCell width={1 / 3}>
             <Paragraph variant="body">24</Paragraph>


### PR DESCRIPTION
## Why
This PR adds an optional caption for screen readers. 

This caption allows screen readers to read a description of what the table contains.

I have also changed `<div role="table">` to `<table>` as the caption element does not work correctly without a table element.

## What
It does not effect the current behavior and there is no change to the UI, it is screen reader only.
