### PR TITLE
fix: custom button now forwards custom props

### DIFF
--- a/packages/button/src/Button/components/GenericButton.spec.tsx
+++ b/packages/button/src/Button/components/GenericButton.spec.tsx
@@ -1,0 +1,84 @@
+import * as React from "react"
+import { render, screen } from "@testing-library/react"
+import GenericButton from "./GenericButton"
+
+it("renders the custom component element when passed the component prop", () => {
+  render(
+    <GenericButton
+      label="button label"
+      component={(props): React.ReactElement => (
+        <div>
+          <div>I'm custom</div>
+          <div>{props.children}</div>
+        </div>
+      )}
+    />
+  )
+  expect(screen.getByText("I'm custom")).toBeInTheDocument()
+  expect(screen.getByText("button label")).toBeInTheDocument()
+})
+
+it("renders an anchor element when passed the href prop and a falsy disabled prop and a falsy working prop", () => {
+  render(<GenericButton label="My link" href="/to-infinity" />)
+  expect(screen.getByRole("link", { name: "My link" })).toBeInTheDocument()
+})
+
+it("does not render an anchor element when passed the href prop but has a truthy disabled prop or a truthy working prop", () => {
+  const { rerender } = render(
+    <GenericButton label="My link" href="/to-infinity" disabled={true} />
+  )
+
+  expect(
+    screen.queryByRole("link", { name: "My link" })
+  ).not.toBeInTheDocument()
+  expect(screen.getByRole("button", { name: "My link" })).toBeInTheDocument()
+
+  rerender(
+    <GenericButton
+      label="My link"
+      href="/to-infinity"
+      working={true}
+      workingLabel={"My link working"}
+    />
+  )
+
+  expect(
+    screen.queryByRole("link", { name: "My link working" })
+  ).not.toBeInTheDocument()
+  expect(
+    screen.getByRole("button", { name: "My link working" })
+  ).toBeInTheDocument()
+})
+
+it("renders a button element when not passed a component prop or when not passed an href and a falsy disabled prop and a falsy working prop", () => {
+  render(<GenericButton label="My button" />)
+
+  expect(screen.getByRole("button", { name: "My button" })).toBeInTheDocument()
+})
+
+it("passes custom props to a custom component", () => {
+  render(
+    <GenericButton
+      label="button label"
+      data-testid="custom-prop"
+      component={(props): React.ReactElement => <div {...props} />}
+    />
+  )
+  expect(screen.getByTestId("custom-prop")).toBeInTheDocument()
+})
+
+it("passes custom props to a link", () => {
+  render(
+    <GenericButton
+      label="button label"
+      data-testid="custom-prop"
+      href="/and-beyond"
+    />
+  )
+  expect(screen.getByTestId("custom-prop")).toBeInTheDocument()
+})
+
+it("passes custom props to a button", () => {
+  render(<GenericButton label="button label" data-testid="custom-prop" />)
+  expect(screen.getByTestId("custom-prop")).toBeInTheDocument()
+})

--- a/packages/button/src/Button/components/GenericButton.tsx
+++ b/packages/button/src/Button/components/GenericButton.tsx
@@ -124,20 +124,25 @@ GenericButton.defaultProps = {
 const renderCustomComponent = (
   CustomComponent: ComponentType<CustomButtonProps>,
   props: Props
-): JSX.Element => (
-  <CustomComponent
-    id={props.id}
-    className={buttonClass(props)}
-    disabled={props.disabled}
-    href={props.href}
-    onClick={props.onClick}
-    onFocus={props.onFocus}
-    onBlur={props.onBlur}
-    aria-label={generateAriaLabel(props)}
-  >
-    {renderContent(props)}
-  </CustomComponent>
-)
+): JSX.Element => {
+  const { id, disabled, href, onClick, onFocus, onBlur, ...rest } = props
+  const customProps = getCustomProps(rest)
+  return (
+    <CustomComponent
+      id={id}
+      className={buttonClass(props)}
+      disabled={disabled}
+      href={href}
+      onClick={onClick}
+      onFocus={onFocus}
+      onBlur={onBlur}
+      aria-label={generateAriaLabel(props)}
+      {...customProps}
+    >
+      {renderContent(props)}
+    </CustomComponent>
+  )
+}
 
 const renderButton = (
   props: Props,


### PR DESCRIPTION
When using the `component` prop of a button, we allow the user to render a custom component via render props. When we do so, we do not generate `customProps` that the link or regular button allow for.

Generate the customProps for the custom button, and pass them through to the custom Component function.