### PR TITLE
fix(storybook css escape hatch): remove outdated css import

### DIFF
--- a/storybook/manager-head.html
+++ b/storybook/manager-head.html
@@ -1,9 +1,3 @@
-<link
-  rel="stylesheet"
-  href="./manager.css"
-/>
-
-
 <!--Styles to target and override storybook theme defaults-->
 <style>
   body .sidebar-item:hover{background:#dfc9ea}


### PR DESCRIPTION
## Why
Because we don't need it.

## What
Removes a `<link>` to a stylesheet in manager-head.html that doesn't exist any more.
