### PR TITLE
feat: KZN-1068 - Expose rte internal state

### DIFF
--- a/packages/rich-text-editor/docs/EditableRichTextContent.stories.tsx
+++ b/packages/rich-text-editor/docs/EditableRichTextContent.stories.tsx
@@ -40,6 +40,8 @@ function InlineEditor(props: {
   const [rteData, setRTEData] = useState<EditorContentArray>(
     props.content || dummyContent
   )
+  const handleOnChange = (editorState): void =>
+    setRTEData(editorState.toJSON().doc.content)
   const handleContentClick = (): void => setEditMode(true)
   const handleCancel = (): void => setEditMode(false)
 
@@ -57,7 +59,7 @@ function InlineEditor(props: {
             { name: "link", group: "link" },
           ]}
           value={rteData}
-          onChange={setRTEData}
+          onChange={handleOnChange}
         />
         <Box mt={0.5} style={{ display: "flex", justifyContent: "end" }}>
           <Button label="Cancel" secondary onClick={handleCancel} />

--- a/packages/rich-text-editor/docs/RichTextEditor.stories.tsx
+++ b/packages/rich-text-editor/docs/RichTextEditor.stories.tsx
@@ -27,11 +27,13 @@ export default {
 
 export const Default: RTEStory = ({ labelText, ...args }) => {
   const [rteData, setRTEData] = useState<EditorContentArray>([])
+  const handleOnChange = (editorState): void =>
+    setRTEData(editorState.toJSON().doc.content)
   return (
     <RichTextEditor
       labelText={labelText}
       value={rteData}
-      onChange={setRTEData}
+      onChange={handleOnChange}
       {...args}
     />
   )
@@ -53,11 +55,13 @@ Default.args = {
 
 export const WithData: RTEStory = ({ labelText, ...args }) => {
   const [rteData, setRTEData] = useState<EditorContentArray>(dummyContent)
+  const handleOnChange = (editorState): void =>
+    setRTEData(editorState.toJSON().doc.content)
   return (
     <RichTextEditor
       labelText={labelText}
       value={rteData}
-      onChange={setRTEData}
+      onChange={handleOnChange}
       {...args}
     />
   )
@@ -80,11 +84,13 @@ export const WithBadData: RTEStory = ({ labelText, ...args }) => {
   const [rteData, setRTEData] = useState<EditorContentArray>(
     dummyMalformedContent
   )
+  const handleOnChange = (editorState): void =>
+    setRTEData(editorState.toJSON().doc.content)
   return (
     <RichTextEditor
       labelText={labelText}
       value={rteData}
-      onChange={setRTEData}
+      onChange={handleOnChange}
       {...args}
     />
   )
@@ -109,19 +115,21 @@ export const WithDescriptionAndValidationMessage: RTEStory = ({
   ...args
 }) => {
   const [rteData, setRTEData] = useState<EditorContentArray>(dummyContent)
+  const handleOnChange = (editorState): void =>
+    setRTEData(editorState.toJSON().doc.content)
   return (
     <>
       <RichTextEditor
         labelText={labelText}
         value={rteData}
-        onChange={setRTEData}
+        onChange={handleOnChange}
         status="error"
         {...args}
       />
       <RichTextEditor
         labelText={labelText}
         value={rteData}
-        onChange={setRTEData}
+        onChange={handleOnChange}
         status="caution"
         {...args}
       />

--- a/packages/rich-text-editor/src/RichTextEditor/RichTextEditor.module.scss
+++ b/packages/rich-text-editor/src/RichTextEditor/RichTextEditor.module.scss
@@ -92,6 +92,9 @@
 
 @for $i from 1 through 20 {
   .editor.rows#{$i} > :global(.ProseMirror) {
-    min-height: calc(#{$typography-paragraph-body-line-height} * #{$i});
+    min-height: calc(
+      ((#{$typography-paragraph-body-line-height} + #{$spacing-16}) * #{$i}) -
+        #{$spacing-16}
+    );
   }
 }

--- a/packages/rich-text-editor/src/RichTextEditor/RichTextEditor.spec.tsx
+++ b/packages/rich-text-editor/src/RichTextEditor/RichTextEditor.spec.tsx
@@ -26,6 +26,8 @@ const TestRTE = (
   const [rteData, setRTEData] = useState<EditorContentArray>(
     args.rteMockData || []
   )
+  const handleOnChange = (editorState): void =>
+    setRTEData(editorState.toJSON().doc.content)
   return (
     <RichTextEditor
       labelText="List RTE"
@@ -35,7 +37,7 @@ const TestRTE = (
         { name: "bulletList", group: "list" },
       ]}
       value={rteData}
-      onChange={setRTEData}
+      onChange={handleOnChange}
       {...rest}
     />
   )

--- a/packages/rich-text-editor/src/RichTextEditor/RichTextEditor.tsx
+++ b/packages/rich-text-editor/src/RichTextEditor/RichTextEditor.tsx
@@ -23,7 +23,7 @@ import styles from "./RichTextEditor.module.scss"
 
 export interface BaseRichTextEditorProps
   extends OverrideClassName<Omit<HTMLAttributes<HTMLDivElement>, "onChange">> {
-  onChange: (content: EditorContentArray) => void
+  onChange: (content: ProseMirrorState.EditorState) => void
   value: EditorContentArray
   controls?: ToolbarItems[]
   /**
@@ -117,7 +117,7 @@ export const RichTextEditor = (props: RichTextEditorProps): JSX.Element => {
   const controlMap = buildControlMap(schema, editorState, controls)
 
   useEffect(() => {
-    onChange(editorState.toJSON().doc.content)
+    onChange(editorState)
     // Including `onContentChange` in the dependencies here will cause a 'Maximum update depth exceeded' issue
   }, [editorState])
 

--- a/packages/rich-text-editor/src/_mixins.scss
+++ b/packages/rich-text-editor/src/_mixins.scss
@@ -12,7 +12,7 @@
   white-space: pre-wrap;
 
   > p {
-    margin: 0 0 $spacing-sm;
+    margin: 0 0 $spacing-16;
   }
 
   > *:last-child {

--- a/packages/rich-text-editor/src/_mixins.scss
+++ b/packages/rich-text-editor/src/_mixins.scss
@@ -47,6 +47,10 @@
 }
 
 @mixin nestedListStyles {
+  ul,
+  ol {
+    padding-inline-start: $spacing-40; // default browser styling
+  }
   ol {
     list-style-type: decimal;
     ol {


### PR DESCRIPTION
## Why
The object current returned on the RTE's `onChange` handler doesn't have all properties needed by some ProseMirror modules to content to/from other formats. Currently, the Performance team is using a different text editor, and saving the format as markdown. As a short term goal, we want to replace this editor with Kaizen's RTE and use a parser to convert to/from markdown, so that no BE and database changes are needed.

**Tasks**:
https://cultureamp.atlassian.net/browse/TX-48

**Solution preview**
https://cultureamp.atlassian.net/wiki/spaces/TV/pages/3066855433/Solution+preview+Use+Kaizen+Rich+Text+Editor+in+Performance

**Discussion:**
https://cultureamp.atlassian.net/browse/KZN-1068

## What
**THIS IS A BREAKING CHANGE.** Instead of returning a content array, we are now returning the whole editorState, giving developers access to important information about the current state of the editor, like its schema. The style of the `ul` and `ol` are also being explicitly set, to avoid conflict with possible CSS resets from other codebases.

As an extra, I also added a secondary commit which fixes the style of the editor's height based on the `rows` prop (now it takes in consideration the margin of the paragraphs and lists).


