### PR TITLE
fix(tailwind): remove w- from borderWidth utilities

### DIFF
--- a/docs/Systems/Tailwind/UtilityClassReferences/Borders/BorderWidth.stories.tsx
+++ b/docs/Systems/Tailwind/UtilityClassReferences/Borders/BorderWidth.stories.tsx
@@ -1,6 +1,7 @@
 import React from "react"
 import { Story } from "@storybook/react"
 import classnames from "classnames"
+import { Card } from "@kaizen/draft-card"
 import { kaizenTailwindTheme } from "@kaizen/tailwind"
 import { CATEGORIES } from "../../../../../storybook/constants"
 import { UtilityClassTemplate } from "../../components/UtilityClassTemplate"
@@ -30,19 +31,36 @@ export default {
 const StickerSheetTemplate: Story<{ isReversed: boolean }> = ({
   isReversed,
 }) => (
-  <UtilityClassTemplate
-    compiledCssPropertyName="border-width"
-    classKeyValues={classEntries}
-    renderExampleComponent={(utilityClass): React.ReactElement => (
-      <div
-        className={classnames(
-          "w-[100px] h-[100px] border-solid border-[black]",
-          utilityClass
-        )}
-      />
-    )}
-    isReversed={isReversed}
-  />
+  <div className="flex flex-col items-center">
+    <Card variant="informative" classNameOverride="mb-24">
+      <div className="p-24 font-family-paragraph max-w-[1000px]">
+        <p>
+          This document demonstrates the list of border-width suffixes available
+          from the Kaizen preset, by showing what they look like on the
+          'border-' prefix.
+        </p>
+        <p>
+          Note that there are other border-width prefixes (such as `border-l-`
+          for `border-left-width`) that can be used instead. Available
+          border-width prefixes can be referenced{" "}
+          <a href="https://tailwindcss.com/docs/border-width">here</a>.
+        </p>
+      </div>
+    </Card>
+    <UtilityClassTemplate
+      compiledCssPropertyName="border-width"
+      classKeyValues={classEntries}
+      renderExampleComponent={(utilityClass): React.ReactElement => (
+        <div
+          className={classnames(
+            "w-[100px] h-[100px] border-solid border-[black] border-default",
+            utilityClass
+          )}
+        />
+      )}
+      isReversed={isReversed}
+    />
+  </div>
 )
 
 export const StickerSheetDefault = StickerSheetTemplate.bind({})

--- a/packages/tailwind/src/tailwind-presets.ts
+++ b/packages/tailwind/src/tailwind-presets.ts
@@ -32,9 +32,9 @@ export const kaizenTailwindTheme: KaizenTailwindTheme = {
   },
 
   borderWidth: {
-    "w-none": "0px",
-    "w-default": "2px",
-    "w-focus-ring": "2px",
+    none: "0px",
+    default: "2px",
+    "focus-ring": "2px",
   },
   borderColor: {
     "default-color": `${defaultTheme.border.solid.borderColor}`,


### PR DESCRIPTION
We've decided that the clarity of adding w- to borderWidth isn't worth the busy utility classes. For example, border-b-w-default isn't as nice as border-b-default.

BREAKING CHANGE: Any border width utilities will need to be renamed without the `w-`. These include the following prefixes, where `?` represents a pixel-based spacing token.
`border-w-?`  -> `border-?`
`border-x-w-?` -> `border-x-?`
`border-y-w-?` -> `border-y-?`
`border-t-w-?` -> `border-t-?`
`border-b-w-?` -> `border-b-?`
`border-r-w-?` -> `border-r-?`
`border-l-w-?` -> `border-l-?`

## Why
Adding `w-` (to represent 'width') is redundant, considering that these only get applied to borderWidth anyway. The unnecessary clarity isn't worth the extra utility-class-bulk.


## What
- Removes `w-` from borderWidth utilities.
- Adds an info card explaining that there are other borderWidth prefixes that can be applied to our Kaizen suffixes

### Before
<img width="1239" alt="image" src="https://user-images.githubusercontent.com/34709943/226245384-f6d9f310-bd93-4556-aca0-a917172e252f.png">

### After
<img width="1353" alt="image" src="https://user-images.githubusercontent.com/34709943/226245137-1b49e6c4-ed29-42b2-a6b8-e97c9d4284d1.png">
