### PR TITLE
chore: ignore components dir for testing

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -2,6 +2,11 @@
   "version": "independent",
   "npmClient": "yarn",
   "packages": ["packages/*", "draft-packages/*"],
-  "ignoreChanges": ["**/*.stories.*", "**/*.spec.*", "**/README.*"],
+  "ignoreChanges": [
+    "**/*.stories.*",
+    "**/*.spec.*",
+    "**/README.*",
+    "packages/components/*"
+  ],
   "useWorkspaces": true
 }


### PR DESCRIPTION
To be safe, we are ignoring the components package to test changesets