### PR TITLE
chore: correct components package.json version to 1.6.5

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kaizen/components",
-  "version": "1.7.0",
+  "version": "1.6.5",
   "description": "Kaizen component library",
   "author": "Geoffrey Chong <geoff.chong@cultureamp.com>",
   "homepage": "https://cultureamp.design",


### PR DESCRIPTION
Changeset updated the version but failed to publish, this is to fix that.