### PR TITLE
feat: Pass HTMLAttributes to content in EditableRichTextContent

### DIFF
--- a/packages/rich-text-editor/src/EditableRichTextContent/EditableRichTextContent.spec.tsx
+++ b/packages/rich-text-editor/src/EditableRichTextContent/EditableRichTextContent.spec.tsx
@@ -1,13 +1,14 @@
 import React from "react"
-import { render, screen, waitFor } from "@testing-library/react"
+import { render } from "@testing-library/react"
 import "@testing-library/jest-dom"
+import { RichTextContentProps } from "../RichTextContent"
 import { EditableRichTextContent } from "./EditableRichTextContent"
 
 const mockFn = jest.fn()
 
 jest.mock("../../", () => ({
   __esModule: true,
-  RichTextContent: props => {
+  RichTextContent: (props: RichTextContentProps): JSX.Element => {
     mockFn(props)
     return <div>Mocked Component</div>
   },

--- a/packages/rich-text-editor/src/EditableRichTextContent/EditableRichTextContent.spec.tsx
+++ b/packages/rich-text-editor/src/EditableRichTextContent/EditableRichTextContent.spec.tsx
@@ -1,0 +1,35 @@
+import React from "react"
+import { render, screen, waitFor } from "@testing-library/react"
+import "@testing-library/jest-dom"
+import { EditableRichTextContent } from "./EditableRichTextContent"
+
+const mockFn = jest.fn()
+
+jest.mock("../../", () => ({
+  __esModule: true,
+  RichTextContent: props => {
+    mockFn(props)
+    return <div>Mocked Component</div>
+  },
+}))
+
+const content = [
+  {
+    type: "paragraph",
+    content: [{ type: "text", text: "Sample rich text content" }],
+  },
+]
+
+describe("Content props are passed", () => {
+  it("should pass them to RichTextContent component", () => {
+    render(
+      <EditableRichTextContent
+        content={content}
+        labelText=""
+        onClick={jest.fn()}
+        contentProps={{ id: "sampleId" }}
+      />
+    )
+    expect(mockFn).toHaveBeenCalledWith({ content, id: "sampleId" })
+  })
+})

--- a/packages/rich-text-editor/src/EditableRichTextContent/EditableRichTextContent.tsx
+++ b/packages/rich-text-editor/src/EditableRichTextContent/EditableRichTextContent.tsx
@@ -3,7 +3,7 @@ import classnames from "classnames"
 import { VisuallyHidden } from "@kaizen/a11y"
 import { OverrideClassName } from "@kaizen/component-base"
 import { Label } from "@kaizen/draft-form"
-import { EditorContentArray, RichTextContent } from "../../"
+import { EditorContentArray, RichTextContent, RichTextContentProps } from "../../"
 import styles from "./EditableRichTextContent.module.scss"
 
 export interface EditableRichTextContentProps
@@ -12,7 +12,7 @@ export interface EditableRichTextContentProps
   content: EditorContentArray
   labelText: string
   isLabelHidden?: boolean
-  contentHTMLAttributes?: HTMLAttributes<HTMLDivElement>
+  contentProps?: Omit<RichTextContentProps, "contents">
 }
 
 const handleEditableClick = (
@@ -34,7 +34,7 @@ export const EditableRichTextContent = (
     classNameOverride,
     labelText,
     isLabelHidden = false,
-    contentHTMLAttributes,
+    contentProps,
     ...restProps
   } = props
 
@@ -55,7 +55,7 @@ export const EditableRichTextContent = (
             aria-label={`Edit ${labelText}`}
           />
         </VisuallyHidden>
-        <RichTextContent content={content} {...contentHTMLAttributes} />
+        <RichTextContent content={content} {...contentProps} />
       </div>
     </>
   )

--- a/packages/rich-text-editor/src/EditableRichTextContent/EditableRichTextContent.tsx
+++ b/packages/rich-text-editor/src/EditableRichTextContent/EditableRichTextContent.tsx
@@ -12,6 +12,7 @@ export interface EditableRichTextContentProps
   content: EditorContentArray
   labelText: string
   isLabelHidden?: boolean
+  contentHTMLAttributes?: HTMLAttributes<HTMLDivElement>
 }
 
 const handleEditableClick = (
@@ -33,6 +34,7 @@ export const EditableRichTextContent = (
     classNameOverride,
     labelText,
     isLabelHidden = false,
+    contentHTMLAttributes,
     ...restProps
   } = props
 
@@ -53,7 +55,7 @@ export const EditableRichTextContent = (
             aria-label={`Edit ${labelText}`}
           />
         </VisuallyHidden>
-        <RichTextContent content={content} />
+        <RichTextContent content={content} {...contentHTMLAttributes} />
       </div>
     </>
   )

--- a/packages/rich-text-editor/src/EditableRichTextContent/EditableRichTextContent.tsx
+++ b/packages/rich-text-editor/src/EditableRichTextContent/EditableRichTextContent.tsx
@@ -3,7 +3,11 @@ import classnames from "classnames"
 import { VisuallyHidden } from "@kaizen/a11y"
 import { OverrideClassName } from "@kaizen/component-base"
 import { Label } from "@kaizen/draft-form"
-import { EditorContentArray, RichTextContent, RichTextContentProps } from "../../"
+import {
+  EditorContentArray,
+  RichTextContent,
+  RichTextContentProps,
+} from "../../"
 import styles from "./EditableRichTextContent.module.scss"
 
 export interface EditableRichTextContentProps

--- a/packages/rich-text-editor/src/EditableRichTextContent/EditableRichTextContent.tsx
+++ b/packages/rich-text-editor/src/EditableRichTextContent/EditableRichTextContent.tsx
@@ -16,7 +16,7 @@ export interface EditableRichTextContentProps
   content: EditorContentArray
   labelText: string
   isLabelHidden?: boolean
-  contentProps?: Omit<RichTextContentProps, "contents">
+  contentProps?: Omit<RichTextContentProps, "content">
 }
 
 const handleEditableClick = (


### PR DESCRIPTION
## Why
- This PR is created to allow passing html attributes to `RichTextContent` component inside the `EditableRichTextContent`.
- This is required for adding id attribute to content div in `EditableRichTextContent`, with this we can use that id for accessible purposes. 
- Without this change if I just pass id to `EditableRichTextContent` and use that id for `aria-labelledby` it will read the button label as well when using voice over.

https://cultureamp.atlassian.net/browse/COMP-664


## What
- Added a separate prop for passing the html attributes to `RichTextContent` inside `EditableRichTextContent`.
- This change does not effect any existing functionality.
