### PR TITLE
chore: GH actions ignore changset PR's

### DIFF
--- a/.github/workflows/chromatic.yaml
+++ b/.github/workflows/chromatic.yaml
@@ -6,9 +6,15 @@ name: "chromatic"
 on:
   pull_request:
     types: [labeled]
+    branches-ignore:
+      - changeset-release/main
   pull_request_review:
     types: [submitted]
+    branches-ignore:
+      - changeset-release/main
   push:
+    branches-ignore:
+      - changeset-release/main
 
 jobs:
   paths-filter:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,9 @@
 name: ci
 
-on: push
+on:
+  push:
+    branches-ignore:
+      - changeset-release/main
 
 jobs:
   yarn-integrity:


### PR DESCRIPTION
The gh-actions bot that creates changeset PR's cannot trigger other gh actions, this change has the gh actions ignore the changeset PR