### PR TITLE
ci(chromatic workflow): add docs folder to chromatic workflow

### DIFF
--- a/.github/workflows/chromatic.yaml
+++ b/.github/workflows/chromatic.yaml
@@ -31,6 +31,7 @@ jobs:
               - 'packages/**'
               - 'draft-packages/**'
               - 'storybook/**'
+              - 'docs/**/*.(mdx|tsx)'
 
   visual-testing:
     needs: [paths-filter]


### PR DESCRIPTION
## Why
To catch visual differences in the docs folder.


## What
Adds the docs folder to the Chromatic workflow check.
