### PR TITLE
feat: Add comment-bank icon

### DIFF
--- a/packages/component-library/icons/comment-bank.icon.svg
+++ b/packages/component-library/icons/comment-bank.icon.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg width="40" height="40" viewBox="0 0 40 40" fill="none" xmlns="http://www.w3.org/2000/svg">
+<svg width="20px" height="20px" viewBox="0 0 20 20" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <title>comment-bank</title>
     <desc>Created with Sketch.</desc>
     <defs>

--- a/packages/component-library/icons/comment-bank.icon.svg
+++ b/packages/component-library/icons/comment-bank.icon.svg
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="40" height="40" viewBox="0 0 40 40" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <title>comment-bank</title>
+    <desc>Created with Sketch.</desc>
+    <defs>
+        <path d="M0 40V3C0 2.23333 0.3 1.54167 0.9 0.925C1.5 0.308334 2.2 0 3 0H37C37.7667 0 38.4583 0.308334 39.075 0.925C39.6917 1.54167 40 2.23333 40 3V29C40 29.7667 39.6917 30.4583 39.075 31.075C38.4583 31.6917 37.7667 32 37 32H8L0 40ZM22.15 16.65L27 14.15L31.8 16.65V3H22.15V16.65Z" id="path-1"/>
+    </defs>
+    <g id="Symbols" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="comment-bank">
+            <mask id="mask-2" fill="white">
+                <use xlink:href="#path-1"></use>
+            </mask>
+            <use id="Icons/Actions/comment-bank" fill="#000000" xlink:href="#path-1"></use>
+        </g>
+    </g>
+</svg>

--- a/packages/component-library/icons/comment-bank.icon.svg
+++ b/packages/component-library/icons/comment-bank.icon.svg
@@ -1,10 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg width="20px" height="20px" viewBox="0 0 20 20" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 46.2 (44496) - http://www.bohemiancoding.com/sketch -->
     <title>comment-bank</title>
-    <desc>Created with Sketch.</desc>
+    <desc>Created with Sketch.</desc>   
     <defs>
-        <path d="M0 40V3C0 2.23333 0.3 1.54167 0.9 0.925C1.5 0.308334 2.2 0 3 0H37C37.7667 0 38.4583 0.308334 39.075 0.925C39.6917 1.54167 40 2.23333 40 3V29C40 29.7667 39.6917 30.4583 39.075 31.075C38.4583 31.6917 37.7667 32 37 32H8L0 40ZM22.15 16.65L27 14.15L31.8 16.65V3H22.15V16.65Z" id="path-1"/>
+        <path d="M0.666748 17.3333V1.91666C0.666748 1.59721 0.791748 1.30902 1.04175 1.05207C1.29175 0.795129 1.58341 0.666656 1.91675 0.666656H16.0834C16.4029 0.666656 16.6911 0.795129 16.948 1.05207C17.2049 1.30902 17.3334 1.59721 17.3334 1.91666V12.75C17.3334 13.0694 17.2049 13.3576 16.948 13.6146C16.6911 13.8715 16.4029 14 16.0834 14H4.00008L0.666748 17.3333ZM9.89591 7.60416L11.9167 6.56249L13.9167 7.60416V1.91666H9.89591V7.60416Z" id="path-1"/>
     </defs>
+
     <g id="Symbols" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
         <g id="comment-bank">
             <mask id="mask-2" fill="white">

--- a/packages/component-library/stories/Icons.ts
+++ b/packages/component-library/stories/Icons.ts
@@ -21,6 +21,7 @@ import actionOn from "../icons/action-on.icon.svg"
 import actionOff from "../icons/action-off.icon.svg"
 import comment from "../icons/comment.icon.svg"
 import commentAdd from "../icons/comment-add.icon.svg"
+import commentBank from "../icons/comment-bank.icon.svg"
 import commentDisabled from "../icons/comment-disabled.icon.svg"
 import clear from "../icons/clear.icon.svg"
 import add from "../icons/add.icon.svg"
@@ -206,6 +207,7 @@ export const Actions = {
   comment,
   commentAdd,
   commentDisabled,
+  commentBank,
   clear,
   add,
   subtract,


### PR DESCRIPTION
## Why
There’s a need by designer from team Compass for a comment-bank icon which is available in Figma but missing in the codebase. This will be used in the 1-on-1 tab in Dossier, refer [here](https://www.figma.com/file/CLx78YeFD7uauDot08bTgs/Amplify-%2F-1-1-save-to-dossier?node-id=15-36574&t=sarxE0xql99rdp5b-0) for more details: https://www.figma.com/file/CLx78YeFD7uauDot08bTgs/Amplify-%2F-1-1-save-to-dossier?node-id=15-36574&t=sarxE0xql99rdp5b-0

## Usage:
<img width="516" alt="Screenshot 2023-04-04 at 4 35 43 PM" src="https://user-images.githubusercontent.com/104351063/229773192-58f56fca-ed05-45f0-a522-313eb6d63e1e.png">

## What
- Add a new comment-bank icon which is available in Figma but missing in the codebase
