### PR TITLE
docs: fix props displayed in controls table

### DIFF
--- a/storybook/main.ts
+++ b/storybook/main.ts
@@ -1,6 +1,6 @@
 import fs from "fs"
 import path from "path"
-import { StorybookConfig } from "@storybook/core-webpack"
+import { StorybookConfig } from "@storybook/react-webpack5"
 
 /**
  * Use `STORIES=path/to/package` environment variable to load all `*.stories.tsx` stories in that folder.
@@ -33,6 +33,19 @@ const config = {
   framework: {
     name: "@storybook/react-webpack5",
     options: {},
+  },
+  typescript: {
+    reactDocgen: "react-docgen-typescript",
+    reactDocgenTypescriptOptions: {
+      skipChildrenPropWithoutDoc: false,
+      shouldExtractLiteralValuesFromEnum: true,
+      propFilter: (prop): boolean => {
+        const isHTMLElementProp =
+          prop.parent?.fileName.includes("node_modules/@types/react") ?? false
+
+        return !isHTMLElementProp
+      },
+    },
   },
 } satisfies StorybookConfig
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "baseUrl": ".",
     "lib": ["es2019", "dom"],
     "module": "commonjs",
     "jsx": "react",
@@ -9,7 +10,13 @@
     "noImplicitAny": false,
     "strict": true,
     "allowJs": false,
-    "noEmit": true
+    "noEmit": true,
+    "paths": {
+      "~types/*": ["packages/components/src/types/*"],
+      "~utils/*": ["packages/components/src/utils/*"],
+      "~components/*": ["packages/components/src/*"],
+      "~icons/*": ["packages/components/src/SVG/icons/*"]
+    }
   },
   "files": ["./types.d.ts"],
   "include": ["packages/**/*", "draft-packages/**/*", "storybook/**/*"],


### PR DESCRIPTION
## Why
<!-- Why have you created this PR? - Is it a new feature, or a bug fix? Or something else? -->
<!-- Reference any relevant Jira tickets so your reviewer can find more context if needed. -->
<!-- Fixing a GitHub issue? Add "Fixes [issue URL]". -->

Controls table for components in the AIO do not properly populate properly.

eg. All these props are custom added. `classNameOverride` is missing from `~types`, and so are the props extended from `@react-aria`.
![image](https://user-images.githubusercontent.com/25891850/230327626-0d569e10-1bc8-4f1a-8f21-a9c0f3064fad.png)


## What
<!-- What do your changes do? How do they change/fix the current behavior? -->
<!-- Add screenshots, GIFs or videos to illustrate the changes.  -->

Add aliases to the root `tsconfig` so Storybook can resolve them, and adjust the props filter to only exclude types from React (HTML attributes).