### PR TITLE
add new design guideline links + styling

### DIFF
--- a/packages/button/docs/Button.stories.tsx
+++ b/packages/button/docs/Button.stories.tsx
@@ -26,10 +26,14 @@ const meta = {
       "npm install @kaizen/button",
       "import { Button } from `@kaizen/button`",
     ],
-    sourceCodeLink:
-      "https://github.com/cultureamp/kaizen-design-system/tree/master/packages/button",
-    figmaLink:
-      "https://www.figma.com/file/eZKEE5kXbEMY3lx84oz8iN/%E2%9D%A4%EF%B8%8F-UI-Kit%3A-Heart?node-id=1929%3A17364",
+    resourceLinks: {
+      sourceCode:
+        "https://github.com/cultureamp/kaizen-design-system/tree/master/packages/button",
+      figma:
+        "https://www.figma.com/file/eZKEE5kXbEMY3lx84oz8iN/%E2%9D%A4%EF%B8%8F-UI-Kit%3A-Heart?node-id=1929%3A17364",
+      designGuidelines:
+        "https://cultureamp.atlassian.net/wiki/spaces/DesignSystem/pages/3062890984/Button",
+    },
     alternatives: [
       "components-icon-button--docs",
       "components-button-group--docs",
@@ -73,7 +77,6 @@ const VariantsTemplate: StoryFn<{ isReversed?: boolean }> = ({
 /**
  * <p>`Default`, `Primary`, `Destructive`, `Secondary`</p>
  * <p>If no `variant` is specified, a `Default` button will be rendered.</p>
- * <p>For more information on when to use each variant, check out the [Component guidelines](https://cultureamp.design/components/button/).</p>
  */
 export const Variants = VariantsTemplate.bind({})
 

--- a/storybook/components/DocsContainer/ComponentDocsTemplate/subcomponents/Links/Links.tsx
+++ b/storybook/components/DocsContainer/ComponentDocsTemplate/subcomponents/Links/Links.tsx
@@ -37,7 +37,7 @@ export const Links = ({ context }: LinksProps): JSX.Element | null => {
             target="_blank"
             rel="noopener noreferrer nofollow"
           >
-            UI Kit
+            Figma
           </a>
         </li>
       )}
@@ -49,7 +49,7 @@ export const Links = ({ context }: LinksProps): JSX.Element | null => {
             target="_blank"
             rel="noopener noreferrer nofollow"
           >
-            Design guidelines
+            Usage Guidelines
           </a>
         </li>
       )}

--- a/storybook/components/DocsContainer/ComponentDocsTemplate/subcomponents/Links/Links.tsx
+++ b/storybook/components/DocsContainer/ComponentDocsTemplate/subcomponents/Links/Links.tsx
@@ -7,20 +7,53 @@ export type LinksProps = {
 }
 
 export const Links = ({ context }: LinksProps): JSX.Element | null => {
-  const sourceCodeLink: string =
-    context.attachedCSFFile.meta.parameters.sourceCodeLink
-  const figmaLink: string = context.attachedCSFFile.meta.parameters.figmaLink
+  const links: Record<string, string> =
+    context.attachedCSFFile.meta.parameters.resourceLinks
 
-  const hasLinks = sourceCodeLink !== undefined || figmaLink !== undefined
+  const sourceCodeLink: string = links.sourceCode
+  const figmaLink: string = links.figma
+  const designGuidelinesLink: string = links.designGuidelines
 
-  if (!hasLinks) return null
+  if (!links) return null
 
   return (
-    <div>
-      {sourceCodeLink && <a href={sourceCodeLink}>Source Code</a>}
-      {sourceCodeLink && figmaLink && <span>&nbsp;|&nbsp;</span>}
-      {figmaLink && <a href={figmaLink}>UI Kit</a>}
-    </div>
+    <ul className="!list-none !p-0 !m-0 flex gap-4 items-center">
+      {sourceCodeLink && (
+        <li className="!mt-0 !text-paragraph">
+          <a
+            href={sourceCodeLink}
+            target="_blank"
+            rel="noopener noreferrer nofollow"
+          >
+            Source Code
+          </a>
+        </li>
+      )}
+      {figmaLink && (
+        <li className="!mt-0 !text-paragraph">
+          |&nbsp;
+          <a
+            href={figmaLink}
+            target="_blank"
+            rel="noopener noreferrer nofollow"
+          >
+            UI Kit
+          </a>
+        </li>
+      )}
+      {designGuidelinesLink && (
+        <li className="!mt-0 !text-paragraph">
+          |&nbsp;
+          <a
+            href={designGuidelinesLink}
+            target="_blank"
+            rel="noopener noreferrer nofollow"
+          >
+            Design guidelines
+          </a>
+        </li>
+      )}
+    </ul>
   )
 }
 

--- a/storybook/components/DocsContainer/ComponentDocsTemplate/subcomponents/Title/Title.tsx
+++ b/storybook/components/DocsContainer/ComponentDocsTemplate/subcomponents/Title/Title.tsx
@@ -10,12 +10,7 @@ export const Title = ({ context }: TitleProps): JSX.Element => {
   const titleHierarchy = context.attachedCSFFile.meta.title
   const title = titleHierarchy.split("/")
 
-  return (
-    <>
-      <h1>{title[title.length - 1]}</h1>
-      <br />
-    </>
-  )
+  return <h1>{title[title.length - 1]}</h1>
 }
 
 Title.displayName = "Title"


### PR DESCRIPTION
## Why

Design guidelines is an important part of the docs, we want to make them more discoverable for anyone browsing our components.

## What

- Added an extra link type to the header of docs
- Updated the styles and logic for rendering links
- Removed awkward space below heading

## Before
![image](https://user-images.githubusercontent.com/820635/231627568-46c288c5-2ce5-45a9-90ca-235fc5d2cb75.png)

## After
![image](https://user-images.githubusercontent.com/820635/231627448-884f0e5e-8af9-424d-8f60-fca94dff689a.png)