### PR TITLE
feat: Add locales folder with English source file

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -1,0 +1,25 @@
+{
+  "smartling": {
+    "string_format": "icu",
+    "translate_paths": [
+      {
+        "instruction": "*/description",
+        "key": "{*}/message",
+        "path": "*/message"
+      }
+    ],
+    "variants_enabled": true
+  },
+  "filterDateRangePicker.dateFrom": {
+    "description": "Label for the 'Date from' date range input field",
+    "message": "Date from"
+  },
+  "filterDateRangePicker.dateTo": {
+    "description": "Label for the 'Date to' date range input field",
+    "message": "Date to"
+  },
+  "filterDateRangePicker.inputFormat": {
+    "description": "Label for the 'Input format' subtext",
+    "message": "Input format"
+  }
+}


### PR DESCRIPTION
## Why
We have hard coded strings in FilterDRP that need to be translated. This source file will be picked up by translate bot to generate PRs with translated versions of the English source file.


## What
Adds an English source file with three messages for the FilterDRP.
