### PR TITLE
Run chromatic when a PR is updated with changes from main

### DIFF
--- a/.github/workflows/chromatic.yaml
+++ b/.github/workflows/chromatic.yaml
@@ -5,7 +5,7 @@ name: "chromatic"
 
 on:
   pull_request:
-    types: [labeled, synchronize]
+    types: [labeled]
     branches-ignore:
       - changeset-release/main
   push:

--- a/.github/workflows/chromatic.yaml
+++ b/.github/workflows/chromatic.yaml
@@ -8,9 +8,7 @@ on:
     types: [labeled, synchronize]
     branches-ignore:
       - changeset-release/main
-
   push:
-    branches: [main]
 
 jobs:
   visual-testing:


### PR DESCRIPTION
## Why
We want chromatic to automatically run again when a branch is updated with code from `main`.


## What

Removal of branch restriction on push event so that the job will detect pushes on all branches.