### PR TITLE
update ci:publish script to include push of tags

### DIFF
--- a/.buildkite/scripts/release.sh
+++ b/.buildkite/scripts/release.sh
@@ -45,6 +45,7 @@ release() {
   yarn install --frozen-lockfile
 
   yarn ci:publish
+  git push --follow-tags
 }
 
 release_canary() {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "pkg:aio:test": "yarn pkg:aio test",
     "pkg:aio:compile": "yarn pkg:aio compile",
     "ci:version": "yarn build && yarn changeset version",
-    "ci:publish": "yarn build && yarn changeset publish && git push --follow-tags"
+    "ci:publish": "yarn build && yarn changeset publish"
   },
   "dependencies": {
     "@kaizen/design-tokens": "^10.0.11",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "pkg:aio:test": "yarn pkg:aio test",
     "pkg:aio:compile": "yarn pkg:aio compile",
     "ci:version": "yarn build && yarn changeset version",
-    "ci:publish": "yarn build && yarn changeset publish"
+    "ci:publish": "yarn build && yarn changeset publish && git push --follow-tags"
   },
   "dependencies": {
     "@kaizen/design-tokens": "^10.0.11",


### PR DESCRIPTION
Co-authored-by: github-actions[bot] <github-actions[bot]@users.noreply.github.com>

## Why
We want to publish the git tags of our released packages to allow people to find the code via our github repo page

## What
Add `git push --follow-tags` to the ci:publish script, according to [instructions](https://github.com/changesets/changesets/blob/main/docs/command-line-options.md#git-tags)