### PR TITLE
docs: update stickersheets to live under Components category

### DIFF
--- a/packages/button/docs/Button.stickersheet.stories.tsx
+++ b/packages/button/docs/Button.stickersheet.stories.tsx
@@ -7,7 +7,11 @@ import { StickerSheet } from "../../../storybook/components/StickerSheet"
 import { Button, ButtonProps } from "../index"
 
 export default {
-  title: "Stickersheets/Button",
+  title: "Components/Button",
+  parameters: {
+    chromatic: { disable: false },
+    controls: { disable: true },
+  },
 } satisfies Meta<typeof Button>
 
 const StickerSheetTemplate: StoryFn<{ isReversed: boolean }> = ({
@@ -227,16 +231,10 @@ const StickerSheetTemplate: StoryFn<{ isReversed: boolean }> = ({
 
 export const StickerSheetDefault = StickerSheetTemplate.bind({})
 StickerSheetDefault.storyName = "Sticker Sheet (Default)"
-StickerSheetDefault.parameters = {
-  chromatic: { disable: false },
-  controls: { disable: true },
-}
 
 export const StickerSheetReversed = StickerSheetTemplate.bind({})
 StickerSheetReversed.storyName = "Sticker Sheet (Reversed)"
 StickerSheetReversed.args = { isReversed: true }
 StickerSheetReversed.parameters = {
-  chromatic: { disable: false },
-  controls: { disable: true },
   backgrounds: { default: "Purple 700" },
 }

--- a/packages/button/docs/Button.stories.tsx
+++ b/packages/button/docs/Button.stories.tsx
@@ -34,10 +34,7 @@ const meta = {
       designGuidelines:
         "https://cultureamp.atlassian.net/wiki/spaces/DesignSystem/pages/3062890984/Button",
     },
-    alternatives: [
-      "components-icon-button--docs",
-      "components-button-group--docs",
-    ],
+    alternatives: ["components-icon-button--docs"],
   },
 } satisfies Meta<typeof Button>
 

--- a/plop-templates/basic-component/docs/{{pascalCase componentName}}.stickersheet.stories.tsx.hbs
+++ b/plop-templates/basic-component/docs/{{pascalCase componentName}}.stickersheet.stories.tsx.hbs
@@ -4,7 +4,11 @@ import { StickerSheet } from "{{storybookDir}}/components/StickerSheet"
 import { {{pascalCase componentName}} } from "../index"
 
 export default {
-  title: "Stickersheets/{{pascalCase componentName}}",
+  title: "Components/{{pascalCase componentName}}",
+  parameters: {
+    chromatic: { disable: false },
+    controls: { disable: true },
+  },
 } satisfies Meta<typeof {{pascalCase componentName}}>
 
 const StickerSheetTemplate: StoryFn<{ isReversed: boolean }> = ({
@@ -30,16 +34,10 @@ const StickerSheetTemplate: StoryFn<{ isReversed: boolean }> = ({
 
 export const StickerSheetDefault = StickerSheetTemplate.bind({})
 StickerSheetDefault.storyName = "Sticker Sheet (Default)"
-StickerSheetDefault.parameters = {
-  chromatic: { disable: false },
-  controls: { disable: true },
-}
 
 export const StickerSheetReversed = StickerSheetTemplate.bind({})
 StickerSheetReversed.storyName = "Sticker Sheet (Reversed)"
 StickerSheetReversed.args = { isReversed: true }
 StickerSheetReversed.parameters = {
-  chromatic: { disable: false },
-  controls: { disable: true },
   backgrounds: { default: "Purple 700" },
 }


### PR DESCRIPTION
## What
<!-- What do your changes do? How do they change/fix the current behavior? -->
<!-- Add screenshots, GIFs or videos to illustrate the changes.  -->
- Move stickersheets from category `Stickersheets` to `Components` and update plop template to reflect the change
- Also removed `Button Group` from the `Button` alternatives (this was accidentally merged in from testing)

## Why

Since we deploy only Docs to our site, Stickersheets (as long as they remain in their own file without the `autodocs` tag) can live under the `Components/{{ componentName }}` structure during dev :)
