### PR TITLE
GenericModal - Add support for server-side hydration

### DIFF
--- a/.changeset/sixty-rivers-care.md
+++ b/.changeset/sixty-rivers-care.md
@@ -1,0 +1,5 @@
+---
+"@kaizen/draft-modal": patch
+---
+
+GenericModal uses client-only APIs which causes issues in frameworks like Next.js that hydrate React components. This change adds a wrapper around the component to render it once mounted.

--- a/draft-packages/modal/KaizenDraft/Modal/Primitives/GenericModal.tsx
+++ b/draft-packages/modal/KaizenDraft/Modal/Primitives/GenericModal.tsx
@@ -289,4 +289,28 @@ const createAriaHider = (dialogNode: HTMLElement): (() => void) => {
   }
 }
 
-export default GenericModalContainer
+const ClientOnly = ({
+  children,
+}: {
+  readonly children: React.ReactNode
+}): JSX.Element => {
+  const [hasMounted, setHasMounted] = React.useState(false)
+
+  React.useEffect(() => {
+    setHasMounted(true)
+  }, [])
+
+  if (!hasMounted) {
+    return <></>
+  }
+
+  return <>{children}</>
+}
+
+const ClientModal = (args: GenericModalContainerProps): JSX.Element => (
+  <ClientOnly>
+    <GenericModalContainer {...args} />
+  </ClientOnly>
+)
+
+export default ClientModal


### PR DESCRIPTION
## Why
Tried to use ContextModal in the performance-review-cycles-ui project that uses Next.js. It encountered errors when accessing `document`
<img width="760" alt="image" src="https://user-images.githubusercontent.com/4666090/233869518-67374f29-3a5d-43a0-86e8-de2fa9d9f64f.png">

As `ContextModal` is built off `GenericModal,` I have added a client-only wrapper for `GenericModal` that renders after mount, which ensures its on the client at that point. This should allow the modals to be used in Next.js apps. I couldn't directly test this in the project as linking the package caused issues with `Illustration` and `lottie` dependencies.

If there's some other global way Kaizen approaches this, happy to be guided.

