### PR TITLE
chore(eslint): add react rules

### DIFF
--- a/.changeset/clean-ladybugs-sip.md
+++ b/.changeset/clean-ladybugs-sip.md
@@ -1,0 +1,14 @@
+---
+"@kaizen/draft-title-block-zen": patch
+"@kaizen/component-library": patch
+"@kaizen/draft-popover": patch
+"@kaizen/draft-table": patch
+"@kaizen/date-picker": patch
+"@kaizen/components": patch
+"@kaizen/pagination": patch
+"@kaizen/draft-tag": patch
+"@kaizen/button": patch
+"@kaizen/select": patch
+---
+
+Add type="button" to buttons missing an explicit type

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -292,7 +292,6 @@ module.exports = {
     "react/jsx-key": "off",
     "react/no-children-prop": "off",
     "react/jsx-no-target-blank": "off",
-    "react/display-name": "off",
   },
   overrides: [
     {

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -23,6 +23,7 @@ module.exports = {
     "plugin:jsx-a11y/recommended",
     "plugin:storybook/recommended",
     "plugin:import/typescript",
+    "plugin:react/recommended",
   ],
   parser: "@typescript-eslint/parser",
   parserOptions: {
@@ -264,6 +265,7 @@ module.exports = {
     "prefer-object-spread": "error",
     "quote-props": ["error", "as-needed"],
     radix: "error",
+    "react/button-has-type": ["error"],
     "space-before-function-paren": [
       "error",
       {

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -291,7 +291,6 @@ module.exports = {
     "react/no-unescaped-entities": "off",
     "react/jsx-key": "off",
     "react/no-children-prop": "off",
-    "react/jsx-no-target-blank": "off",
   },
   overrides: [
     {

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -290,7 +290,6 @@ module.exports = {
     "valid-typeof": "off",
     "react/no-unescaped-entities": "off",
     "react/jsx-key": "off",
-    "react/no-children-prop": "off",
   },
   overrides: [
     {

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -306,7 +306,10 @@ module.exports = {
     {
       files: ["*.ts", "*.mts", "*.cts", "*.tsx"],
       rules: {
-        "@typescript-eslint/explicit-function-return-type": "error",
+        "@typescript-eslint/explicit-function-return-type": [
+          "error",
+          { allowExpressions: true },
+        ],
       },
     },
   ],

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -288,7 +288,6 @@ module.exports = {
     ],
     "use-isnan": "error",
     "valid-typeof": "off",
-    "react/no-unescaped-entities": "off",
   },
   overrides: [
     {

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -16,6 +16,9 @@ module.exports = {
     "import/resolver": {
       typescript: {}, // this empty key is required for eslint-import-resolver-typescript
     },
+    react: {
+      version: "detect",
+    },
   },
   extends: [
     "prettier",
@@ -266,6 +269,7 @@ module.exports = {
     "quote-props": ["error", "as-needed"],
     radix: "error",
     "react/button-has-type": ["error"],
+    "react/prop-types": "off",
     "space-before-function-paren": [
       "error",
       {
@@ -284,6 +288,11 @@ module.exports = {
     ],
     "use-isnan": "error",
     "valid-typeof": "off",
+    "react/no-unescaped-entities": "off",
+    "react/jsx-key": "off",
+    "react/no-children-prop": "off",
+    "react/jsx-no-target-blank": "off",
+    "react/display-name": "off",
   },
   overrides: [
     {

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -289,7 +289,6 @@ module.exports = {
     "use-isnan": "error",
     "valid-typeof": "off",
     "react/no-unescaped-entities": "off",
-    "react/jsx-key": "off",
   },
   overrides: [
     {

--- a/docs/Systems/Tailwind/UtilityClassReferences/Modifiers/pseudo-states.stories.tsx
+++ b/docs/Systems/Tailwind/UtilityClassReferences/Modifiers/pseudo-states.stories.tsx
@@ -26,7 +26,10 @@ export const PseudoSelectors: StoryFn<{ isReversed: boolean }> = ({
     <StoryWrapper.Row rowTitle="hover">
       <p className="font-family-paragraph">hover:bg-blue-200</p>
       <p className="font-family-paragraph">background-color: #bde2f5</p>
-      <button className="border-solid bg-white border-[black] font-family-paragraph w-[150px] rounded-default hover:bg-blue-200 py-16 px-12 text-center">
+      <button
+        type="button"
+        className="border-solid bg-white border-[black] font-family-paragraph w-[150px] rounded-default hover:bg-blue-200 py-16 px-12 text-center"
+      >
         Hover me
       </button>
     </StoryWrapper.Row>
@@ -34,6 +37,7 @@ export const PseudoSelectors: StoryFn<{ isReversed: boolean }> = ({
       <p className="font-family-paragraph">focus:bg-blue-200</p>
       <p className="font-family-paragraph">background-color: #bde2f5</p>
       <button
+        type="button"
         tabIndex={0}
         className="border-solid bg-white border-[black] font-family-paragraph w-[150px] rounded-default focus:bg-blue-200 py-16 px-12 text-center"
       >

--- a/docs/Systems/Tailwind/components/CodeSnippet.tsx
+++ b/docs/Systems/Tailwind/components/CodeSnippet.tsx
@@ -18,6 +18,7 @@ export const CodeSnippet = ({ text, onCopy }: Props): React.ReactElement => {
 
   return (
     <button
+      type="button"
       className="flex bg-[#00182e] h-min rounded-default justify-between items-center px-12 border-none cursor-pointer w-100"
       onClick={(): void => handleCopy(text)}
       onBlur={(): void => setCopyIconIsChecked(false)}

--- a/draft-packages/collapsible/docs/SingleCollapsible.stories.tsx
+++ b/draft-packages/collapsible/docs/SingleCollapsible.stories.tsx
@@ -52,7 +52,7 @@ const SingleCollapsibleNoPadding = (): JSX.Element => (
     </ListItem>
     <ListItem>
       <Paragraph variant="body">
-        In that case you should use the 'noSectionPadding' prop.
+        In that case you should use the &#39;noSectionPadding&#39; prop.
       </Paragraph>
     </ListItem>
   </Collapsible>
@@ -99,8 +99,8 @@ const SingleCollapsibleCustomHeader = (): JSX.Element => (
 const SingleCollapsibleLazyLoad = (): JSX.Element => (
   <Collapsible id="collapsible-single" title="Single collapsible" lazyLoad>
     <Paragraph variant="body">
-      This content won't be rendered until the collapsible is opened. This is
-      particularly useful when you have data being queried inside your
+      This content won&#39;t be rendered until the collapsible is opened. This
+      is particularly useful when you have data being queried inside your
       collapsible content.
     </Paragraph>
     <Paragraph variant="body">

--- a/draft-packages/collapsible/docs/SingleCollapsible.stories.tsx
+++ b/draft-packages/collapsible/docs/SingleCollapsible.stories.tsx
@@ -52,7 +52,7 @@ const SingleCollapsibleNoPadding = (): JSX.Element => (
     </ListItem>
     <ListItem>
       <Paragraph variant="body">
-        In that case you should use the &#39;noSectionPadding&#39; prop.
+        In that case you should use the &apos;noSectionPadding&apos; prop.
       </Paragraph>
     </ListItem>
   </Collapsible>
@@ -99,7 +99,7 @@ const SingleCollapsibleCustomHeader = (): JSX.Element => (
 const SingleCollapsibleLazyLoad = (): JSX.Element => (
   <Collapsible id="collapsible-single" title="Single collapsible" lazyLoad>
     <Paragraph variant="body">
-      This content won&#39;t be rendered until the collapsible is opened. This
+      This content won&apos;t be rendered until the collapsible is opened. This
       is particularly useful when you have data being queried inside your
       collapsible content.
     </Paragraph>

--- a/draft-packages/divider/docs/Divider.stories.tsx
+++ b/draft-packages/divider/docs/Divider.stories.tsx
@@ -46,7 +46,7 @@ const StickerSheetTemplate: StoryFn<{ isReversed: boolean }> = ({
       <Card variant={isReversed ? "highlight" : "default"}>
         <Box p={0.75}>
           <Heading variant="heading-4" color="dark">
-            Understands people&#39;s agenda and perspectives
+            Understands people&apos;s agenda and perspectives
           </Heading>
           <Box pt={0.25}>
             <Paragraph variant="small" color="dark-reduced-opacity">

--- a/draft-packages/divider/docs/Divider.stories.tsx
+++ b/draft-packages/divider/docs/Divider.stories.tsx
@@ -46,7 +46,7 @@ const StickerSheetTemplate: StoryFn<{ isReversed: boolean }> = ({
       <Card variant={isReversed ? "highlight" : "default"}>
         <Box p={0.75}>
           <Heading variant="heading-4" color="dark">
-            Understands people's agenda and perspectives
+            Understands people&#39;s agenda and perspectives
           </Heading>
           <Box pt={0.25}>
             <Paragraph variant="small" color="dark-reduced-opacity">

--- a/draft-packages/form/KaizenDraft/Form/CheckboxGroup/CheckboxGroup.spec.tsx
+++ b/draft-packages/form/KaizenDraft/Form/CheckboxGroup/CheckboxGroup.spec.tsx
@@ -28,9 +28,7 @@ describe("<CheckboxGroup />", () => {
   it("renders a title", () => {
     const title = "Label"
 
-    const { queryByText } = render(
-      <CheckboxGroup labelText={title} children={null} />
-    )
+    const { queryByText } = render(<CheckboxGroup labelText={title} />)
     expect(queryByText(title)).toBeTruthy()
   })
 

--- a/draft-packages/form/KaizenDraft/Form/RadioGroup/RadioGroup.spec.tsx
+++ b/draft-packages/form/KaizenDraft/Form/RadioGroup/RadioGroup.spec.tsx
@@ -7,9 +7,7 @@ describe("<RadioGroup />", () => {
     it("renders a title", () => {
       const title = "Label"
 
-      const { queryByText } = render(
-        <RadioGroup labelText={title} children={null} />
-      )
+      const { queryByText } = render(<RadioGroup labelText={title} />)
       expect(queryByText(title)).toBeTruthy()
     })
   })

--- a/draft-packages/illustration/KaizenDraft/Illustration/Spot.tsx
+++ b/draft-packages/illustration/KaizenDraft/Illustration/Spot.tsx
@@ -209,6 +209,7 @@ export const Assertive = ({
 const SPOT_ILLUSTRATION_BASE_PATH = "illustrations/heart/spot/"
 const createSpotIllustration =
   (fileName: string) =>
+  // eslint-disable-next-line react/display-name
   ({ enableAspectRatio, ...props }: SpotProps): JSX.Element =>
     (
       <Base

--- a/draft-packages/illustration/docs/IllustrationScene.stories.tsx
+++ b/draft-packages/illustration/docs/IllustrationScene.stories.tsx
@@ -139,13 +139,12 @@ const IllustrationScenesTemplate: StoryFn<IllustrationScenesTemplateProps> = ({
     <>
       {sceneComponents.map(({ Component, heading, width }: SceneComponent) => {
         const sceneWrapperProps = {
-          key: heading,
           width: width || "450px",
           heading,
         }
         if (isAnimatedScene(Component)) {
           return (
-            <SceneWrapper {...sceneWrapperProps}>
+            <SceneWrapper key={heading} {...sceneWrapperProps}>
               {isAnimatedStory ? (
                 <Component
                   isAnimated={true}
@@ -161,7 +160,7 @@ const IllustrationScenesTemplate: StoryFn<IllustrationScenesTemplateProps> = ({
         }
 
         return (
-          <SceneWrapper {...sceneWrapperProps}>
+          <SceneWrapper key={heading} {...sceneWrapperProps}>
             <Component alt={alt} {...restProps} />
           </SceneWrapper>
         )

--- a/draft-packages/menu/docs/MenuExamples.stories.tsx
+++ b/draft-packages/menu/docs/MenuExamples.stories.tsx
@@ -105,8 +105,8 @@ export const AutoHideBehaviours: StoryFn = () => (
         </Menu>
         <Box mt={1}>
           <Paragraph variant="body">
-            <strong>autoHide=&#34;on&#34;</strong> menu will close when clicking
-            inside or outside the menu
+            <strong>autoHide=&quot;on&quot;</strong> menu will close when
+            clicking inside or outside the menu
           </Paragraph>
         </Box>
       </div>
@@ -122,7 +122,7 @@ export const AutoHideBehaviours: StoryFn = () => (
         </Menu>
         <Box mt={1}>
           <Paragraph variant="body">
-            <strong>autoHide=&#34;outside-click-only&#34;</strong> menu will
+            <strong>autoHide=&quot;outside-click-only&quot;</strong> menu will
             close when clicking outside the menu, but not inside the menu
           </Paragraph>
         </Box>
@@ -139,7 +139,7 @@ export const AutoHideBehaviours: StoryFn = () => (
         </Menu>
         <Box mt={1}>
           <Paragraph variant="body">
-            <strong>autoHide=&#34;off&#34;</strong> menu will closes only when
+            <strong>autoHide=&quot;off&quot;</strong> menu will closes only when
             button is pressed
           </Paragraph>
         </Box>
@@ -226,9 +226,9 @@ export const MenuWithActiveItem: StoryFn = () => (
   <>
     <Box mb={1}>
       <Paragraph variant="body">
-        Menus don&#39;t usually have &#34;active&#34; items, since they are just
-        a collection of links or actions, but in non-standard cases like the
-        navigation bar, the `isActive` prop provides a way to do this.
+        Menus don&#39;t usually have &quot;active&quot; items, since they are
+        just a collection of links or actions, but in non-standard cases like
+        the navigation bar, the `isActive` prop provides a way to do this.
       </Paragraph>
     </Box>
     <Menu

--- a/draft-packages/menu/docs/MenuExamples.stories.tsx
+++ b/draft-packages/menu/docs/MenuExamples.stories.tsx
@@ -226,7 +226,7 @@ export const MenuWithActiveItem: StoryFn = () => (
   <>
     <Box mb={1}>
       <Paragraph variant="body">
-        Menus don&#39;t usually have &quot;active&quot; items, since they are
+        Menus don&apos;t usually have &quot;active&quot; items, since they are
         just a collection of links or actions, but in non-standard cases like
         the navigation bar, the `isActive` prop provides a way to do this.
       </Paragraph>

--- a/draft-packages/menu/docs/MenuExamples.stories.tsx
+++ b/draft-packages/menu/docs/MenuExamples.stories.tsx
@@ -105,8 +105,8 @@ export const AutoHideBehaviours: StoryFn = () => (
         </Menu>
         <Box mt={1}>
           <Paragraph variant="body">
-            <strong>autoHide="on"</strong> menu will close when clicking inside
-            or outside the menu
+            <strong>autoHide=&#34;on&#34;</strong> menu will close when clicking
+            inside or outside the menu
           </Paragraph>
         </Box>
       </div>
@@ -122,8 +122,8 @@ export const AutoHideBehaviours: StoryFn = () => (
         </Menu>
         <Box mt={1}>
           <Paragraph variant="body">
-            <strong>autoHide="outside-click-only"</strong> menu will close when
-            clicking outside the menu, but not inside the menu
+            <strong>autoHide=&#34;outside-click-only&#34;</strong> menu will
+            close when clicking outside the menu, but not inside the menu
           </Paragraph>
         </Box>
       </div>
@@ -139,8 +139,8 @@ export const AutoHideBehaviours: StoryFn = () => (
         </Menu>
         <Box mt={1}>
           <Paragraph variant="body">
-            <strong>autoHide="off"</strong> menu will closes only when button is
-            pressed
+            <strong>autoHide=&#34;off&#34;</strong> menu will closes only when
+            button is pressed
           </Paragraph>
         </Box>
       </div>
@@ -226,8 +226,8 @@ export const MenuWithActiveItem: StoryFn = () => (
   <>
     <Box mb={1}>
       <Paragraph variant="body">
-        Menus don't usually have "active" items, since they are just a
-        collection of links or actions, but in non-standard cases like the
+        Menus don&#39;t usually have &#34;active&#34; items, since they are just
+        a collection of links or actions, but in non-standard cases like the
         navigation bar, the `isActive` prop provides a way to do this.
       </Paragraph>
     </Box>

--- a/draft-packages/modal/KaizenDraft/Modal/Presets/ConfirmationModal.spec.tsx
+++ b/draft-packages/modal/KaizenDraft/Modal/Presets/ConfirmationModal.spec.tsx
@@ -3,9 +3,10 @@ import { render, fireEvent } from "@testing-library/react"
 import { ConfirmationModal, ConfirmationModalProps } from "./ConfirmationModal"
 import "./matchMedia.mock"
 
-const ConfirmationModalWrapper = (
-  props: Partial<ConfirmationModalProps>
-): JSX.Element => (
+const ConfirmationModalWrapper = ({
+  children,
+  ...props
+}: Partial<ConfirmationModalProps>): JSX.Element => (
   <ConfirmationModal
     mood="informative"
     isOpen={true}
@@ -14,7 +15,7 @@ const ConfirmationModalWrapper = (
     onConfirm={(): void => undefined}
     {...props}
   >
-    Example Modal body
+    {children}
   </ConfirmationModal>
 )
 

--- a/draft-packages/modal/KaizenDraft/Modal/Presets/ConfirmationModal.spec.tsx
+++ b/draft-packages/modal/KaizenDraft/Modal/Presets/ConfirmationModal.spec.tsx
@@ -12,9 +12,10 @@ const ConfirmationModalWrapper = (
     title="Example Modal Title"
     onDismiss={(): void => undefined}
     onConfirm={(): void => undefined}
-    children="Example Modal body"
     {...props}
-  />
+  >
+    Example Modal body
+  </ConfirmationModal>
 )
 
 describe("<ConfirmationModal />", () => {

--- a/draft-packages/modal/KaizenDraft/Modal/Presets/ContextModal.spec.tsx
+++ b/draft-packages/modal/KaizenDraft/Modal/Presets/ContextModal.spec.tsx
@@ -3,9 +3,10 @@ import { render, fireEvent } from "@testing-library/react"
 import { ContextModal, ContextModalProps } from "./ContextModal"
 import "./matchMedia.mock"
 
-const ContextModalWrapper = (
-  props: Partial<ContextModalProps>
-): JSX.Element => (
+const ContextModalWrapper = ({
+  children,
+  ...props
+}: Partial<ContextModalProps>): JSX.Element => (
   <ContextModal
     isOpen={true}
     title="Example modal title"
@@ -15,7 +16,7 @@ const ContextModalWrapper = (
     onSecondaryAction={(): void => undefined}
     {...props}
   >
-    Example modal body
+    {children}
   </ContextModal>
 )
 

--- a/draft-packages/modal/KaizenDraft/Modal/Presets/ContextModal.spec.tsx
+++ b/draft-packages/modal/KaizenDraft/Modal/Presets/ContextModal.spec.tsx
@@ -11,11 +11,12 @@ const ContextModalWrapper = (
     title="Example modal title"
     onConfirm={(): void => undefined}
     onDismiss={(): void => undefined}
-    children="Example modal body"
     secondaryLabel="Example secondary"
     onSecondaryAction={(): void => undefined}
     {...props}
-  />
+  >
+    Example modal body
+  </ContextModal>
 )
 
 describe("<ContextModal />", () => {

--- a/draft-packages/modal/KaizenDraft/Modal/Presets/InputEditModal.spec.tsx
+++ b/draft-packages/modal/KaizenDraft/Modal/Presets/InputEditModal.spec.tsx
@@ -3,9 +3,10 @@ import { render, fireEvent } from "@testing-library/react"
 import { InputEditModal, InputEditModalProps } from "./InputEditModal"
 import "./matchMedia.mock"
 
-const InputEditModalWrapper = (
-  props: Partial<InputEditModalProps>
-): JSX.Element => (
+const InputEditModalWrapper = ({
+  children,
+  ...props
+}: Partial<InputEditModalProps>): JSX.Element => (
   <InputEditModal
     isOpen={true}
     mood="positive"
@@ -14,7 +15,7 @@ const InputEditModalWrapper = (
     onDismiss={(): void => undefined}
     {...props}
   >
-    Example modal body
+    {children}
   </InputEditModal>
 )
 

--- a/draft-packages/modal/KaizenDraft/Modal/Presets/InputEditModal.spec.tsx
+++ b/draft-packages/modal/KaizenDraft/Modal/Presets/InputEditModal.spec.tsx
@@ -12,9 +12,10 @@ const InputEditModalWrapper = (
     title="Example modal title"
     onSubmit={(): void => undefined}
     onDismiss={(): void => undefined}
-    children="Example modal body"
     {...props}
-  />
+  >
+    Example modal body
+  </InputEditModal>
 )
 
 describe("<InputEditModal />", () => {

--- a/draft-packages/modal/KaizenDraft/Modal/Presets/RoadblockModal.spec.tsx
+++ b/draft-packages/modal/KaizenDraft/Modal/Presets/RoadblockModal.spec.tsx
@@ -3,16 +3,17 @@ import { render, fireEvent } from "@testing-library/react"
 import { RoadblockModal, RoadblockModalProps } from "./RoadblockModal"
 import "./matchMedia.mock"
 
-const RoadblockModalWrapper = (
-  props: Partial<RoadblockModalProps>
-): JSX.Element => (
+const RoadblockModalWrapper = ({
+  children,
+  ...props
+}: Partial<RoadblockModalProps>): JSX.Element => (
   <RoadblockModal
     isOpen={true}
     title="Example modal title"
     onDismiss={(): void => undefined}
     {...props}
   >
-    Example modal body
+    {children}
   </RoadblockModal>
 )
 

--- a/draft-packages/modal/KaizenDraft/Modal/Presets/RoadblockModal.spec.tsx
+++ b/draft-packages/modal/KaizenDraft/Modal/Presets/RoadblockModal.spec.tsx
@@ -10,9 +10,10 @@ const RoadblockModalWrapper = (
     isOpen={true}
     title="Example modal title"
     onDismiss={(): void => undefined}
-    children="Example modal body"
     {...props}
-  />
+  >
+    Example modal body
+  </RoadblockModal>
 )
 
 describe("<RoadblockModal />", () => {

--- a/draft-packages/modal/KaizenDraft/Modal/Primitives/GenericModal.spec.tsx
+++ b/draft-packages/modal/KaizenDraft/Modal/Primitives/GenericModal.spec.tsx
@@ -24,9 +24,10 @@ const ExampleModalWithState = (props: {
       onOutsideModalClick={handleDismiss}
       onEscapeKeyup={handleDismiss}
       onAfterLeave={props.onAfterLeave}
-      children={props.children}
       automationId="GenericModalAutomationId"
-    />
+    >
+      {props.children}
+    </GenericModal>
   )
 }
 

--- a/draft-packages/page-layout/docs/PageLayout.stories.tsx
+++ b/draft-packages/page-layout/docs/PageLayout.stories.tsx
@@ -43,7 +43,7 @@ export const DefaultStory: StoryFn = () => (
           and bringing up the rear of every funeral I meet; and especially
           whenever my hypos get such an upper hand of me, that it requires a
           strong moral principle to prevent me from deliberately stepping into
-          the street, and methodically knocking people's hats off - then, I
+          the street, and methodically knocking people&#39;s hats off - then, I
           account it high time to get to sea as soon as I can. This is my
           substitute for pistol and ball. With a philosophical flourish Cato
           throws himself upon his sword; I quietly take to the ship.
@@ -69,10 +69,11 @@ export const FullBleedBackgroundStory: StoryFn = () => (
           warehouses, and bringing up the rear of every funeral I meet; and
           especially whenever my hypos get such an upper hand of me, that it
           requires a strong moral principle to prevent me from deliberately
-          stepping into the street, and methodically knocking people's hats off
-          - then, I account it high time to get to sea as soon as I can. This is
-          my substitute for pistol and ball. With a philosophical flourish Cato
-          throws himself upon his sword; I quietly take to the ship.
+          stepping into the street, and methodically knocking people&#39;s hats
+          off - then, I account it high time to get to sea as soon as I can.
+          This is my substitute for pistol and ball. With a philosophical
+          flourish Cato throws himself upon his sword; I quietly take to the
+          ship.
         </Paragraph>
       </Content>
     </Container>

--- a/draft-packages/page-layout/docs/PageLayout.stories.tsx
+++ b/draft-packages/page-layout/docs/PageLayout.stories.tsx
@@ -90,7 +90,9 @@ export const SkirtStory: StoryFn = () => (
         text: "Back to home",
         handleClick: () => alert("breadcrumb clicked!"),
       }}
-      navigationTabs={[<NavigationTab text="Label" href="#" active />]}
+      navigationTabs={[
+        <NavigationTab key="Label" text="Label" href="#" active />,
+      ]}
     />
     <Skirt>
       <SkirtCard>
@@ -152,7 +154,13 @@ export const SkirtEducationVariant: StoryFn = () => (
         handleClick: () => alert("breadcrumb clicked!"),
       }}
       navigationTabs={[
-        <NavigationTab variant="education" text="Label" href="#" active />,
+        <NavigationTab
+          key="Label"
+          variant="education"
+          text="Label"
+          href="#"
+          active
+        />,
       ]}
     />
     <Skirt variant="education">

--- a/draft-packages/page-layout/docs/PageLayout.stories.tsx
+++ b/draft-packages/page-layout/docs/PageLayout.stories.tsx
@@ -43,7 +43,7 @@ export const DefaultStory: StoryFn = () => (
           and bringing up the rear of every funeral I meet; and especially
           whenever my hypos get such an upper hand of me, that it requires a
           strong moral principle to prevent me from deliberately stepping into
-          the street, and methodically knocking people&#39;s hats off - then, I
+          the street, and methodically knocking people&apos;s hats off - then, I
           account it high time to get to sea as soon as I can. This is my
           substitute for pistol and ball. With a philosophical flourish Cato
           throws himself upon his sword; I quietly take to the ship.
@@ -69,7 +69,7 @@ export const FullBleedBackgroundStory: StoryFn = () => (
           warehouses, and bringing up the rear of every funeral I meet; and
           especially whenever my hypos get such an upper hand of me, that it
           requires a strong moral principle to prevent me from deliberately
-          stepping into the street, and methodically knocking people&#39;s hats
+          stepping into the street, and methodically knocking people&apos;s hats
           off - then, I account it high time to get to sea as soon as I can.
           This is my substitute for pistol and ball. With a philosophical
           flourish Cato throws himself upon his sword; I quietly take to the

--- a/draft-packages/popover/KaizenDraft/Popover/Popover.tsx
+++ b/draft-packages/popover/KaizenDraft/Popover/Popover.tsx
@@ -213,6 +213,7 @@ export const usePopover = (): [
   // In this situation however, the value is rarely going to change, and
   // popovers aren't going to include content with expensive render times.
   const PopoverWithRef = useMemo(
+    // eslint-disable-next-line react/display-name
     () => (props: PopoverPropsWithoutRef) =>
       referenceElement ? (
         <Popover {...props} referenceElement={referenceElement} />

--- a/draft-packages/popover/KaizenDraft/Popover/PopoverLegacy.tsx
+++ b/draft-packages/popover/KaizenDraft/Popover/PopoverLegacy.tsx
@@ -114,7 +114,7 @@ export const PopoverLegacy = React.forwardRef<
             )}
             <div className={styles.singleLine}>{heading}</div>
             {dismissible && (
-              <button className={styles.close} onClick={onClose}>
+              <button type="button" className={styles.close} onClick={onClose}>
                 <Icon role="presentation" icon={closeIcon} />
               </button>
             )}

--- a/draft-packages/popover/KaizenDraft/Popover/PopoverLegacy.tsx
+++ b/draft-packages/popover/KaizenDraft/Popover/PopoverLegacy.tsx
@@ -140,3 +140,5 @@ export const PopoverLegacy = React.forwardRef<
     </div>
   )
 )
+
+PopoverLegacy.displayName = "PopoverLegacy"

--- a/draft-packages/popover/docs/Popover.stories.tsx
+++ b/draft-packages/popover/docs/Popover.stories.tsx
@@ -37,7 +37,7 @@ const Container = ({
   <>
     <p>
       Default Placement is &#39;above&#39;. Scroll horizontally or vertically to
-      view the Popover &#34;flip&#34; and move according to the space of the
+      view the Popover &quot;flip&quot; and move according to the space of the
       viewport. Ensuring the Popover does not get cut off.
     </p>
     <div

--- a/draft-packages/popover/docs/Popover.stories.tsx
+++ b/draft-packages/popover/docs/Popover.stories.tsx
@@ -36,9 +36,9 @@ const Container = ({
 }): JSX.Element => (
   <>
     <p>
-      Default Placement is &#39;above&#39;. Scroll horizontally or vertically to
-      view the Popover &quot;flip&quot; and move according to the space of the
-      viewport. Ensuring the Popover does not get cut off.
+      Default Placement is &apos;above&apos;. Scroll horizontally or vertically
+      to view the Popover &quot;flip&quot; and move according to the space of
+      the viewport. Ensuring the Popover does not get cut off.
     </p>
     <div
       style={{

--- a/draft-packages/popover/docs/Popover.stories.tsx
+++ b/draft-packages/popover/docs/Popover.stories.tsx
@@ -36,9 +36,9 @@ const Container = ({
 }): JSX.Element => (
   <>
     <p>
-      Default Placement is 'above'. Scroll horizontally or vertically to view
-      the Popover "flip" and move according to the space of the viewport.
-      Ensuring the Popover does not get cut off.
+      Default Placement is &#39;above&#39;. Scroll horizontally or vertically to
+      view the Popover &#34;flip&#34; and move according to the space of the
+      viewport. Ensuring the Popover does not get cut off.
     </p>
     <div
       style={{

--- a/draft-packages/select/KaizenDraft/Select/Select.tsx
+++ b/draft-packages/select/KaizenDraft/Select/Select.tsx
@@ -210,12 +210,13 @@ const SingleValue: typeof components.SingleValue = props => (
 const MultiValue: typeof components.MultiValue = props => (
   <div className={styles.multiValue}>
     <Tag
-      children={props.children}
       variant="default"
       dismissible
       inline
       onDismiss={props.removeProps.onClick}
-    />
+    >
+      {props.children}
+    </Tag>
   </div>
 )
 

--- a/draft-packages/table/KaizenDraft/Table/Table.tsx
+++ b/draft-packages/table/KaizenDraft/Table/Table.tsx
@@ -242,6 +242,7 @@ export const TableHeaderRowCell = ({
     </a>
   ) : onClick ? (
     <button
+      type="button"
       data-automation-id={automationId}
       className={classNames(styles.headerRowCellButton, {
         [styles.headerRowCellButtonReversed]: !!reversed,
@@ -357,6 +358,7 @@ export const TableCard = ({
     </a>
   ) : onClick ? (
     <button
+      type="button"
       className={className}
       onClick={onClick as ButtonClickEvent}
       {...otherProps}

--- a/draft-packages/table/docs/Table.stories.tsx
+++ b/draft-packages/table/docs/Table.stories.tsx
@@ -496,13 +496,14 @@ export const Tooltip: StoryFn = () => (
           </TableRowCell>
           <TableRowCell width={1 / 4}>
             <Paragraph tag="div" variant="body">
-              The header of this cell has a tooltip. It's content is wrapped.
+              The header of this cell has a tooltip. It&#39;s content is
+              wrapped.
             </Paragraph>
           </TableRowCell>
           <TableRowCell width={1 / 4}>
             <Paragraph tag="div" variant="body">
-              The header of this cell has a tooltip. It's content is end (right)
-              aligned. It does not have a tooltip icon.
+              The header of this cell has a tooltip. It&#39;s content is end
+              (right) aligned. It does not have a tooltip icon.
             </Paragraph>
           </TableRowCell>
         </TableRow>
@@ -547,7 +548,7 @@ export const AnchorLink: StoryFn = () => (
           </TableRowCell>
           <TableRowCell width={1 / 2}>
             <Paragraph tag="div" variant="body">
-              Typically you'd need to hook this up with your routing library
+              Typically you&#39;d need to hook this up with your routing library
               (eg. react-router)
             </Paragraph>
           </TableRowCell>

--- a/draft-packages/table/docs/Table.stories.tsx
+++ b/draft-packages/table/docs/Table.stories.tsx
@@ -496,13 +496,13 @@ export const Tooltip: StoryFn = () => (
           </TableRowCell>
           <TableRowCell width={1 / 4}>
             <Paragraph tag="div" variant="body">
-              The header of this cell has a tooltip. It&#39;s content is
+              The header of this cell has a tooltip. It&apos;s content is
               wrapped.
             </Paragraph>
           </TableRowCell>
           <TableRowCell width={1 / 4}>
             <Paragraph tag="div" variant="body">
-              The header of this cell has a tooltip. It&#39;s content is end
+              The header of this cell has a tooltip. It&apos;s content is end
               (right) aligned. It does not have a tooltip icon.
             </Paragraph>
           </TableRowCell>
@@ -548,8 +548,8 @@ export const AnchorLink: StoryFn = () => (
           </TableRowCell>
           <TableRowCell width={1 / 2}>
             <Paragraph tag="div" variant="body">
-              Typically you&#39;d need to hook this up with your routing library
-              (eg. react-router)
+              Typically you&apos;d need to hook this up with your routing
+              library (eg. react-router)
             </Paragraph>
           </TableRowCell>
         </TableRow>

--- a/draft-packages/tag/KaizenDraft/Tag/Tag.tsx
+++ b/draft-packages/tag/KaizenDraft/Tag/Tag.tsx
@@ -150,6 +150,7 @@ export const Tag = (props: TagProps): JSX.Element => {
           {dismissible && (
             <>
               <button
+                type="button"
                 className={styles.dismissButton}
                 onClick={onDismiss}
                 onMouseDown={onMouseDown}

--- a/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/MobileActions.tsx
+++ b/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/MobileActions.tsx
@@ -243,6 +243,7 @@ const ButtonOrLink = ({ action, children }: ButtonOrLinkProps): JSX.Element => {
   if (typeof action === "function") {
     return (
       <button
+        type="button"
         onClick={action}
         className={classnames(
           styles.mobileActionsPrimaryLabel,
@@ -272,6 +273,7 @@ const ButtonOrLink = ({ action, children }: ButtonOrLinkProps): JSX.Element => {
   // when there's no action (e.g. primary button is disabled)
   return (
     <button
+      type="button"
       className={classnames(
         styles.mobileActionsPrimaryLabel,
         styles.mobileActionsPrimaryButton
@@ -337,6 +339,7 @@ const DrawerHandle = ({
           data-automation-id="title-block-mobile-actions-drawer-handle"
         >
           <button
+            type="button"
             className={classnames(
               styles.mobileActionsExpandButton,
               styles.mobileActionsPrimaryLabel
@@ -391,6 +394,7 @@ const DrawerHandle = ({
           {/* If there are no secondary etc. actions, just show the button without drawer */}
           {showDrawer && (
             <button
+              type="button"
               className={styles.mobileActionsExpandButton}
               onClick={toggleDisplay}
               aria-expanded={isOpen}
@@ -417,6 +421,7 @@ const DrawerHandle = ({
         data-automation-id="title-block-mobile-actions-drawer-handle"
       >
         <button
+          type="button"
           className={classnames(
             styles.mobileActionsExpandButton,
             styles.mobileActionsPrimaryLabel

--- a/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/NavigationTabs.spec.tsx
+++ b/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/NavigationTabs.spec.tsx
@@ -5,6 +5,7 @@ import { NavigationTab, CustomNavigationTabProps } from "./NavigationTabs"
 
 const CustomComponent = (props: CustomNavigationTabProps): JSX.Element => (
   <button
+    type="button"
     onClick={props.handleClick}
     className={props.className}
   >{`${props.href} - ${props.text} - ${props.active}`}</button>

--- a/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/TitleBlockZen.spec.tsx
+++ b/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/TitleBlockZen.spec.tsx
@@ -538,7 +538,7 @@ describe("<TitleBlockZen />", () => {
     it("renders a custom element in section title", async () => {
       const expectedText = "This is a button"
       const CustomComponent = (props: SectionTitleRenderProps): JSX.Element => (
-        <button>{props.sectionTitle}</button>
+        <button type="button">{props.sectionTitle}</button>
       )
       render(
         <TitleBlockZen
@@ -870,6 +870,7 @@ describe("<TitleBlockZen />", () => {
     )
     const MockButtonComponent = (props: any): JSX.Element => (
       <button
+        type="button"
         className={props.className}
         onClick={props.onClick}
         data-automation-id={props.automationId}

--- a/draft-packages/title-block-zen/docs/TitleBlockZen.stories.tsx
+++ b/draft-packages/title-block-zen/docs/TitleBlockZen.stories.tsx
@@ -98,12 +98,12 @@ Default.args = {
     handleClick: (): void => alert("breadcrumb clicked!"),
   },
   navigationTabs: [
-    <NavigationTab text="Label" href="#" active />,
-    <NavigationTab text="Label" href="#" />,
-    <NavigationTab text="Label" href="#" />,
-    <NavigationTab text="Label" href="#" />,
-    <NavigationTab text="Label" href="#" />,
-    <NavigationTab text="Label" href="#" />,
+    <NavigationTab key="1" text="Label" href="#" active />,
+    <NavigationTab key="2" text="Label" href="#" />,
+    <NavigationTab key="3" text="Label" href="#" />,
+    <NavigationTab key="4" text="Label" href="#" />,
+    <NavigationTab key="5" text="Label" href="#" />,
+    <NavigationTab key="6" text="Label" href="#" />,
   ],
 }
 
@@ -221,12 +221,12 @@ export const DefaultWithMenuButton: StoryFn = () => (
         handleClick: () => alert("breadcrumb clicked!"),
       }}
       navigationTabs={[
-        <NavigationTab text="Label" href="#" active />,
-        <NavigationTab text="Label" href="#" />,
-        <NavigationTab text="Label" href="#" />,
-        <NavigationTab text="Label" href="#" />,
-        <NavigationTab text="Label" href="#" />,
-        <NavigationTab text="Label" href="#" />,
+        <NavigationTab key="1" text="Label" href="#" active />,
+        <NavigationTab key="2" text="Label" href="#" />,
+        <NavigationTab key="3" text="Label" href="#" />,
+        <NavigationTab key="4" text="Label" href="#" />,
+        <NavigationTab key="5" text="Label" href="#" />,
+        <NavigationTab key="6" text="Label" href="#" />,
       ]}
     />
   </OffsetPadding>
@@ -283,12 +283,12 @@ export const AdminVariantWithNavTabs: StoryFn = () => (
         handleClick: () => alert("breadcrumb clicked!"),
       }}
       navigationTabs={[
-        <NavigationTab text="Label" href="#" active variant="admin" />,
-        <NavigationTab text="Label" href="#" variant="admin" />,
-        <NavigationTab text="Label" href="#" variant="admin" />,
-        <NavigationTab text="Label" href="#" variant="admin" />,
-        <NavigationTab text="Label" href="#" variant="admin" />,
-        <NavigationTab text="Label" href="#" variant="admin" />,
+        <NavigationTab key="1" text="Label" href="#" active variant="admin" />,
+        <NavigationTab key="2" text="Label" href="#" variant="admin" />,
+        <NavigationTab key="3" text="Label" href="#" variant="admin" />,
+        <NavigationTab key="4" text="Label" href="#" variant="admin" />,
+        <NavigationTab key="5" text="Label" href="#" variant="admin" />,
+        <NavigationTab key="6" text="Label" href="#" variant="admin" />,
       ]}
     />
   </OffsetPadding>
@@ -375,16 +375,17 @@ export const Engagement: StoryFn = () => (
         handleClick: () => alert("breadcrumb clicked!"),
       }}
       navigationTabs={[
-        <NavigationTab text="Summary" href="#" />,
+        <NavigationTab key="summary" text="Summary" href="#" />,
         <NavigationTab
+          key="insight"
           text="Insight"
           href="#"
           handleClick={(): void => alert("Label clicked!")}
         />,
-        <NavigationTab text="Participation" href="#" />,
-        <NavigationTab text="Questions" href="#" active />,
-        <NavigationTab text="Heatmap" href="#" />,
-        <NavigationTab text="Comments" href="#" />,
+        <NavigationTab key="participation" text="Participation" href="#" />,
+        <NavigationTab key="questions" text="Questions" href="#" active />,
+        <NavigationTab key="heatmap" text="Heatmap" href="#" />,
+        <NavigationTab key="comments" text="Comments" href="#" />,
       ]}
     />
   </OffsetPadding>
@@ -424,15 +425,16 @@ export const Performance: StoryFn = () => (
         handleClick: () => alert("breadcrumb clicked!"),
       }}
       navigationTabs={[
-        <NavigationTab text="Feedback" href="#" active />,
+        <NavigationTab key="feedback" text="Feedback" href="#" active />,
         <NavigationTab
+          key="self-reflection"
           text="Self-reflection"
           href="#"
           handleClick={(): void => alert("Self-reflection clicked!")}
         />,
-        <NavigationTab text="Goal" href="#" />,
-        <NavigationTab text="Evaluations" href="#" />,
-        <NavigationTab text="Notes" href="#" />,
+        <NavigationTab key="goal" text="Goal" href="#" />,
+        <NavigationTab key="evaluations" text="Evaluations" href="#" />,
+        <NavigationTab key="notes" text="Notes" href="#" />,
       ]}
     />
   </OffsetPadding>
@@ -475,15 +477,16 @@ export const PerformanceWithAvatarProps: StoryFn = () => (
         handleClick: () => alert("breadcrumb clicked!"),
       }}
       navigationTabs={[
-        <NavigationTab text="Feedback" href="#" active />,
+        <NavigationTab key="feedback" text="Feedback" href="#" active />,
         <NavigationTab
+          key="self-reflection"
           text="Self-reflection"
           href="#"
           handleClick={(): void => alert("Self-reflection clicked!")}
         />,
-        <NavigationTab text="Goal" href="#" />,
-        <NavigationTab text="Evaluations" href="#" />,
-        <NavigationTab text="Notes" href="#" />,
+        <NavigationTab key="goal" text="Goal" href="#" />,
+        <NavigationTab key="evaluations" text="Evaluations" href="#" />,
+        <NavigationTab key="notes" text="Notes" href="#" />,
       ]}
     />
   </OffsetPadding>
@@ -523,15 +526,16 @@ export const PerformanceWithEmptyAvatarProps: StoryFn = () => (
         handleClick: () => alert("breadcrumb clicked!"),
       }}
       navigationTabs={[
-        <NavigationTab text="Feedback" href="#" active />,
+        <NavigationTab key="feedback" text="Feedback" href="#" active />,
         <NavigationTab
+          key="self-reflection"
           text="Self-reflection"
           href="#"
           handleClick={(): void => alert("Self-reflection clicked!")}
         />,
-        <NavigationTab text="Goal" href="#" />,
-        <NavigationTab text="Evaluations" href="#" />,
-        <NavigationTab text="Notes" href="#" />,
+        <NavigationTab key="goal" text="Goal" href="#" />,
+        <NavigationTab key="evaluations" text="Evaluations" href="#" />,
+        <NavigationTab key="notes" text="Notes" href="#" />,
       ]}
     />
   </OffsetPadding>
@@ -573,15 +577,16 @@ export const LongLabels: StoryFn = () => (
       avatar={<img alt="" src={assetUrl("site/empty-state.png")} />}
       subtitle="Wissenschaftlicher Mitarbeiter (Habilitation)"
       navigationTabs={[
-        <NavigationTab text="Feedback" href="#" active />,
+        <NavigationTab key="Feedback" text="Feedback" href="#" active />,
         <NavigationTab
+          key="Selbstreflexion"
           text="Selbstreflexion"
           href="#"
           handleClick={(): void => alert("Self-reflection clicked!")}
         />,
-        <NavigationTab text="Tor" href="#" />,
-        <NavigationTab text="Bewertungen" href="#" />,
-        <NavigationTab text="Anmerkungen" href="#" />,
+        <NavigationTab key="Tor" text="Tor" href="#" />,
+        <NavigationTab key="Bewertungen" text="Bewertungen" href="#" />,
+        <NavigationTab key="Anmerkungen" text="Anmerkungen" href="#" />,
       ]}
     />
   </OffsetPadding>
@@ -631,12 +636,12 @@ export const DefaultWithContent: StoryFn = () => (
         handleClick: () => alert("breadcrumb clicked!"),
       }}
       navigationTabs={[
-        <NavigationTab text="Label" href="#" active />,
-        <NavigationTab text="Label" href="#" />,
-        <NavigationTab text="Label" href="#" />,
-        <NavigationTab text="Label" href="#" />,
-        <NavigationTab text="Label" href="#" />,
-        <NavigationTab text="Label" href="#" />,
+        <NavigationTab key="1" text="Label" href="#" active />,
+        <NavigationTab key="2" text="Label" href="#" />,
+        <NavigationTab key="3" text="Label" href="#" />,
+        <NavigationTab key="4" text="Label" href="#" />,
+        <NavigationTab key="5" text="Label" href="#" />,
+        <NavigationTab key="6" text="Label" href="#" />,
       ]}
     />
     <Container>
@@ -744,12 +749,12 @@ export const DefaultNoSecondary: StoryFn = () => (
         handleClick: () => alert("breadcrumb clicked!"),
       }}
       navigationTabs={[
-        <NavigationTab text="Label" href="#" active />,
-        <NavigationTab text="Label" href="#" />,
-        <NavigationTab text="Label" href="#" />,
-        <NavigationTab text="Label" href="#" />,
-        <NavigationTab text="Label" href="#" />,
-        <NavigationTab text="Label" href="#" />,
+        <NavigationTab key="1" text="Label" href="#" active />,
+        <NavigationTab key="2" text="Label" href="#" />,
+        <NavigationTab key="3" text="Label" href="#" />,
+        <NavigationTab key="4" text="Label" href="#" />,
+        <NavigationTab key="5" text="Label" href="#" />,
+        <NavigationTab key="6" text="Label" href="#" />,
       ]}
     />
     {/* <Skirt>
@@ -851,12 +856,12 @@ export const DefaultOnlyPrimary: StoryFn = () => (
         handleClick: () => alert("breadcrumb clicked!"),
       }}
       navigationTabs={[
-        <NavigationTab text="Label" href="#" active />,
-        <NavigationTab text="Label" href="#" />,
-        <NavigationTab text="Label" href="#" />,
-        <NavigationTab text="Label" href="#" />,
-        <NavigationTab text="Label" href="#" />,
-        <NavigationTab text="Label" href="#" />,
+        <NavigationTab key="1" text="Label" href="#" active />,
+        <NavigationTab key="2" text="Label" href="#" />,
+        <NavigationTab key="3" text="Label" href="#" />,
+        <NavigationTab key="4" text="Label" href="#" />,
+        <NavigationTab key="5" text="Label" href="#" />,
+        <NavigationTab key="6" text="Label" href="#" />,
       ]}
     />
   </OffsetPadding>
@@ -876,12 +881,12 @@ export const DefaultOnlySecondary: StoryFn = () => (
         handleClick: () => alert("breadcrumb clicked!"),
       }}
       navigationTabs={[
-        <NavigationTab text="Label" href="#" active />,
-        <NavigationTab text="Label" href="#" />,
-        <NavigationTab text="Label" href="#" />,
-        <NavigationTab text="Label" href="#" />,
-        <NavigationTab text="Label" href="#" />,
-        <NavigationTab text="Label" href="#" />,
+        <NavigationTab key="1" text="Label" href="#" active />,
+        <NavigationTab key="2" text="Label" href="#" />,
+        <NavigationTab key="3" text="Label" href="#" />,
+        <NavigationTab key="4" text="Label" href="#" />,
+        <NavigationTab key="5" text="Label" href="#" />,
+        <NavigationTab key="6" text="Label" href="#" />,
       ]}
     />
   </OffsetPadding>
@@ -927,12 +932,12 @@ export const DefaultWithReportSwitcher: StoryFn = () => (
         handleClick: () => alert("breadcrumb clicked!"),
       }}
       navigationTabs={[
-        <NavigationTab text="Label" href="#" active />,
-        <NavigationTab text="Label" href="#" />,
-        <NavigationTab text="Label" href="#" />,
-        <NavigationTab text="Label" href="#" />,
-        <NavigationTab text="Label" href="#" />,
-        <NavigationTab text="Label" href="#" />,
+        <NavigationTab key="1" text="Label" href="#" active />,
+        <NavigationTab key="2" text="Label" href="#" />,
+        <NavigationTab key="3" text="Label" href="#" />,
+        <NavigationTab key="4" text="Label" href="#" />,
+        <NavigationTab key="5" text="Label" href="#" />,
+        <NavigationTab key="6" text="Label" href="#" />,
       ]}
     />
   </OffsetPadding>
@@ -974,12 +979,12 @@ export const DefaultNoLink: StoryFn = () => (
         handleClick: () => alert("breadcrumb clicked!"),
       }}
       navigationTabs={[
-        <NavigationTab text="Label" href="#" active />,
-        <NavigationTab text="Label" href="#" />,
-        <NavigationTab text="Label" href="#" />,
-        <NavigationTab text="Label" href="#" />,
-        <NavigationTab text="Label" href="#" />,
-        <NavigationTab text="Label" href="#" />,
+        <NavigationTab key="1" text="Label" href="#" active />,
+        <NavigationTab key="2" text="Label" href="#" />,
+        <NavigationTab key="3" text="Label" href="#" />,
+        <NavigationTab key="4" text="Label" href="#" />,
+        <NavigationTab key="5" text="Label" href="#" />,
+        <NavigationTab key="6" text="Label" href="#" />,
       ]}
     />
     <Skirt titleBlockHasNavigation={false}>
@@ -1133,9 +1138,15 @@ export const RenderProps: StoryFn = () => {
           ),
         }}
         navigationTabs={[
-          <NavigationTab text="Label" href="#" active render={CustomTab} />,
-          <NavigationTab text="Label" href="#" render={CustomTab} />,
-          <NavigationTab text="Label" href="#" render={CustomTab} />,
+          <NavigationTab
+            key="1"
+            text="Label"
+            href="#"
+            active
+            render={CustomTab}
+          />,
+          <NavigationTab key="2" text="Label" href="#" render={CustomTab} />,
+          <NavigationTab key="3" text="Label" href="#" render={CustomTab} />,
         ]}
       />
     </OffsetPadding>

--- a/draft-packages/title-block-zen/docs/TitleBlockZen.stories.tsx
+++ b/draft-packages/title-block-zen/docs/TitleBlockZen.stories.tsx
@@ -1200,6 +1200,7 @@ const MockRouterLink = ({
   ...otherProps
 }: MockRouterPropsType): JSX.Element => (
   <button
+    type="button"
     {...otherProps}
     // this is in place of using Link's `to` prop
     onClick={(): void => alert(`Mock route change to ${href}`)}
@@ -1289,7 +1290,7 @@ export const MenuHierarchyExample: StoryFn = () => (
             icon: reportSharingIcon,
             iconPosition: "end",
             onClick: (): void => alert("a primary action"),
-            component: props => <button {...props} />,
+            component: props => <button type="button" {...props} />,
           },
         ],
       }}

--- a/draft-packages/tooltip/docs/Tooltip.stories.tsx
+++ b/draft-packages/tooltip/docs/Tooltip.stories.tsx
@@ -274,9 +274,9 @@ StickerSheet.parameters = { chromatic: { disable: false } }
 export const OverflowScroll: StoryFn<typeof Tooltip> = props => (
   <>
     <p>
-      Default Placement is 'above'. Scroll horizontally or vertically to view
-      the Tooltip "flip" and move according to the space of the viewport.
-      Ensuring the Tooltip does not get cut off.
+      Default Placement is &#39;above&#39;. Scroll horizontally or vertically to
+      view the Tooltip &#34;flip&#34; and move according to the space of the
+      viewport. Ensuring the Tooltip does not get cut off.
     </p>
 
     <div

--- a/draft-packages/tooltip/docs/Tooltip.stories.tsx
+++ b/draft-packages/tooltip/docs/Tooltip.stories.tsx
@@ -275,7 +275,7 @@ export const OverflowScroll: StoryFn<typeof Tooltip> = props => (
   <>
     <p>
       Default Placement is &#39;above&#39;. Scroll horizontally or vertically to
-      view the Tooltip &#34;flip&#34; and move according to the space of the
+      view the Tooltip &quot;flip&quot; and move according to the space of the
       viewport. Ensuring the Tooltip does not get cut off.
     </p>
 

--- a/draft-packages/tooltip/docs/Tooltip.stories.tsx
+++ b/draft-packages/tooltip/docs/Tooltip.stories.tsx
@@ -274,9 +274,9 @@ StickerSheet.parameters = { chromatic: { disable: false } }
 export const OverflowScroll: StoryFn<typeof Tooltip> = props => (
   <>
     <p>
-      Default Placement is &#39;above&#39;. Scroll horizontally or vertically to
-      view the Tooltip &quot;flip&quot; and move according to the space of the
-      viewport. Ensuring the Tooltip does not get cut off.
+      Default Placement is &apos;above&apos;. Scroll horizontally or vertically
+      to view the Tooltip &quot;flip&quot; and move according to the space of
+      the viewport. Ensuring the Tooltip does not get cut off.
     </p>
 
     <div

--- a/package.json
+++ b/package.json
@@ -101,6 +101,7 @@
     "eslint-plugin-import": "^2.27.5",
     "eslint-plugin-jest": "^27.2.1",
     "eslint-plugin-jsx-a11y": "^6.7.1",
+    "eslint-plugin-react": "^7.32.2",
     "eslint-plugin-sort-imports-es6-autofix": "^0.6.0",
     "eslint-plugin-ssr-friendly": "^1.2.0",
     "eslint-plugin-storybook": "^0.6.11",

--- a/packages/a11y/docs/VisuallyHidden.stories.tsx
+++ b/packages/a11y/docs/VisuallyHidden.stories.tsx
@@ -17,8 +17,8 @@ export default {
 
 export const TextWithVisuallyHidden: StoryFn = () => (
   <div>
-    There is visually hidden text between the two brackets (click "Show code" to
-    see more): [<VisuallyHidden>👋 Hello!</VisuallyHidden>]
+    There is visually hidden text between the two brackets (click &#34;Show
+    code&#34; to see more): [<VisuallyHidden>👋 Hello!</VisuallyHidden>]
   </div>
 )
 TextWithVisuallyHidden.storyName = "Hidden text embedded in visible text"

--- a/packages/a11y/docs/VisuallyHidden.stories.tsx
+++ b/packages/a11y/docs/VisuallyHidden.stories.tsx
@@ -17,8 +17,8 @@ export default {
 
 export const TextWithVisuallyHidden: StoryFn = () => (
   <div>
-    There is visually hidden text between the two brackets (click &#34;Show
-    code&#34; to see more): [<VisuallyHidden>👋 Hello!</VisuallyHidden>]
+    There is visually hidden text between the two brackets (click &quot;Show
+    code&quot; to see more): [<VisuallyHidden>👋 Hello!</VisuallyHidden>]
   </div>
 )
 TextWithVisuallyHidden.storyName = "Hidden text embedded in visible text"

--- a/packages/button/src/Button/components/GenericButton.spec.tsx
+++ b/packages/button/src/Button/components/GenericButton.spec.tsx
@@ -9,7 +9,7 @@ describe("<GenericButton />", () => {
         label="button label"
         component={(props): React.ReactElement => (
           <div>
-            <div>I&#39;m custom</div>
+            <div>I&apos;m custom</div>
             <div>{props.children}</div>
           </div>
         )}

--- a/packages/button/src/Button/components/GenericButton.spec.tsx
+++ b/packages/button/src/Button/components/GenericButton.spec.tsx
@@ -9,7 +9,7 @@ describe("<GenericButton />", () => {
         label="button label"
         component={(props): React.ReactElement => (
           <div>
-            <div>I'm custom</div>
+            <div>I&#39;m custom</div>
             <div>{props.children}</div>
           </div>
         )}

--- a/packages/button/src/Button/components/GenericButton.tsx
+++ b/packages/button/src/Button/components/GenericButton.tsx
@@ -201,7 +201,9 @@ const renderLink = (props: Props, ref: Ref<HTMLAnchorElement>): JSX.Element => {
   } = props
   const customProps = getCustomProps(rest)
 
-  const target = newTabAndIUnderstandTheAccessibilityImplications ? "_blank" : "_self"
+  const target = newTabAndIUnderstandTheAccessibilityImplications
+    ? "_blank"
+    : "_self"
 
   return (
     <a

--- a/packages/button/src/Button/components/GenericButton.tsx
+++ b/packages/button/src/Button/components/GenericButton.tsx
@@ -164,6 +164,8 @@ const renderButton = (
 
   return (
     <button
+      // eslint-disable-next-line react/button-has-type
+      type={type}
       id={id}
       disabled={disabled}
       className={buttonClass(props)}
@@ -171,7 +173,6 @@ const renderButton = (
       onFocus={onFocus}
       onBlur={onBlur}
       onMouseDown={(e): void => onMouseDown && onMouseDown(e)}
-      type={type}
       aria-label={generateAriaLabel(props)}
       aria-disabled={disabled || props.working ? true : undefined}
       tabIndex={

--- a/packages/button/src/Button/components/GenericButton.tsx
+++ b/packages/button/src/Button/components/GenericButton.tsx
@@ -121,6 +121,7 @@ GenericButton.defaultProps = {
   disableTabFocusAndIUnderstandTheAccessibilityImplications: false,
   type: "button",
 }
+GenericButton.displayName = "GenericButton"
 
 const renderCustomComponent = (
   CustomComponent: ComponentType<CustomButtonProps>,

--- a/packages/button/src/Button/components/GenericButton.tsx
+++ b/packages/button/src/Button/components/GenericButton.tsx
@@ -201,13 +201,14 @@ const renderLink = (props: Props, ref: Ref<HTMLAnchorElement>): JSX.Element => {
   } = props
   const customProps = getCustomProps(rest)
 
+  const target = newTabAndIUnderstandTheAccessibilityImplications ? "_blank" : "_self"
+
   return (
     <a
       id={id}
       href={href}
-      target={
-        newTabAndIUnderstandTheAccessibilityImplications ? "_blank" : "_self"
-      }
+      target={target}
+      rel={target === "_blank" ? "noopener noreferrer" : undefined}
       className={buttonClass(props)}
       onClick={onClick}
       onFocus={onFocus}

--- a/packages/component-library/components/Dropdown/Dropdown.tsx
+++ b/packages/component-library/components/Dropdown/Dropdown.tsx
@@ -69,6 +69,7 @@ class Dropdown extends React.Component<DropdownProps, DropdownState> {
     return (
       <div className={styles.dropdown}>
         <button
+          type="button"
           className={btnClass}
           onClick={this.toggleDropdownMenu}
           onMouseDown={(e): void => e.preventDefault()}

--- a/packages/component-library/components/Dropdown/__snapshots__/Dropdown.spec.tsx.snap
+++ b/packages/component-library/components/Dropdown/__snapshots__/Dropdown.spec.tsx.snap
@@ -6,6 +6,7 @@ exports[`<Dropdown /> renders control action dropdown 1`] = `
 >
   <button
     class="dropdownButton dropdownControlAction"
+    type="button"
   >
     <span
       class="dropdownIcon"
@@ -51,6 +52,7 @@ exports[`<Dropdown /> renders default view 1`] = `
 >
   <button
     class="dropdownButton"
+    type="button"
   >
     <span
       class="dropdownIcon"
@@ -76,6 +78,7 @@ exports[`<Dropdown /> renders drop down with icon 1`] = `
 >
   <button
     class="dropdownButton"
+    type="button"
   >
     <span
       class="dropdownIcon"
@@ -102,6 +105,7 @@ exports[`<Dropdown /> renders drop down with icon and label 1`] = `
 >
   <button
     class="dropdownButton"
+    type="button"
   >
     <span
       class="dropdownIcon"
@@ -133,6 +137,7 @@ exports[`<Dropdown /> renders drop down with only label 1`] = `
 >
   <button
     class="dropdownButton"
+    type="button"
   >
     <span
       class="dropdownLabel"
@@ -149,6 +154,7 @@ exports[`<Dropdown /> renders reversed color control action dropdown 1`] = `
 >
   <button
     class="dropdownButton dropdownControlAction reversedColor"
+    type="button"
   >
     <span
       class="dropdownIcon"

--- a/packages/component-library/stories/Icon.stories.tsx
+++ b/packages/component-library/stories/Icon.stories.tsx
@@ -110,8 +110,8 @@ const StickerSheetTemplate: StoryFn = () => {
           backgroundColor: "#E5E5E5",
         }}
       >
-        import <strong>draft</strong> from "@kaizen/component-library/icons/
-        <strong>writing</strong>.icon.svg"
+        import <strong>draft</strong> from &#34;@kaizen/component-library/icons/
+        <strong>writing</strong>.icon.svg&#34;
       </code>
 
       <Heading

--- a/packages/component-library/stories/Icon.stories.tsx
+++ b/packages/component-library/stories/Icon.stories.tsx
@@ -110,8 +110,9 @@ const StickerSheetTemplate: StoryFn = () => {
           backgroundColor: "#E5E5E5",
         }}
       >
-        import <strong>draft</strong> from &#34;@kaizen/component-library/icons/
-        <strong>writing</strong>.icon.svg&#34;
+        import <strong>draft</strong> from
+        &quot;@kaizen/component-library/icons/
+        <strong>writing</strong>.icon.svg&quot;
       </code>
 
       <Heading

--- a/packages/component-library/stories/Text.stories.tsx
+++ b/packages/component-library/stories/Text.stories.tsx
@@ -108,7 +108,7 @@ export const Div: StoryFn<typeof Text> = () => (
 
 export const DivWithPageTitleStyles: StoryFn<typeof Text> = () => (
   <Text tag="div" style="page-title">
-    Div with "Page Title" styles
+    Div with &#34;Page Title&#34; styles
   </Text>
 )
 DivWithPageTitleStyles.storyName = "Div with Page Title styles"
@@ -119,27 +119,27 @@ export const Span: StoryFn<typeof Text> = () => (
 
 export const BodyBold: StoryFn<typeof Text> = () => (
   <Text tag="div" style="body-bold">
-    Div with "Body Bold" styles
+    Div with &#34;Body Bold&#34; styles
   </Text>
 )
 BodyBold.storyName = "Body-bold"
 
 export const Small: StoryFn<typeof Text> = () => (
   <Text tag="div" style="small">
-    Div with "Small" styles
+    Div with &#34;Small&#34; styles
   </Text>
 )
 
 export const SmallBold: StoryFn<typeof Text> = () => (
   <Text tag="div" style="small-bold">
-    Div with "Small Bold" styles
+    Div with &#34;Small Bold&#34; styles
   </Text>
 )
 SmallBold.storyName = "Small-bold"
 
 export const Notification: StoryFn<typeof Text> = () => (
   <Text tag="div" style="notification">
-    Div with "Notification" styles
+    Div with &#34;Notification&#34; styles
     <br />
     that have a smaller line-height
   </Text>
@@ -147,20 +147,20 @@ export const Notification: StoryFn<typeof Text> = () => (
 
 export const Label: StoryFn<typeof Text> = () => (
   <Text tag="div" style="label">
-    Div with "Label" styles
+    Div with &#34;Label&#34; styles
   </Text>
 )
 
 export const ControlAction: StoryFn<typeof Text> = () => (
   <Text tag="div" style="control-action">
-    Div with "Control Action" styles
+    Div with &#34;Control Action&#34; styles
   </Text>
 )
 ControlAction.storyName = "Control-action"
 
 export const Button: StoryFn<typeof Text> = () => (
   <Text tag="div" style="button">
-    Div with "Button" styles
+    Div with &#34;Button&#34; styles
   </Text>
 )
 

--- a/packages/component-library/stories/Text.stories.tsx
+++ b/packages/component-library/stories/Text.stories.tsx
@@ -108,7 +108,7 @@ export const Div: StoryFn<typeof Text> = () => (
 
 export const DivWithPageTitleStyles: StoryFn<typeof Text> = () => (
   <Text tag="div" style="page-title">
-    Div with &#34;Page Title&#34; styles
+    Div with &quot;Page Title&quot; styles
   </Text>
 )
 DivWithPageTitleStyles.storyName = "Div with Page Title styles"
@@ -119,27 +119,27 @@ export const Span: StoryFn<typeof Text> = () => (
 
 export const BodyBold: StoryFn<typeof Text> = () => (
   <Text tag="div" style="body-bold">
-    Div with &#34;Body Bold&#34; styles
+    Div with &quot;Body Bold&quot; styles
   </Text>
 )
 BodyBold.storyName = "Body-bold"
 
 export const Small: StoryFn<typeof Text> = () => (
   <Text tag="div" style="small">
-    Div with &#34;Small&#34; styles
+    Div with &quot;Small&quot; styles
   </Text>
 )
 
 export const SmallBold: StoryFn<typeof Text> = () => (
   <Text tag="div" style="small-bold">
-    Div with &#34;Small Bold&#34; styles
+    Div with &quot;Small Bold&quot; styles
   </Text>
 )
 SmallBold.storyName = "Small-bold"
 
 export const Notification: StoryFn<typeof Text> = () => (
   <Text tag="div" style="notification">
-    Div with &#34;Notification&#34; styles
+    Div with &quot;Notification&quot; styles
     <br />
     that have a smaller line-height
   </Text>
@@ -147,20 +147,20 @@ export const Notification: StoryFn<typeof Text> = () => (
 
 export const Label: StoryFn<typeof Text> = () => (
   <Text tag="div" style="label">
-    Div with &#34;Label&#34; styles
+    Div with &quot;Label&quot; styles
   </Text>
 )
 
 export const ControlAction: StoryFn<typeof Text> = () => (
   <Text tag="div" style="control-action">
-    Div with &#34;Control Action&#34; styles
+    Div with &quot;Control Action&quot; styles
   </Text>
 )
 ControlAction.storyName = "Control-action"
 
 export const Button: StoryFn<typeof Text> = () => (
   <Text tag="div" style="button">
-    Div with &#34;Button&#34; styles
+    Div with &quot;Button&quot; styles
   </Text>
 )
 

--- a/packages/components/src/FilterButton/FilterButtonRemovable/FilterButtonRemovable.spec.tsx
+++ b/packages/components/src/FilterButton/FilterButtonRemovable/FilterButtonRemovable.spec.tsx
@@ -63,7 +63,9 @@ describe("<FilterButtonRemovable />", () => {
                 id: "test__remove-button",
               }}
             />
-            <button onClick={handleClick}>Click me</button>
+            <button type="button" onClick={handleClick}>
+              Click me
+            </button>
           </>
         )
       }

--- a/packages/components/src/FilterButton/_subcomponents/FilterButtonBase/FilterButtonBase.tsx
+++ b/packages/components/src/FilterButton/_subcomponents/FilterButtonBase/FilterButtonBase.tsx
@@ -14,6 +14,7 @@ export const FilterButtonBase = forwardRef<
 >(({ children, classNameOverride, ...restProps }, ref) => (
   <button
     ref={ref}
+    type="button"
     className={classNames(styles.filterButtonBase, classNameOverride)}
     {...restProps}
   >

--- a/packages/components/src/FilterDateRangePicker/_docs/FilterDateRangePicker.stories.tsx
+++ b/packages/components/src/FilterDateRangePicker/_docs/FilterDateRangePicker.stories.tsx
@@ -352,7 +352,8 @@ const ValidationHelpText = ({
 
     <ul>
       <li>
-        <code>isInvalid</code>: A date that cannot be parsed. e.g "potato".
+        <code>isInvalid</code>: A date that cannot be parsed. e.g
+        &#34;potato&#34;.
       </li>
       <li>
         <code>isDisabled</code>: A date that have been set as disabled through

--- a/packages/components/src/FilterDateRangePicker/_docs/FilterDateRangePicker.stories.tsx
+++ b/packages/components/src/FilterDateRangePicker/_docs/FilterDateRangePicker.stories.tsx
@@ -353,7 +353,7 @@ const ValidationHelpText = ({
     <ul>
       <li>
         <code>isInvalid</code>: A date that cannot be parsed. e.g
-        &#34;potato&#34;.
+        &quot;potato&quot;.
       </li>
       <li>
         <code>isDisabled</code>: A date that have been set as disabled through

--- a/packages/components/src/FilterDateRangePicker/subcomponents/DateRangeInputField/DateRangeInputField.spec.tsx
+++ b/packages/components/src/FilterDateRangePicker/subcomponents/DateRangeInputField/DateRangeInputField.spec.tsx
@@ -98,7 +98,9 @@ describe("<DateRangeInputField />", () => {
               inputEndDateProps={{ labelText: "End" }}
               locale={enAU}
             />
-            <button onClick={handleClick}>Click me</button>
+            <button type="button" onClick={handleClick}>
+              Click me
+            </button>
           </>
         )
       }

--- a/packages/components/src/FilterSelect/FilterSelect.spec.tsx
+++ b/packages/components/src/FilterSelect/FilterSelect.spec.tsx
@@ -185,9 +185,9 @@ describe("FilterSelect generic", () => {
         {({ items }): JSX.Element[] =>
           items.map(item =>
             item.type === "item" ? (
-              <li>{item.value.isRubberDuck}</li>
+              <li key={item.key}>{item.value.isRubberDuck}</li>
             ) : (
-              <li>Section</li>
+              <li key={item.key}>Section</li>
             )
           )
         }

--- a/packages/components/src/FilterSelect/_docs/FilterSelect.stories.tsx
+++ b/packages/components/src/FilterSelect/_docs/FilterSelect.stories.tsx
@@ -85,6 +85,7 @@ export const AdditionalProperties: StoryFn = () => {
         items.map(item =>
           item.type === "item" ? (
             <FilterSelect.Option
+              key={item.key}
               item={{
                 ...item,
                 rendered: item.value.isFruit
@@ -93,7 +94,7 @@ export const AdditionalProperties: StoryFn = () => {
               }}
             />
           ) : (
-            <FilterSelect.ItemDefaultRender item={item} />
+            <FilterSelect.ItemDefaultRender key={item.key} item={item} />
           )
         )
       }

--- a/packages/date-picker/docs/DatePicker.stories.tsx
+++ b/packages/date-picker/docs/DatePicker.stories.tsx
@@ -182,7 +182,7 @@ export const ValidationStory: StoryFn = () => {
         <ul>
           <li>
             <code>isInvalid</code>: A date that cannot be parsed. e.g
-            &#34;potato&#34;.
+            &quot;potato&quot;.
           </li>
           <li>
             <code>isDisabled</code>: A date that have been set as disabled

--- a/packages/date-picker/docs/DatePicker.stories.tsx
+++ b/packages/date-picker/docs/DatePicker.stories.tsx
@@ -181,7 +181,8 @@ export const ValidationStory: StoryFn = () => {
         />
         <ul>
           <li>
-            <code>isInvalid</code>: A date that cannot be parsed. e.g "potato".
+            <code>isInvalid</code>: A date that cannot be parsed. e.g
+            &#34;potato&#34;.
           </li>
           <li>
             <code>isDisabled</code>: A date that have been set as disabled

--- a/packages/date-picker/src/DatePicker/components/DateInputField/DateInputField.spec.tsx
+++ b/packages/date-picker/src/DatePicker/components/DateInputField/DateInputField.spec.tsx
@@ -113,7 +113,9 @@ describe("<DateInputField />", () => {
               onButtonClick={jest.fn<void, []>()}
               locale={enUS}
             />
-            <button onClick={handleClick}>Click me</button>
+            <button type="button" onClick={handleClick}>
+              Click me
+            </button>
           </>
         )
       }

--- a/packages/date-picker/src/DateRangePicker/DateRangePicker.tsx
+++ b/packages/date-picker/src/DateRangePicker/DateRangePicker.tsx
@@ -144,6 +144,7 @@ export const DateRangePicker = ({
       <div ref={containerRef} className={classNameOverride}>
         <Label disabled={isDisabled} htmlFor={id} labelText={labelText} />
         <button
+          type="button"
           id={id}
           className={cx(
             dateRangePickerStyles.button,

--- a/packages/date-picker/src/FilterDateRangePicker/components/DateRangeInputField/DateRangeInputField.spec.tsx
+++ b/packages/date-picker/src/FilterDateRangePicker/components/DateRangeInputField/DateRangeInputField.spec.tsx
@@ -96,7 +96,9 @@ describe("<DateRangeInputField />", () => {
               inputRangeEndProps={{ labelText: "End" }}
               locale={enAU}
             />
-            <button onClick={handleClick}>Click me</button>
+            <button type="button" onClick={handleClick}>
+              Click me
+            </button>
           </>
         )
       }

--- a/packages/date-picker/src/FilterDateRangePicker/components/Trigger/FilterBaseButton/FilterBaseButton.tsx
+++ b/packages/date-picker/src/FilterDateRangePicker/components/Trigger/FilterBaseButton/FilterBaseButton.tsx
@@ -14,6 +14,7 @@ export const FilterBaseButton = forwardRef<
 >(({ children, classNameOverride, ...restProps }, ref) => (
   <button
     ref={ref}
+    type="button"
     className={classNames(styles.filterBaseButton, classNameOverride)}
     {...restProps}
   >

--- a/packages/date-picker/src/FilterDateRangePicker/components/Trigger/RemovableFilterTriggerButton/RemovableFilterTriggerButton.spec.tsx
+++ b/packages/date-picker/src/FilterDateRangePicker/components/Trigger/RemovableFilterTriggerButton/RemovableFilterTriggerButton.spec.tsx
@@ -59,7 +59,9 @@ describe("<RemovableFilterTriggerButton />", () => {
                 id: "test__remove-button",
               }}
             />
-            <button onClick={handleClick}>Click me</button>
+            <button type="button" onClick={handleClick}>
+              Click me
+            </button>
           </>
         )
       }

--- a/packages/date-picker/src/_subcomponents/DateInput/DateInputWithIconButton.spec.tsx
+++ b/packages/date-picker/src/_subcomponents/DateInput/DateInputWithIconButton.spec.tsx
@@ -75,7 +75,9 @@ describe("<DateInputWithIconButton />", () => {
               labelText="label"
               onButtonClick={jest.fn<void, []>()}
             />
-            <button onClick={handleClick}>Click me</button>
+            <button type="button" onClick={handleClick}>
+              Click me
+            </button>
           </>
         )
       }

--- a/packages/design-tokens/docs/DocsComponents.tsx
+++ b/packages/design-tokens/docs/DocsComponents.tsx
@@ -105,7 +105,7 @@ const themesBlocks: Array<
     code: heartThemeSrc,
     caption: (
       <code>
-        import {"{ heartTheme }"} from &#34;@kaizen/design-tokens&#34;
+        import {"{ heartTheme }"} from &quot;@kaizen/design-tokens&quot;
       </code>
     ),
   },
@@ -133,7 +133,7 @@ const sassBlocks: Array<
     language: "scss",
     code: colorsSass,
     caption: (
-      <code>@import &#34;~@kaizen/design-tokens/sass/color.scss&#34;</code>
+      <code>@import &quot;~@kaizen/design-tokens/sass/color.scss&quot;</code>
     ),
   },
   {
@@ -141,7 +141,9 @@ const sassBlocks: Array<
     language: "scss",
     code: typographySass,
     caption: (
-      <code>@import &#34;~@kaizen/design-tokens/sass/typography.scss&#34;</code>
+      <code>
+        @import &quot;~@kaizen/design-tokens/sass/typography.scss&quot;
+      </code>
     ),
   },
   {
@@ -149,7 +151,7 @@ const sassBlocks: Array<
     language: "scss",
     code: spacingSass,
     caption: (
-      <code>@import &#34;~@kaizen/design-tokens/sass/spacing.scss&#34;</code>
+      <code>@import &quot;~@kaizen/design-tokens/sass/spacing.scss&quot;</code>
     ),
   },
   {
@@ -157,7 +159,7 @@ const sassBlocks: Array<
     language: "scss",
     code: borderSass,
     caption: (
-      <code>@import &#34;~@kaizen/design-tokens/sass/border.scss&#34;</code>
+      <code>@import &quot;~@kaizen/design-tokens/sass/border.scss&quot;</code>
     ),
   },
   {
@@ -165,7 +167,7 @@ const sassBlocks: Array<
     language: "scss",
     code: layoutSass,
     caption: (
-      <code>@import &#34;~@kaizen/design-tokens/sass/layout.scss&#34;</code>
+      <code>@import &quot;~@kaizen/design-tokens/sass/layout.scss&quot;</code>
     ),
   },
   {
@@ -173,7 +175,7 @@ const sassBlocks: Array<
     language: "scss",
     code: shadowSass,
     caption: (
-      <code>@import &#34;~@kaizen/design-tokens/sass/shadow.scss&#34;</code>
+      <code>@import &quot;~@kaizen/design-tokens/sass/shadow.scss&quot;</code>
     ),
   },
   {
@@ -181,7 +183,9 @@ const sassBlocks: Array<
     language: "scss",
     code: animationSass,
     caption: (
-      <code>@import &#34;~@kaizen/design-tokens/sass/animation.scss&#34;</code>
+      <code>
+        @import &quot;~@kaizen/design-tokens/sass/animation.scss&quot;
+      </code>
     ),
   },
 ]

--- a/packages/design-tokens/docs/DocsComponents.tsx
+++ b/packages/design-tokens/docs/DocsComponents.tsx
@@ -104,7 +104,9 @@ const themesBlocks: Array<
     language: "typescript",
     code: heartThemeSrc,
     caption: (
-      <code>import {"{ heartTheme }"} from "@kaizen/design-tokens"</code>
+      <code>
+        import {"{ heartTheme }"} from &#34;@kaizen/design-tokens&#34;
+      </code>
     ),
   },
   {
@@ -130,43 +132,57 @@ const sassBlocks: Array<
     name: "Color",
     language: "scss",
     code: colorsSass,
-    caption: <code>@import "~@kaizen/design-tokens/sass/color.scss"</code>,
+    caption: (
+      <code>@import &#34;~@kaizen/design-tokens/sass/color.scss&#34;</code>
+    ),
   },
   {
     name: "Typography",
     language: "scss",
     code: typographySass,
-    caption: <code>@import "~@kaizen/design-tokens/sass/typography.scss"</code>,
+    caption: (
+      <code>@import &#34;~@kaizen/design-tokens/sass/typography.scss&#34;</code>
+    ),
   },
   {
     name: "Spacing",
     language: "scss",
     code: spacingSass,
-    caption: <code>@import "~@kaizen/design-tokens/sass/spacing.scss"</code>,
+    caption: (
+      <code>@import &#34;~@kaizen/design-tokens/sass/spacing.scss&#34;</code>
+    ),
   },
   {
     name: "Border",
     language: "scss",
     code: borderSass,
-    caption: <code>@import "~@kaizen/design-tokens/sass/border.scss"</code>,
+    caption: (
+      <code>@import &#34;~@kaizen/design-tokens/sass/border.scss&#34;</code>
+    ),
   },
   {
     name: "Layout",
     language: "scss",
     code: layoutSass,
-    caption: <code>@import "~@kaizen/design-tokens/sass/layout.scss"</code>,
+    caption: (
+      <code>@import &#34;~@kaizen/design-tokens/sass/layout.scss&#34;</code>
+    ),
   },
   {
     name: "Shadow",
     language: "scss",
     code: shadowSass,
-    caption: <code>@import "~@kaizen/design-tokens/sass/shadow.scss"</code>,
+    caption: (
+      <code>@import &#34;~@kaizen/design-tokens/sass/shadow.scss&#34;</code>
+    ),
   },
   {
     name: "Animation",
     language: "scss",
     code: animationSass,
-    caption: <code>@import "~@kaizen/design-tokens/sass/animation.scss"</code>,
+    caption: (
+      <code>@import &#34;~@kaizen/design-tokens/sass/animation.scss&#34;</code>
+    ),
   },
 ]
 

--- a/packages/notification/docs/GlobalNotification.stories.tsx
+++ b/packages/notification/docs/GlobalNotification.stories.tsx
@@ -50,7 +50,7 @@ const StickerSheetTemplate: StoryFn<{ isReversed: boolean }> = ({
           automationId="notification2"
           persistent
         >
-          [Survey name]&#39;s status has been changed to &#39;Archived&#39;.{" "}
+          [Survey name]&apos;s status has been changed to &apos;Archived&apos;.{" "}
           <a href="/">View all</a>
         </GlobalNotification>
       </StoryWrapper.Row>
@@ -85,7 +85,7 @@ const StickerSheetTemplate: StoryFn<{ isReversed: boolean }> = ({
       </StoryWrapper.Row>
       <StoryWrapper.Row rowTitle="Informative">
         <GlobalNotification type="informative" automationId="notification2">
-          [Survey name]&#39;s status has been changed to &#39;Archived&#39;.{" "}
+          [Survey name]&apos;s status has been changed to &apos;Archived&apos;.{" "}
           <a href="/">View all</a>
         </GlobalNotification>
       </StoryWrapper.Row>

--- a/packages/notification/docs/GlobalNotification.stories.tsx
+++ b/packages/notification/docs/GlobalNotification.stories.tsx
@@ -50,7 +50,7 @@ const StickerSheetTemplate: StoryFn<{ isReversed: boolean }> = ({
           automationId="notification2"
           persistent
         >
-          [Survey name]'s status has been changed to 'Archived'.{" "}
+          [Survey name]&#39;s status has been changed to &#39;Archived&#39;.{" "}
           <a href="/">View all</a>
         </GlobalNotification>
       </StoryWrapper.Row>
@@ -85,7 +85,7 @@ const StickerSheetTemplate: StoryFn<{ isReversed: boolean }> = ({
       </StoryWrapper.Row>
       <StoryWrapper.Row rowTitle="Informative">
         <GlobalNotification type="informative" automationId="notification2">
-          [Survey name]'s status has been changed to 'Archived'.{" "}
+          [Survey name]&#39;s status has been changed to &#39;Archived&#39;.{" "}
           <a href="/">View all</a>
         </GlobalNotification>
       </StoryWrapper.Row>

--- a/packages/notification/docs/InlineNotification.stories.tsx
+++ b/packages/notification/docs/InlineNotification.stories.tsx
@@ -61,13 +61,14 @@ const StickerSheetTemplate: StoryFn<{ isReversed: boolean }> = ({
     <>
       There’s a problem connecting to your HRIS. Check your HRIS is working and
       check your <a href="/">integration settings</a>, or if you require more
-      assistance please <a href="/">contact support</a>... or just don't do
+      assistance please <a href="/">contact support</a>... or just don&#39;t do
       anything and observe that this notification contains an absurd amount of
       text that is purposely verbose in order to demonstrate that verbosity is,
-      in most cases, just in general really, i guess it's debatable, unnecessary
-      and to demonstrate that verbosity makes this notification's body text spit
-      into multiple lines because there is, surely, unequivocally, no way that
-      all of this can fit into one line of text on an average screen...
+      in most cases, just in general really, i guess it&#39;s debatable,
+      unnecessary and to demonstrate that verbosity makes this
+      notification&#39;s body text spit into multiple lines because there is,
+      surely, unequivocally, no way that all of this can fit into one line of
+      text on an average screen...
     </>
   )
   return (
@@ -82,8 +83,8 @@ const StickerSheetTemplate: StoryFn<{ isReversed: boolean }> = ({
         </Heading>
         <StoryWrapper.Row rowTitle="Informative">
           <InlineNotification type="informative" title="Informative title">
-            "All Employees - North America" status has been changed to
-            'Archived'.
+            &#34;All Employees - North America&#34; status has been changed to
+            &#39;Archived&#39;.
             <a href="/">View all</a>
           </InlineNotification>
         </StoryWrapper.Row>
@@ -94,8 +95,8 @@ const StickerSheetTemplate: StoryFn<{ isReversed: boolean }> = ({
             title="Informative title"
             hideCloseIcon
           >
-            "All Employees - North America" status has been changed to
-            'Archived'. <a href="/">View all</a>
+            &#34;All Employees - North America&#34; status has been changed to
+            &#39;Archived&#39;. <a href="/">View all</a>
           </InlineNotification>
         </StoryWrapper.Row>
         <StoryWrapper.Row rowTitle="Positive">

--- a/packages/notification/docs/InlineNotification.stories.tsx
+++ b/packages/notification/docs/InlineNotification.stories.tsx
@@ -61,12 +61,12 @@ const StickerSheetTemplate: StoryFn<{ isReversed: boolean }> = ({
     <>
       There’s a problem connecting to your HRIS. Check your HRIS is working and
       check your <a href="/">integration settings</a>, or if you require more
-      assistance please <a href="/">contact support</a>... or just don&#39;t do
+      assistance please <a href="/">contact support</a>... or just don&apos;t do
       anything and observe that this notification contains an absurd amount of
       text that is purposely verbose in order to demonstrate that verbosity is,
-      in most cases, just in general really, i guess it&#39;s debatable,
+      in most cases, just in general really, i guess it&apos;s debatable,
       unnecessary and to demonstrate that verbosity makes this
-      notification&#39;s body text spit into multiple lines because there is,
+      notification&apos;s body text spit into multiple lines because there is,
       surely, unequivocally, no way that all of this can fit into one line of
       text on an average screen...
     </>
@@ -84,7 +84,7 @@ const StickerSheetTemplate: StoryFn<{ isReversed: boolean }> = ({
         <StoryWrapper.Row rowTitle="Informative">
           <InlineNotification type="informative" title="Informative title">
             &quot;All Employees - North America&quot; status has been changed to
-            &#39;Archived&#39;.
+            &apos;Archived&apos;.
             <a href="/">View all</a>
           </InlineNotification>
         </StoryWrapper.Row>
@@ -96,7 +96,7 @@ const StickerSheetTemplate: StoryFn<{ isReversed: boolean }> = ({
             hideCloseIcon
           >
             &quot;All Employees - North America&quot; status has been changed to
-            &#39;Archived&#39;. <a href="/">View all</a>
+            &apos;Archived&apos;. <a href="/">View all</a>
           </InlineNotification>
         </StoryWrapper.Row>
         <StoryWrapper.Row rowTitle="Positive">

--- a/packages/notification/docs/InlineNotification.stories.tsx
+++ b/packages/notification/docs/InlineNotification.stories.tsx
@@ -83,7 +83,7 @@ const StickerSheetTemplate: StoryFn<{ isReversed: boolean }> = ({
         </Heading>
         <StoryWrapper.Row rowTitle="Informative">
           <InlineNotification type="informative" title="Informative title">
-            &#34;All Employees - North America&#34; status has been changed to
+            &quot;All Employees - North America&quot; status has been changed to
             &#39;Archived&#39;.
             <a href="/">View all</a>
           </InlineNotification>
@@ -95,7 +95,7 @@ const StickerSheetTemplate: StoryFn<{ isReversed: boolean }> = ({
             title="Informative title"
             hideCloseIcon
           >
-            &#34;All Employees - North America&#34; status has been changed to
+            &quot;All Employees - North America&quot; status has been changed to
             &#39;Archived&#39;. <a href="/">View all</a>
           </InlineNotification>
         </StoryWrapper.Row>

--- a/packages/notification/src/ToastNotificationsList.tsx
+++ b/packages/notification/src/ToastNotificationsList.tsx
@@ -17,7 +17,6 @@ export const ToastNotificationsList = ({
         style="toast"
         type={notification.type}
         title={notification.title}
-        children={notification.message}
         autohide={notification.autohide}
         autohideDelay={notification.autohideDelay}
         automationId={notification.automationId}
@@ -28,7 +27,9 @@ export const ToastNotificationsList = ({
           }
           onHide(notification.id)
         }}
-      />
+      >
+        {notification.message}
+      </GenericNotification>
     ))}
   </div>
 )

--- a/packages/pagination/src/PageIndicator.tsx
+++ b/packages/pagination/src/PageIndicator.tsx
@@ -16,6 +16,7 @@ export const PageIndicator = ({
   onPageClick,
 }: PageIndicatorProps): JSX.Element => (
   <button
+    type="button"
     className={cx(styles.pageIndicator, {
       [styles.pageIndicatorSelected]: selected,
     })}

--- a/packages/pagination/src/Pagination.tsx
+++ b/packages/pagination/src/Pagination.tsx
@@ -150,6 +150,7 @@ export const Pagination = ({
       {...restProps}
     >
       <button
+        type="button"
         className={classnames(styles.arrowIconWrapper)}
         aria-label={ariaLabelPreviousPage}
         disabled={previousPageDisabled}
@@ -158,8 +159,11 @@ export const Pagination = ({
         <Icon icon={arrowBackward} role="presentation" />
         <div className={styles.pageIndicatorFocusRing} />
       </button>
+
       <div className={styles.pagesIndicatorWrapper}>{pagination()}</div>
+
       <button
+        type="button"
         className={classnames(styles.arrowIconWrapper, {
           [styles.arrowIconWrapperDisabled]: nextPageDisabled,
         })}

--- a/packages/responsive/src/useMediaQueries.spec.tsx
+++ b/packages/responsive/src/useMediaQueries.spec.tsx
@@ -10,13 +10,15 @@ const ExampleComponent = (): JSX.Element => {
 
   return (
     <div>
-      {queries.isSmall && <button>Small only boolean</button>}
+      {queries.isSmall && <button type="button">Small only boolean</button>}
       <MediumOnly>
-        <button>Medium only component</button>
+        <button type="button">Medium only component</button>
       </MediumOnly>
-      {queries.prefersReducedMotion && <button>Prefers reduced boolean</button>}
+      {queries.prefersReducedMotion && (
+        <button type="button">Prefers reduced boolean</button>
+      )}
       <PrefersReducedMotion>
-        <button>Prefers reduced component</button>
+        <button type="button">Prefers reduced component</button>
       </PrefersReducedMotion>
     </div>
   )

--- a/packages/rich-text-editor/src/RichTextEditor/components/Toolbar/Toolbar.spec.tsx
+++ b/packages/rich-text-editor/src/RichTextEditor/components/Toolbar/Toolbar.spec.tsx
@@ -62,7 +62,7 @@ describe("Tabbing out of the toolbar", () => {
     render(
       <>
         <ExampleToolbar />
-        <button>I'm here for the focus</button>
+        <button type="button">I'm here for the focus</button>
       </>
     )
     screen.getByRole("toolbar").focus()

--- a/packages/rich-text-editor/src/RichTextEditor/components/Toolbar/Toolbar.spec.tsx
+++ b/packages/rich-text-editor/src/RichTextEditor/components/Toolbar/Toolbar.spec.tsx
@@ -62,7 +62,7 @@ describe("Tabbing out of the toolbar", () => {
     render(
       <>
         <ExampleToolbar />
-        <button type="button">I&#39;m here for the focus</button>
+        <button type="button">I&apos;m here for the focus</button>
       </>
     )
     screen.getByRole("toolbar").focus()

--- a/packages/rich-text-editor/src/RichTextEditor/components/Toolbar/Toolbar.spec.tsx
+++ b/packages/rich-text-editor/src/RichTextEditor/components/Toolbar/Toolbar.spec.tsx
@@ -62,7 +62,7 @@ describe("Tabbing out of the toolbar", () => {
     render(
       <>
         <ExampleToolbar />
-        <button type="button">I'm here for the focus</button>
+        <button type="button">I&#39;m here for the focus</button>
       </>
     )
     screen.getByRole("toolbar").focus()

--- a/packages/select/docs/FilterMultiSelect.stories.tsx
+++ b/packages/select/docs/FilterMultiSelect.stories.tsx
@@ -319,6 +319,7 @@ export const FilterBarDemo = (): JSX.Element => {
         <div className={styles.filters}>
           {selectedGroups.map(({ name, id }) => (
             <DemographicValueSelect
+              key={id}
               label={name}
               selectedKeys={new Set(selectedDemographicValues[id])}
               id={id}

--- a/packages/select/src/FilterMultiSelect/components/SelectionControlButton/ClearButton/ClearButton.tsx
+++ b/packages/select/src/FilterMultiSelect/components/SelectionControlButton/ClearButton/ClearButton.tsx
@@ -20,6 +20,7 @@ export const ClearButton = (): JSX.Element => {
 
   return (
     <button
+      type="button"
       className={classNames(styles.button, isDisabled ? styles.isDisabled : "")}
       aria-disabled={isDisabled}
       onClick={

--- a/packages/select/src/FilterMultiSelect/components/SelectionControlButton/SelectAllButton/SelectAllButton.tsx
+++ b/packages/select/src/FilterMultiSelect/components/SelectionControlButton/SelectAllButton/SelectAllButton.tsx
@@ -18,6 +18,7 @@ export const SelectAllButton = (): JSX.Element => {
 
   return (
     <button
+      type="button"
       className={classNames(styles.button, {
         [styles.isDisabled]: selectionState.selectionManager.isSelectAll,
       })}

--- a/packages/select/src/FilterMultiSelect/components/Trigger/RemovableFilterTrigger/RemovableFilterTrigger.tsx
+++ b/packages/select/src/FilterMultiSelect/components/Trigger/RemovableFilterTrigger/RemovableFilterTrigger.tsx
@@ -26,6 +26,7 @@ export const RemovableFilterTrigger = ({
       <div className={styles.divider} />
       <Tooltip text={removeButtonLabel} position="below">
         <button
+          type="button"
           className={styles.removeButton}
           aria-label={removeButtonLabel}
           onClick={onRemove}

--- a/packages/select/src/FilterMultiSelect/components/Trigger/TriggerButtonBase/TriggerButtonBase.tsx
+++ b/packages/select/src/FilterMultiSelect/components/Trigger/TriggerButtonBase/TriggerButtonBase.tsx
@@ -20,6 +20,7 @@ export const TriggerButtonBase = ({
 
   return (
     <button
+      type="button"
       {...buttonProps}
       ref={buttonRef}
       className={classNames(styles.button, classNameOverride)}

--- a/packages/select/src/FilterMultiSelect/provider/MenuTriggerProvider/MenuTriggerProvider.spec.tsx
+++ b/packages/select/src/FilterMultiSelect/provider/MenuTriggerProvider/MenuTriggerProvider.spec.tsx
@@ -15,7 +15,7 @@ const MenuTriggerProviderWrapper = (
     <TriggerButtonBase>trigger-display-label-mock</TriggerButtonBase>
     <MenuPopup>
       <span>menu-content-mock</span>
-      <button>menu-content-button-mock</button>
+      <button type="button">menu-content-button-mock</button>
     </MenuPopup>
   </MenuTriggerProvider>
 )

--- a/packages/select/src/Select/components/TriggerButton/TriggerButton.tsx
+++ b/packages/select/src/Select/components/TriggerButton/TriggerButton.tsx
@@ -49,6 +49,7 @@ export const TriggerButton = React.forwardRef<
 
     return (
       <button
+        type="button"
         {...mergeProps(buttonProps, restProps)}
         ref={ref}
         className={classnames([

--- a/packages/tabs/docs/Tabs.stories.tsx
+++ b/packages/tabs/docs/Tabs.stories.tsx
@@ -111,7 +111,7 @@ export const ManualKeyboardActivation: StoryFn = () => (
           <Box mb={0.5}>
             <Paragraph variant="body">
               When using arrow keys to navigate these tabs, the tab will only be
-              focused (rather than automatically made active). You&#39;ll need
+              focused (rather than automatically made active). You&apos;ll need
               to press enter/space to then active the tab.
             </Paragraph>
           </Box>

--- a/packages/tabs/docs/Tabs.stories.tsx
+++ b/packages/tabs/docs/Tabs.stories.tsx
@@ -111,8 +111,8 @@ export const ManualKeyboardActivation: StoryFn = () => (
           <Box mb={0.5}>
             <Paragraph variant="body">
               When using arrow keys to navigate these tabs, the tab will only be
-              focused (rather than automatically made active). You'll need to
-              press enter/space to then active the tab.
+              focused (rather than automatically made active). You&#39;ll need
+              to press enter/space to then active the tab.
             </Paragraph>
           </Box>
           <Paragraph variant="body">

--- a/packages/typography/docs/Heading.stories.tsx
+++ b/packages/typography/docs/Heading.stories.tsx
@@ -94,7 +94,7 @@ const StickerSheetTemplate: StoryFn<{ isReversed: boolean }> = ({
       <StoryWrapper isReversed={isReversed} hasRowDivider>
         <StoryWrapper.Row rowTitle="Display 0">
           <Heading variant="display-0" color={fontColour}>
-            Let&#39;s create a better world of work
+            Let&apos;s create a better world of work
           </Heading>
         </StoryWrapper.Row>
         <StoryWrapper.Row rowTitle="Heading 1">

--- a/packages/typography/docs/Heading.stories.tsx
+++ b/packages/typography/docs/Heading.stories.tsx
@@ -94,7 +94,7 @@ const StickerSheetTemplate: StoryFn<{ isReversed: boolean }> = ({
       <StoryWrapper isReversed={isReversed} hasRowDivider>
         <StoryWrapper.Row rowTitle="Display 0">
           <Heading variant="display-0" color={fontColour}>
-            Let's create a better world of work
+            Let&#39;s create a better world of work
           </Heading>
         </StoryWrapper.Row>
         <StoryWrapper.Row rowTitle="Heading 1">

--- a/storybook/components/DocsContainer/BackToTop/BackToTop.tsx
+++ b/storybook/components/DocsContainer/BackToTop/BackToTop.tsx
@@ -19,6 +19,7 @@ export const BackToTop = ({
 
   return (
     <button
+      type="button"
       onClick={(): void =>
         window.scroll({ top: 0, left: 0, behavior: "smooth" })
       }

--- a/storybook/components/LinkTo/LinkTo.tsx
+++ b/storybook/components/LinkTo/LinkTo.tsx
@@ -15,6 +15,7 @@ export const LinkTo = ({
   ...restButtonAttributes
 }: LinkToProps): JSX.Element => (
   <button
+    type="button"
     onClick={linkTo(pageId, sectionName)}
     className={classnames(
       "bg-transparent border-none text-blue-400 hover:underline cursor-pointer p-0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5833,6 +5833,17 @@ array.prototype.flatmap@^1.3.1:
     es-abstract "^1.20.4"
     es-shim-unscopables "^1.0.0"
 
+array.prototype.tosorted@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/array.prototype.tosorted/-/array.prototype.tosorted-1.1.1.tgz#ccf44738aa2b5ac56578ffda97c03fd3e23dd532"
+  integrity sha512-pZYPXPRl2PqWcsUs6LOMn+1f1532nEoPTYowBtqLwAW+W8vSVhkIGnmOX1t/UQjD6YGI0vcD2B1U7ZFGQH9jnQ==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.1.4"
+    es-abstract "^1.20.4"
+    es-shim-unscopables "^1.0.0"
+    get-intrinsic "^1.1.3"
+
 arrify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
@@ -8272,6 +8283,27 @@ eslint-plugin-jsx-a11y@^6.7.1:
     object.fromentries "^2.0.6"
     semver "^6.3.0"
 
+eslint-plugin-react@^7.32.2:
+  version "7.32.2"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.32.2.tgz#e71f21c7c265ebce01bcbc9d0955170c55571f10"
+  integrity sha512-t2fBMa+XzonrrNkyVirzKlvn5RXzzPwRHtMvLAtVZrt8oxgnTQaYbU6SXTOO1mwQgp1y5+toMSKInnzGr0Knqg==
+  dependencies:
+    array-includes "^3.1.6"
+    array.prototype.flatmap "^1.3.1"
+    array.prototype.tosorted "^1.1.1"
+    doctrine "^2.1.0"
+    estraverse "^5.3.0"
+    jsx-ast-utils "^2.4.1 || ^3.0.0"
+    minimatch "^3.1.2"
+    object.entries "^1.1.6"
+    object.fromentries "^2.0.6"
+    object.hasown "^1.1.2"
+    object.values "^1.1.6"
+    prop-types "^15.8.1"
+    resolve "^2.0.0-next.4"
+    semver "^6.3.0"
+    string.prototype.matchall "^4.0.8"
+
 eslint-plugin-sort-imports-es6-autofix@^0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-sort-imports-es6-autofix/-/eslint-plugin-sort-imports-es6-autofix-0.6.0.tgz#b8cd8639d7a54cefce6b17898b102fd5ec31e52b"
@@ -8411,7 +8443,7 @@ estraverse@^4.1.1:
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.3.0.tgz#398ad3f3c5a24948be7725e83d11a7de28cdbd1d"
   integrity sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==
 
-estraverse@^5.1.0, estraverse@^5.2.0:
+estraverse@^5.1.0, estraverse@^5.2.0, estraverse@^5.3.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-5.3.0.tgz#2eea5290702f26ab8fe5370370ff86c965d21123"
   integrity sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==
@@ -9909,7 +9941,7 @@ inquirer@^8.2.2:
     through "^2.3.6"
     wrap-ansi "^7.0.0"
 
-internal-slot@^1.0.4:
+internal-slot@^1.0.3, internal-slot@^1.0.4:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/internal-slot/-/internal-slot-1.0.5.tgz#f2a2ee21f668f8627a4667f309dc0f4fb6674986"
   integrity sha512-Y+R5hJrzs52QCG2laLn4udYVnxsfny9CpOhNhUvk/SSSVyF6T27FzRbF0sroPidSu3X8oEAkOn2K804mjpt6UQ==
@@ -11127,7 +11159,7 @@ jsonwebtoken@^9.0.0:
     ms "^2.1.1"
     semver "^7.3.8"
 
-jsx-ast-utils@^3.3.3:
+"jsx-ast-utils@^2.4.1 || ^3.0.0", jsx-ast-utils@^3.3.3:
   version "3.3.3"
   resolved "https://registry.yarnpkg.com/jsx-ast-utils/-/jsx-ast-utils-3.3.3.tgz#76b3e6e6cece5c69d49a5792c3d01bd1a0cdc7ea"
   integrity sha512-fYQHZTZ8jSfmWZ0iyzfwiU4WDX4HpHbMCZ3gPlWYiCl3BoeOTsqKBqnTVfH2rYT7eP5c3sVbeSPHnnJOaTrWiw==
@@ -12555,6 +12587,14 @@ object.fromentries@^2.0.6:
     define-properties "^1.1.4"
     es-abstract "^1.20.4"
 
+object.hasown@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/object.hasown/-/object.hasown-1.1.2.tgz#f919e21fad4eb38a57bc6345b3afd496515c3f92"
+  integrity sha512-B5UIT3J1W+WuWIU55h0mjlwaqxiE5vYENJXIXZ4VFe05pNYrkKuK0U/6aFcb0pKywYJh7IhfoqUfKVmrJJHZHw==
+  dependencies:
+    define-properties "^1.1.4"
+    es-abstract "^1.20.4"
+
 object.map@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/object.map/-/object.map-1.0.1.tgz#cf83e59dc8fcc0ad5f4250e1f78b3b81bd801d37"
@@ -13967,7 +14007,7 @@ prompts@^2.0.1, prompts@^2.4.0:
     kleur "^3.0.3"
     sisteransi "^1.0.5"
 
-prop-types@^15.5.10, prop-types@^15.6.0, prop-types@^15.6.2, prop-types@^15.7.2:
+prop-types@^15.5.10, prop-types@^15.6.0, prop-types@^15.6.2, prop-types@^15.7.2, prop-types@^15.8.1:
   version "15.8.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5"
   integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==
@@ -14854,6 +14894,15 @@ resolve@^1.1.6, resolve@^1.10.0, resolve@^1.14.2:
     path-parse "^1.0.7"
     supports-preserve-symlinks-flag "^1.0.0"
 
+resolve@^2.0.0-next.4:
+  version "2.0.0-next.4"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-2.0.0-next.4.tgz#3d37a113d6429f496ec4752d2a2e58efb1fd4660"
+  integrity sha512-iMDbmAWtfU+MHpxt/I5iWI7cY6YVEZUQ3MBgPQ++XD1PELuJHIl82xBmObyP2KyQmkNB2dsqF7seoQQiAn5yDQ==
+  dependencies:
+    is-core-module "^2.9.0"
+    path-parse "^1.0.7"
+    supports-preserve-symlinks-flag "^1.0.0"
+
 responselike@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/responselike/-/responselike-2.0.1.tgz#9a0bc8fdc252f3fb1cca68b016591059ba1422bc"
@@ -15707,6 +15756,20 @@ string-width@^1.0.1:
     emoji-regex "^8.0.0"
     is-fullwidth-code-point "^3.0.0"
     strip-ansi "^6.0.1"
+
+string.prototype.matchall@^4.0.8:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/string.prototype.matchall/-/string.prototype.matchall-4.0.8.tgz#3bf85722021816dcd1bf38bb714915887ca79fd3"
+  integrity sha512-6zOCOcJ+RJAQshcTvXPHoxoQGONa3e/Lqx90wUA+wEzX78sg5Bo+1tQo4N0pohS0erG9qtCqJDjNCQBjeWVxyg==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.1.4"
+    es-abstract "^1.20.4"
+    get-intrinsic "^1.1.3"
+    has-symbols "^1.0.3"
+    internal-slot "^1.0.3"
+    regexp.prototype.flags "^1.4.3"
+    side-channel "^1.0.4"
 
 string.prototype.trimend@^1.0.6:
   version "1.0.6"


### PR DESCRIPTION
## Why
<!-- Why have you created this PR? - Is it a new feature, or a bug fix? Or something else? -->
<!-- Reference any relevant Jira tickets so your reviewer can find more context if needed. -->
<!-- Fixing a GitHub issue? Add "Fixes [issue URL]". -->

We kept forgetting to put `type` on our `<button>`s, which leads to accidental form submissions for our consumers.

## What
<!-- What do your changes do? How do they change/fix the current behavior? -->
<!-- Add screenshots, GIFs or videos to illustrate the changes.  -->

- Add eslint rule `react/button-has-type` and fix issues
- Extra rules added as a side-effect of enabling `react/button-has-type`:
	- `react/no-unescaped-entities` (fixed)
	- `react/jsx-key` (fixed)
	- `react/no-children-prop` (fixed)
	- `react/jsx-no-target-blank` (fixed)
	- `react/display-name` (fixed)
	- `react/prop-types` (disabled)
- Loosened `@typescript-eslint/explicit-function-return-type` to allow expressions to not have to declare the return type
	- eg. `onClick={(): void => doSomething()}` can now be `onClick={() => doSomething()}`