### PR TITLE
docs(filter-drp): update stickersheets to all have dates in the past

### DIFF
--- a/packages/components/src/FilterDateRangePicker/_docs/FilterDateRangePicker.stickersheet.stories.tsx
+++ b/packages/components/src/FilterDateRangePicker/_docs/FilterDateRangePicker.stickersheet.stories.tsx
@@ -90,7 +90,7 @@ const StickerSheetTemplate: StoryFn<{ textDirection: "ltr" | "rtl" }> = ({
               id={`${textDirection}-stickersheet--filter-drp-field--default`}
               label="Dates"
               locale="en-US"
-              defaultMonth={new Date("2023-05-01")}
+              defaultMonth={new Date("2022-05-01")}
               selectedRange={rangeFieldDefault}
               onRangeChange={setRangeFieldDefault}
             />


### PR DESCRIPTION
## What
<!-- What do your changes do? How do they change/fix the current behavior? -->
<!-- Add screenshots, GIFs or videos to illustrate the changes.  -->

Update FilterDateRangePicker sticker sheet examples to use dates in the past.

## Why
<!-- Why have you created this PR? - Is it a new feature, or a bug fix? Or something else? -->
<!-- Reference any relevant Jira tickets so your reviewer can find more context if needed. -->
<!-- Fixing a GitHub issue? Add "Fixes [issue URL]". -->

"Today" has a different style, so the snapshots will change every day if the date is within the shown calendars.