### PR TITLE
Remove dependency on focus-visible polyfill

### DIFF
--- a/.changeset/tame-horses-chew.md
+++ b/.changeset/tame-horses-chew.md
@@ -1,0 +1,22 @@
+---
+"@kaizen/draft-likert-scale-legacy": patch
+"@kaizen/draft-title-block-zen": patch
+"@kaizen/rich-text-editor": patch
+"@kaizen/draft-popover": patch
+"@kaizen/notification": patch
+"@kaizen/split-button": patch
+"@kaizen/draft-modal": patch
+"@kaizen/date-picker": patch
+"@kaizen/draft-form": patch
+"@kaizen/draft-menu": patch
+"@kaizen/draft-tabs": patch
+"@kaizen/components": patch
+"@kaizen/pagination": patch
+"@kaizen/draft-tag": patch
+"@kaizen/button": patch
+"@kaizen/select": patch
+"@kaizen/a11y": patch
+"@kaizen/tabs": patch
+---
+
+Use native focus-visible selector for focus styling instead of polyfill class

--- a/draft-packages/form/KaizenDraft/Form/Primitives/ClearButton/ClearButton.module.scss
+++ b/draft-packages/form/KaizenDraft/Form/Primitives/ClearButton/ClearButton.module.scss
@@ -7,7 +7,7 @@ $story-className--clear-button-hover: ":global(.story__clear-button-hover)";
 
 // Combined pseudo state classes
 $selectors--clear-button-hover: "&:hover, &#{$story-className--clear-button-hover}";
-$selectors--clear-button-focus: "&:focus-visible";
+$selectors--clear-button-focus: "&:focus-visible, &:global(.focus-visible)";
 
 .clearButton {
   @include button-reset;

--- a/draft-packages/form/KaizenDraft/Form/Primitives/ClearButton/ClearButton.module.scss
+++ b/draft-packages/form/KaizenDraft/Form/Primitives/ClearButton/ClearButton.module.scss
@@ -4,10 +4,11 @@
 
 // Classnames to simulate pseudo states in storybook
 $story-className--clear-button-hover: ":global(.story__clear-button-hover)";
+$story-className--clear-button-focus: ":global(.story__clear-button-focus)";
 
 // Combined pseudo state classes
 $selectors--clear-button-hover: "&:hover, &#{$story-className--clear-button-hover}";
-$selectors--clear-button-focus: "&:focus-visible, &:global(.focus-visible)";
+$selectors--clear-button-focus: "&:focus-visible, &#{$story-className--clear-button-focus}";
 
 .clearButton {
   @include button-reset;

--- a/draft-packages/form/KaizenDraft/Form/Primitives/ClearButton/ClearButton.module.scss
+++ b/draft-packages/form/KaizenDraft/Form/Primitives/ClearButton/ClearButton.module.scss
@@ -2,15 +2,12 @@
 @import "~@kaizen/design-tokens/sass/color";
 @import "../../mixins";
 
-// Polyfill
-$polyfill--focus-visible: ":global(.js-focus-visible) &:global(.focus-visible)";
-
 // Classnames to simulate pseudo states in storybook
 $story-className--clear-button-hover: ":global(.story__clear-button-hover)";
 
 // Combined pseudo state classes
 $selectors--clear-button-hover: "&:hover, &#{$story-className--clear-button-hover}";
-$selectors--clear-button-focus: "&:focus-visible, #{$polyfill--focus-visible}";
+$selectors--clear-button-focus: "&:focus-visible";
 
 .clearButton {
   @include button-reset;

--- a/draft-packages/form/KaizenDraft/Form/Primitives/InputRange/InputRange.module.scss
+++ b/draft-packages/form/KaizenDraft/Form/Primitives/InputRange/InputRange.module.scss
@@ -69,7 +69,7 @@ input[type="range"].ratingScaleRange {
     outline: 0;
   }
 
-  :global(.js-focus-visible) &:global(.focus-visible) {
+  :focus-visible {
     outline: 2px solid $color-blue-500;
   }
 

--- a/draft-packages/form/KaizenDraft/Form/Primitives/InputRange/InputRange.module.scss
+++ b/draft-packages/form/KaizenDraft/Form/Primitives/InputRange/InputRange.module.scss
@@ -69,7 +69,8 @@ input[type="range"].ratingScaleRange {
     outline: 0;
   }
 
-  :focus-visible {
+  &:focus-visible,
+  &:global(.focus-visible) {
     outline: 2px solid $color-blue-500;
   }
 

--- a/draft-packages/form/KaizenDraft/Form/Primitives/InputRange/InputRange.module.scss
+++ b/draft-packages/form/KaizenDraft/Form/Primitives/InputRange/InputRange.module.scss
@@ -69,8 +69,7 @@ input[type="range"].ratingScaleRange {
     outline: 0;
   }
 
-  &:focus-visible,
-  &:global(.focus-visible) {
+  &:focus-visible {
     outline: 2px solid $color-blue-500;
   }
 

--- a/draft-packages/form/docs/ClearButton.stories.tsx
+++ b/draft-packages/form/docs/ClearButton.stories.tsx
@@ -38,7 +38,7 @@ const StickerSheetTemplate: StoryFn<{ isReversed: boolean }> = ({
         />
         <ClearButton
           isReversed={isReversed}
-          classNameOverride="focus-visible"
+          classNameOverride="story__clear-button-focus"
         />
       </StickerSheet.Row>
     </StickerSheet.Body>

--- a/draft-packages/likert-scale-legacy/KaizenDraft/LikertScaleLegacy/LikertScaleLegacy.module.scss
+++ b/draft-packages/likert-scale-legacy/KaizenDraft/LikertScaleLegacy/LikertScaleLegacy.module.scss
@@ -118,10 +118,6 @@ $fifth: $color-red-500;
   outline: none;
 }
 
-.reversed:not(.rated) .likertItem:focus-visible .likertItemFill {
-  outline-color: $color-blue-300;
-}
-
 .likertItem:focus-visible .likertItemFill {
   outline-offset: 1px;
   outline: $color-blue-500 $border-focus-ring-border-style

--- a/draft-packages/likert-scale-legacy/KaizenDraft/LikertScaleLegacy/LikertScaleLegacy.module.scss
+++ b/draft-packages/likert-scale-legacy/KaizenDraft/LikertScaleLegacy/LikertScaleLegacy.module.scss
@@ -118,20 +118,17 @@ $fifth: $color-red-500;
   outline: none;
 }
 
-.reversed:not(.rated) .likertItem:focus-visible .likertItemFill,
-.reversed:not(.rated) .likertItem:global(.focus-visible) .likertItemFill {
+.reversed:not(.rated) .likertItem:focus-visible .likertItemFill {
   outline-color: $color-blue-300;
 }
 
-.likertItem:focus-visible .likertItemFill,
-.likertItem:global(.focus-visible) .likertItemFill {
+.likertItem:focus-visible .likertItemFill {
   outline-offset: 1px;
   outline: $color-blue-500 $border-focus-ring-border-style
     $border-focus-ring-border-width;
 }
 
-.reversed .likertItem:focus-visible .likertItemFill,
-.reversed .likertItem:global(.focus-visible) .likertItemFill {
+.reversed .likertItem:focus-visible .likertItemFill {
   outline-color: $color-blue-300;
 }
 

--- a/draft-packages/likert-scale-legacy/KaizenDraft/LikertScaleLegacy/LikertScaleLegacy.module.scss
+++ b/draft-packages/likert-scale-legacy/KaizenDraft/LikertScaleLegacy/LikertScaleLegacy.module.scss
@@ -118,17 +118,20 @@ $fifth: $color-red-500;
   outline: none;
 }
 
-.reversed:not(.rated) .likertItem:focus-visible .likertItemFill {
+.reversed:not(.rated) .likertItem:focus-visible .likertItemFill,
+.reversed:not(.rated) .likertItem:global(.focus-visible) .likertItemFill {
   outline-color: $color-blue-300;
 }
 
-.likertItem:focus-visible .likertItemFill {
+.likertItem:focus-visible .likertItemFill,
+.likertItem:global(.focus-visible) .likertItemFill {
   outline-offset: 1px;
   outline: $color-blue-500 $border-focus-ring-border-style
     $border-focus-ring-border-width;
 }
 
-.reversed .likertItem:focus-visible .likertItemFill {
+.reversed .likertItem:focus-visible .likertItemFill,
+.reversed .likertItem:global(.focus-visible) .likertItemFill {
   outline-color: $color-blue-300;
 }
 

--- a/draft-packages/likert-scale-legacy/KaizenDraft/LikertScaleLegacy/LikertScaleLegacy.module.scss
+++ b/draft-packages/likert-scale-legacy/KaizenDraft/LikertScaleLegacy/LikertScaleLegacy.module.scss
@@ -113,31 +113,23 @@ $fifth: $color-red-500;
   }
 }
 
-:global(.js-focus-visible) {
-  .likertItem:focus,
-  .likertItemFill:focus {
-    outline: none;
-  }
+.likertItem:focus,
+.likertItemFill:focus {
+  outline: none;
+}
 
-  .reversed:not(.rated)
-    :global([data-focus-visible-added]).likertItem:focus
-    .likertItemFill {
-    outline-color: $color-blue-300;
-  }
+.reversed:not(.rated) .likertItem:focus-visible .likertItemFill {
+  outline-color: $color-blue-300;
+}
 
-  // React seems to be causing the .focus-visible class to only be added sometimes,
-  // so we need to use [data-focus-visible-added] here instead.
-  // See https://github.com/WICG/focus-visible#2-update-your-css
+.likertItem:focus-visible .likertItemFill {
+  outline-offset: 1px;
+  outline: $color-blue-500 $border-focus-ring-border-style
+    $border-focus-ring-border-width;
+}
 
-  :global([data-focus-visible-added]).likertItem .likertItemFill {
-    outline-offset: 1px;
-    outline: $color-blue-500 $border-focus-ring-border-style
-      $border-focus-ring-border-width;
-  }
-
-  .reversed :global([data-focus-visible-added]).likertItem .likertItemFill {
-    outline-color: $color-blue-300;
-  }
+.reversed .likertItem:focus-visible .likertItemFill {
+  outline-color: $color-blue-300;
 }
 
 .itemContainer {

--- a/draft-packages/menu/KaizenDraft/Menu/components/MenuItem.module.scss
+++ b/draft-packages/menu/KaizenDraft/Menu/components/MenuItem.module.scss
@@ -53,8 +53,7 @@
     outline: none;
   }
 
-  &:focus-visible,
-  &:global(.focus-visible) {
+  &:focus-visible {
     border-color: $color-blue-500;
   }
 

--- a/draft-packages/menu/KaizenDraft/Menu/components/MenuItem.module.scss
+++ b/draft-packages/menu/KaizenDraft/Menu/components/MenuItem.module.scss
@@ -53,7 +53,8 @@
     outline: none;
   }
 
-  &:focus-visible {
+  &:focus-visible,
+  &:global(.focus-visible) {
     border-color: $color-blue-500;
   }
 

--- a/draft-packages/menu/KaizenDraft/Menu/components/MenuItem.module.scss
+++ b/draft-packages/menu/KaizenDraft/Menu/components/MenuItem.module.scss
@@ -49,7 +49,7 @@
     }
   }
 
-  :focus {
+  &:focus {
     outline: none;
   }
 

--- a/draft-packages/menu/KaizenDraft/Menu/components/MenuItem.module.scss
+++ b/draft-packages/menu/KaizenDraft/Menu/components/MenuItem.module.scss
@@ -49,10 +49,12 @@
     }
   }
 
-  &:focus-visible,
-  &.focus-visible {
-    border-color: $color-blue-500;
+  :focus {
     outline: none;
+  }
+
+  &:focus-visible {
+    border-color: $color-blue-500;
   }
 
   [dir="rtl"] & {

--- a/draft-packages/modal/KaizenDraft/Modal/Primitives/ModalAccessibleLabel.module.scss
+++ b/draft-packages/modal/KaizenDraft/Modal/Primitives/ModalAccessibleLabel.module.scss
@@ -35,7 +35,8 @@ $ca-breakpoint-small-mobile: 375px;
     outline: none;
   }
 
-  &:focus-visible::after {
+  &:focus-visible::after,
+  &:global(.focus-visible)::after {
     $focus-ring-offset: calc((#{$border-focus-ring-border-width} * 2) + 1px);
     content: "";
     position: absolute;

--- a/draft-packages/modal/KaizenDraft/Modal/Primitives/ModalAccessibleLabel.module.scss
+++ b/draft-packages/modal/KaizenDraft/Modal/Primitives/ModalAccessibleLabel.module.scss
@@ -31,28 +31,22 @@ $ca-breakpoint-small-mobile: 375px;
     text-align: left;
   }
 
-  // Use JS polyfill to simulate :focus-visible, not yet supported by browsers
-  // https://github.com/WICG/focus-visible#backwards-compatibility
-  :global(.js-focus-visible) & {
-    // hide native focus ring when :focus but not :focus-visible
-    &:focus {
-      outline: none;
-    }
+  &:focus {
+    outline: none;
+  }
 
-    // show custom focus ring when :focus-visible
-    &:global(.focus-visible)::after {
-      $focus-ring-offset: calc((#{$border-focus-ring-border-width} * 2) + 1px);
-      content: "";
-      position: absolute;
-      background: transparent;
-      border-radius: $border-focus-ring-border-radius;
-      border-width: $border-focus-ring-border-width;
-      border-style: $border-focus-ring-border-style;
-      border-color: $color-blue-500;
-      top: calc(-1 * #{$focus-ring-offset});
-      left: calc(-1 * #{$focus-ring-offset});
-      right: calc(-1 * #{$focus-ring-offset});
-      bottom: calc(-1 * #{$focus-ring-offset});
-    }
+  &:focus-visible::after {
+    $focus-ring-offset: calc((#{$border-focus-ring-border-width} * 2) + 1px);
+    content: "";
+    position: absolute;
+    background: transparent;
+    border-radius: $border-focus-ring-border-radius;
+    border-width: $border-focus-ring-border-width;
+    border-style: $border-focus-ring-border-style;
+    border-color: $color-blue-500;
+    top: calc(-1 * #{$focus-ring-offset});
+    left: calc(-1 * #{$focus-ring-offset});
+    right: calc(-1 * #{$focus-ring-offset});
+    bottom: calc(-1 * #{$focus-ring-offset});
   }
 }

--- a/draft-packages/modal/KaizenDraft/Modal/Primitives/ModalAccessibleLabel.module.scss
+++ b/draft-packages/modal/KaizenDraft/Modal/Primitives/ModalAccessibleLabel.module.scss
@@ -35,8 +35,7 @@ $ca-breakpoint-small-mobile: 375px;
     outline: none;
   }
 
-  &:focus-visible::after,
-  &:global(.focus-visible)::after {
+  &:focus-visible::after {
     $focus-ring-offset: calc((#{$border-focus-ring-border-width} * 2) + 1px);
     content: "";
     position: absolute;

--- a/draft-packages/popover/KaizenDraft/Popover/Popover.module.scss
+++ b/draft-packages/popover/KaizenDraft/Popover/Popover.module.scss
@@ -168,7 +168,8 @@ $negative-box-border-color: $color-red-300;
     outline: none;
   }
 
-  &:focus-visible {
+  &:focus-visible,
+  &:global(.focus-visible) {
     color: $color-purple-800;
     outline: $color-blue-500 $border-focus-ring-border-style
       $border-focus-ring-border-width;

--- a/draft-packages/popover/KaizenDraft/Popover/Popover.module.scss
+++ b/draft-packages/popover/KaizenDraft/Popover/Popover.module.scss
@@ -164,7 +164,7 @@ $negative-box-border-color: $color-red-300;
     color: $color-purple-800;
   }
 
-  :focus {
+  &:focus {
     outline: none;
   }
 

--- a/draft-packages/popover/KaizenDraft/Popover/Popover.module.scss
+++ b/draft-packages/popover/KaizenDraft/Popover/Popover.module.scss
@@ -164,16 +164,16 @@ $negative-box-border-color: $color-red-300;
     color: $color-purple-800;
   }
 
-  &:global(.focus-visible) {
+  :focus {
+    outline: none;
+  }
+
+  &:focus-visible {
     color: $color-purple-800;
     outline: $color-blue-500 $border-focus-ring-border-style
       $border-focus-ring-border-width;
     outline-offset: calc(-1 * #{$border-focus-ring-border-width});
     border-radius: $border-borderless-border-radius;
-  }
-
-  :focus {
-    outline: none;
   }
 }
 

--- a/draft-packages/popover/KaizenDraft/Popover/Popover.module.scss
+++ b/draft-packages/popover/KaizenDraft/Popover/Popover.module.scss
@@ -168,8 +168,7 @@ $negative-box-border-color: $color-red-300;
     outline: none;
   }
 
-  &:focus-visible,
-  &:global(.focus-visible) {
+  &:focus-visible {
     color: $color-purple-800;
     outline: $color-blue-500 $border-focus-ring-border-style
       $border-focus-ring-border-width;

--- a/draft-packages/tabs/KaizenDraft/Tabs/Tabs.module.scss
+++ b/draft-packages/tabs/KaizenDraft/Tabs/Tabs.module.scss
@@ -30,33 +30,29 @@
     font-weight: $typography-heading-4-font-weight;
   }
 
-  // Use JS polyfill to simulate :focus-visible, not yet supported by bhorizontalsers
-  // https://github.com/WICG/focus-visible#backwards-compatibility
-  :global(.js-focus-visible) & {
-    // hide native focus ring when :focus but not :focus-visible
-    &:focus {
-      outline: none;
-    }
+  &:focus {
+    outline: none;
+  }
 
-    &:focus-visible {
-      color: $color-blue-500;
-      text-decoration: none;
-      background-color: $color-blue-100;
-      font-weight: $typography-heading-4-font-weight;
+  &:focus-visible,
+  &:global(.focus-visible) {
+    color: $color-blue-500;
+    text-decoration: none;
+    background-color: $color-blue-100;
+    font-weight: $typography-heading-4-font-weight;
 
-      &:after {
-        content: "";
-        position: absolute;
-        background: transparent;
-        $focus-ring-offset: calc(#{$border-focus-ring-border-width} - 1px);
-        border-width: $border-focus-ring-border-width;
-        border-style: $border-focus-ring-border-style;
-        border-color: $color-blue-500;
-        top: calc(-1 * #{$focus-ring-offset});
-        left: calc(-1 * #{$focus-ring-offset});
-        right: calc(-1 * #{$focus-ring-offset});
-        bottom: calc(-1 * #{$focus-ring-offset});
-      }
+    &:after {
+      content: "";
+      position: absolute;
+      background: transparent;
+      $focus-ring-offset: calc(#{$border-focus-ring-border-width} - 1px);
+      border-width: $border-focus-ring-border-width;
+      border-style: $border-focus-ring-border-style;
+      border-color: $color-blue-500;
+      top: calc(-1 * #{$focus-ring-offset});
+      left: calc(-1 * #{$focus-ring-offset});
+      right: calc(-1 * #{$focus-ring-offset});
+      bottom: calc(-1 * #{$focus-ring-offset});
     }
   }
 }
@@ -77,7 +73,8 @@
   justify-content: center;
   min-width: 4.5rem - ($ca-grid * 0.75) * 2; // give tabs with short text some breathing room
 
-  :focus-visible:after {
+  :focus-visible:after,
+  :global(.focus-visible):after {
     border-radius: $border-borderless-border-radius
       $border-borderless-border-radius 0 0;
   }
@@ -143,7 +140,8 @@
     padding-left: $spacing-sm;
   }
 
-  :focus-visible:after {
+  :focus-visible:after,
+  :global(.focus-visible):after {
     border-radius: $border-borderless-border-radius;
     z-index: 1; // pop the border out so sibling tabs don't overlap
   }

--- a/draft-packages/tabs/KaizenDraft/Tabs/Tabs.module.scss
+++ b/draft-packages/tabs/KaizenDraft/Tabs/Tabs.module.scss
@@ -38,7 +38,7 @@
       outline: none;
     }
 
-    &:global(.focus-visible) {
+    &:focus-visible {
       color: $color-blue-500;
       text-decoration: none;
       background-color: $color-blue-100;
@@ -77,7 +77,7 @@
   justify-content: center;
   min-width: 4.5rem - ($ca-grid * 0.75) * 2; // give tabs with short text some breathing room
 
-  :global(.js-focus-visible) &:global(.focus-visible):after {
+  :focus-visible:after {
     border-radius: $border-borderless-border-radius
       $border-borderless-border-radius 0 0;
   }
@@ -143,7 +143,7 @@
     padding-left: $spacing-sm;
   }
 
-  :global(.js-focus-visible) &:global(.focus-visible):after {
+  :focus-visible:after {
     border-radius: $border-borderless-border-radius;
     z-index: 1; // pop the border out so sibling tabs don't overlap
   }

--- a/draft-packages/tabs/KaizenDraft/Tabs/Tabs.module.scss
+++ b/draft-packages/tabs/KaizenDraft/Tabs/Tabs.module.scss
@@ -34,8 +34,7 @@
     outline: none;
   }
 
-  &:focus-visible,
-  &:global(.focus-visible) {
+  &:focus-visible {
     color: $color-blue-500;
     text-decoration: none;
     background-color: $color-blue-100;
@@ -73,8 +72,7 @@
   justify-content: center;
   min-width: 4.5rem - ($ca-grid * 0.75) * 2; // give tabs with short text some breathing room
 
-  :focus-visible:after,
-  :global(.focus-visible):after {
+  :focus-visible:after {
     border-radius: $border-borderless-border-radius
       $border-borderless-border-radius 0 0;
   }
@@ -140,8 +138,7 @@
     padding-left: $spacing-sm;
   }
 
-  :focus-visible:after,
-  :global(.focus-visible):after {
+  :focus-visible:after {
     border-radius: $border-borderless-border-radius;
     z-index: 1; // pop the border out so sibling tabs don't overlap
   }

--- a/draft-packages/tabs/KaizenDraft/Tabs/Tabs.module.scss
+++ b/draft-packages/tabs/KaizenDraft/Tabs/Tabs.module.scss
@@ -72,7 +72,7 @@
   justify-content: center;
   min-width: 4.5rem - ($ca-grid * 0.75) * 2; // give tabs with short text some breathing room
 
-  :focus-visible:after {
+  &:focus-visible::after {
     border-radius: $border-borderless-border-radius
       $border-borderless-border-radius 0 0;
   }
@@ -138,7 +138,7 @@
     padding-left: $spacing-sm;
   }
 
-  :focus-visible:after {
+  &:focus-visible::after {
     border-radius: $border-borderless-border-radius;
     z-index: 1; // pop the border out so sibling tabs don't overlap
   }

--- a/draft-packages/tag/KaizenDraft/Tag/Tag.module.scss
+++ b/draft-packages/tag/KaizenDraft/Tag/Tag.module.scss
@@ -93,8 +93,7 @@ $small: $spacing-md;
     outline: none;
   }
 
-  &:focus-visible .iconWrapper,
-  &:global(.focus-visible) .iconWrapper {
+  &:focus-visible .iconWrapper {
     color: $color-purple-800;
 
     &::after {

--- a/draft-packages/tag/KaizenDraft/Tag/Tag.module.scss
+++ b/draft-packages/tag/KaizenDraft/Tag/Tag.module.scss
@@ -93,7 +93,8 @@ $small: $spacing-md;
     outline: none;
   }
 
-  &:focus-visible .iconWrapper {
+  &:focus-visible .iconWrapper,
+  &:global(.focus-visible) .iconWrapper {
     color: $color-purple-800;
 
     &::after {

--- a/draft-packages/tag/KaizenDraft/Tag/Tag.module.scss
+++ b/draft-packages/tag/KaizenDraft/Tag/Tag.module.scss
@@ -89,27 +89,26 @@ $small: $spacing-md;
     position: relative;
   }
 
-  :global(.js-focus-visible) & {
+  :focus {
     outline: none;
+  }
 
-    // show custom focus ring when :focus-visible
-    &:global(.focus-visible) .iconWrapper {
-      color: $color-purple-800;
+  &:focus-visible .iconWrapper {
+    color: $color-purple-800;
 
-      &::after {
-        $focus-ring-offset: calc((#{$border-focus-ring-border-width}));
-        content: "";
-        position: absolute;
-        background: transparent;
-        border-radius: 50%;
-        border-width: $border-focus-ring-border-width;
-        border-style: $border-focus-ring-border-style;
-        border-color: $color-blue-500;
-        top: calc(-1 * #{$focus-ring-offset});
-        left: calc(-1 * #{$focus-ring-offset});
-        right: calc(-1 * #{$focus-ring-offset});
-        bottom: calc(-1 * #{$focus-ring-offset});
-      }
+    &::after {
+      $focus-ring-offset: calc((#{$border-focus-ring-border-width}));
+      content: "";
+      position: absolute;
+      background: transparent;
+      border-radius: 50%;
+      border-width: $border-focus-ring-border-width;
+      border-style: $border-focus-ring-border-style;
+      border-color: $color-blue-500;
+      top: calc(-1 * #{$focus-ring-offset});
+      left: calc(-1 * #{$focus-ring-offset});
+      right: calc(-1 * #{$focus-ring-offset});
+      bottom: calc(-1 * #{$focus-ring-offset});
     }
   }
 }

--- a/draft-packages/tag/KaizenDraft/Tag/Tag.module.scss
+++ b/draft-packages/tag/KaizenDraft/Tag/Tag.module.scss
@@ -89,7 +89,7 @@ $small: $spacing-md;
     position: relative;
   }
 
-  :focus {
+  &:focus {
     outline: none;
   }
 

--- a/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/MobileActions.module.scss
+++ b/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/MobileActions.module.scss
@@ -100,7 +100,8 @@ $space-for-focus-ring: ($focus-ring-border-width * 2) + ($focus-spacing * 2);
     outline: none;
   }
 
-  &:focus-visible {
+  &:focus-visible,
+  &:global(.focus-visible) {
     height: $layout-mobile-actions-drawer-height - $space-for-focus-ring;
 
     &::after {
@@ -130,7 +131,8 @@ $space-for-focus-ring: ($focus-ring-border-width * 2) + ($focus-spacing * 2);
   border-start-start-radius: $border-solid-border-radius;
   border-start-end-radius: $border-solid-border-radius;
 
-  &:focus-visible {
+  &:focus-visible,
+  &:global(.focus-visible) {
     flex-basis: calc(100% - #{$space-for-focus-ring});
 
     &::after {
@@ -144,7 +146,8 @@ $space-for-focus-ring: ($focus-ring-border-width * 2) + ($focus-spacing * 2);
 .mobileActionsPrimaryButton:not(:only-child) {
   flex: 0 0 calc(100% - #{$expand-button-width});
 
-  &:focus-visible {
+  &:focus-visible,
+  &:global(.focus-visible) {
     flex-basis: calc(100% - #{$expand-button-width} - #{$space-for-focus-ring});
     margin-left: $focus-ring-border-width * 2;
     border-start-start-radius: $border-solid-border-radius;
@@ -164,7 +167,8 @@ $space-for-focus-ring: ($focus-ring-border-width * 2) + ($focus-spacing * 2);
   border-left: 2px solid $color-blue-200;
   justify-content: center;
 
-  &:focus-visible {
+  &:focus-visible,
+  &:global(.focus-visible) {
     border-color: $color-white;
     flex-basis: calc(#{$expand-button-width} - #{$space-for-focus-ring});
     margin-right: $focus-ring-border-width * 2;

--- a/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/MobileActions.module.scss
+++ b/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/MobileActions.module.scss
@@ -100,7 +100,7 @@ $space-for-focus-ring: ($focus-ring-border-width * 2) + ($focus-spacing * 2);
     outline: none;
   }
 
-  &:global(.focus-visible) {
+  &:focus-visible {
     height: $layout-mobile-actions-drawer-height - $space-for-focus-ring;
 
     &::after {
@@ -130,7 +130,7 @@ $space-for-focus-ring: ($focus-ring-border-width * 2) + ($focus-spacing * 2);
   border-start-start-radius: $border-solid-border-radius;
   border-start-end-radius: $border-solid-border-radius;
 
-  &:global(.focus-visible) {
+  &:focus-visible {
     flex-basis: calc(100% - #{$space-for-focus-ring});
 
     &::after {
@@ -144,7 +144,7 @@ $space-for-focus-ring: ($focus-ring-border-width * 2) + ($focus-spacing * 2);
 .mobileActionsPrimaryButton:not(:only-child) {
   flex: 0 0 calc(100% - #{$expand-button-width});
 
-  &:global(.focus-visible) {
+  &:focus-visible {
     flex-basis: calc(100% - #{$expand-button-width} - #{$space-for-focus-ring});
     margin-left: $focus-ring-border-width * 2;
     border-start-start-radius: $border-solid-border-radius;
@@ -164,7 +164,7 @@ $space-for-focus-ring: ($focus-ring-border-width * 2) + ($focus-spacing * 2);
   border-left: 2px solid $color-blue-200;
   justify-content: center;
 
-  &:global(.focus-visible) {
+  &:focus-visible {
     border-color: $color-white;
     flex-basis: calc(#{$expand-button-width} - #{$space-for-focus-ring});
     margin-right: $focus-ring-border-width * 2;

--- a/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/MobileActions.module.scss
+++ b/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/MobileActions.module.scss
@@ -100,8 +100,7 @@ $space-for-focus-ring: ($focus-ring-border-width * 2) + ($focus-spacing * 2);
     outline: none;
   }
 
-  &:focus-visible,
-  &:global(.focus-visible) {
+  &:focus-visible {
     height: $layout-mobile-actions-drawer-height - $space-for-focus-ring;
 
     &::after {
@@ -131,8 +130,7 @@ $space-for-focus-ring: ($focus-ring-border-width * 2) + ($focus-spacing * 2);
   border-start-start-radius: $border-solid-border-radius;
   border-start-end-radius: $border-solid-border-radius;
 
-  &:focus-visible,
-  &:global(.focus-visible) {
+  &:focus-visible {
     flex-basis: calc(100% - #{$space-for-focus-ring});
 
     &::after {
@@ -146,8 +144,7 @@ $space-for-focus-ring: ($focus-ring-border-width * 2) + ($focus-spacing * 2);
 .mobileActionsPrimaryButton:not(:only-child) {
   flex: 0 0 calc(100% - #{$expand-button-width});
 
-  &:focus-visible,
-  &:global(.focus-visible) {
+  &:focus-visible {
     flex-basis: calc(100% - #{$expand-button-width} - #{$space-for-focus-ring});
     margin-left: $focus-ring-border-width * 2;
     border-start-start-radius: $border-solid-border-radius;
@@ -167,8 +164,7 @@ $space-for-focus-ring: ($focus-ring-border-width * 2) + ($focus-spacing * 2);
   border-left: 2px solid $color-blue-200;
   justify-content: center;
 
-  &:focus-visible,
-  &:global(.focus-visible) {
+  &:focus-visible {
     border-color: $color-white;
     flex-basis: calc(#{$expand-button-width} - #{$space-for-focus-ring});
     margin-right: $focus-ring-border-width * 2;

--- a/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/TitleBlockMenuItem.module.scss
+++ b/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/TitleBlockMenuItem.module.scss
@@ -49,8 +49,7 @@
     }
   }
 
-  &:focus-visible,
-  &.focus-visible {
+  &:focus-visible {
     border-color: $color-blue-500;
     outline: none;
   }

--- a/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/TitleBlockMenuItem.module.scss
+++ b/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/TitleBlockMenuItem.module.scss
@@ -49,9 +49,12 @@
     }
   }
 
+  &:focus {
+    outline: none;
+  }
+
   &:focus-visible {
     border-color: $color-blue-500;
-    outline: none;
   }
 
   [dir="rtl"] & {

--- a/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/TitleBlockMenuItem.module.scss
+++ b/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/TitleBlockMenuItem.module.scss
@@ -49,7 +49,8 @@
     }
   }
 
-  &:focus-visible {
+  &:focus-visible,
+  &:global(.focus-visible) {
     border-color: $color-blue-500;
     outline: none;
   }

--- a/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/TitleBlockMenuItem.module.scss
+++ b/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/TitleBlockMenuItem.module.scss
@@ -49,8 +49,7 @@
     }
   }
 
-  &:focus-visible,
-  &:global(.focus-visible) {
+  &:focus-visible {
     border-color: $color-blue-500;
     outline: none;
   }

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "@storybook/react": "^7.0.5",
     "@storybook/theming": "^7.0.5",
     "classnames": "^2.3.2",
-    "focus-visible": "^5.2.0",
     "identity-obj-proxy": "^3.0.0",
     "lodash.isempty": "^4.4.0",
     "normalize.css": "^8.0.1",

--- a/packages/a11y/src/SkipLink.module.scss
+++ b/packages/a11y/src/SkipLink.module.scss
@@ -59,8 +59,9 @@ $caButtonIcon-height: 20px;
   background: $color-white;
   border-color: $border-borderless-border-color;
   color: $color-purple-800;
-  // show custom focus ring when :focus-visible
-  &:focus-visible::after {
+
+  &:focus-visible::after,
+  &:global(.focus-visible)::after {
     $focus-ring-offset: calc((#{$border-focus-ring-border-width} * 2) + 1px);
     content: "";
     position: absolute;

--- a/packages/a11y/src/SkipLink.module.scss
+++ b/packages/a11y/src/SkipLink.module.scss
@@ -60,7 +60,7 @@ $caButtonIcon-height: 20px;
   border-color: $border-borderless-border-color;
   color: $color-purple-800;
   // show custom focus ring when :focus-visible
-  &:global(.focus-visible)::after {
+  &:focus-visible::after {
     $focus-ring-offset: calc((#{$border-focus-ring-border-width} * 2) + 1px);
     content: "";
     position: absolute;

--- a/packages/a11y/src/SkipLink.module.scss
+++ b/packages/a11y/src/SkipLink.module.scss
@@ -60,8 +60,7 @@ $caButtonIcon-height: 20px;
   border-color: $border-borderless-border-color;
   color: $color-purple-800;
 
-  &:focus-visible::after,
-  &:global(.focus-visible)::after {
+  &:focus-visible::after {
     $focus-ring-offset: calc((#{$border-focus-ring-border-width} * 2) + 1px);
     content: "";
     position: absolute;

--- a/packages/button/src/Button/Button.module.scss
+++ b/packages/button/src/Button/Button.module.scss
@@ -39,7 +39,6 @@
       transform: translateY(1px);
     }
 
-    // hide native focus ring when :focus but not :focus-visible
     &:focus {
       outline: none;
     }

--- a/packages/button/src/Button/_variables.scss
+++ b/packages/button/src/Button/_variables.scss
@@ -14,9 +14,6 @@ $button-vertical-padding--form: calc(
 // Elements
 $className--content: ".content";
 
-// Polyfill
-$polyfill--focus-visible: ":global(.js-focus-visible) &:global(.focus-visible)";
-
 // Classnames to simulate pseudo states in storybook
 $story-className--button-hover: ":global(.story__button-hover)";
 $story-className--button-active: ":global(.story__button-active)";
@@ -25,4 +22,4 @@ $story-className--button-focus: ":global(.story__button-focus)";
 // Combined pseudo state classes
 $selectors--button-hover: "&:hover, &#{$story-className--button-hover}";
 $selectors--button-active: "&:active, &#{$story-className--button-active}";
-$selectors--button-focus: "&:focus-visible, #{$polyfill--focus-visible}, &#{$story-className--button-focus}";
+$selectors--button-focus: "&:focus-visible, &#{$story-className--button-focus}";

--- a/packages/button/src/Button/_variables.scss
+++ b/packages/button/src/Button/_variables.scss
@@ -22,4 +22,4 @@ $story-className--button-focus: ":global(.story__button-focus)";
 // Combined pseudo state classes
 $selectors--button-hover: "&:hover, &#{$story-className--button-hover}";
 $selectors--button-active: "&:active, &#{$story-className--button-active}";
-$selectors--button-focus: "&:focus-visible, &#{$story-className--button-focus}";
+$selectors--button-focus: "&:focus-visible, &:global(.focus-visible), &#{$story-className--button-focus}";

--- a/packages/button/src/Button/_variables.scss
+++ b/packages/button/src/Button/_variables.scss
@@ -22,4 +22,4 @@ $story-className--button-focus: ":global(.story__button-focus)";
 // Combined pseudo state classes
 $selectors--button-hover: "&:hover, &#{$story-className--button-hover}";
 $selectors--button-active: "&:active, &#{$story-className--button-active}";
-$selectors--button-focus: "&:focus-visible, &:global(.focus-visible), &#{$story-className--button-focus}";
+$selectors--button-focus: "&:focus-visible, &#{$story-className--button-focus}";

--- a/packages/components/src/ButtonGroup/ButtonGroup.module.scss
+++ b/packages/components/src/ButtonGroup/ButtonGroup.module.scss
@@ -4,14 +4,11 @@
 $focus-ring-offset: 1px;
 $focus-ring-offset-inner: calc(-1 * #{$focus-ring-offset});
 
-// Polyfill
-$polyfill--focus-visible: ":global(.js-focus-visible) &:global(.focus-visible)";
-
 // Classnames to simulate pseudo states in storybook
 $story-className--button-group--focus: ":global(.story__button-group--focus)";
 
 // Combined pseudo state classes
-$selectors--button-group--focus: "&:focus-visible, #{$polyfill--focus-visible}, &#{$story-className--button-group--focus}";
+$selectors--button-group--focus: "&:focus-visible, &#{$story-className--button-group--focus}";
 
 %firstChildBorders {
   border-start-start-radius: $border-focus-ring-border-radius;

--- a/packages/components/src/ButtonGroup/ButtonGroup.module.scss
+++ b/packages/components/src/ButtonGroup/ButtonGroup.module.scss
@@ -8,7 +8,7 @@ $focus-ring-offset-inner: calc(-1 * #{$focus-ring-offset});
 $story-className--button-group--focus: ":global(.story__button-group--focus)";
 
 // Combined pseudo state classes
-$selectors--button-group--focus: "&:focus-visible, &#{$story-className--button-group--focus}";
+$selectors--button-group--focus: "&:focus-visible, &:global(.focus-visible), &#{$story-className--button-group--focus}";
 
 %firstChildBorders {
   border-start-start-radius: $border-focus-ring-border-radius;

--- a/packages/components/src/ButtonGroup/ButtonGroup.module.scss
+++ b/packages/components/src/ButtonGroup/ButtonGroup.module.scss
@@ -8,7 +8,7 @@ $focus-ring-offset-inner: calc(-1 * #{$focus-ring-offset});
 $story-className--button-group--focus: ":global(.story__button-group--focus)";
 
 // Combined pseudo state classes
-$selectors--button-group--focus: "&:focus-visible, &:global(.focus-visible), &#{$story-className--button-group--focus}";
+$selectors--button-group--focus: "&:focus-visible, &#{$story-className--button-group--focus}";
 
 %firstChildBorders {
   border-start-start-radius: $border-focus-ring-border-radius;

--- a/packages/components/src/FilterButton/_subcomponents/FilterButtonBase/_variables.scss
+++ b/packages/components/src/FilterButton/_subcomponents/FilterButtonBase/_variables.scss
@@ -6,9 +6,6 @@ $focus-ring-offset-outer: calc(
   -1 * calc(#{$border-focus-ring-border-width} + #{$focus-ring-offset})
 );
 
-// Polyfill
-$polyfill--focus-visible: ":global(.js-focus-visible) &:global(.focus-visible)";
-
 // Classnames to simulate pseudo states in storybook
 $story-className--filter-button-base--hover: ":global(.story__filter-button-base--hover)";
 $story-className--filter-button-base--active: ":global(.story__filter-button-base--active)";
@@ -17,4 +14,4 @@ $story-className--filter-button-base--focus: ":global(.story__filter-button-base
 // Combined pseudo state classes
 $selectors--filter-button-base--hover: "&:hover, &#{$story-className--filter-button-base--hover}";
 $selectors--filter-button-base--active: "&:active, &#{$story-className--filter-button-base--active}";
-$selectors--filter-button-base--focus: "&:focus-visible, #{$polyfill--focus-visible}, &#{$story-className--filter-button-base--focus}";
+$selectors--filter-button-base--focus: "&:focus-visible, &#{$story-className--filter-button-base--focus}";

--- a/packages/components/src/FilterButton/_subcomponents/FilterButtonBase/_variables.scss
+++ b/packages/components/src/FilterButton/_subcomponents/FilterButtonBase/_variables.scss
@@ -14,4 +14,4 @@ $story-className--filter-button-base--focus: ":global(.story__filter-button-base
 // Combined pseudo state classes
 $selectors--filter-button-base--hover: "&:hover, &#{$story-className--filter-button-base--hover}";
 $selectors--filter-button-base--active: "&:active, &#{$story-className--filter-button-base--active}";
-$selectors--filter-button-base--focus: "&:focus-visible, &#{$story-className--filter-button-base--focus}";
+$selectors--filter-button-base--focus: "&:focus-visible, &:global(.focus-visible), &#{$story-className--filter-button-base--focus}";

--- a/packages/components/src/FilterButton/_subcomponents/FilterButtonBase/_variables.scss
+++ b/packages/components/src/FilterButton/_subcomponents/FilterButtonBase/_variables.scss
@@ -14,4 +14,4 @@ $story-className--filter-button-base--focus: ":global(.story__filter-button-base
 // Combined pseudo state classes
 $selectors--filter-button-base--hover: "&:hover, &#{$story-className--filter-button-base--hover}";
 $selectors--filter-button-base--active: "&:active, &#{$story-className--filter-button-base--active}";
-$selectors--filter-button-base--focus: "&:focus-visible, &:global(.focus-visible), &#{$story-className--filter-button-base--focus}";
+$selectors--filter-button-base--focus: "&:focus-visible, &#{$story-className--filter-button-base--focus}";

--- a/packages/date-picker/docs/Calendars.stories.tsx
+++ b/packages/date-picker/docs/Calendars.stories.tsx
@@ -158,7 +158,7 @@ const applyStickerSheetStyles = (canvasElement: HTMLElement): void => {
       "story__datepicker__calendar--hover"
     )
     getElementWithinCalendar(`${row}-focus`, buttonDescription).classList.add(
-      "focus-visible"
+      "story__datepicker__calendar--focus"
     )
   })
 }

--- a/packages/date-picker/src/DateRangePicker/DateRangePicker.module.scss
+++ b/packages/date-picker/src/DateRangePicker/DateRangePicker.module.scss
@@ -33,13 +33,15 @@ $placeholder-opacity: 0.7;
   padding: 0 $button-base-padding-horizontal;
 
   &:focus-visible:not([disabled]),
+  &:global(.focus-visible):not([disabled]),
   &:hover:not([disabled]) {
     background-color: $color-gray-200;
     border-color: $color-gray-600;
     color: $color-purple-800;
   }
 
-  &:focus-visible:not([disabled]) {
+  &:focus-visible:not([disabled]),
+  &:global(.focus-visible):not([disabled]) {
     outline: $color-blue-500 $border-focus-ring-border-style
       $border-focus-ring-border-width;
     outline-offset: 1px;

--- a/packages/date-picker/src/DateRangePicker/DateRangePicker.module.scss
+++ b/packages/date-picker/src/DateRangePicker/DateRangePicker.module.scss
@@ -33,15 +33,13 @@ $placeholder-opacity: 0.7;
   padding: 0 $button-base-padding-horizontal;
 
   &:focus-visible:not([disabled]),
-  &:global(.focus-visible):not([disabled]),
   &:hover:not([disabled]) {
     background-color: $color-gray-200;
     border-color: $color-gray-600;
     color: $color-purple-800;
   }
 
-  &:focus-visible:not([disabled]),
-  &:global(.focus-visible):not([disabled]) {
+  &:focus-visible:not([disabled]) {
     outline: $color-blue-500 $border-focus-ring-border-style
       $border-focus-ring-border-width;
     outline-offset: 1px;

--- a/packages/date-picker/src/DateRangePicker/DateRangePicker.module.scss
+++ b/packages/date-picker/src/DateRangePicker/DateRangePicker.module.scss
@@ -32,14 +32,14 @@ $placeholder-opacity: 0.7;
   border-radius: $border-solid-border-radius;
   padding: 0 $button-base-padding-horizontal;
 
-  &:global(.focus-visible):not([disabled]),
+  &:focus-visible:not([disabled]),
   &:hover:not([disabled]) {
     background-color: $color-gray-200;
     border-color: $color-gray-600;
     color: $color-purple-800;
   }
 
-  &:global(.focus-visible):not([disabled]) {
+  &:focus-visible:not([disabled]) {
     outline: $color-blue-500 $border-focus-ring-border-style
       $border-focus-ring-border-width;
     outline-offset: 1px;

--- a/packages/date-picker/src/FilterDateRangePicker/components/Trigger/_variables.scss
+++ b/packages/date-picker/src/FilterDateRangePicker/components/Trigger/_variables.scss
@@ -6,9 +6,6 @@ $focus-ring-offset-outer: calc(
   -1 * calc(#{$border-focus-ring-border-width} + #{$focus-ring-offset})
 );
 
-// Polyfill
-$polyfill--focus-visible: ":global(.js-focus-visible) &:global(.focus-visible)";
-
 // Classnames to simulate pseudo states in storybook
 $story-className--filter-button--hover: ":global(.story__filter-button--hover)";
 $story-className--filter-button--active: ":global(.story__filter-button--active)";
@@ -17,4 +14,4 @@ $story-className--filter-button--focus: ":global(.story__filter-button--focus)";
 // Combined pseudo state classes
 $selectors--filter-button--hover: "&:hover, &#{$story-className--filter-button--hover}";
 $selectors--filter-button--active: "&:active, &#{$story-className--filter-button--active}";
-$selectors--filter-button--focus: "&:focus-visible, #{$polyfill--focus-visible}, &#{$story-className--filter-button--focus}";
+$selectors--filter-button--focus: "&:focus-visible, &#{$story-className--filter-button--focus}";

--- a/packages/date-picker/src/FilterDateRangePicker/components/Trigger/_variables.scss
+++ b/packages/date-picker/src/FilterDateRangePicker/components/Trigger/_variables.scss
@@ -14,4 +14,4 @@ $story-className--filter-button--focus: ":global(.story__filter-button--focus)";
 // Combined pseudo state classes
 $selectors--filter-button--hover: "&:hover, &#{$story-className--filter-button--hover}";
 $selectors--filter-button--active: "&:active, &#{$story-className--filter-button--active}";
-$selectors--filter-button--focus: "&:focus-visible, &:global(.focus-visible), &#{$story-className--filter-button--focus}";
+$selectors--filter-button--focus: "&:focus-visible, &#{$story-className--filter-button--focus}";

--- a/packages/date-picker/src/FilterDateRangePicker/components/Trigger/_variables.scss
+++ b/packages/date-picker/src/FilterDateRangePicker/components/Trigger/_variables.scss
@@ -14,4 +14,4 @@ $story-className--filter-button--focus: ":global(.story__filter-button--focus)";
 // Combined pseudo state classes
 $selectors--filter-button--hover: "&:hover, &#{$story-className--filter-button--hover}";
 $selectors--filter-button--active: "&:active, &#{$story-className--filter-button--active}";
-$selectors--filter-button--focus: "&:focus-visible, &#{$story-className--filter-button--focus}";
+$selectors--filter-button--focus: "&:focus-visible, &:global(.focus-visible), &#{$story-className--filter-button--focus}";

--- a/packages/date-picker/src/TimeField/components/TimeSegment/TimeSegment.module.scss
+++ b/packages/date-picker/src/TimeField/components/TimeSegment/TimeSegment.module.scss
@@ -7,7 +7,7 @@ $story-className--timesegment-hover: ":global(.story__timefield-hover) #{$classN
 $story-className--timesegment-focus: ":global(.story__timefield-focus) #{$className--timesegment-wrapper}:first-child &";
 
 $selectors--timesegment-hover: "&:hover, #{$story-className--timesegment-hover}";
-$selectors--timesegment-focus: "&:focus-visible, &:global(.focus-visible), #{$story-className--timesegment-focus}";
+$selectors--timesegment-focus: "&:focus-visible, #{$story-className--timesegment-focus}";
 
 // Chrome has a bug where `contenteditable` elements receive focus from external clicks.
 // This (in combination with the invisible character &#8203;) creates boundaries

--- a/packages/date-picker/src/TimeField/components/TimeSegment/TimeSegment.module.scss
+++ b/packages/date-picker/src/TimeField/components/TimeSegment/TimeSegment.module.scss
@@ -7,7 +7,7 @@ $story-className--timesegment-hover: ":global(.story__timefield-hover) #{$classN
 $story-className--timesegment-focus: ":global(.story__timefield-focus) #{$className--timesegment-wrapper}:first-child &";
 
 $selectors--timesegment-hover: "&:hover, #{$story-className--timesegment-hover}";
-$selectors--timesegment-focus: "&:focus-visible, #{$story-className--timesegment-focus}";
+$selectors--timesegment-focus: "&:focus-visible, &:global(.focus-visible), #{$story-className--timesegment-focus}";
 
 // Chrome has a bug where `contenteditable` elements receive focus from external clicks.
 // This (in combination with the invisible character &#8203;) creates boundaries

--- a/packages/date-picker/src/TimeField/components/TimeSegment/TimeSegment.module.scss
+++ b/packages/date-picker/src/TimeField/components/TimeSegment/TimeSegment.module.scss
@@ -1,7 +1,5 @@
 @import "~@kaizen/design-tokens/sass/color";
 
-$polyfill--focus-visible: ":global(.js-focus-visible) &:global(.focus-visible)";
-
 $className--timesegment-wrapper: ".timeSegmentWrapper";
 
 // Classnames to simulate pseudo states in storybook
@@ -9,7 +7,7 @@ $story-className--timesegment-hover: ":global(.story__timefield-hover) #{$classN
 $story-className--timesegment-focus: ":global(.story__timefield-focus) #{$className--timesegment-wrapper}:first-child &";
 
 $selectors--timesegment-hover: "&:hover, #{$story-className--timesegment-hover}";
-$selectors--timesegment-focus: "&:focus-visible, #{$polyfill--focus-visible}, #{$story-className--timesegment-focus}";
+$selectors--timesegment-focus: "&:focus-visible, #{$story-className--timesegment-focus}";
 
 // Chrome has a bug where `contenteditable` elements receive focus from external clicks.
 // This (in combination with the invisible character &#8203;) creates boundaries

--- a/packages/date-picker/src/_subcomponents/Calendar/Calendar.module.scss
+++ b/packages/date-picker/src/_subcomponents/Calendar/Calendar.module.scss
@@ -7,7 +7,10 @@
 $button-border-radius: 3px;
 $rdp-cell-size: 40px;
 
-$selectors--button-focus: "&:focus-visible";
+$story-className--calendar--hover: ":global(.story__datepicker__calendar--hover)";
+$story-className--calendar--focus: ":global(.story__datepicker__calendar--focus)";
+
+$selectors--button-focus: "&:focus-visible, &#{$story-className--calendar--focus}";
 
 %focus-ring {
   position: relative;
@@ -93,7 +96,7 @@ $selectors--button-focus: "&:focus-visible";
   border-radius: $button-border-radius;
 
   &:hover,
-  &:global(.story__datepicker__calendar--hover) {
+  &#{$story-className--calendar--hover} {
     background-color: $color-blue-100;
     color: $color-blue-500;
   }
@@ -159,7 +162,7 @@ $selectors--button-focus: "&:focus-visible";
   color: $color-purple-800;
 
   &:hover,
-  &:global(.story__datepicker__calendar--hover) {
+  &#{$story-className--calendar--hover} {
     background-color: $color-blue-100;
     color: $color-blue-500;
   }
@@ -180,7 +183,7 @@ $selectors--button-focus: "&:focus-visible";
   color: $color-white;
 
   &:hover,
-  &:global(.story__datepicker__calendar--hover),
+  &#{$story-className--calendar--hover},
   #{$selectors--button-focus} {
     background-color: $color-blue-400;
     color: $color-white;

--- a/packages/date-picker/src/_subcomponents/Calendar/Calendar.module.scss
+++ b/packages/date-picker/src/_subcomponents/Calendar/Calendar.module.scss
@@ -7,8 +7,7 @@
 $button-border-radius: 3px;
 $rdp-cell-size: 40px;
 
-$polyfill--focus-visible: ":global(.js-focus-visible) &:global(.focus-visible)";
-$selectors--button-focus: "&:focus-visible, #{$polyfill--focus-visible}";
+$selectors--button-focus: "&:focus-visible";
 
 %focus-ring {
   position: relative;

--- a/packages/date-picker/src/_subcomponents/Calendar/Calendar.module.scss
+++ b/packages/date-picker/src/_subcomponents/Calendar/Calendar.module.scss
@@ -7,13 +7,13 @@
 $button-border-radius: 3px;
 $rdp-cell-size: 40px;
 
-$selectors--button-focus: "&:focus-visible";
+$selectors--button-focus: "&:focus-visible, &:global(.focus-visible)";
 
 %focus-ring {
   position: relative;
 
   &:focus,
-  &:focus-visible {
+  #{$selectors--button-focus} {
     outline: none;
   }
 

--- a/packages/date-picker/src/_subcomponents/Calendar/Calendar.module.scss
+++ b/packages/date-picker/src/_subcomponents/Calendar/Calendar.module.scss
@@ -7,7 +7,7 @@
 $button-border-radius: 3px;
 $rdp-cell-size: 40px;
 
-$selectors--button-focus: "&:focus-visible, &:global(.focus-visible)";
+$selectors--button-focus: "&:focus-visible";
 
 %focus-ring {
   position: relative;

--- a/packages/date-picker/src/_subcomponents/DateInput/DateInputWithIconButton.module.scss
+++ b/packages/date-picker/src/_subcomponents/DateInput/DateInputWithIconButton.module.scss
@@ -30,7 +30,8 @@ $input-disabled-opacity: 0.3;
     outline: none;
   }
 
-  &:focus-visible {
+  &:focus-visible,
+  &:global(.focus-visible) {
     outline-offset: -2px;
     outline: $color-blue-500 $border-focus-ring-border-style
       $border-focus-ring-border-width;

--- a/packages/date-picker/src/_subcomponents/DateInput/DateInputWithIconButton.module.scss
+++ b/packages/date-picker/src/_subcomponents/DateInput/DateInputWithIconButton.module.scss
@@ -30,8 +30,7 @@ $input-disabled-opacity: 0.3;
     outline: none;
   }
 
-  &:focus-visible,
-  &:global(.focus-visible) {
+  &:focus-visible {
     outline-offset: -2px;
     outline: $color-blue-500 $border-focus-ring-border-style
       $border-focus-ring-border-width;

--- a/packages/date-picker/src/_subcomponents/DateInput/DateInputWithIconButton.module.scss
+++ b/packages/date-picker/src/_subcomponents/DateInput/DateInputWithIconButton.module.scss
@@ -30,8 +30,7 @@ $input-disabled-opacity: 0.3;
     outline: none;
   }
 
-  &:focus-visible,
-  :global(.js-focus-visible) &:global(.focus-visible) {
+  &:focus-visible {
     outline-offset: -2px;
     outline: $color-blue-500 $border-focus-ring-border-style
       $border-focus-ring-border-width;

--- a/packages/notification/src/components/GenericNotification.module.scss
+++ b/packages/notification/src/components/GenericNotification.module.scss
@@ -34,7 +34,7 @@
   &:focus {
     outline: none;
   }
-  &:global(.focus-visible)::after {
+  &:focus-visible::after {
     content: "";
     $focus-ring-offset: 6px;
     pointer-events: none;

--- a/packages/notification/src/components/GenericNotification.module.scss
+++ b/packages/notification/src/components/GenericNotification.module.scss
@@ -31,10 +31,13 @@
   display: flex;
   align-items: center;
   justify-content: center;
+
   &:focus {
     outline: none;
   }
-  &:focus-visible::after {
+
+  &:focus-visible::after,
+  &:global(.focus-visible)::after {
     content: "";
     $focus-ring-offset: 6px;
     pointer-events: none;

--- a/packages/notification/src/components/GenericNotification.module.scss
+++ b/packages/notification/src/components/GenericNotification.module.scss
@@ -36,8 +36,7 @@
     outline: none;
   }
 
-  &:focus-visible::after,
-  &:global(.focus-visible)::after {
+  &:focus-visible::after {
     content: "";
     $focus-ring-offset: 6px;
     pointer-events: none;

--- a/packages/pagination/src/Pagination.module.scss
+++ b/packages/pagination/src/Pagination.module.scss
@@ -37,8 +37,7 @@
   &:focus {
     background-color: $color-blue-200;
 
-    &:focus-visible,
-    &:global(.focus-visible) {
+    &:focus-visible {
       outline: none;
     }
 
@@ -86,8 +85,7 @@
   &:hover {
     background-color: $color-blue-100;
   }
-  &:focus-visible,
-  &:global(.focus-visible) {
+  &:focus-visible {
     outline: none;
   }
   &:focus {

--- a/packages/pagination/src/Pagination.module.scss
+++ b/packages/pagination/src/Pagination.module.scss
@@ -36,9 +36,12 @@
 
   &:focus {
     background-color: $color-blue-200;
-    &:focus-visible {
+
+    &:focus-visible,
+    &:global(.focus-visible) {
       outline: none;
     }
+
     .pageIndicatorFocusRing {
       border: $border-focus-ring-border-width $border-focus-ring-border-style
         $color-blue-500;
@@ -83,7 +86,8 @@
   &:hover {
     background-color: $color-blue-100;
   }
-  &:focus-visible {
+  &:focus-visible,
+  &:global(.focus-visible) {
     outline: none;
   }
   &:focus {

--- a/packages/rich-text-editor/src/RichTextEditor/RichTextEditor.module.scss
+++ b/packages/rich-text-editor/src/RichTextEditor/RichTextEditor.module.scss
@@ -23,7 +23,7 @@
     outline: none;
   }
 
-  &:global(.focus-visible)::after {
+  &:focus-visible::after {
     $focus-ring-offset: 5px;
     content: "";
     pointer-events: none;

--- a/packages/rich-text-editor/src/RichTextEditor/RichTextEditor.module.scss
+++ b/packages/rich-text-editor/src/RichTextEditor/RichTextEditor.module.scss
@@ -23,7 +23,8 @@
     outline: none;
   }
 
-  &:focus-visible::after {
+  &:focus-visible::after,
+  &:global(.focus-visible):after {
     $focus-ring-offset: 5px;
     content: "";
     pointer-events: none;

--- a/packages/rich-text-editor/src/RichTextEditor/RichTextEditor.module.scss
+++ b/packages/rich-text-editor/src/RichTextEditor/RichTextEditor.module.scss
@@ -23,8 +23,7 @@
     outline: none;
   }
 
-  &:focus-visible::after,
-  &:global(.focus-visible):after {
+  &:focus-visible::after {
     $focus-ring-offset: 5px;
     content: "";
     pointer-events: none;

--- a/packages/rich-text-editor/src/RichTextEditor/components/ToggleIconButton/ToggleIconButton.module.scss
+++ b/packages/rich-text-editor/src/RichTextEditor/components/ToggleIconButton/ToggleIconButton.module.scss
@@ -18,7 +18,8 @@
     outline: none;
   }
 
-  &:focus-visible:after {
+  &:focus-visible::after,
+  &:global(.focus-visible)::after {
     $focus-ring-offset: 3px;
     content: "";
     position: absolute;
@@ -35,7 +36,9 @@
 
   &.disabled {
     opacity: 0.3;
-    &:focus-visible:after {
+
+    &:focus-visible:after,
+    &:global(.focus-visible):after {
       color: rgba($color-purple-800-rgb, 0.3);
       outline-offset: -2px;
       background-color: transparent;
@@ -54,7 +57,8 @@
 
   &:not(.disabled) {
     &:hover:not(.active),
-    &:focus-visible:not(.active) {
+    &:focus-visible:not(.active),
+    &:global(.focus-visible):not(.active) {
       background-color: $color-gray-200;
     }
 
@@ -71,7 +75,8 @@
 
   &:not(.disabled) {
     &:hover:not(.active),
-    &:focus-visible:not(.active) {
+    &:focus-visible:not(.active),
+    &:global(.focus-visible):not(.active) {
       background-color: $color-blue-100;
     }
 
@@ -87,7 +92,8 @@
 
   &:not(.disabled) {
     &:hover:not(.active),
-    &:focus-visible:not(.active) {
+    &:focus-visible:not(.active),
+    &:global(.focus-visible):not(.active) {
       background-color: $color-blue-600;
     }
 
@@ -103,7 +109,8 @@
 
   &:not(.disabled) {
     &:hover:not(.active),
-    &:focus-visible:not(.active) {
+    &:focus-visible:not(.active),
+    &:global(.focus-visible):not(.active) {
       background-color: $color-red-600;
     }
 
@@ -119,7 +126,8 @@
 
   &:not(.disabled) {
     &:hover:not(.active),
-    &:focus-visible:not(.active) {
+    &:focus-visible:not(.active),
+    &:global(.focus-visible):not(.active) {
       background-color: $color-red-100;
     }
 

--- a/packages/rich-text-editor/src/RichTextEditor/components/ToggleIconButton/ToggleIconButton.module.scss
+++ b/packages/rich-text-editor/src/RichTextEditor/components/ToggleIconButton/ToggleIconButton.module.scss
@@ -18,7 +18,6 @@
     outline: none;
   }
 
-  &:global(.focus-visible)::after,
   &:focus-visible:after {
     $focus-ring-offset: 3px;
     content: "";
@@ -36,7 +35,6 @@
 
   &.disabled {
     opacity: 0.3;
-    &:global(.focus-visible)::after,
     &:focus-visible:after {
       color: rgba($color-purple-800-rgb, 0.3);
       outline-offset: -2px;
@@ -56,7 +54,7 @@
 
   &:not(.disabled) {
     &:hover:not(.active),
-    &:global(.focus-visible):not(.active) {
+    &:focus-visible:not(.active) {
       background-color: $color-gray-200;
     }
 
@@ -73,7 +71,7 @@
 
   &:not(.disabled) {
     &:hover:not(.active),
-    &:global(.focus-visible):not(.active) {
+    &:focus-visible:not(.active) {
       background-color: $color-blue-100;
     }
 
@@ -89,7 +87,7 @@
 
   &:not(.disabled) {
     &:hover:not(.active),
-    &:global(.focus-visible):not(.active) {
+    &:focus-visible:not(.active) {
       background-color: $color-blue-600;
     }
 
@@ -105,7 +103,7 @@
 
   &:not(.disabled) {
     &:hover:not(.active),
-    &:global(.focus-visible):not(.active) {
+    &:focus-visible:not(.active) {
       background-color: $color-red-600;
     }
 
@@ -121,7 +119,7 @@
 
   &:not(.disabled) {
     &:hover:not(.active),
-    &:global(.focus-visible):not(.active) {
+    &:focus-visible:not(.active) {
       background-color: $color-red-100;
     }
 

--- a/packages/rich-text-editor/src/RichTextEditor/components/ToggleIconButton/ToggleIconButton.module.scss
+++ b/packages/rich-text-editor/src/RichTextEditor/components/ToggleIconButton/ToggleIconButton.module.scss
@@ -18,8 +18,7 @@
     outline: none;
   }
 
-  &:focus-visible::after,
-  &:global(.focus-visible)::after {
+  &:focus-visible::after {
     $focus-ring-offset: 3px;
     content: "";
     position: absolute;
@@ -37,8 +36,7 @@
   &.disabled {
     opacity: 0.3;
 
-    &:focus-visible:after,
-    &:global(.focus-visible):after {
+    &:focus-visible:after {
       color: rgba($color-purple-800-rgb, 0.3);
       outline-offset: -2px;
       background-color: transparent;
@@ -57,8 +55,7 @@
 
   &:not(.disabled) {
     &:hover:not(.active),
-    &:focus-visible:not(.active),
-    &:global(.focus-visible):not(.active) {
+    &:focus-visible:not(.active) {
       background-color: $color-gray-200;
     }
 
@@ -75,8 +72,7 @@
 
   &:not(.disabled) {
     &:hover:not(.active),
-    &:focus-visible:not(.active),
-    &:global(.focus-visible):not(.active) {
+    &:focus-visible:not(.active) {
       background-color: $color-blue-100;
     }
 
@@ -92,8 +88,7 @@
 
   &:not(.disabled) {
     &:hover:not(.active),
-    &:focus-visible:not(.active),
-    &:global(.focus-visible):not(.active) {
+    &:focus-visible:not(.active) {
       background-color: $color-blue-600;
     }
 
@@ -109,8 +104,7 @@
 
   &:not(.disabled) {
     &:hover:not(.active),
-    &:focus-visible:not(.active),
-    &:global(.focus-visible):not(.active) {
+    &:focus-visible:not(.active) {
       background-color: $color-red-600;
     }
 
@@ -126,8 +120,7 @@
 
   &:not(.disabled) {
     &:hover:not(.active),
-    &:focus-visible:not(.active),
-    &:global(.focus-visible):not(.active) {
+    &:focus-visible:not(.active) {
       background-color: $color-red-100;
     }
 

--- a/packages/select/src/FilterMultiSelect/components/MultiSelectOption/MultiSelectOption.module.scss
+++ b/packages/select/src/FilterMultiSelect/components/MultiSelectOption/MultiSelectOption.module.scss
@@ -39,7 +39,8 @@
   }
 
   &.isFocused,
-  &:focus-visible {
+  &:focus-visible,
+  &:global(.focus-visible) {
     background-color: $color-blue-100;
     &::after {
       $focus-ring-offset: calc((#{$border-focus-ring-border-width} * 2) + 1px);

--- a/packages/select/src/FilterMultiSelect/components/MultiSelectOption/MultiSelectOption.module.scss
+++ b/packages/select/src/FilterMultiSelect/components/MultiSelectOption/MultiSelectOption.module.scss
@@ -39,8 +39,7 @@
   }
 
   &.isFocused,
-  &:focus-visible,
-  &:global(.focus-visible) {
+  &:focus-visible {
     background-color: $color-blue-100;
     &::after {
       $focus-ring-offset: calc((#{$border-focus-ring-border-width} * 2) + 1px);

--- a/packages/select/src/FilterMultiSelect/components/MultiSelectOption/MultiSelectOption.module.scss
+++ b/packages/select/src/FilterMultiSelect/components/MultiSelectOption/MultiSelectOption.module.scss
@@ -39,8 +39,7 @@
   }
 
   &.isFocused,
-  &:focus-visible,
-  &:global(.js-focus-visible) &:global(.focus-visible) {
+  &:focus-visible {
     background-color: $color-blue-100;
     &::after {
       $focus-ring-offset: calc((#{$border-focus-ring-border-width} * 2) + 1px);

--- a/packages/select/src/FilterMultiSelect/components/SelectionControlButton/SelectionControlButton.module.scss
+++ b/packages/select/src/FilterMultiSelect/components/SelectionControlButton/SelectionControlButton.module.scss
@@ -40,7 +40,7 @@ $focus-ring-offset: 1px;
     outline: none;
   }
 
-  &:global(.focus-visible)::after {
+  &:focus-visible::after {
     $focus-ring-offset: calc((#{$border-focus-ring-border-width} * 2) + 1px);
     content: "";
     position: absolute;
@@ -65,17 +65,14 @@ $focus-ring-offset: 1px;
     color: rgba($color-purple-800-rgb, 0.3);
     opacity: 1;
 
-    :global(.js-focus-visible) & {
-      // hide native focus ring when :focus but not :focus-visible
-      &:focus {
-        outline: none;
-        border: 2px solid transparent;
-      }
+    &:focus {
+      outline: none;
+      border: 2px solid transparent;
+    }
 
-      &:global(.focus-visible)::after {
-        border-style: $border-dashed-border-style;
-        border-color: $color-gray-400;
-      }
+    &:focus-visible::after {
+      border-style: $border-dashed-border-style;
+      border-color: $color-gray-400;
     }
   }
 }

--- a/packages/select/src/FilterMultiSelect/components/SelectionControlButton/SelectionControlButton.module.scss
+++ b/packages/select/src/FilterMultiSelect/components/SelectionControlButton/SelectionControlButton.module.scss
@@ -40,7 +40,8 @@ $focus-ring-offset: 1px;
     outline: none;
   }
 
-  &:focus-visible::after {
+  &:focus-visible::after,
+  &:global(.focus-visible)::after {
     $focus-ring-offset: calc((#{$border-focus-ring-border-width} * 2) + 1px);
     content: "";
     position: absolute;
@@ -70,7 +71,8 @@ $focus-ring-offset: 1px;
       border: 2px solid transparent;
     }
 
-    &:focus-visible::after {
+    &:focus-visible::after,
+    &:global(.focus-visible)::after {
       border-style: $border-dashed-border-style;
       border-color: $color-gray-400;
     }

--- a/packages/select/src/FilterMultiSelect/components/SelectionControlButton/SelectionControlButton.module.scss
+++ b/packages/select/src/FilterMultiSelect/components/SelectionControlButton/SelectionControlButton.module.scss
@@ -40,8 +40,7 @@ $focus-ring-offset: 1px;
     outline: none;
   }
 
-  &:focus-visible::after,
-  &:global(.focus-visible)::after {
+  &:focus-visible::after {
     $focus-ring-offset: calc((#{$border-focus-ring-border-width} * 2) + 1px);
     content: "";
     position: absolute;
@@ -71,8 +70,7 @@ $focus-ring-offset: 1px;
       border: 2px solid transparent;
     }
 
-    &:focus-visible::after,
-    &:global(.focus-visible)::after {
+    &:focus-visible::after {
       border-style: $border-dashed-border-style;
       border-color: $color-gray-400;
     }

--- a/packages/select/src/FilterMultiSelect/components/Trigger/_variables.scss
+++ b/packages/select/src/FilterMultiSelect/components/Trigger/_variables.scss
@@ -3,8 +3,5 @@
 
 $button-vertical-padding: calc(#{$spacing-sm} - #{$border-solid-border-width});
 
-// Polyfill
-$polyfill--focus-visible: ":global(.js-focus-visible) &:global(.focus-visible)";
-
 // Combined pseudo state classes
-$selectors--button-focus: "&:focus-visible, #{$polyfill--focus-visible}";
+$selectors--button-focus: "&:focus-visible";

--- a/packages/select/src/FilterMultiSelect/components/Trigger/_variables.scss
+++ b/packages/select/src/FilterMultiSelect/components/Trigger/_variables.scss
@@ -4,4 +4,4 @@
 $button-vertical-padding: calc(#{$spacing-sm} - #{$border-solid-border-width});
 
 // Combined pseudo state classes
-$selectors--button-focus: "&:focus-visible, &:global(.focus-visible)";
+$selectors--button-focus: "&:focus-visible";

--- a/packages/select/src/FilterMultiSelect/components/Trigger/_variables.scss
+++ b/packages/select/src/FilterMultiSelect/components/Trigger/_variables.scss
@@ -4,4 +4,4 @@
 $button-vertical-padding: calc(#{$spacing-sm} - #{$border-solid-border-width});
 
 // Combined pseudo state classes
-$selectors--button-focus: "&:focus-visible";
+$selectors--button-focus: "&:focus-visible, &:global(.focus-visible)";

--- a/packages/split-button/docs/SplitButton.stories.tsx
+++ b/packages/split-button/docs/SplitButton.stories.tsx
@@ -153,7 +153,7 @@ const StickerSheetTemplate: StoryFn<{ isReversed: boolean }> = ({
               isReversed={isReversed}
               actionButtonProps={{
                 ...ACTION_BUTTON_PROPS__BUTTON,
-                classNameOverride: "__focus",
+                classNameOverride: "focus-visible",
               }}
               dropdownContent={DROPDOWN_CONTENT__ENABLED}
             />
@@ -175,7 +175,7 @@ const StickerSheetTemplate: StoryFn<{ isReversed: boolean }> = ({
               isReversed={isReversed}
               actionButtonProps={ACTION_BUTTON_PROPS__BUTTON}
               dropdownContent={DROPDOWN_CONTENT__ENABLED}
-              dropdownButtonProps={{ classNameOverride: "__focus" }}
+              dropdownButtonProps={{ classNameOverride: "focus-visible" }}
             />
           </StickerSheet.Row>
         </StickerSheet.Body>

--- a/packages/split-button/docs/SplitButton.stories.tsx
+++ b/packages/split-button/docs/SplitButton.stories.tsx
@@ -153,7 +153,7 @@ const StickerSheetTemplate: StoryFn<{ isReversed: boolean }> = ({
               isReversed={isReversed}
               actionButtonProps={{
                 ...ACTION_BUTTON_PROPS__BUTTON,
-                classNameOverride: "focus-visible",
+                classNameOverride: "__focus",
               }}
               dropdownContent={DROPDOWN_CONTENT__ENABLED}
             />
@@ -175,7 +175,7 @@ const StickerSheetTemplate: StoryFn<{ isReversed: boolean }> = ({
               isReversed={isReversed}
               actionButtonProps={ACTION_BUTTON_PROPS__BUTTON}
               dropdownContent={DROPDOWN_CONTENT__ENABLED}
-              dropdownButtonProps={{ classNameOverride: "focus-visible" }}
+              dropdownButtonProps={{ classNameOverride: "__focus" }}
             />
           </StickerSheet.Row>
         </StickerSheet.Body>

--- a/packages/split-button/src/SplitButton/components/BaseButton/BaseButton.module.scss
+++ b/packages/split-button/src/SplitButton/components/BaseButton/BaseButton.module.scss
@@ -34,7 +34,6 @@
     }
 
     &:focus-visible,
-    &#{$polyfill--focus-visible},
     &#{$story-className__focus} {
       z-index: 3;
       outline-width: $border-solid-border-width;
@@ -60,7 +59,6 @@
     &:active,
     &#{$story-className--active},
     &:focus-visible,
-    &#{$polyfill--focus-visible},
     &#{$story-className__focus} {
       background-color: $color-gray-200;
       border-color: $color-gray-600;
@@ -68,7 +66,6 @@
     }
 
     &:focus-visible,
-    &#{$polyfill--focus-visible},
     &#{$story-className__focus} {
       outline-color: $color-blue-500;
     }
@@ -87,7 +84,6 @@
     &:active,
     &#{$story-className--active},
     &:focus-visible,
-    &#{$polyfill--focus-visible},
     &#{$story-className__focus} {
       background-color: rgba($color-white-rgb, 0.1);
       border-color: $color-white;
@@ -95,7 +91,6 @@
     }
 
     &:focus-visible,
-    &#{$polyfill--focus-visible},
     &#{$story-className__focus} {
       outline-color: $color-blue-300;
     }

--- a/packages/split-button/src/SplitButton/components/DropdownButton/DropdownButton.module.scss
+++ b/packages/split-button/src/SplitButton/components/DropdownButton/DropdownButton.module.scss
@@ -27,7 +27,6 @@
     &:active,
     &#{$story-className--active},
     &:focus-visible,
-    &#{$polyfill--focus-visible},
     &#{$story-className__focus} {
       left: calc(-1 * #{$border-solid-border-width});
       margin-left: unset;

--- a/packages/split-button/src/SplitButton/components/_variables.scss
+++ b/packages/split-button/src/SplitButton/components/_variables.scss
@@ -1,5 +1,3 @@
-$polyfill--focus-visible: ":global(.focus-visible)";
-
 // Classnames to simulate pseudo states in storybook
 $story-className--hover: ":global(.__hover)";
 $story-className--active: ":global(.__active)";

--- a/packages/split-button/src/SplitButton/components/_variables.scss
+++ b/packages/split-button/src/SplitButton/components/_variables.scss
@@ -1,4 +1,4 @@
 // Classnames to simulate pseudo states in storybook
 $story-className--hover: ":global(.__hover)";
 $story-className--active: ":global(.__active)";
-$story-className--focus: ":global(.focus-visible)";
+$story-className--focus: ":global(.__focus)";

--- a/packages/split-button/src/SplitButton/components/_variables.scss
+++ b/packages/split-button/src/SplitButton/components/_variables.scss
@@ -1,4 +1,4 @@
 // Classnames to simulate pseudo states in storybook
 $story-className--hover: ":global(.__hover)";
 $story-className--active: ":global(.__active)";
-$story-className--focus: ":global(.__focus)";
+$story-className--focus: ":global(.focus-visible)";

--- a/packages/tabs/src/Tab.module.scss
+++ b/packages/tabs/src/Tab.module.scss
@@ -37,7 +37,8 @@
     outline: none;
   }
 
-  &:focus-visible {
+  &:focus-visible,
+  &:global(.focus-visible) {
     background: $color-blue-100;
     color: $color-blue-500;
     border-color: $color-blue-500;
@@ -77,7 +78,8 @@
   .tab {
     border: 2px solid transparent;
 
-    &:focus-visible::after {
+    &:focus-visible::after,
+    &:global(.focus-visible)::after {
       $focus-ring-offset: calc((#{$border-focus-ring-border-width} * 2) + 1px);
       content: "";
       position: absolute;

--- a/packages/tabs/src/Tab.module.scss
+++ b/packages/tabs/src/Tab.module.scss
@@ -37,7 +37,7 @@
     outline: none;
   }
 
-  &:global(.focus-visible) {
+  &:focus-visible {
     background: $color-blue-100;
     color: $color-blue-500;
     border-color: $color-blue-500;
@@ -77,7 +77,7 @@
   .tab {
     border: 2px solid transparent;
 
-    &:global(.focus-visible)::after {
+    &:focus-visible::after {
       $focus-ring-offset: calc((#{$border-focus-ring-border-width} * 2) + 1px);
       content: "";
       position: absolute;

--- a/packages/tabs/src/Tab.module.scss
+++ b/packages/tabs/src/Tab.module.scss
@@ -37,8 +37,7 @@
     outline: none;
   }
 
-  &:focus-visible,
-  &:global(.focus-visible) {
+  &:focus-visible {
     background: $color-blue-100;
     color: $color-blue-500;
     border-color: $color-blue-500;
@@ -78,8 +77,7 @@
   .tab {
     border: 2px solid transparent;
 
-    &:focus-visible::after,
-    &:global(.focus-visible)::after {
+    &:focus-visible::after {
       $focus-ring-offset: calc((#{$border-focus-ring-border-width} * 2) + 1px);
       content: "";
       position: absolute;

--- a/packages/tabs/src/TabPanel.module.scss
+++ b/packages/tabs/src/TabPanel.module.scss
@@ -7,7 +7,9 @@
   &:focus {
     outline: none;
   }
-  &:focus-visible {
+
+  &:focus-visible,
+  &:global(.focus-visible) {
     border-color: $color-blue-500;
     border-radius: $border-focus-ring-border-radius;
   }

--- a/packages/tabs/src/TabPanel.module.scss
+++ b/packages/tabs/src/TabPanel.module.scss
@@ -8,8 +8,7 @@
     outline: none;
   }
 
-  &:focus-visible,
-  &:global(.focus-visible) {
+  &:focus-visible {
     border-color: $color-blue-500;
     border-radius: $border-focus-ring-border-radius;
   }

--- a/packages/tabs/src/TabPanel.module.scss
+++ b/packages/tabs/src/TabPanel.module.scss
@@ -7,7 +7,7 @@
   &:focus {
     outline: none;
   }
-  &:global(.focus-visible) {
+  &:focus-visible {
     border-color: $color-blue-500;
     border-radius: $border-focus-ring-border-radius;
   }

--- a/storybook/preview.tsx
+++ b/storybook/preview.tsx
@@ -7,10 +7,6 @@ import { DefaultDocsContainer } from "./components/DocsContainer"
 
 import "highlight.js/styles/a11y-light.css"
 
-// Polyfill for :focus-visible pseudo-selector
-// See: https://github.com/WICG/focus-visible
-import "focus-visible"
-
 // Standard base stylesheet used across Culture Amp products
 // See: https://github.com/necolas/normalize.css/
 import "normalize.css"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8891,11 +8891,6 @@ focus-lock@^0.11.6:
   dependencies:
     tslib "^2.0.3"
 
-focus-visible@^5.2.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/focus-visible/-/focus-visible-5.2.0.tgz#3a9e41fccf587bd25dcc2ef045508284f0a4d6b3"
-  integrity sha512-Rwix9pBtC1Nuy5wysTmKy+UjbDJpIfg8eHjw0rjZ1mX4GNLz1Bmd16uDpI3Gk1i70Fgcs8Csg2lPm8HULFg9DQ==
-
 for-each@^0.3.3:
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/for-each/-/for-each-0.3.3.tgz#69b447e88a0a5d32c3e7084f3f1710034b21376e"


### PR DESCRIPTION
## Why
Closes https://github.com/cultureamp/kaizen-discourse/issues/86

## What
* Removes any references to `.js-focus-visible` which was a way to target the document when the polyfill had been applied.
* Went through all styling related to `focus-visible` and made sure they are all using the native `:focus-visible` selector instead of the class based `:global(.focus-visible)` that was used in conjunction with the polyfill.
* Removed the polyfill from our package and storybook config