### PR TITLE
Revert "chore(deps): update dependency typescript to v5"

### DIFF
--- a/package.json
+++ b/package.json
@@ -133,7 +133,7 @@
     "tailwindcss": "^3.3.1",
     "ts-jest": "^29.1.0",
     "turbo": "^1.8.8",
-    "typescript": "^5.0.2",
+    "typescript": "^4.9.5",
     "webpack": "^5.77.0"
   },
   "resolutions": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -16681,10 +16681,10 @@ typescript-transform-paths@^3.4.6:
   dependencies:
     minimatch "^3.0.4"
 
-typescript@^5.0.2:
-  version "5.0.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.0.2.tgz#891e1a90c5189d8506af64b9ef929fca99ba1ee5"
-  integrity sha512-wVORMBGO/FAs/++blGNeAVdbNKtIh1rbBL2EyQ1+J9lClJ93KiiKe8PmFIVdXhHcyv44SL9oglmfeSsndo0jRw==
+typescript@^4.9.5:
+  version "4.9.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
+  integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
 
 uglify-js@^3.1.4:
   version "3.17.4"


### PR DESCRIPTION
Reverts cultureamp/kaizen-design-system#3366

`ttypescript` in `@kaizen/components` is not compatible with v5.