### PR TITLE
Date picker selectedDay fix

### DIFF
--- a/.changeset/metal-cameras-fly.md
+++ b/.changeset/metal-cameras-fly.md
@@ -1,0 +1,6 @@
+---
+"@kaizen/date-picker": patch
+---
+
+* Add selectedDay to DatePicker useEffect Hook to trigger a re-render on change
+* Adds test to validate async return of selectedDay from server

--- a/packages/date-picker/src/DatePicker/DatePicker.spec.tsx
+++ b/packages/date-picker/src/DatePicker/DatePicker.spec.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react"
+import React, { useEffect, useState } from "react"
 import { render, screen, waitFor } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { ValidationResponse } from "../types"
@@ -38,6 +38,34 @@ describe("<DatePicker />", () => {
   it("should pre-fill the input when an initial date is provided", () => {
     render(<DatePickerWrapper selectedDay={new Date("2022-03-01")} />)
     expect(screen.getByDisplayValue("Mar 1, 2022")).toBeInTheDocument()
+  })
+
+  it("re-renders the displayed input when an selectedDay is updated after initial render", async () => {
+    const DelayedSelectedDate = (): JSX.Element => {
+      const [selectedDate, setValueDate] = useState<Date | undefined>(undefined)
+
+      // mocks a slow server response
+      useEffect(() => {
+        setTimeout(() => setValueDate(new Date("2022-03-01")), 1000)
+      }, [])
+
+      return (
+        <DatePicker
+          id="test__date-picker"
+          labelText="Input label"
+          onDayChange={setValueDate}
+          selectedDay={selectedDate}
+          locale="en-US"
+        />
+      )
+    }
+
+    render(<DelayedSelectedDate />)
+    expect(screen.getByRole("combobox")).toBeInTheDocument()
+    expect(screen.getByRole("combobox")).toHaveValue("")
+    await waitFor(() => {
+      expect(screen.getByDisplayValue("Mar 1, 2022")).toBeInTheDocument()
+    })
   })
 
   it("allows you to tab through input, button and calendar", async () => {

--- a/packages/date-picker/src/DatePicker/DatePicker.tsx
+++ b/packages/date-picker/src/DatePicker/DatePicker.tsx
@@ -262,7 +262,7 @@ export const DatePicker = ({
         handleValidation(validationResponse)
       }
     }
-  }, [])
+  }, [selectedDay])
 
   const calendarId = `${id}-calendar-dialog`
 


### PR DESCRIPTION
## Why

The UI doesn't update if the if a selectedDay prop is returned after the component is rendered. This is a problem if data is returned async / from the server after render - as was the case for SR.




## What

- Add selectedDay to the useEffect hook to ensure that this will trigger a rerender of the input if the selectedDay changes
- Add test coverage for this scenario

## To replicate the issue

go to the Kaizen storybook (not this branch) and update the `selectedDay` control in the Datepicker story
