### PR TITLE
remove capitalize function and pass status directly to title

### DIFF
--- a/.changeset/thin-trains-dress.md
+++ b/.changeset/thin-trains-dress.md
@@ -1,0 +1,5 @@
+---
+"@kaizen/draft-form": patch
+---
+
+- Remove capitalize function from field message title string

--- a/draft-packages/form/KaizenDraft/Form/Primitives/FieldMessage/FieldMessage.spec.tsx
+++ b/draft-packages/form/KaizenDraft/Form/Primitives/FieldMessage/FieldMessage.spec.tsx
@@ -70,13 +70,13 @@ describe("<FieldMessage />", () => {
     const { container } = renderFieldMessage({ status: "error" })
 
     expect(container.querySelector(".warningIcon")).toBeTruthy()
-    expect(screen.getByLabelText("Error message")).toBeInTheDocument()
+    expect(screen.getByLabelText("error message")).toBeInTheDocument()
   })
 
   it("renders a warning icon with an error status", () => {
     const { container } = renderFieldMessage({ status: "caution" })
 
     expect(container.querySelector(".warningIcon")).toBeTruthy()
-    expect(screen.getByLabelText("Caution message")).toBeInTheDocument()
+    expect(screen.getByLabelText("caution message")).toBeInTheDocument()
   })
 })

--- a/draft-packages/form/KaizenDraft/Form/Primitives/FieldMessage/FieldMessage.tsx
+++ b/draft-packages/form/KaizenDraft/Form/Primitives/FieldMessage/FieldMessage.tsx
@@ -7,10 +7,6 @@ import errorWhiteIcon from "@kaizen/component-library/icons/exclamation-white.ic
 import { Paragraph } from "@kaizen/typography"
 import styles from "./FieldMessage.module.scss"
 
-function capitalize(word: string): string {
-  return word[0].toUpperCase() + word.slice(1)
-}
-
 export type FieldMessageStatus = "default" | "success" | "error" | "caution"
 
 export interface FieldMessageProps
@@ -56,7 +52,7 @@ export const FieldMessage = ({
         <span className={styles.warningIcon}>
           <Icon
             icon={status === "error" ? errorWhiteIcon : cautionWhiteIcon}
-            title={`${capitalize(status)} message`}
+            title={`${status} message`}
             role="img"
             inheritSize={false}
           />

--- a/packages/date-picker/src/DatePicker/DatePicker.spec.tsx
+++ b/packages/date-picker/src/DatePicker/DatePicker.spec.tsx
@@ -329,7 +329,7 @@ describe("<DatePicker /> - Validation", () => {
           selectedDay={new Date("potato")}
         />
       )
-      const icon = screen.getByLabelText("Error message")
+      const icon = screen.getByLabelText("error message")
 
       expect(icon).toBeInTheDocument()
       expect(screen.getByText("Custom validation message")).toBeVisible()
@@ -339,7 +339,7 @@ describe("<DatePicker /> - Validation", () => {
     it("does not show inbuilt validation message when onValidate is set", () => {
       const onValidate = jest.fn<void, [ValidationResponse]>()
       render(<DatePickerWrapper onValidate={onValidate} />)
-      expect(screen.queryByTitle("Error message")).not.toBeInTheDocument()
+      expect(screen.queryByTitle("error message")).not.toBeInTheDocument()
       expect(
         screen.queryByText("Custom validation message")
       ).not.toBeInTheDocument()
@@ -412,7 +412,7 @@ describe("<DatePicker /> - Validation", () => {
   describe("Inbuilt Validation", () => {
     it("displays error message when selected day is invalid", () => {
       render(<DatePickerWrapper selectedDay={new Date("potato")} />)
-      const icon = screen.getByLabelText("Error message")
+      const icon = screen.getByLabelText("error message")
 
       expect(screen.getByText("Date is invalid")).toBeVisible()
       expect(icon).toBeInTheDocument()


### PR DESCRIPTION
## Why
In the SR rebuild repo, the FieldMessage (as part of the date-picker) component was throwing ts error for `noUncheckedIndexedAccess`. To unblock this we're removing the capitalize function from the FieldMessage since it passes the status prop directly to the icon title (used for aria-label), which provides little value to screen readers.

## What
- remove capitalize function
- pass status directly to the Icon title