### PR TITLE
allow users to override the title tag in guidanceblock

### DIFF
--- a/.changeset/odd-cats-eat.md
+++ b/.changeset/odd-cats-eat.md
@@ -1,0 +1,5 @@
+---
+"@kaizen/draft-guidance-block": minor
+---
+
+allow users to override the title tag

--- a/draft-packages/guidance-block/KaizenDraft/GuidanceBlock/GuidanceBlock.spec.tsx
+++ b/draft-packages/guidance-block/KaizenDraft/GuidanceBlock/GuidanceBlock.spec.tsx
@@ -157,4 +157,43 @@ describe("GuidanceBlock", () => {
     const secondaryAction = container.querySelector(".secondaryAction")
     expect(secondaryAction).not.toBeNull()
   })
+
+  it("has a default title tag of h3", () => {
+    const { getByRole } = render(
+      <GuidanceBlock
+        illustration={<Informative alt="" />}
+        text={{
+          title: "This is the call to action title",
+          description:
+            "Mussum Ipsum, cacilds vidis litro abertis. Suco de cevadiss, é um leite divinis.",
+        }}
+      />
+    )
+    expect(
+      getByRole("heading", {
+        level: 3,
+        name: "This is the call to action title",
+      })
+    ).toBeInTheDocument()
+  })
+
+  it("can allow the user to override the title tag", () => {
+    const { getByRole } = render(
+      <GuidanceBlock
+        illustration={<Informative alt="" />}
+        text={{
+          title: "This is the call to action title",
+          description:
+            "Mussum Ipsum, cacilds vidis litro abertis. Suco de cevadiss, é um leite divinis.",
+          titleTag: "h2",
+        }}
+      />
+    )
+    expect(
+      getByRole("heading", {
+        level: 2,
+        name: "This is the call to action title",
+      })
+    ).toBeInTheDocument()
+  })
 })

--- a/draft-packages/guidance-block/KaizenDraft/GuidanceBlock/GuidanceBlock.tsx
+++ b/draft-packages/guidance-block/KaizenDraft/GuidanceBlock/GuidanceBlock.tsx
@@ -7,7 +7,7 @@ import configureIcon from "@kaizen/component-library/icons/arrow-forward.icon.sv
 import closeIcon from "@kaizen/component-library/icons/close.icon.svg"
 import { SceneProps, SpotProps } from "@kaizen/draft-illustration"
 import { Tooltip, TooltipProps } from "@kaizen/draft-tooltip"
-import { Heading, Paragraph } from "@kaizen/typography"
+import { Heading, HeadingProps, Paragraph } from "@kaizen/typography"
 import styles from "./GuidanceBlock.module.scss"
 
 export type ActionProps = ButtonProps & {
@@ -64,6 +64,7 @@ interface BaseGuidanceBlockProps {
 interface GuidanceBlockWithText extends BaseGuidanceBlockProps {
   text: {
     title: string
+    titleTag?: HeadingProps["tag"]
     description: string | React.ReactNode
   }
 }
@@ -233,7 +234,10 @@ class GuidanceBlock extends React.Component<
             {"text" in this.props && (
               <>
                 <div className={styles.headingWrapper}>
-                  <Heading tag="h3" variant="heading-3">
+                  <Heading
+                    tag={this.props.text.titleTag ?? "h3"}
+                    variant="heading-3"
+                  >
                     {this.props.text.title}
                   </Heading>
                 </div>


### PR DESCRIPTION
## Why
Needed to be able to override the h3 in Guidance block for Performance-UI to fix accessibility issues
<!-- Why have you created this PR? - Is it a new feature, or a bug fix? Or something else? -->
<!-- Reference any relevant Jira tickets so your reviewer can find more context if needed. -->
https://cultureamp.atlassian.net/jira/software/c/projects/HOME/boards/387?modal=detail&selectedIssue=HOME-439
<!-- Fixing a GitHub issue? Add "Fixes [issue URL]". -->


## What
<!-- What do your changes do? How do they change/fix the current behavior? -->
Added title tag to Guidanceblock to be able to override from a h3
<!-- Add screenshots, GIFs or videos to illustrate the changes.  -->

