### PR TITLE
fix: ensure alt is empty string to hide from screen reader

### DIFF
--- a/.changeset/sixty-ants-mix.md
+++ b/.changeset/sixty-ants-mix.md
@@ -1,0 +1,5 @@
+---
+"@kaizen/draft-collapsible": patch
+---
+
+set alt to empty string for decorative img

--- a/draft-packages/collapsible/KaizenDraft/ExpertAdviceCollapsible/ExpertAdviceCollapsible.spec.tsx
+++ b/draft-packages/collapsible/KaizenDraft/ExpertAdviceCollapsible/ExpertAdviceCollapsible.spec.tsx
@@ -21,9 +21,7 @@ describe("<ExpertAdviceCollapsible />", () => {
         Expert advice collapsible component
       </ExpertAdviceCollapsible>
     )
-    expect(
-      screen.getByRole("img", { name: "Collective Intelligence" })
-    ).toBeInTheDocument()
+    expect(screen.getByRole("img")).toBeInTheDocument()
   })
 
   it("renders collapsible component and its children", () => {

--- a/draft-packages/collapsible/KaizenDraft/ExpertAdviceCollapsible/ExpertAdviceCollapsible.tsx
+++ b/draft-packages/collapsible/KaizenDraft/ExpertAdviceCollapsible/ExpertAdviceCollapsible.tsx
@@ -25,7 +25,7 @@ export const ExpertAdviceCollapsible = (
         <div className={styles.expertAdviceHeader}>
           <Brand
             classNameOverride={styles.expertAdviceIcon}
-            alt="Collective Intelligence"
+            alt=""
             variant="collective-intelligence"
             reversed
           />


### PR DESCRIPTION
## Why
In a11y audit in develop, the following issue is raised:

Decorative image is not hidden from assistive technologies

The collective intelligence icon on an accordion is a decorative image, and is not hidden from assistive technologies. The icon has alt="Collective intelligence" applied.

![image](https://github.com/cultureamp/kaizen-design-system/assets/8596435/d70ffbd5-448b-41d4-a451-4fb49c98db53)



## What
Mark up the decorative icon with an empty alt attribute to hide them from screen reader users. This needs to be done using alt="" (empty string). 
