### PR TITLE
KDS-1447-add-missing-motion-ui-settings

### DIFF
--- a/.changeset/thin-countries-travel.md
+++ b/.changeset/thin-countries-travel.md
@@ -1,0 +1,5 @@
+---
+"@kaizen/component-library": patch
+---
+
+Add missing motion-ui-settings to component-library's animations settings to fix an issue with certain animations being unable to access settings

--- a/packages/component-library/styles/animations/_settings.scss
+++ b/packages/component-library/styles/animations/_settings.scss
@@ -33,3 +33,18 @@ $motion-ui-easings: (
   bounce-out: $animation-easing-function-bounce-out,
   bounce-in-out: $animation-easing-function-bounce-in-out,
 );
+
+/// Miscellaneous settings related to Motion UI.
+/// @type Map
+/// @prop {Boolean} slide-and-fade [false] - Defines if slide motions should also fade in/out.
+/// @prop {Boolean} slide-and-fade [true] - Defines if hinge motions should also fade in/out.
+/// @prop {Boolean} slide-and-fade [true] - Defines if scale motions should also fade in/out.
+/// @prop {Boolean} slide-and-fade [true] - Defines if spin motions should also fade in/out.
+$motion-ui-settings: (
+  slide-and-fade: false,
+  hinge-and-fade: true,
+  scale-and-fade: true,
+  spin-and-fade: true,
+  pause-queue-class: "is-paused",
+  activate-queue-class: "is-animating",
+) !default;


### PR DESCRIPTION
## Why

Certain animations require motion-ui's default settings which haven't been added

## What

Copied over motion-ui's settings: https://github.com/foundation/motion-ui/blob/cd1070ec5024b1a36dced76c88717cf8d7a8b99c/src/_settings.scss#LL49C1-L62C12