### PR TITLE
fix(Select): Set background color to white by default [KDS-1449]

### DIFF
--- a/.changeset/friendly-planets-design.md
+++ b/.changeset/friendly-planets-design.md
@@ -1,0 +1,5 @@
+---
+"@kaizen/select": patch
+---
+
+Select background is now always white (not transparent) to address potential contrast issues

--- a/packages/select/src/Select/components/TriggerButton/TriggerButton.module.scss
+++ b/packages/select/src/Select/components/TriggerButton/TriggerButton.module.scss
@@ -11,7 +11,7 @@
 
 .button {
   @include button;
-
+  background-color: $color-white;
   border-radius: $border-solid-border-radius;
   margin-top: $spacing-xs;
   width: 100%;
@@ -121,6 +121,7 @@
 }
 
 .reversed.disabled {
+  background-color: transparent;
   border-color: rgba($color-white-rgb, 0.3);
   color: rgba($color-white-rgb, 0.3);
 

--- a/packages/select/src/Select/components/TriggerButton/TriggerButton.module.scss
+++ b/packages/select/src/Select/components/TriggerButton/TriggerButton.module.scss
@@ -11,6 +11,7 @@
 
 .button {
   @include button;
+
   background-color: $color-white;
   border-radius: $border-solid-border-radius;
   margin-top: $spacing-xs;


### PR DESCRIPTION
## Why
- Current Select doesn't set background color unless hovered or focused; when placed on non-white background this could potentially be an issue (e.g. color contrast)


## What
- Set BG to white for non-reversed variant
<img width="825" alt="image" src="https://github.com/cultureamp/kaizen-design-system/assets/763385/04482aec-2571-49f3-9cd4-a1062e5bb6fe">


## What not
- Doesn't address any problems of label or description not meeting color contrast guidelines (as there is no background to be set)
