### PR TITLE
fix: multiple RTE usage a11y issues

### DIFF
--- a/.changeset/yellow-clocks-jam.md
+++ b/.changeset/yellow-clocks-jam.md
@@ -1,0 +1,5 @@
+---
+"@kaizen/rich-text-editor": patch
+---
+
+Removed unused id attribute for rich text editor toolbar buttons

--- a/packages/rich-text-editor/src/RichTextEditor/components/Toolbar/Toolbar.tsx
+++ b/packages/rich-text-editor/src/RichTextEditor/components/Toolbar/Toolbar.tsx
@@ -87,7 +87,6 @@ export const Toolbar = (props: ToolbarProps): JSX.Element => {
               return (
                 <toolbarButton.type
                   {...toolbarButton.props}
-                  id={`rte-button-${buttonIndex}`}
                   key={`rte-button-${buttonIndex}`}
                   tabIndex={buttonIndex === buttonFocusIndex ? 0 : -1}
                   onKeyDown={(e: React.KeyboardEvent<HTMLElement>): void =>


### PR DESCRIPTION
## Why
Using multiple RTE and testing with storybook a11y detected non-unique ids on the toolbar buttons.
https://cultureamp.atlassian.net/browse/KDS-1450


## What
- Removed ids from toolbar buttons
