### PR TITLE
Use Collapsible title as toggle button accessible label

### DIFF
--- a/.changeset/six-poets-learn.md
+++ b/.changeset/six-poets-learn.md
@@ -1,0 +1,5 @@
+---
+"@kaizen/draft-collapsible": patch
+---
+
+Use the Collapsible title as a better accessible label for the toggle button

--- a/draft-packages/collapsible/KaizenDraft/Collapsible/Collapsible.tsx
+++ b/draft-packages/collapsible/KaizenDraft/Collapsible/Collapsible.tsx
@@ -130,7 +130,7 @@ export class Collapsible extends React.Component<CollapsibleProps, State> {
           )}
           <div>
             <IconButton
-              label="Toggle section"
+              label={title}
               icon={open ? chevronUp : chevronDown}
               type="button"
               aria-expanded={open}

--- a/draft-packages/collapsible/KaizenDraft/ExpertAdviceCollapsible/ExpertAdviceCollapsible.spec.tsx
+++ b/draft-packages/collapsible/KaizenDraft/ExpertAdviceCollapsible/ExpertAdviceCollapsible.spec.tsx
@@ -33,7 +33,9 @@ describe("<ExpertAdviceCollapsible />", () => {
         <Paragraph variant="body">Text Expert advice section content</Paragraph>
       </ExpertAdviceCollapsible>
     )
-    expect(screen.getByLabelText("Toggle section")).toBeInTheDocument()
+    expect(
+      screen.getByLabelText("Expert advice collapsible children")
+    ).toBeInTheDocument()
     expect(
       screen.getByText("Text Expert advice section content")
     ).toBeInTheDocument()


### PR DESCRIPTION
## Why
This toggle button for Collapsible's has a built in label of "Toggle section".
<img width="955" alt="image" src="https://github.com/cultureamp/kaizen-design-system/assets/1811583/08f825ae-56ed-45cb-93b6-b20b0edd245c">

The problem with this is that when a screen reader user scans the page's buttons, these don't have the context that would help them.

## What
Use the Collapsible title as a better accessible label for toggling the collapsible, rather than a generic built in "Toggle section" string.