### PR TITLE
fix: rgb functions allow 3 arguments only

### DIFF
--- a/draft-packages/popover/KaizenDraft/Popover/Popover.module.scss
+++ b/draft-packages/popover/KaizenDraft/Popover/Popover.module.scss
@@ -56,7 +56,7 @@ $large-width: 450px;
 %box {
   background: $color-white;
   border: $border-solid-border-width $border-solid-border-style $color-gray-300;
-  filter: drop-shadow(0 0 7px rgb(0, 0, 0, 10%));
+  filter: drop-shadow(0 0 7px rgba(0, 0, 0, 10%));
   border-radius: $border-solid-border-radius;
   color: $color-purple-800;
   text-align: left;

--- a/draft-packages/table/KaizenDraft/Table/Table.module.scss
+++ b/draft-packages/table/KaizenDraft/Table/Table.module.scss
@@ -7,7 +7,7 @@
 
 // Taken from design-tokens/sass/shadow
 // we need control of the x and y offset in this component
-$box-shadow-color-sm: rgb(53, 55, 74, 9%);
+$box-shadow-color-sm: rgba(53, 55, 74, 9%);
 $row-height: 60px;
 $row-height-data-variant: 48px;
 
@@ -121,7 +121,7 @@ $row-height-data-variant: 48px;
 
   // This is an optical hack to stop the card shadow from overlapping over
   // the proceeding cards
-  box-shadow: 0 4px 6px rgb(53, 55, 74, 4%);
+  box-shadow: 0 4px 6px rgba(53, 55, 74, 4%);
 
   // These css properties are required for when the rows are anchor elements
   composes: anchorReset;

--- a/packages/select/src/Select/components/TriggerButton/TriggerButton.module.scss
+++ b/packages/select/src/Select/components/TriggerButton/TriggerButton.module.scss
@@ -74,7 +74,7 @@
   }
 
   .icon {
-    color: rgb(255, 255, 255, 80%);
+    color: rgba(255, 255, 255, 80%);
   }
 
   #{$story-className--button-active},


### PR DESCRIPTION
## Why
Got further build errors with the select component. 

## What
- Changed all rgb functions with 4 args into rgba (Sylelint cannot enforce this correctly)
- Changed all alpha values to numbers only (Sylelint cannot enforce this correctly)
