### PR TITLE
fix: convert rgba percentage value to opacity value

### DIFF
--- a/.changeset/wicked-points-retire.md
+++ b/.changeset/wicked-points-retire.md
@@ -1,0 +1,7 @@
+---
+"@kaizen/draft-popover": minor
+"@kaizen/draft-table": minor
+"@kaizen/select": minor
+---
+
+changed percentage value to opacity value

--- a/.changeset/wicked-points-retire.md
+++ b/.changeset/wicked-points-retire.md
@@ -4,4 +4,5 @@
 "@kaizen/select": minor
 ---
 
-changed percentage value to opacity value
+- changed percentage value to opacity value
+- removed percentage rule from stylelint

--- a/.changeset/wicked-points-retire.md
+++ b/.changeset/wicked-points-retire.md
@@ -4,5 +4,5 @@
 "@kaizen/select": minor
 ---
 
-- changed percentage value to opacity value
+- changed opacity percentage values to decimal values
 - removed percentage rule from stylelint

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -7,7 +7,6 @@
     }
   ],
   "rules": {
-    "alpha-value-notation": "percentage",
     "at-rule-empty-line-before": [
       "always",
       {

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -7,6 +7,7 @@
     }
   ],
   "rules": {
+    "alpha-value-notation": null,
     "at-rule-empty-line-before": [
       "always",
       {

--- a/draft-packages/popover/KaizenDraft/Popover/Popover.module.scss
+++ b/draft-packages/popover/KaizenDraft/Popover/Popover.module.scss
@@ -56,7 +56,7 @@ $large-width: 450px;
 %box {
   background: $color-white;
   border: $border-solid-border-width $border-solid-border-style $color-gray-300;
-  filter: drop-shadow(0 0 7px rgba(0, 0, 0, 10%));
+  filter: drop-shadow(0 0 7px rgba(0, 0, 0, 0.1));
   border-radius: $border-solid-border-radius;
   color: $color-purple-800;
   text-align: left;

--- a/draft-packages/table/KaizenDraft/Table/Table.module.scss
+++ b/draft-packages/table/KaizenDraft/Table/Table.module.scss
@@ -7,7 +7,7 @@
 
 // Taken from design-tokens/sass/shadow
 // we need control of the x and y offset in this component
-$box-shadow-color-sm: rgba(53, 55, 74, 9%);
+$box-shadow-color-sm: rgba(53, 55, 74, 0.09);
 $row-height: 60px;
 $row-height-data-variant: 48px;
 
@@ -121,7 +121,7 @@ $row-height-data-variant: 48px;
 
   // This is an optical hack to stop the card shadow from overlapping over
   // the proceeding cards
-  box-shadow: 0 4px 6px rgba(53, 55, 74, 4%);
+  box-shadow: 0 4px 6px rgba(53, 55, 74, 0.04);
 
   // These css properties are required for when the rows are anchor elements
   composes: anchorReset;

--- a/packages/select/src/Select/components/TriggerButton/TriggerButton.module.scss
+++ b/packages/select/src/Select/components/TriggerButton/TriggerButton.module.scss
@@ -74,7 +74,7 @@
   }
 
   .icon {
-    color: rgba(255, 255, 255, 80%);
+    color: rgba(255, 255, 255, 0.8);
   }
 
   #{$story-className--button-active},


### PR DESCRIPTION
## Why
This PR converts the rgba percentage value to an opacity value.

Fixes [KDS-1457](https://cultureamp.atlassian.net/browse/KDS-1457).


## What
The rgba percentage value was not valid and caused the browser to convert the RGBA value to HEX.

Before
<img width="1020" alt="image" src="https://github.com/cultureamp/kaizen-design-system/assets/115598563/62b7ba8e-e2ef-4484-9643-8262b6716336">

After
<img width="1007" alt="image" src="https://github.com/cultureamp/kaizen-design-system/assets/115598563/880f381f-d1c1-4cf6-ae7a-08c0585e7c16">


[KDS-1457]: https://cultureamp.atlassian.net/browse/KDS-1457?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ