### PR TITLE
fix(DatePicker): Fixes regression in DatePicker validation

### DIFF
--- a/.changeset/lemon-cobras-unite.md
+++ b/.changeset/lemon-cobras-unite.md
@@ -1,0 +1,5 @@
+---
+"@kaizen/date-picker": patch
+---
+
+Fix for regression in DatePicker validation, marking correct dates as invalid

--- a/packages/date-picker/src/DatePicker/DatePicker.tsx
+++ b/packages/date-picker/src/DatePicker/DatePicker.tsx
@@ -19,7 +19,7 @@ import { getLocale } from "../utils/getLocale"
 import { isDisabledDate } from "../utils/isDisabledDate"
 import { isInvalidDate } from "../utils/isInvalidDate"
 import { isSelectingDayInCalendar } from "../utils/isSelectingDayInCalendar"
-import { parseDateFromNumeralFormatValue } from "../utils/parseDateFromNumeralFormatValue"
+import { parseDateAsTextOrNumeral } from "../utils/parseDateAsTextOrNumeral"
 import { setFocusInCalendar } from "../utils/setFocusInCalendar"
 import { validateDate } from "../utils/validateDate"
 import {
@@ -198,7 +198,7 @@ export const DatePicker = ({
     if (isSelectingDayInCalendar(e.relatedTarget)) return
 
     if (inputValue !== "") {
-      const parsedDate = parseDateFromNumeralFormatValue(inputValue, locale)
+      const parsedDate = parseDateAsTextOrNumeral(inputValue, locale)
 
       if (!isInvalidDate(parsedDate)) {
         setInputValue(formatDateAsText(parsedDate, disabledDays, locale))
@@ -216,7 +216,7 @@ export const DatePicker = ({
   const handleKeyDown: React.KeyboardEventHandler<HTMLInputElement> = e => {
     if (e.key === "Enter") {
       setIsOpen(false)
-      const parsedDate = parseDateFromNumeralFormatValue(inputValue, locale)
+      const parsedDate = parseDateAsTextOrNumeral(inputValue, locale)
       handleDayChange(parsedDate, e.currentTarget.value)
     }
 

--- a/packages/date-picker/src/utils/parseDateAsTextOrNumeral.spec.ts
+++ b/packages/date-picker/src/utils/parseDateAsTextOrNumeral.spec.ts
@@ -1,0 +1,29 @@
+import { enAU } from "date-fns/locale"
+import { parseDateAsTextOrNumeral } from "./parseDateAsTextOrNumeral"
+
+describe("parseDateAsTextOrNumeral()", () => {
+  describe("given a text date", () => {
+    it("returns a valid date", () => {
+      const parsedDate = parseDateAsTextOrNumeral("1 May 2025", enAU)
+      expect(parsedDate.toString()).toEqual(
+        "Thu May 01 2025 00:00:00 GMT+0000 (Coordinated Universal Time)"
+      )
+    })
+  })
+
+  describe("given a numeral date", () => {
+    it("returns a valid date", () => {
+      const parsedDate = parseDateAsTextOrNumeral("1/5/2025", enAU)
+      expect(parsedDate.toString()).toEqual(
+        "Thu May 01 2025 00:00:00 GMT+0000 (Coordinated Universal Time)"
+      )
+    })
+  })
+
+  describe("given a non date string", () => {
+    it("returns an invalid date", () => {
+      const parsedDate = parseDateAsTextOrNumeral("🥔", enAU)
+      expect(parsedDate.toString()).toEqual("Invalid Date")
+    })
+  })
+})

--- a/packages/date-picker/src/utils/parseDateAsTextOrNumeral.ts
+++ b/packages/date-picker/src/utils/parseDateAsTextOrNumeral.ts
@@ -1,0 +1,12 @@
+import { parseDateFromNumeralFormatValue } from "./parseDateFromNumeralFormatValue"
+import { parseDateFromTextFormatValue } from "./parseDateFromTextFormatValue"
+
+export const parseDateAsTextOrNumeral = (
+  value: string,
+  locale: Locale
+): Date => {
+  const parsedAsText = parseDateFromTextFormatValue(value, locale)
+  if (parsedAsText.toString() !== "Invalid Date") return parsedAsText
+
+  return parseDateFromNumeralFormatValue(value, locale)
+}


### PR DESCRIPTION
## Why
<img width="448" alt="image" src="https://github.com/cultureamp/kaizen-design-system/assets/763385/44cf5f0c-2abd-4cd5-a0ac-e5ecfe1fbdef">

- When entering or picking a (valid) date, the date picker would still mark it as invalid
- This was introduced when we fixed the ability to change/set the current day after render

## What
- Error happens because it tries to parse a "text" date (eg. "1 May 2023") as a "numeral" date (eg. "01/05/2023")
- Hence the logic now tries both approaches to parse the string into a valid date

*Important:* This is just a quick patch to make things work again. This bug highlights the need for a bigger refactor (for many of our form/filter components) to properly accept a "default (starting) value" and also be able to be reset from the outside again.
