### PR TITLE
Update all components relying on component-library to latest

### DIFF
--- a/.changeset/stupid-rules-love.md
+++ b/.changeset/stupid-rules-love.md
@@ -1,0 +1,30 @@
+---
+"@kaizen/draft-likert-scale-legacy": patch
+"@kaizen/draft-filter-menu-button": patch
+"@kaizen/draft-title-block-zen": patch
+"@kaizen/draft-guidance-block": patch
+"@kaizen/draft-illustration": patch
+"@kaizen/draft-collapsible": patch
+"@kaizen/rich-text-editor": patch
+"@kaizen/draft-popover": patch
+"@kaizen/draft-tooltip": patch
+"@kaizen/draft-avatar": patch
+"@kaizen/draft-select": patch
+"@kaizen/brand-moment": patch
+"@kaizen/notification": patch
+"@kaizen/progress-bar": patch
+"@kaizen/split-button": patch
+"@kaizen/draft-modal": patch
+"@kaizen/draft-table": patch
+"@kaizen/date-picker": patch
+"@kaizen/draft-form": patch
+"@kaizen/draft-menu": patch
+"@kaizen/draft-tabs": patch
+"@kaizen/draft-tile": patch
+"@kaizen/pagination": patch
+"@kaizen/draft-tag": patch
+"@kaizen/button": patch
+"@kaizen/select": patch
+---
+
+Bump outdated `component-library` and `draft-form` dependencies to latest

--- a/draft-packages/avatar/package.json
+++ b/draft-packages/avatar/package.json
@@ -26,7 +26,7 @@
   "license": "MIT",
   "dependencies": {
     "@kaizen/component-base": "^1.1.7",
-    "@kaizen/component-library": "^16.7.6",
+    "@kaizen/component-library": "^16.8.2",
     "classnames": "^2.3.2",
     "react-textfit": "^1.1.1"
   },

--- a/draft-packages/collapsible/package.json
+++ b/draft-packages/collapsible/package.json
@@ -28,7 +28,7 @@
     "@kaizen/brand": "^1.5.8",
     "@kaizen/button": "^3.0.3",
     "@kaizen/component-base": "^1.1.7",
-    "@kaizen/component-library": "^16.8.0",
+    "@kaizen/component-library": "^16.8.2",
     "@kaizen/typography": "^2.3.11",
     "classnames": "^2.3.2",
     "react-animate-height": "^3.1.1"

--- a/draft-packages/filter-menu-button/package.json
+++ b/draft-packages/filter-menu-button/package.json
@@ -26,7 +26,7 @@
   "license": "MIT",
   "dependencies": {
     "@kaizen/button": "^3.0.3",
-    "@kaizen/component-library": "^16.7.6",
+    "@kaizen/component-library": "^16.8.2",
     "@kaizen/draft-menu": "^5.0.0",
     "classnames": "^2.3.2"
   },

--- a/draft-packages/form/package.json
+++ b/draft-packages/form/package.json
@@ -26,7 +26,7 @@
   "license": "MIT",
   "dependencies": {
     "@kaizen/component-base": "^1.1.7",
-    "@kaizen/component-library": "^16.8.0",
+    "@kaizen/component-library": "^16.8.2",
     "@kaizen/deprecated-component-library-helpers": "^2.5.8",
     "@kaizen/loading-spinner": "^2.3.11",
     "@kaizen/typography": "^2.3.11",

--- a/draft-packages/guidance-block/package.json
+++ b/draft-packages/guidance-block/package.json
@@ -26,7 +26,7 @@
   "license": "MIT",
   "dependencies": {
     "@kaizen/button": "^3.0.3",
-    "@kaizen/component-library": "^16.7.6",
+    "@kaizen/component-library": "^16.8.2",
     "@kaizen/draft-illustration": "^6.0.32",
     "@kaizen/draft-tooltip": "^5.4.44",
     "@kaizen/typography": "^2.3.11",

--- a/draft-packages/illustration/package.json
+++ b/draft-packages/illustration/package.json
@@ -26,14 +26,14 @@
   "license": "MIT",
   "dependencies": {
     "@kaizen/button": "^2.1.4",
-    "@kaizen/component-library": "^16.8.0",
+    "@kaizen/component-library": "^16.8.2",
     "@kaizen/hosted-assets": "^2.0.3",
     "classnames": "^2.3.2",
     "jszip": "^3.10.1",
     "lottie-web": "^5.11.0"
   },
   "devDependencies": {
-    "@kaizen/component-library": "^16.8.0",
+    "@kaizen/component-library": "^16.8.2",
     "@types/jszip": "^3.4.0"
   },
   "peerDependencies": {

--- a/draft-packages/likert-scale-legacy/package.json
+++ b/draft-packages/likert-scale-legacy/package.json
@@ -25,8 +25,8 @@
   "private": false,
   "license": "MIT",
   "dependencies": {
-    "@kaizen/component-library": "^16.7.6",
-    "@kaizen/draft-form": "^10.4.3",
+    "@kaizen/component-library": "^16.8.2",
+    "@kaizen/draft-form": "^10.4.5",
     "@kaizen/typography": "^2.3.11",
     "classnames": "^2.3.2"
   },

--- a/draft-packages/menu/package.json
+++ b/draft-packages/menu/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "@kaizen/component-base": "^1.1.7",
     "@kaizen/button": "^3.0.3",
-    "@kaizen/component-library": "^16.7.6",
+    "@kaizen/component-library": "^16.8.2",
     "@kaizen/draft-divider": "^2.2.11",
     "@kaizen/typography": "^2.3.11",
     "@popperjs/core": "^2.11.7",

--- a/draft-packages/modal/package.json
+++ b/draft-packages/modal/package.json
@@ -27,10 +27,10 @@
   "dependencies": {
     "@headlessui/react": "<=1.5.0",
     "@kaizen/button": "^3.0.3",
-    "@kaizen/component-library": "^16.7.6",
+    "@kaizen/component-library": "^16.8.2",
     "@kaizen/deprecated-component-library-helpers": "^2.5.8",
     "@kaizen/draft-divider": "^2.2.11",
-    "@kaizen/draft-form": "^10.4.3",
+    "@kaizen/draft-form": "^10.4.5",
     "@kaizen/draft-illustration": "^6.0.32",
     "@kaizen/responsive": "^1.8.10",
     "@kaizen/typography": "^2.3.11",

--- a/draft-packages/popover/package.json
+++ b/draft-packages/popover/package.json
@@ -26,7 +26,7 @@
   "license": "MIT",
   "dependencies": {
     "@kaizen/component-base": "^1.1.7",
-    "@kaizen/component-library": "^16.8.1",
+    "@kaizen/component-library": "^16.8.2",
     "@kaizen/deprecated-component-library-helpers": "^2.5.8",
     "@kaizen/typography": "^2.3.11",
     "@popperjs/core": "^2.11.7",

--- a/draft-packages/select/package.json
+++ b/draft-packages/select/package.json
@@ -26,8 +26,8 @@
   "license": "MIT",
   "dependencies": {
     "@kaizen/button": "^3.0.3",
-    "@kaizen/component-library": "^16.7.6",
-    "@kaizen/draft-form": "^10.4.3",
+    "@kaizen/component-library": "^16.8.2",
+    "@kaizen/draft-form": "^10.4.5",
     "@kaizen/draft-tag": "^3.4.16",
     "classnames": "^2.3.2",
     "react-select": "^5.7.3"

--- a/draft-packages/table/package.json
+++ b/draft-packages/table/package.json
@@ -26,8 +26,8 @@
   "license": "MIT",
   "dependencies": {
     "@kaizen/component-base": "^1.1.7",
-    "@kaizen/component-library": "^16.8.1",
-    "@kaizen/draft-form": "^10.4.3",
+    "@kaizen/component-library": "^16.8.2",
+    "@kaizen/draft-form": "^10.4.5",
     "@kaizen/draft-tooltip": "^5.4.44",
     "@kaizen/typography": "^2.3.11",
     "classnames": "^2.3.2"

--- a/draft-packages/tabs/package.json
+++ b/draft-packages/tabs/package.json
@@ -25,7 +25,7 @@
   "private": false,
   "license": "MIT",
   "dependencies": {
-    "@kaizen/component-library": "^16.7.6",
+    "@kaizen/component-library": "^16.8.2",
     "@kaizen/deprecated-component-library-helpers": "^2.5.8",
     "classnames": "^2.3.2"
   },

--- a/draft-packages/tag/package.json
+++ b/draft-packages/tag/package.json
@@ -25,7 +25,7 @@
   "private": false,
   "license": "MIT",
   "dependencies": {
-    "@kaizen/component-library": "^16.7.6",
+    "@kaizen/component-library": "^16.8.2",
     "@kaizen/draft-avatar": "^2.8.39",
     "classnames": "^2.3.2"
   },

--- a/draft-packages/tile/package.json
+++ b/draft-packages/tile/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "@kaizen/button": "^3.0.3",
     "@kaizen/component-base": "^1.1.7",
-    "@kaizen/component-library": "^16.7.6",
+    "@kaizen/component-library": "^16.8.2",
     "@kaizen/typography": "^2.3.11",
     "classnames": "^2.3.2"
   },

--- a/draft-packages/title-block-zen/package.json
+++ b/draft-packages/title-block-zen/package.json
@@ -26,7 +26,7 @@
   "license": "MIT",
   "dependencies": {
     "@kaizen/button": "^3.0.3",
-    "@kaizen/component-library": "^16.7.6",
+    "@kaizen/component-library": "^16.8.2",
     "@kaizen/draft-avatar": "^2.8.39",
     "@kaizen/draft-badge": "^1.13.11",
     "@kaizen/draft-menu": "^5.0.0",

--- a/draft-packages/tooltip/package.json
+++ b/draft-packages/tooltip/package.json
@@ -25,7 +25,7 @@
   "private": false,
   "license": "MIT",
   "dependencies": {
-    "@kaizen/component-library": "^16.7.6",
+    "@kaizen/component-library": "^16.8.2",
     "@kaizen/deprecated-component-library-helpers": "^2.5.8",
     "@popperjs/core": "^2.11.7",
     "classnames": "^2.3.2",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "ci:publish": "yarn turbo prepublish && yarn changeset publish"
   },
   "dependencies": {
+    "@kaizen/component-library": "16.8.2",
     "@kaizen/design-tokens": "^10.0.11",
     "@kaizen/tailwind": "*",
     "@storybook/addons": "^7.0.12",

--- a/packages/brand-moment/package.json
+++ b/packages/brand-moment/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "@kaizen/button": "^3.0.3",
     "@kaizen/component-base": "^1.1.7",
-    "@kaizen/component-library": "^16.7.6",
+    "@kaizen/component-library": "^16.8.2",
     "@kaizen/draft-illustration": "^6.0.32",
     "@kaizen/hosted-assets": "^2.0.3",
     "@kaizen/responsive": "^1.8.10",

--- a/packages/button/package.json
+++ b/packages/button/package.json
@@ -25,7 +25,7 @@
   "private": false,
   "license": "MIT",
   "dependencies": {
-    "@kaizen/component-library": "^16.7.6",
+    "@kaizen/component-library": "^16.8.2",
     "@kaizen/draft-badge": "^1.13.11",
     "@kaizen/loading-spinner": "^2.3.11",
     "classnames": "^2.3.2"

--- a/packages/date-picker/package.json
+++ b/packages/date-picker/package.json
@@ -28,7 +28,7 @@
     "@internationalized/date": "^3.2.0",
     "@kaizen/a11y": "^1.7.12",
     "@kaizen/component-base": "^1.1.7",
-    "@kaizen/component-library": "^16.7.6",
+    "@kaizen/component-library": "^16.8.2",
     "@kaizen/draft-form": "^10.4.4",
     "@kaizen/draft-tooltip": "^5.4.44",
     "@kaizen/typography": "^2.3.11",

--- a/packages/notification/package.json
+++ b/packages/notification/package.json
@@ -26,7 +26,7 @@
   "license": "MIT",
   "dependencies": {
     "@kaizen/component-base": "^1.1.7",
-    "@kaizen/component-library": "^16.7.6",
+    "@kaizen/component-library": "^16.8.2",
     "classnames": "^2.3.2",
     "uuid": "^9.0.0"
   },

--- a/packages/pagination/package.json
+++ b/packages/pagination/package.json
@@ -26,7 +26,7 @@
   "license": "MIT",
   "dependencies": {
     "@kaizen/component-base": "^1.1.7",
-    "@kaizen/component-library": "^16.7.6",
+    "@kaizen/component-library": "^16.8.2",
     "classnames": "^2.3.2"
   },
   "peerDependencies": {

--- a/packages/progress-bar/package.json
+++ b/packages/progress-bar/package.json
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "@kaizen/component-base": "^1.1.7",
-    "@kaizen/component-library": "^16.7.6",
+    "@kaizen/component-library": "^16.8.2",
     "@kaizen/typography": "^2.3.11",
     "classnames": "^2.3.2"
   }

--- a/packages/rich-text-editor/package.json
+++ b/packages/rich-text-editor/package.json
@@ -28,7 +28,7 @@
     "@cultureamp/rich-text-toolkit": "^2.0.2",
     "@kaizen/a11y": "^1.7.12",
     "@kaizen/component-base": "^1.1.7",
-    "@kaizen/component-library": "^16.8.0",
+    "@kaizen/component-library": "^16.8.2",
     "@kaizen/draft-form": "^10.4.5",
     "@kaizen/draft-tooltip": "^5.4.44",
     "@kaizen/notification": "^1.5.8",

--- a/packages/select/package.json
+++ b/packages/select/package.json
@@ -28,7 +28,7 @@
     "@kaizen/a11y": "^1.7.12",
     "@kaizen/button": "^3.0.3",
     "@kaizen/component-base": "^1.1.7",
-    "@kaizen/component-library": "^16.8.1",
+    "@kaizen/component-library": "^16.8.2",
     "@kaizen/draft-badge": "^1.13.11",
     "@kaizen/draft-divider": "^2.2.11",
     "@kaizen/draft-form": "^10.4.5",

--- a/packages/split-button/package.json
+++ b/packages/split-button/package.json
@@ -26,7 +26,7 @@
   "license": "MIT",
   "dependencies": {
     "@kaizen/component-base": "^1.1.7",
-    "@kaizen/component-library": "^16.7.6",
+    "@kaizen/component-library": "^16.8.2",
     "@kaizen/draft-menu": "^5.0.0",
     "classnames": "^2.3.2"
   },


### PR DESCRIPTION
## Why
Consumers still seeing issues with `rgb` and token values going missing.


## What
Bumped components which haven't been updated to use the latest patches for rgab to latest
