### PR TITLE
fix(EmptyState): Apply illustration sizing rules

### DIFF
--- a/.changeset/shiny-elephants-hang.md
+++ b/.changeset/shiny-elephants-hang.md
@@ -1,0 +1,5 @@
+---
+"@kaizen/draft-empty-state": patch
+---
+
+fix: Empty State illustration size

--- a/draft-packages/empty-state/KaizenDraft/EmptyState/EmptyState.module.scss
+++ b/draft-packages/empty-state/KaizenDraft/EmptyState/EmptyState.module.scss
@@ -104,7 +104,7 @@
 }
 
 .illustration,
-.illustrationSide > video {
+.illustrationSide video {
   max-width: 100%;
   max-height: 366px;
   width: auto;


### PR DESCRIPTION
## Why
<!-- Why have you created this PR? - Is it a new feature, or a bug fix? Or something else? -->
<!-- Reference any relevant Jira tickets so your reviewer can find more context if needed. -->
<!-- Fixing a GitHub issue? Add "Fixes [issue URL]". -->

Recent updates to kaizen illustration has modified the markup adding a figure tag. This means that the targeting rules in EmptyState no longer apply causing the illustration to be too big.

Thread: https://cultureamp.slack.com/archives/C0189KBPM4Y/p1685336384933739

## What
<!-- What do your changes do? How do they change/fix the current behavior? -->
<!-- Add screenshots, GIFs or videos to illustrate the changes.  -->

Update styling selector in EmptyState to take into account changes in illustration markup.
