### PR TITLE
docs(storybook): add reusable SB docs components for mdx

### DIFF
--- a/packages/components/src/FilterButton/_docs/filter-buttons.mdx
+++ b/packages/components/src/FilterButton/_docs/filter-buttons.mdx
@@ -1,32 +1,25 @@
-import { Canvas, Controls, DocsStory, Meta, Source } from "@storybook/blocks"
-import { LinkTo } from "../../../../../storybook/components/LinkTo"
+import { Canvas, Controls, DocsStory, Meta } from "@storybook/blocks"
+import { Installation, KaioNotification, ResourceLinks } from "../../../../../storybook/components"
 import * as FilterButtonExamples from "./FilterButton.stories"
 import * as FilterButtonRemovableExamples from "./FilterButtonRemovable.stories"
-import { KaioNotification } from "../../../../../storybook/components/DocsContainer/ComponentDocsTemplate/subcomponents/KaioInstallation/KaioNotification"
 
 <Meta title="Components/Filter/Filter Buttons" />
 
 # Filter Buttons
 
-<ul className="!list-none !p-0 flex gap-4 items-center mb-8">
-  <li className="!mt-0 !text-paragraph">
-    <a
-      href="https://github.com/cultureamp/kaizen-design-system/tree/main/packages/components/src/FilterButton"
-      target="_blank"
-      rel="noopener noreferrer nofollow"
-    >Source Code</a>
-  </li>
-</ul>
+<ResourceLinks
+  sourceCode="https://github.com/cultureamp/kaizen-design-system/tree/main/packages/components/src/FilterButton"
+  className="!mb-8"
+/>
 
 <KaioNotification />
 
-Filter-compatible trigger buttons.
+Trigger buttons for use by components using the `<Filter>` abstraction.
 
-<div>
-  <h2 id="installation">Installation</h2>
-  <Source code="yarn add @kaizen/components" language="tsx" />
-  <Source code='import { FilterButton, FilterButtonRemovable } from "@kaizen/components"' language="tsx" />
-</div>
+<Installation
+  installCommand="yarn add @kaizen/components"
+  importStatement='import { FilterButton, FilterButtonRemovable } from "@kaizen/components"'
+/>
 
 ## Filter Button
 

--- a/packages/components/src/KaizenProvider/_docs/KaizenProvider.mdx
+++ b/packages/components/src/KaizenProvider/_docs/KaizenProvider.mdx
@@ -4,7 +4,7 @@ import migrationToV1 from "!!raw-loader!./code-diffs/migration-to-v1.diff"
 import migrationBonus from "!!raw-loader!./code-diffs/migration-bonus.diff"
 import migrationFETToV1 from "!!raw-loader!./code-diffs/migration-fe-template-to-v1.diff"
 import migrationFETBonus from "!!raw-loader!./code-diffs/migration-fe-template-bonus.diff"
-import { KaioNotification } from "../../../../../storybook/components/DocsContainer/ComponentDocsTemplate/subcomponents/KaioInstallation/KaioNotification"
+import { KaioNotification } from "../../../../../storybook/components"
 
 <Meta title="Components/KaizenProvider/Installation" />
 

--- a/packages/components/src/Workflow/_docs/Workflow.mdx
+++ b/packages/components/src/Workflow/_docs/Workflow.mdx
@@ -1,33 +1,26 @@
-import { Canvas, Controls, DocsStory, Meta, Source, ArgTypes  } from "@storybook/blocks"
-import { LinkTo } from "../../../../../storybook/components/LinkTo"
+import { ArgTypes, Canvas, Meta } from "@storybook/blocks"
+import { Installation, KaioNotification, ResourceLinks } from "../../../../../storybook/components"
 import * as Workflow from "./Workflow.stories"
 import * as WorkflowFooter from "./WorkflowFooter.stories"
 import * as WorkflowHeader from "./WorkflowHeader.stories"
-import { KaioNotification } from "../../../../../storybook/components/DocsContainer/ComponentDocsTemplate/subcomponents/KaioInstallation/KaioNotification"
 
 <Meta title="Pages/Workflow" />
 
 # Workflow
 
-<ul className="!list-none !p-0 flex gap-4 items-center mb-8">
-  <li className="!mt-0 !text-paragraph">
-    <a
-      href="https://github.com/cultureamp/kaizen-design-system/tree/main/packages/components/src/Workflow"
-      target="_blank"
-      rel="noopener noreferrer nofollow"
-    >Source Code</a>
-  </li>
-</ul>
+<ResourceLinks
+  sourceCode="https://github.com/cultureamp/kaizen-design-system/tree/main/packages/components/src/Workflow"
+  className="!mb-8"
+/>
 
 <KaioNotification />
 
-<div>
-  <h2 id="installation">Installation</h2>
-  <Source code="yarn add @kaizen/components" language="tsx" />
-  <Source code='import { Workflow } from "@kaizen/components"' language="tsx" />
-</div>
+<Installation
+  installCommand="yarn add @kaizen/components"
+  importStatement='import { Workflow } from "@kaizen/components"'
+/>
 
-## Playground
+## Overview
 
 This is a page template component containing the header, footer and main landmarks that compose a Workflow page. Its purpose is to guide an customer through a multi-step form to create a Workflow.
 
@@ -45,7 +38,7 @@ While the number of JSX element is not limited, is important to consider the rea
 
 <Canvas
   layout="fullscreen"
-  of={WorkflowHeader.MultipleActions} 
+  of={WorkflowHeader.MultipleActions}
   source={{code: `<Workflow
     headerActions={[
       <Button
@@ -68,7 +61,7 @@ While the number of JSX element is not limited, is important to consider the rea
     {...otherProps}
   >
     <MockContent />
-  </Workflow>`}} 
+  </Workflow>`}}
 />
 
 
@@ -96,7 +89,7 @@ This triggers a modal that can provide context to a customers and confirm thier 
     {...otherProps}
   >
     <MockContent />
-  </Workflow>`}} 
+  </Workflow>`}}
 />
 
 ## Tracking progress
@@ -118,7 +111,7 @@ The Footer tracks the progress of the form by comparing the current step, indica
     {...otherProps}
   >
     <MockContent />
-  </Workflow>`}} 
+  </Workflow>`}}
 />
 
 The Footer is agnostic to the JSX elements that are used in the `previousAction` and `nextAction`. While we recommend using the Kaizen Button, a button-like component can be used in its place to satisfy project-specific requirements.
@@ -135,7 +128,7 @@ To hide, disable or change the appearance of the Footer buttons you can leverage
     {...otherProps}
   >
     <MockContent />
-  </Workflow>`}} 
+  </Workflow>`}}
 />
 
 Instances where users are returning to a completed worklow you can pass the `isComplete` prop to set the indicators to their "complete" status. This will also be reflected in their aria title.
@@ -148,7 +141,7 @@ Instances where users are returning to a completed worklow you can pass the `isC
     {...otherProps}
   >
     <MockContent />
-  </Workflow>`}} 
+  </Workflow>`}}
 />
 
 ## Compsable Worflow
@@ -160,4 +153,3 @@ While we do not advise this path, a composable Workflow may be created if requir
 ## Worflow API at a glance
 
 <ArgTypes of={Workflow.Playground} />
-

--- a/storybook/components/DocsContainer/ComponentDocsTemplate/subcomponents/Installation/Installation.tsx
+++ b/storybook/components/DocsContainer/ComponentDocsTemplate/subcomponents/Installation/Installation.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { Source } from "@storybook/blocks"
+import { Installation as InstallSection } from "../../../../Installation"
 
 export type InstallationProps = {
   //   context: DocsContainerProps["context"]
@@ -17,13 +17,10 @@ export const Installation = ({
   if (!isInstallationLinks) return null
 
   return (
-    <div>
-      <h2 id="installation">Installation</h2>
-      {/* npm link */}
-      <Source code={installationLinks[0]} language="tsx" />
-      {/* import link */}
-      <Source code={installationLinks[1]} language="tsx" />
-    </div>
+    <InstallSection
+      installCommand={installationLinks[0]}
+      importStatement={installationLinks[1]}
+    />
   )
 }
 

--- a/storybook/components/DocsContainer/ComponentDocsTemplate/subcomponents/Links/Links.tsx
+++ b/storybook/components/DocsContainer/ComponentDocsTemplate/subcomponents/Links/Links.tsx
@@ -1,4 +1,5 @@
 import React from "react"
+import { ResourceLinks } from "../../../../ResourceLinks"
 
 export type LinksProps = {
   //   context: DocsContainerProps["context"]
@@ -17,43 +18,11 @@ export const Links = ({ context }: LinksProps): JSX.Element | null => {
   if (!links) return null
 
   return (
-    <ul className="!list-none !p-0 !m-0 flex gap-4 items-center">
-      {sourceCodeLink && (
-        <li className="!mt-0 !text-paragraph">
-          <a
-            href={sourceCodeLink}
-            target="_blank"
-            rel="noopener noreferrer nofollow"
-          >
-            Source Code
-          </a>
-        </li>
-      )}
-      {figmaLink && (
-        <li className="!mt-0 !text-paragraph">
-          |&nbsp;
-          <a
-            href={figmaLink}
-            target="_blank"
-            rel="noopener noreferrer nofollow"
-          >
-            Figma
-          </a>
-        </li>
-      )}
-      {designGuidelinesLink && (
-        <li className="!mt-0 !text-paragraph">
-          |&nbsp;
-          <a
-            href={designGuidelinesLink}
-            target="_blank"
-            rel="noopener noreferrer nofollow"
-          >
-            Usage Guidelines
-          </a>
-        </li>
-      )}
-    </ul>
+    <ResourceLinks
+      sourceCode={sourceCodeLink}
+      figma={figmaLink}
+      designGuidelines={designGuidelinesLink}
+    />
   )
 }
 

--- a/storybook/components/Installation/Installation.tsx
+++ b/storybook/components/Installation/Installation.tsx
@@ -1,0 +1,20 @@
+import React from "react"
+import { Source } from "@storybook/blocks"
+
+export type InstallationProps = {
+  installCommand: string
+  importStatement: string
+}
+
+export const Installation = ({
+  installCommand,
+  importStatement,
+}: InstallationProps): JSX.Element => (
+  <div>
+    <h2 id="installation">Installation</h2>
+    <Source code={installCommand} language="tsx" />
+    <Source code={importStatement} language="tsx" />
+  </div>
+)
+
+Installation.displayName = "Installation"

--- a/storybook/components/Installation/index.ts
+++ b/storybook/components/Installation/index.ts
@@ -1,0 +1,1 @@
+export * from "./Installation"

--- a/storybook/components/ResourceLinks/ResourceLinks.module.scss
+++ b/storybook/components/ResourceLinks/ResourceLinks.module.scss
@@ -1,0 +1,27 @@
+@import "~@kaizen/design-tokens/sass/color";
+@import "~@kaizen/design-tokens/sass/spacing";
+@import "~@kaizen/design-tokens/sass/typography";
+
+$gap: $spacing-6;
+
+.resourceLinkContainer {
+  &:not(:first-child) {
+    border-left: 1.5px solid $color-gray-500;
+    padding-left: $gap;
+  }
+}
+
+.resourceLink {
+  text-decoration: none;
+  color: $color-blue-400;
+}
+
+.resourceLinks {
+  display: inline-flex;
+  gap: $gap;
+  margin: 0;
+  padding: $spacing-4 0;
+  list-style: none;
+  font-size: $typography-paragraph-body-font-size;
+  line-height: 1;
+}

--- a/storybook/components/ResourceLinks/ResourceLinks.tsx
+++ b/storybook/components/ResourceLinks/ResourceLinks.tsx
@@ -1,0 +1,48 @@
+import React, { HTMLAttributes } from "react"
+import { Unstyled } from "@storybook/blocks"
+import classnames from "classnames"
+import styles from "./ResourceLinks.module.scss"
+
+type ResourceLinkProps = {
+  href: string
+  text: string
+}
+
+const ResourceLink = ({ href, text }: ResourceLinkProps): JSX.Element => (
+  <li className={styles.resourceLinkContainer}>
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer nofollow"
+      className={styles.resourceLink}
+    >
+      {text}
+    </a>
+  </li>
+)
+
+export type ResourceLinksProps = HTMLAttributes<HTMLUListElement> & {
+  sourceCode: string
+  figma?: string
+  designGuidelines?: string
+}
+
+export const ResourceLinks = ({
+  sourceCode,
+  figma,
+  designGuidelines,
+  className,
+  ...attributes
+}: ResourceLinksProps): JSX.Element => (
+  <Unstyled>
+    <ul className={classnames(styles.resourceLinks, className)} {...attributes}>
+      <ResourceLink href={sourceCode} text="Source Code" />
+      {figma && <ResourceLink href={figma} text="Figma" />}
+      {designGuidelines && (
+        <ResourceLink href={designGuidelines} text="Usage Guidelines" />
+      )}
+    </ul>
+  </Unstyled>
+)
+
+ResourceLinks.displayName = "ResourceLinks"

--- a/storybook/components/ResourceLinks/index.ts
+++ b/storybook/components/ResourceLinks/index.ts
@@ -1,0 +1,1 @@
+export * from "./ResourceLinks"

--- a/storybook/components/index.ts
+++ b/storybook/components/index.ts
@@ -1,0 +1,3 @@
+export * from "./DocsContainer/ComponentDocsTemplate/subcomponents/KaioInstallation/KaioNotification"
+export * from "./Installation"
+export * from "./ResourceLinks"


### PR DESCRIPTION
## Why
<!-- Why have you created this PR? - Is it a new feature, or a bug fix? Or something else? -->
<!-- Reference any relevant Jira tickets so your reviewer can find more context if needed. -->
<!-- Fixing a GitHub issue? Add "Fixes [issue URL]". -->
Parts of the Storybook docs template such as Installation and Resource Links should be reusable between pages, but the components were tied to context for autodocs, so we were duplicating the code within MDX docs.

## What
<!-- What do your changes do? How do they change/fix the current behavior? -->
<!-- Add screenshots, GIFs or videos to illustrate the changes.  -->
- Abstract the visuals for Installation and Resource Links to be able to use them within MDX, and update the template to use these components.
- Update the MDX files with the duplicate code to use the components.