### PR TITLE
Remove component library from the root package json

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "ci:publish": "yarn turbo prepublish && yarn changeset publish"
   },
   "dependencies": {
-    "@kaizen/component-library": "16.8.2",
     "@kaizen/design-tokens": "^10.0.11",
     "@kaizen/tailwind": "*",
     "@storybook/addons": "^7.0.18",


### PR DESCRIPTION
## Why
This was breaking the build of our storybook.

## Context
Prebuild was failing, cause it looked into node_modules found the compiled component-library. Normally it would work it’s way into the source directory, but was compiled to the wrong folder


## Original slack thread:
https://cultureamp.slack.com/archives/C02NUQ27G56/p1685593697359189


## What
- removes component-library as a root dependency
