### PR TITLE
update release conditional

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -14,7 +14,7 @@ steps:
   - name: ":butterfly: Release"
     command: ".buildkite/scripts/release.sh"
     timeout_in_minutes: 15
-    if: build.branch == "main" && build.author.name == "github-actions[bot]"
+    if: build.branch == "main" && build.branch == "changeset-release/main"
     <<: *defaults
     plugins:
       - cultureamp/aws-assume-role#v0.2.0:


### PR DESCRIPTION
## Why
Sometimes publishing doesn't work and we need a way for humans to force a release without making a new version

## What
Base the conditional that triggers a release on the branch name rather than the branch author.