### PR TITLE
add changeset to trigger re-release

### DIFF
--- a/.changeset/modern-icons-hammer.md
+++ b/.changeset/modern-icons-hammer.md
@@ -1,0 +1,5 @@
+---
+"@kaizen/components": patch
+---
+
+This is a patch to manually trigger a re-release


### PR DESCRIPTION
## Why
This is a PR to patch KAIO to trigger a re-release.

## Context
This was made necessary following us merging in a [release](https://github.com/cultureamp/kaizen-design-system/commit/16d22011b46befbb8f18aa42caeb824b2c3d77af) that failed its build, which caused versioning to [fail](https://buildkite.com/culture-amp/kaizen-design-system) on buildkite.

The root cause of this was the `component-library` package dependency in our root folders, which caused the prebuild to fail as the compiled component-library was found in our node_modules instead of within the source directory.


## What
-  no changes