### PR TITLE
Draft select: link label with select

### DIFF
--- a/.changeset/wild-llamas-swim.md
+++ b/.changeset/wild-llamas-swim.md
@@ -1,0 +1,6 @@
+---
+"@kaizen/draft-select": patch
+---
+
+Adds an id to the label on the draft select and link up with aria-labelledby  
+

--- a/draft-packages/select/KaizenDraft/Select/Select.tsx
+++ b/draft-packages/select/KaizenDraft/Select/Select.tsx
@@ -1,4 +1,4 @@
-import React from "react"
+import React, { useState } from "react"
 import classnames from "classnames"
 import ReactSelect, {
   components,
@@ -6,6 +6,7 @@ import ReactSelect, {
   NoticeProps,
 } from "react-select"
 import Async, { AsyncProps as ReactAsyncSelectProps } from "react-select/async"
+import { v4 } from "uuid"
 import { Icon } from "@kaizen/component-library"
 import chevronDownIcon from "@kaizen/component-library/icons/chevron-down.icon.svg"
 import chevronUpIcon from "@kaizen/component-library/icons/chevron-up.icon.svg"
@@ -78,12 +79,20 @@ export const Select = React.forwardRef<any, SelectProps>((props, ref) => {
     props.isDisabled && styles.disabled,
     status === "error" && styles.error
   )
+
+  const [labelId] = useState<string | undefined>(label ? v4() : undefined)
+
   return (
     <>
-      {label ? <Label reversed={reversed}>{label}</Label> : null}
+      {label ? (
+        <Label reversed={reversed} id={labelId}>
+          {label}
+        </Label>
+      ) : null}
       <ReactSelect
         {...props}
         ref={ref}
+        aria-labelledby={labelId}
         components={{
           Control,
           Placeholder,

--- a/draft-packages/select/package.json
+++ b/draft-packages/select/package.json
@@ -30,7 +30,8 @@
     "@kaizen/draft-form": "^10.4.6",
     "@kaizen/draft-tag": "^3.4.17",
     "classnames": "^2.3.2",
-    "react-select": "^5.7.3"
+    "react-select": "^5.7.3",
+    "uuid": "^9.0.0"
   },
   "peerDependencies": {
     "@kaizen/design-tokens": "^2.10.3 || ^3.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0",


### PR DESCRIPTION
## Why
<!-- Why have you created this PR? - Is it a new feature, or a bug fix? Or something else? -->
<!-- Reference any relevant Jira tickets so your reviewer can find more context if needed. -->
<!-- Fixing a GitHub issue? Add "Fixes [issue URL]". -->
Draft select's label was not linked to the react selects input field as there was no `id` and  `aria-labelledby`. 

## What
<!-- What do your changes do? How do they change/fix the current behavior? -->
<!-- Add screenshots, GIFs or videos to illustrate the changes.  -->
This PR adds a `ID` to the label, and links this to the input field / select field using `aria-labelledby` 