### PR TITLE
set default month to the past in filterdatepicker stories to prevent chromatic changes

### DIFF
--- a/packages/components/src/FilterDatePicker/_docs/FilterDatePicker.stickersheet.stories.tsx
+++ b/packages/components/src/FilterDatePicker/_docs/FilterDatePicker.stickersheet.stories.tsx
@@ -97,6 +97,7 @@ const StickerSheetTemplate: StoryFn<{ textDirection: "ltr" | "rtl" }> = ({
               inputProps={{ labelText: "Date" }}
               locale="en-AU"
               selectedDate={dateValueValidation}
+              defaultMonth={new Date("01-01-2022")}
               onDateChange={setDateValueValidation}
               onValidate={action("Validation story: date start onValidate")}
               validationMessage={{


### PR DESCRIPTION
## Why

DatePicker's current date shifts every day, causing chromatic to take a new snapshot 


## What

Place the default month in the past, so that the date never changes.