### PR TITLE
InlineNotification: change to `width: auto`

### DIFF
--- a/.changeset/eleven-pears-pull.md
+++ b/.changeset/eleven-pears-pull.md
@@ -1,0 +1,5 @@
+---
+"@kaizen/notification": patch
+---
+
+InlineNotification width has changed from `100%` to `auto` so that it can be used side by side with other components. Should not affect any current usages.

--- a/packages/notification/src/_styles.scss
+++ b/packages/notification/src/_styles.scss
@@ -29,7 +29,7 @@ $notification-slide-right: transform 300ms ease-out;
   }
 
   &%ca-notification---inline {
-    width: 100%;
+    width: auto;
     min-height: 46px;
     padding: $notification-vertical-padding $spacing-sm;
     transition: $notification-fade-out, $notification-pop-up,


### PR DESCRIPTION
## Why

Potential fix for: https://github.com/cultureamp/kaizen-discourse/issues/92


## What
The change allows the InlineNotification to be placed side by side with other elements, without taking up an excessive amount of space. Seeing as `width: auto` has the desired behaviour of fillling the available space created by the parent, there doesn't seem any advantage or reason to have `width: 100%` instead of `width: auto`.

There are no changes to existing stories in Chromatic, showing that this does not change the current behaviour (other than 2 changes in the date picker that look like flakes)

_note: for some reason I couldn't reopen https://github.com/cultureamp/kaizen-design-system/pull/3724, so I created this new PR._


<!-- What do your changes do? How do they change/fix the current behavior? -->
<!-- Add screenshots, GIFs or videos to illustrate the changes.  -->