### PR TITLE
add classnameOverride prop to InlineNotification

### DIFF
--- a/packages/notification/src/InlineNotification.tsx
+++ b/packages/notification/src/InlineNotification.tsx
@@ -1,11 +1,11 @@
 import React from "react"
+import { OverrideClassName } from "@kaizen/component-base"
 import { HeadingProps } from "@kaizen/typography"
 import GenericNotification, {
   NotificationType,
 } from "./components/GenericNotification"
-import styles from "./components/GenericNotification.module.scss"
 
-export type InlineNotificationProps = {
+export type InlineNotificationProps = OverrideClassName<{
   type: NotificationType
   children?: React.ReactNode
   autohide?: boolean
@@ -23,7 +23,7 @@ export type InlineNotificationProps = {
    * @deprecated
    */
   title?: string
-}
+}>
 
 /**
  * {@link https://cultureamp.design/components/inline-notification/ Guidance} |
@@ -32,13 +32,11 @@ export type InlineNotificationProps = {
 export const InlineNotification = ({
   persistent,
   hideCloseIcon,
-  isSubtle,
   ...otherProps
 }: InlineNotificationProps): JSX.Element => (
   <GenericNotification
     style="inline"
     persistent={persistent || hideCloseIcon}
-    classNameOverride={isSubtle ? styles.subtle : undefined}
     {...otherProps}
   />
 )

--- a/packages/notification/src/components/GenericNotification.tsx
+++ b/packages/notification/src/components/GenericNotification.tsx
@@ -31,6 +31,7 @@ export type GenericNotificationProps = OverrideClassName<{
   noBottomMargin?: boolean
   forceMultiline?: boolean
   headingProps?: HeadingProps
+  isSubtle?: boolean
 }>
 
 type State = {
@@ -136,6 +137,7 @@ class GenericNotification extends React.Component<
       styles[this.props.style],
       this.state.hidden && styles.hidden,
       this.props.noBottomMargin && styles.noBottomMargin,
+      this.props.isSubtle && styles.isSubtle,
       this.props.classNameOverride
     )
   }


### PR DESCRIPTION
## Why

Potential fix for: https://github.com/cultureamp/kaizen-discourse/issues/92

The use case is that we want to be able to remove the `width: 100%` style as we have a use case where we want the notification to shrink wrap its contents and use it alongside another element. Ie: an "inline" InlineNotification.




## What

To do so requires making isSubtle a new property of GenericNofication, as classnameOverride is already being used by InlineNotification for the isSubtle variant
