### PR TITLE
add widthAuto prop to InlineNotification

### DIFF
--- a/packages/notification/src/InlineNotification.tsx
+++ b/packages/notification/src/InlineNotification.tsx
@@ -23,6 +23,7 @@ export type InlineNotificationProps = {
    * @deprecated
    */
   title?: string
+  widthAuto?: boolean
 }
 
 /**
@@ -33,12 +34,14 @@ export const InlineNotification = ({
   persistent,
   hideCloseIcon,
   isSubtle,
+  widthAuto,
   ...otherProps
 }: InlineNotificationProps): JSX.Element => (
   <GenericNotification
     style="inline"
     persistent={persistent || hideCloseIcon}
     classNameOverride={isSubtle ? styles.subtle : undefined}
+    inlineWidthAuto={widthAuto}
     {...otherProps}
   />
 )

--- a/packages/notification/src/_styles.scss
+++ b/packages/notification/src/_styles.scss
@@ -34,6 +34,10 @@ $notification-slide-right: transform 300ms ease-out;
     padding: $notification-vertical-padding $spacing-sm;
     transition: $notification-fade-out, $notification-pop-up,
       $notification-collapse-height;
+
+    &%ca-notification---inlineWidthAuto {
+      width: auto;
+    }
   }
 
   &%ca-notification---toast {

--- a/packages/notification/src/components/GenericNotification.module.scss
+++ b/packages/notification/src/components/GenericNotification.module.scss
@@ -117,3 +117,7 @@
 .subtle {
   @extend %ca-notification---subtle;
 }
+
+.inlineWidthAuto {
+  @extend %ca-notification---inlineWidthAuto;
+}

--- a/packages/notification/src/components/GenericNotification.tsx
+++ b/packages/notification/src/components/GenericNotification.tsx
@@ -31,6 +31,7 @@ export type GenericNotificationProps = OverrideClassName<{
   noBottomMargin?: boolean
   forceMultiline?: boolean
   headingProps?: HeadingProps
+  inlineWidthAuto?: boolean
 }>
 
 type State = {
@@ -136,7 +137,7 @@ class GenericNotification extends React.Component<
       styles[this.props.style],
       this.state.hidden && styles.hidden,
       this.props.noBottomMargin && styles.noBottomMargin,
-      this.props.classNameOverride
+      this.props.inlineWidthAuto && styles.inlineWidthAuto
     )
   }
 


### PR DESCRIPTION

## Why
Potential fix for: https://github.com/cultureamp/kaizen-discourse/issues/92


## What

rather than the default of `width: 100%`, this new property sets `width: auto` for when you need that.
