### PR TITLE
patch: Submit typo

### DIFF
--- a/.changeset/cold-ties-guess.md
+++ b/.changeset/cold-ties-guess.md
@@ -1,0 +1,5 @@
+---
+"@kaizen/button": patch
+---
+
+Submit typo

--- a/.changeset/cold-ties-guess.md
+++ b/.changeset/cold-ties-guess.md
@@ -1,5 +1,0 @@
----
-"@kaizen/button": patch
----
-
-Submit typo

--- a/packages/button/docs/Button.stories.tsx
+++ b/packages/button/docs/Button.stories.tsx
@@ -169,7 +169,7 @@ export const NativeFormButton: StoryFn = () => (
       <input type="text" defaultValue="content" />
     </form>
     <Button
-      label="Sumbit"
+      label="Submit"
       form="unique-form-id"
       formTarget="_blank"
       formAction="/"


### PR DESCRIPTION
## Why
In the Kaizen Storybook, the button text reads "Sumbit". It should be "Submit".


## What
This PR fixes the Submit typo.
