### PR TITLE
draft-tabs: Add aria-current=page to active tab

### DIFF
--- a/.changeset/chilled-baboons-compare.md
+++ b/.changeset/chilled-baboons-compare.md
@@ -1,0 +1,5 @@
+---
+"@kaizen/draft-tabs": patch
+---
+
+Add aria-current=page to active tab

--- a/draft-packages/tabs/KaizenDraft/Tabs/Tabs.tsx
+++ b/draft-packages/tabs/KaizenDraft/Tabs/Tabs.tsx
@@ -80,6 +80,7 @@ const RowTab = ({
             t.active && styles.horizontalTabActive,
             t.disabled && styles.horizontalTabDisabled
           )}
+          aria-current={t.active ? "page" : undefined}
         >
           {t.label}
         </a>

--- a/draft-packages/tabs/KaizenDraft/Tabs/__snapshots__/Tabs.spec.tsx.snap
+++ b/draft-packages/tabs/KaizenDraft/Tabs/__snapshots__/Tabs.spec.tsx.snap
@@ -61,6 +61,7 @@ exports[`<Tabs /> renders an active tab 1`] = `
   dir="ltr"
 >
   <a
+    aria-current="page"
     class="horizontalTabActive"
   >
     One


### PR DESCRIPTION
## Why
Conveys the 'active' state that we see with styling to screen reader users.

## What
Add `aria-current=page` to the active tab in draft-tabs
