### PR TITLE
Add auth token to github packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,8 +34,8 @@ jobs:
         with:
           cache: yarn
           node-version-file: .nvmrc
-          registry-url: https://npm.pkg.github.com/
       - run: |
+          npm config set "//npm.pkg.github.com/:_authToken" "$GITHUB_TOKEN"
           yarn install --frozen-lockfile
           yarn changeset status --since=origin/main
 


### PR DESCRIPTION
I think the yarn install for changesets check needs extra permissions, hard to tell if this will fix the issue until it hits `main`.

Edit: Seems PR's are fine without this now...? Only merge if it becomes a problem again soon...