### PR TITLE
stop chromatic on draft pull requests

### DIFF
--- a/.github/workflows/chromatic.yaml
+++ b/.github/workflows/chromatic.yaml
@@ -1,5 +1,4 @@
 # Chromatic action from https://www.chromatic.com/docs/github-actions
-# Using this github action from https://github.com/lightspeedretail/actions-label-prs
 
 name: "chromatic"
 

--- a/.github/workflows/chromatic.yaml
+++ b/.github/workflows/chromatic.yaml
@@ -12,6 +12,7 @@ on:
 jobs:
   visual-testing:
     runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3


### PR DESCRIPTION
## Why
Drafts generally are very work in progress and shouldn't need to be verified until it's ready for review.

## What
Add a condition to chromatic to ignore draft pull reuests.
