### PR TITLE
feat: expose portalSelector for TableHeaderRow

### DIFF
--- a/.changeset/fuzzy-melons-try.md
+++ b/.changeset/fuzzy-melons-try.md
@@ -1,0 +1,5 @@
+---
+"@kaizen/draft-table": patch
+---
+
+Expose tooltipPortalSelector prop on TableHeaderRow

--- a/draft-packages/table/KaizenDraft/Table/Table.tsx
+++ b/draft-packages/table/KaizenDraft/Table/Table.tsx
@@ -117,6 +117,10 @@ export type TableHeaderRowCellProps = OverrideClassName<
   align?: "start" | "center" | "end"
   tooltipInfo?: string
   isTooltipIconHidden?: boolean
+  /**
+   * Specify where the tooltip should be rendered.
+   */
+  tooltipPortalSelector?: string | undefined
   sortingArrowsOnHover?: "ascending" | "descending" | undefined
 }
 
@@ -147,6 +151,7 @@ export const TableHeaderRowCell = ({
   // the table header does not have enough space. However, we should always show a
   // tooltip icon as the default based on design system tooltip guidelines.
   isTooltipIconHidden = false,
+  tooltipPortalSelector,
   // If set, this will show the arrow in the direction provided
   // when the header cell is hovered over.
   sortingArrowsOnHover,
@@ -270,6 +275,7 @@ export const TableHeaderRowCell = ({
         animationDuration={0}
         classNameOverride={styles.headerRowCellTooltip}
         text={tooltipInfo}
+        portalSelector={tooltipPortalSelector}
       >
         {cellContents}
       </Tooltip>


### PR DESCRIPTION
## Why
<!-- Why have you created this PR? - Is it a new feature, or a bug fix? Or something else? -->
<!-- Reference any relevant Jira tickets so your reviewer can find more context if needed. -->
<!-- Fixing a GitHub issue? Add "Fixes [issue URL]". -->
Expose the portalSelector prop for the Tooltip component being used within the TableHeaderRow. Enables consumers to override the location of the tooltip rendered for edge cases where the tooltip can be cut off due to conflicting styles

## What
<!-- What do your changes do? How do they change/fix the current behavior? -->
<!-- Add screenshots, GIFs or videos to illustrate the changes.  -->
