### PR TITLE
Title block: stop title block mobile actions from receiving keyboard focus when menu is closed

### DIFF
--- a/.changeset/nervous-dodos-battle.md
+++ b/.changeset/nervous-dodos-battle.md
@@ -1,0 +1,5 @@
+---
+"@kaizen/draft-title-block-zen": patch
+---
+
+Uses visibility:hidden on MobileActions to hide the menu from screen readers and avoid potential keyboard focus when menu is closed

--- a/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/MobileActions.module.scss
+++ b/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/MobileActions.module.scss
@@ -12,6 +12,7 @@ $expand-button-width: 3.75rem;
 $focus-spacing: 2px;
 $focus-ring-border-width: 2px; // should be $border-focus-ring-border-width but CSS vars makes this hard
 $space-for-focus-ring: ($focus-ring-border-width * 2) + ($focus-spacing * 2);
+$slide-up-duration: 0.4s;
 
 /* stylelint-disable no-descending-specificity */
 .mobileActionsContainer {
@@ -28,11 +29,15 @@ $space-for-focus-ring: ($focus-ring-border-width * 2) + ($focus-spacing * 2);
   -moz-osx-font-smoothing: grayscale;
   overflow: hidden;
   transform: translateY(calc(100% - #{$layout-mobile-actions-drawer-height}));
-  transition: 0.4s ease;
+  transition: $slide-up-duration ease;
   animation: slide-up 1s ease;
 
   &.isOpen {
     transform: translateY(0%);
+
+    .mobileActionsMenuContainer {
+      visibility: visible;
+    }
   }
 
   @include title-block-small {
@@ -52,10 +57,11 @@ $space-for-focus-ring: ($focus-ring-border-width * 2) + ($focus-spacing * 2);
 }
 
 .mobileActionsMenuContainer {
-  display: block;
+  visibility: hidden;
   width: 100%;
   background: $color-white;
   padding: $spacing-xs 0;
+  transition: visibility $slide-up-duration;
 }
 
 .drawerHandleIcon {


### PR DESCRIPTION
## Why
Fixes https://github.com/cultureamp/kaizen-discourse/issues/76

## What
Uses `visibility: hidden` on Title Block's MobileActions so that the contents are hidden from screen readers, and unavailable in the keyboard tab order while the menu is closed.

The reason I didn't use `display: none` instead is because there's an animation with this. When using `display: none`, the closing animation breaks. Using `visibility` meant that I could hide the contents of the menu at the same time as the animation finishes.
