### PR TITLE
feat(filter-bar): add Clear All button

### DIFF
--- a/.changeset/brown-horses-cheat.md
+++ b/.changeset/brown-horses-cheat.md
@@ -1,0 +1,7 @@
+---
+"@kaizen/components": minor
+---
+
+Add clear all functionality to FilterBar.
+
+All selected values are cleared, and any active removable filters are made inactive and moved into the Add Filters menu.

--- a/packages/components/src/FilterBar/FilterBar.module.scss
+++ b/packages/components/src/FilterBar/FilterBar.module.scss
@@ -5,10 +5,15 @@
 
 .filterBar {
   display: flex;
-  flex-wrap: wrap;
-  gap: $spacing-8;
   padding: $spacing-8;
   box-shadow: $shadow-small-box-shadow;
   border-radius: $border-solid-border-radius;
   background-color: $color-white;
+}
+
+.filtersContainer {
+  display: flex;
+  flex-grow: 1;
+  flex-wrap: wrap;
+  gap: $spacing-8;
 }

--- a/packages/components/src/FilterBar/FilterBar.spec.tsx
+++ b/packages/components/src/FilterBar/FilterBar.spec.tsx
@@ -11,7 +11,6 @@ const TEST_ID__FILTER = "testid__filter"
 
 type ValuesSimple = {
   flavour: string
-  topping: string
   sugarLevel: number
   iceLevel: number
 }
@@ -231,6 +230,68 @@ describe("<FilterBar />", () => {
       expect(filters[0]).toHaveTextContent("Ice Level")
       expect(filters[1]).toHaveTextContent("Flavour")
       expect(filters[2]).toHaveTextContent("Sugar Level")
+    })
+  })
+
+  describe("Clear all", () => {
+    it("clears all the values of all the filters", async () => {
+      const { getByRole } = render(
+        <FilterBarWrapper<ValuesSimple>
+          filters={simpleFilters}
+          defaultValues={{
+            flavour: "jasmine-milk-tea",
+            sugarLevel: 50,
+            iceLevel: 100,
+          }}
+        />
+      )
+
+      const flavourButton = getByRole("button", {
+        name: "Flavour : Jasmine Milk Tea",
+      })
+      const sugarLevelButton = getByRole("button", {
+        name: "Sugar Level : 50%",
+      })
+      const iceLevelButton = getByRole("button", { name: "Ice Level : 100%" })
+
+      expect(flavourButton.textContent).toBe("Flavour:Jasmine Milk Tea")
+      expect(sugarLevelButton.textContent).toBe("Sugar Level:50%")
+      expect(iceLevelButton.textContent).toBe("Ice Level:100%")
+
+      await user.click(getByRole("button", { name: "Clear all" }))
+
+      await waitFor(() => {
+        expect(flavourButton.textContent).toBe("Flavour")
+        expect(sugarLevelButton.textContent).toBe("Sugar Level")
+        expect(iceLevelButton.textContent).toBe("Ice Level")
+      })
+    })
+
+    it("removes all removable filters", async () => {
+      const { getByRole } = render(
+        <FilterBarWrapper<ValuesRemovable>
+          filters={filtersRemovable}
+          defaultValues={{
+            flavour: "jasmine-milk-tea",
+            topping: "pearls",
+          }}
+        />
+      )
+
+      const flavourButton = getByRole("button", {
+        name: "Flavour : Jasmine Milk Tea",
+      })
+      const toppingButton = getByRole("button", { name: "Topping : Pearls" })
+
+      expect(flavourButton).toBeVisible()
+      expect(toppingButton).toBeVisible()
+
+      await user.click(getByRole("button", { name: "Clear all" }))
+
+      await waitFor(() => {
+        expect(flavourButton).not.toBeInTheDocument()
+        expect(toppingButton).not.toBeInTheDocument()
+      })
     })
   })
 

--- a/packages/components/src/FilterBar/FilterBar.spec.tsx
+++ b/packages/components/src/FilterBar/FilterBar.spec.tsx
@@ -258,7 +258,7 @@ describe("<FilterBar />", () => {
       expect(sugarLevelButton.textContent).toBe("Sugar Level:50%")
       expect(iceLevelButton.textContent).toBe("Ice Level:100%")
 
-      await user.click(getByRole("button", { name: "Clear all" }))
+      await user.click(getByRole("button", { name: "Clear all filters" }))
 
       await waitFor(() => {
         expect(flavourButton.textContent).toBe("Flavour")
@@ -286,7 +286,7 @@ describe("<FilterBar />", () => {
       expect(flavourButton).toBeVisible()
       expect(toppingButton).toBeVisible()
 
-      await user.click(getByRole("button", { name: "Clear all" }))
+      await user.click(getByRole("button", { name: "Clear all filters" }))
 
       await waitFor(() => {
         expect(flavourButton).not.toBeInTheDocument()

--- a/packages/components/src/FilterBar/FilterBar.tsx
+++ b/packages/components/src/FilterBar/FilterBar.tsx
@@ -13,6 +13,7 @@ import {
   FilterBarSelect,
 } from "./subcomponents"
 import { AddFiltersMenu } from "./subcomponents/AddFiltersMenu"
+import { ClearAllButton } from "./subcomponents/ClearAllButton"
 import styles from "./FilterBar.module.scss"
 
 export type FilterBarProps<ValuesMap extends FiltersValues> = OverrideClassName<
@@ -27,13 +28,19 @@ export const FilterBar = <ValuesMap extends FiltersValues>({
   <FilterBarProvider<ValuesMap> filters={filters} {...providerProps}>
     {(activeFilters): JSX.Element => (
       <div className={classnames(styles.filterBar, classNameOverride)}>
-        {Object.values(activeFilters).map(({ id, Component }) => (
-          // `id` will always be `string`, but keyof ValuesMap transformed it
-          <React.Fragment key={id as string}>
-            {React.cloneElement(Component, { id })}
-          </React.Fragment>
-        ))}
-        <AddFiltersMenu />
+        <div className={styles.filtersContainer}>
+          {Object.values(activeFilters).map(({ id, Component }) => (
+            // `id` will always be `string`, but keyof ValuesMap transformed it
+            <React.Fragment key={id as string}>
+              {React.cloneElement(Component, { id })}
+            </React.Fragment>
+          ))}
+          <AddFiltersMenu />
+        </div>
+
+        <div>
+          <ClearAllButton />
+        </div>
       </div>
     )}
   </FilterBarProvider>

--- a/packages/components/src/FilterBar/_docs/FilterBar.mdx
+++ b/packages/components/src/FilterBar/_docs/FilterBar.mdx
@@ -23,6 +23,8 @@ import * as FilterBarStories from "./FilterBar.stories"
 
 The Filter Bar is a collection of Filter components, used to filter data.
 
+The `Clear all` button clears all active values, and moves any removable filters into the `Add Filters` menu.
+
 This example showcases a minimal implementation of the FilterBar.
 
 <NoClipCanvas of={FilterBarStories.BasicImplementation} />

--- a/packages/components/src/FilterBar/context/FilterBarContext.tsx
+++ b/packages/components/src/FilterBar/context/FilterBarContext.tsx
@@ -21,6 +21,7 @@ export type FilterBarContextValue<
   showFilter: (id: keyof ValuesMap) => void
   hideFilter: (id: keyof ValuesMap) => void
   getInactiveFilters: () => Array<BaseFilterState<keyof ValuesMap>>
+  clearAllFilters: () => void
 }
 
 const FilterBarContext = React.createContext<FilterBarContextValue<any> | null>(
@@ -91,6 +92,10 @@ export const FilterBarProvider = <ValuesMap extends FiltersValues>({
       onValuesChange({ ...values, [id]: undefined })
     },
     getInactiveFilters: () => getInactiveFilters<ValuesMap>(state),
+    clearAllFilters: () => {
+      dispatch({ type: "deactivate_filters" })
+      onValuesChange({})
+    },
   } satisfies FilterBarContextValue<any, ValuesMap>
 
   useEffect(() => {

--- a/packages/components/src/FilterBar/context/FilterBarContext.tsx
+++ b/packages/components/src/FilterBar/context/FilterBarContext.tsx
@@ -92,10 +92,8 @@ export const FilterBarProvider = <ValuesMap extends FiltersValues>({
       onValuesChange({ ...values, [id]: undefined })
     },
     getInactiveFilters: () => getInactiveFilters<ValuesMap>(state),
-    clearAllFilters: () => {
-      dispatch({ type: "deactivate_filters" })
-      onValuesChange({})
-    },
+    clearAllFilters: () =>
+      dispatch({ type: "deactivate_filters", onValuesChange }),
   } satisfies FilterBarContextValue<any, ValuesMap>
 
   useEffect(() => {

--- a/packages/components/src/FilterBar/context/FilterBarContext.tsx
+++ b/packages/components/src/FilterBar/context/FilterBarContext.tsx
@@ -93,7 +93,7 @@ export const FilterBarProvider = <ValuesMap extends FiltersValues>({
     },
     getInactiveFilters: () => getInactiveFilters<ValuesMap>(state),
     clearAllFilters: () =>
-      dispatch({ type: "deactivate_filters", onValuesChange }),
+      dispatch({ type: "clear_all_filters", onValuesChange }),
   } satisfies FilterBarContextValue<any, ValuesMap>
 
   useEffect(() => {

--- a/packages/components/src/FilterBar/context/reducer/filterBarStateReducer.spec.ts
+++ b/packages/components/src/FilterBar/context/reducer/filterBarStateReducer.spec.ts
@@ -94,13 +94,17 @@ describe("filterBarStateReducer", () => {
         activeFilterIds: new Set<keyof Values>(["flavour", "sugarLevel"]),
       } satisfies FilterBarState<Values>
 
+      const onValuesChange = jest.fn<void, [Partial<Values>]>()
+
       const newState = filterBarStateReducer<Values>(state, {
         type: "deactivate_filters",
+        onValuesChange,
       })
 
       expect(newState.activeFilterIds).toEqual(
         new Set<keyof Values>(["flavour"])
       )
+      expect(onValuesChange).toHaveBeenCalledWith({})
     })
   })
 })

--- a/packages/components/src/FilterBar/context/reducer/filterBarStateReducer.spec.ts
+++ b/packages/components/src/FilterBar/context/reducer/filterBarStateReducer.spec.ts
@@ -74,4 +74,33 @@ describe("filterBarStateReducer", () => {
       expect(newState.activeFilterIds).toEqual(new Set())
     })
   })
+
+  describe("filterBarStateReducer: deactivate_filters", () => {
+    it("sets all removable filters to inactive", () => {
+      const state = {
+        filters: {
+          flavour: {
+            id: "flavour",
+            name: "Flavour",
+            isOpen: false,
+          },
+          sugarLevel: {
+            id: "sugarLevel",
+            name: "Sugar Level",
+            isOpen: false,
+            isRemovable: true,
+          },
+        },
+        activeFilterIds: new Set<keyof Values>(["flavour", "sugarLevel"]),
+      } satisfies FilterBarState<Values>
+
+      const newState = filterBarStateReducer<Values>(state, {
+        type: "deactivate_filters",
+      })
+
+      expect(newState.activeFilterIds).toEqual(
+        new Set<keyof Values>(["flavour"])
+      )
+    })
+  })
 })

--- a/packages/components/src/FilterBar/context/reducer/filterBarStateReducer.spec.ts
+++ b/packages/components/src/FilterBar/context/reducer/filterBarStateReducer.spec.ts
@@ -75,7 +75,7 @@ describe("filterBarStateReducer", () => {
     })
   })
 
-  describe("filterBarStateReducer: deactivate_filters", () => {
+  describe("filterBarStateReducer: clear_all_filters", () => {
     it("sets all removable filters to inactive", () => {
       const state = {
         filters: {
@@ -97,7 +97,7 @@ describe("filterBarStateReducer", () => {
       const onValuesChange = jest.fn<void, [Partial<Values>]>()
 
       const newState = filterBarStateReducer<Values>(state, {
-        type: "deactivate_filters",
+        type: "clear_all_filters",
         onValuesChange,
       })
 

--- a/packages/components/src/FilterBar/context/reducer/filterBarStateReducer.ts
+++ b/packages/components/src/FilterBar/context/reducer/filterBarStateReducer.ts
@@ -1,7 +1,7 @@
 import { FilterBarState, FiltersValues, InternalFilterState } from "../types"
 import { updateSingleFilter } from "./updateSingleFilter"
 
-type Actions<ValuesMap> =
+type Actions<ValuesMap extends FiltersValues> =
   | {
       type: "update_single_filter"
       id: keyof ValuesMap
@@ -10,7 +10,10 @@ type Actions<ValuesMap> =
   | { type: "activate_filter"; id: keyof ValuesMap }
   | { type: "activate_filters_with_values"; values: Partial<ValuesMap> }
   | { type: "deactivate_filter"; id: keyof ValuesMap }
-  | { type: "deactivate_filters" }
+  | {
+      type: "deactivate_filters"
+      onValuesChange: (values: Partial<ValuesMap>) => void
+    }
 
 export const filterBarStateReducer = <ValuesMap extends FiltersValues>(
   state: FilterBarState<ValuesMap>,
@@ -41,6 +44,7 @@ export const filterBarStateReducer = <ValuesMap extends FiltersValues>(
       state.activeFilterIds.forEach(id => {
         if (state.filters[id].isRemovable) state.activeFilterIds.delete(id)
       })
+      action.onValuesChange({})
       return { ...state }
   }
 }

--- a/packages/components/src/FilterBar/context/reducer/filterBarStateReducer.ts
+++ b/packages/components/src/FilterBar/context/reducer/filterBarStateReducer.ts
@@ -11,7 +11,7 @@ type Actions<ValuesMap extends FiltersValues> =
   | { type: "activate_filters_with_values"; values: Partial<ValuesMap> }
   | { type: "deactivate_filter"; id: keyof ValuesMap }
   | {
-      type: "deactivate_filters"
+      type: "clear_all_filters"
       onValuesChange: (values: Partial<ValuesMap>) => void
     }
 
@@ -40,7 +40,7 @@ export const filterBarStateReducer = <ValuesMap extends FiltersValues>(
       state.activeFilterIds.delete(action.id)
       return { ...state }
 
-    case "deactivate_filters":
+    case "clear_all_filters":
       state.activeFilterIds.forEach(id => {
         if (state.filters[id].isRemovable) state.activeFilterIds.delete(id)
       })

--- a/packages/components/src/FilterBar/context/reducer/filterBarStateReducer.ts
+++ b/packages/components/src/FilterBar/context/reducer/filterBarStateReducer.ts
@@ -10,6 +10,7 @@ type Actions<ValuesMap> =
   | { type: "activate_filter"; id: keyof ValuesMap }
   | { type: "activate_filters_with_values"; values: Partial<ValuesMap> }
   | { type: "deactivate_filter"; id: keyof ValuesMap }
+  | { type: "deactivate_filters" }
 
 export const filterBarStateReducer = <ValuesMap extends FiltersValues>(
   state: FilterBarState<ValuesMap>,
@@ -34,6 +35,12 @@ export const filterBarStateReducer = <ValuesMap extends FiltersValues>(
 
     case "deactivate_filter":
       state.activeFilterIds.delete(action.id)
+      return { ...state }
+
+    case "deactivate_filters":
+      state.activeFilterIds.forEach(id => {
+        if (state.filters[id].isRemovable) state.activeFilterIds.delete(id)
+      })
       return { ...state }
   }
 }

--- a/packages/components/src/FilterBar/subcomponents/ClearAllButton/ClearAllButton.module.scss
+++ b/packages/components/src/FilterBar/subcomponents/ClearAllButton/ClearAllButton.module.scss
@@ -1,0 +1,3 @@
+.clearAllButton {
+  white-space: nowrap;
+}

--- a/packages/components/src/FilterBar/subcomponents/ClearAllButton/ClearAllButton.tsx
+++ b/packages/components/src/FilterBar/subcomponents/ClearAllButton/ClearAllButton.tsx
@@ -1,0 +1,18 @@
+import React from "react"
+import { Button } from "~components/Button"
+import { useFilterBarContext } from "../../context/FilterBarContext"
+import styles from "./ClearAllButton.module.scss"
+
+export const ClearAllButton = (): JSX.Element => {
+  const {} = useFilterBarContext()
+
+  return (
+    <Button
+      label="Clear all"
+      classNameOverride={styles.clearAllButton}
+      secondary
+    />
+  )
+}
+
+ClearAllButton.displayName = "FilterBar.ClearAllButton"

--- a/packages/components/src/FilterBar/subcomponents/ClearAllButton/ClearAllButton.tsx
+++ b/packages/components/src/FilterBar/subcomponents/ClearAllButton/ClearAllButton.tsx
@@ -4,13 +4,14 @@ import { useFilterBarContext } from "../../context/FilterBarContext"
 import styles from "./ClearAllButton.module.scss"
 
 export const ClearAllButton = (): JSX.Element => {
-  const {} = useFilterBarContext()
+  const { clearAllFilters } = useFilterBarContext()
 
   return (
     <Button
       label="Clear all"
       classNameOverride={styles.clearAllButton}
       secondary
+      onClick={clearAllFilters}
     />
   )
 }

--- a/packages/components/src/FilterBar/subcomponents/ClearAllButton/ClearAllButton.tsx
+++ b/packages/components/src/FilterBar/subcomponents/ClearAllButton/ClearAllButton.tsx
@@ -9,6 +9,7 @@ export const ClearAllButton = (): JSX.Element => {
   return (
     <Button
       label="Clear all"
+      aria-label="Clear all filters"
       classNameOverride={styles.clearAllButton}
       secondary
       onClick={clearAllFilters}

--- a/packages/components/src/FilterBar/subcomponents/ClearAllButton/index.ts
+++ b/packages/components/src/FilterBar/subcomponents/ClearAllButton/index.ts
@@ -1,0 +1,1 @@
+export * from "./ClearAllButton"


### PR DESCRIPTION
## What
<!-- What do your changes do? How do they change/fix the current behavior? -->
<!-- Add screenshots, GIFs or videos to illustrate the changes.  -->
Add a Clear All button to the FilterBar.

All selected values are cleared, and any active removable filters are made inactive and moved into the Add Filters menu.

![image](https://github.com/cultureamp/kaizen-design-system/assets/25891850/94d78805-dc18-44be-ab83-36de0671277b)

## Why
<!-- Why have you created this PR? - Is it a new feature, or a bug fix? Or something else? -->
<!-- Reference any relevant Jira tickets so your reviewer can find more context if needed. -->
<!-- Fixing a GitHub issue? Add "Fixes [issue URL]". -->
[KDS-1471](https://cultureamp.atlassian.net/jira/software/projects/KDS/boards/289?selectedIssue=KDS-1471)


[KDS-1471]: https://cultureamp.atlassian.net/browse/KDS-1471?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ