### PR TITLE
update the future release /dist reference path in package.json

### DIFF
--- a/.changeset/eight-socks-fly.md
+++ b/.changeset/eight-socks-fly.md
@@ -1,0 +1,7 @@
+---
+"@kaizen/components": patch
+---
+
+Updates the future release /dist reference path in package.json
+- this will fix the imports for future components
+- ie: `import {Workflow} from "@kaizen/components/future"

--- a/packages/components/future/package.json
+++ b/packages/components/future/package.json
@@ -1,5 +1,5 @@
 {
-  "main": "../dist/__future__/index.js",
-  "module": "../dist/esm/__future__/index.js",
-  "types": "../dist/__future__/index.d.ts"
+  "main": "../dist/cjs/future.js",
+  "module": "../dist/esm/future.js",
+  "types": "../dist/esm/dts/__future__/index.d.ts"
 }


### PR DESCRIPTION
## Why
The dist reference paths did not align to the outputs and we could not import components from the future folder.
```
{
  "main": "../dist/__future__/index.js",
  "module": "../dist/esm/__future__/index.js",
  "types": "../dist/__future__/index.d.ts"
}
```

This is a small fix to update the paths to the `future.js` file in the esm and cjs folders, and the types pulled from `esm/dts/__future__`

### Before
![Screenshot 2023-06-22 at 11 35 18 am](https://github.com/cultureamp/kaizen-design-system/assets/36558508/a7a2841b-449d-4b92-97e3-24fea74da070)

### After
![Screenshot 2023-06-22 at 11 34 34 am](https://github.com/cultureamp/kaizen-design-system/assets/36558508/96b3bc15-0e1a-4258-acf3-fd19bc5aa3ad)

## What
- updates `@kaizen/components` future package.json
