### PR TITLE
Add option for custom icon in tags

### DIFF
--- a/.changeset/curly-chairs-behave.md
+++ b/.changeset/curly-chairs-behave.md
@@ -1,0 +1,5 @@
+---
+"@kaizen/draft-tag": minor
+---
+
+Tags with custom icon

--- a/.changeset/curly-chairs-behave.md
+++ b/.changeset/curly-chairs-behave.md
@@ -2,4 +2,4 @@
 "@kaizen/draft-tag": minor
 ---
 
-Tags with custom icon
+Adds variant for tags with custom icon

--- a/draft-packages/tag/KaizenDraft/Tag/Tag.module.scss
+++ b/draft-packages/tag/KaizenDraft/Tag/Tag.module.scss
@@ -217,6 +217,15 @@ $small: $spacing-md;
   background-color: $color-red-100;
 }
 
+.customIcon {
+  background-color: $color-blue-100;
+
+  .validationIcon {
+    color: $color-blue-500;
+  }
+}
+
+
 .statusDraft {
   background-color: $color-blue-100;
   color: $color-purple-800;
@@ -228,6 +237,7 @@ $pulse-size-after: $pulse-size-initial * $pulse-scale-factor;
 $pulse-ring-position: calc(
   -1 * (#{$pulse-size-after} / 2) + (#{$pulse-size-initial} / 2)
 );
+
 
 .pulse {
   margin-inline-start: calc(#{$spacing-md} * 0.35);
@@ -265,3 +275,4 @@ $pulse-ring-position: calc(
     opacity: 0%;
   }
 }
+

--- a/draft-packages/tag/KaizenDraft/Tag/Tag.module.scss
+++ b/draft-packages/tag/KaizenDraft/Tag/Tag.module.scss
@@ -219,8 +219,13 @@ $small: $spacing-md;
 
 .customIcon {
   background-color: $color-blue-100;
+  margin-right: 0px;
+  align-items: center;
+  display: flex;
+  margin-inline-start: calc(#{$spacing-md} * -0.15);
+  margin-inline-end: $spacing-xs;
 
-  .validationIcon {
+  .icon {
     color: $color-blue-500;
   }
 }

--- a/draft-packages/tag/KaizenDraft/Tag/Tag.module.scss
+++ b/draft-packages/tag/KaizenDraft/Tag/Tag.module.scss
@@ -219,8 +219,7 @@ $small: $spacing-md;
 
 .customIcon {
   background-color: $color-blue-100;
-  margin-right: 0px;
-  // align-items: center;
+  margin-right: 0;
   place-items: center;
   display: flex;
   margin-inline-start: calc(#{$spacing-md} * -0.15);
@@ -228,7 +227,9 @@ $small: $spacing-md;
 
   .icon {
     color: $color-blue-500;
-    // vertical-align: text-top;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
   }
 }
 

--- a/draft-packages/tag/KaizenDraft/Tag/Tag.module.scss
+++ b/draft-packages/tag/KaizenDraft/Tag/Tag.module.scss
@@ -220,16 +220,17 @@ $small: $spacing-md;
 .customIcon {
   background-color: $color-blue-100;
   margin-right: 0px;
-  align-items: center;
+  // align-items: center;
+  place-items: center;
   display: flex;
   margin-inline-start: calc(#{$spacing-md} * -0.15);
   margin-inline-end: $spacing-xs;
 
   .icon {
     color: $color-blue-500;
+    // vertical-align: text-top;
   }
 }
-
 
 .statusDraft {
   background-color: $color-blue-100;
@@ -242,7 +243,6 @@ $pulse-size-after: $pulse-size-initial * $pulse-scale-factor;
 $pulse-ring-position: calc(
   -1 * (#{$pulse-size-after} / 2) + (#{$pulse-size-initial} / 2)
 );
-
 
 .pulse {
   margin-inline-start: calc(#{$spacing-md} * 0.35);
@@ -280,4 +280,3 @@ $pulse-ring-position: calc(
     opacity: 0%;
   }
 }
-

--- a/draft-packages/tag/KaizenDraft/Tag/Tag.spec.tsx
+++ b/draft-packages/tag/KaizenDraft/Tag/Tag.spec.tsx
@@ -130,11 +130,9 @@ describe("<Tag />", () => {
       const { container } = renderTag({
         variant: "customIcon",
         children: "Label",
-        customIcon: "newIcon",
       })
 
       expect(container.querySelector(".customIcon")).toBeTruthy()
-      expect(container.querySelector(".newIcon")).toBeTruthy()
     })
 
     it("renders a profile Tag with a Avatar component provided", () => {

--- a/draft-packages/tag/KaizenDraft/Tag/Tag.spec.tsx
+++ b/draft-packages/tag/KaizenDraft/Tag/Tag.spec.tsx
@@ -126,6 +126,17 @@ describe("<Tag />", () => {
       expect(container.querySelector(".statusAction")).toBeTruthy()
     })
 
+    it("renders a Tag with a custom icon", () => {
+      const { container } = renderTag({
+        variant: "customIcon",
+        children: "Label",
+        customIcon: "newIcon",
+      })
+
+      expect(container.querySelector(".customIcon")).toBeTruthy()
+      expect(container.querySelector(".newIcon")).toBeTruthy()
+    })
+
     it("renders a profile Tag with a Avatar component provided", () => {
       const { container } = render(
         <Tag

--- a/draft-packages/tag/KaizenDraft/Tag/Tag.tsx
+++ b/draft-packages/tag/KaizenDraft/Tag/Tag.tsx
@@ -24,6 +24,8 @@ type Variant =
   | "statusClosed"
   | "statusAction"
   | "customIcon"
+
+type CustomIcon = string
 export interface TagWithAvatarProps extends Omit<DefaultTagProps, "variant"> {
   variant: "profile"
   avatar: JSX.Element | AvatarProps
@@ -39,7 +41,7 @@ export interface DefaultTagProps {
   onMouseDown?: React.MouseEventHandler<HTMLSpanElement>
   onMouseLeave?: React.MouseEventHandler<HTMLSpanElement>
   truncateWidth?: number
-  customIcon?: string
+  customIcon?: CustomIcon
 }
 
 export type TagProps = DefaultTagProps | TagWithAvatarProps
@@ -75,6 +77,12 @@ export const Tag = (props: TagProps): JSX.Element => {
     truncateWidth,
     customIcon,
   } = props
+
+  const renderCustomIcon = (customIcon: CustomIcon): JSX.Element => (
+    <span className={styles.icon}>
+      {customIcon && <Icon icon={customIcon} role="presentation" />}
+    </span>
+  )
 
   const isTruncated = truncateWidth && truncateWidth > 0
   const canShowIcon = size === "medium"
@@ -120,10 +128,8 @@ export const Tag = (props: TagProps): JSX.Element => {
                   )
                 case "customIcon":
                   return (
-                    <span className={styles.validationIcon}>
-                      {customIcon && (
-                        <Icon icon={customIcon} role="presentation" />
-                      )}
+                    <span className={styles.customIcon}>
+                      {customIcon && renderCustomIcon(customIcon)}
                     </span>
                   )
                 case "profile":

--- a/draft-packages/tag/KaizenDraft/Tag/Tag.tsx
+++ b/draft-packages/tag/KaizenDraft/Tag/Tag.tsx
@@ -26,6 +26,11 @@ type Variant =
   | "customIcon"
 
 type CustomIcon = string
+
+interface CustomIconProps extends React.SVGAttributes<SVGElement> {
+  icon: string
+  inheritSize?: boolean
+}
 export interface TagWithAvatarProps extends Omit<DefaultTagProps, "variant"> {
   variant: "profile"
   avatar: JSX.Element | AvatarProps
@@ -41,7 +46,7 @@ export interface DefaultTagProps {
   onMouseDown?: React.MouseEventHandler<HTMLSpanElement>
   onMouseLeave?: React.MouseEventHandler<HTMLSpanElement>
   truncateWidth?: number
-  customIcon?: CustomIcon
+  customIcon?: React.ReactElement<CustomIconProps> | null
 }
 
 export type TagProps = DefaultTagProps | TagWithAvatarProps
@@ -78,9 +83,9 @@ export const Tag = (props: TagProps): JSX.Element => {
     customIcon,
   } = props
 
-  const renderCustomIcon = (customIcon: CustomIcon): JSX.Element => (
+  const renderCustomIcon = (icon: CustomIcon): JSX.Element => (
     <span className={styles.icon}>
-      {customIcon && <Icon icon={customIcon} role="presentation" />}
+      {icon && <Icon icon={icon} role="presentation" />}
     </span>
   )
 

--- a/draft-packages/tag/KaizenDraft/Tag/Tag.tsx
+++ b/draft-packages/tag/KaizenDraft/Tag/Tag.tsx
@@ -23,6 +23,7 @@ type Variant =
   | "statusDraft"
   | "statusClosed"
   | "statusAction"
+  | "customIcon"
 export interface TagWithAvatarProps extends Omit<DefaultTagProps, "variant"> {
   variant: "profile"
   avatar: JSX.Element | AvatarProps
@@ -38,6 +39,7 @@ export interface DefaultTagProps {
   onMouseDown?: React.MouseEventHandler<HTMLSpanElement>
   onMouseLeave?: React.MouseEventHandler<HTMLSpanElement>
   truncateWidth?: number
+  customIcon?: string
 }
 
 export type TagProps = DefaultTagProps | TagWithAvatarProps
@@ -71,6 +73,7 @@ export const Tag = (props: TagProps): JSX.Element => {
     onMouseDown,
     onMouseLeave,
     truncateWidth,
+    customIcon,
   } = props
 
   const isTruncated = truncateWidth && truncateWidth > 0
@@ -113,6 +116,14 @@ export const Tag = (props: TagProps): JSX.Element => {
                   return (
                     <span className={styles.validationIcon}>
                       <Icon icon={informationIcon} role="presentation" />
+                    </span>
+                  )
+                case "customIcon":
+                  return (
+                    <span className={styles.validationIcon}>
+                      {customIcon && (
+                        <Icon icon={customIcon} role="presentation" />
+                      )}
                     </span>
                   )
                 case "profile":

--- a/draft-packages/tag/KaizenDraft/Tag/Tag.tsx
+++ b/draft-packages/tag/KaizenDraft/Tag/Tag.tsx
@@ -24,13 +24,6 @@ type Variant =
   | "statusClosed"
   | "statusAction"
   | "customIcon"
-
-type CustomIcon = string
-
-interface CustomIconProps extends React.SVGAttributes<SVGElement> {
-  icon: string
-  inheritSize?: boolean
-}
 export interface TagWithAvatarProps extends Omit<DefaultTagProps, "variant"> {
   variant: "profile"
   avatar: JSX.Element | AvatarProps
@@ -46,7 +39,7 @@ export interface DefaultTagProps {
   onMouseDown?: React.MouseEventHandler<HTMLSpanElement>
   onMouseLeave?: React.MouseEventHandler<HTMLSpanElement>
   truncateWidth?: number
-  customIcon?: React.ReactElement<CustomIconProps> | null
+  customIcon?: React.SVGAttributes<SVGElement>
 }
 
 export type TagProps = DefaultTagProps | TagWithAvatarProps
@@ -83,7 +76,9 @@ export const Tag = (props: TagProps): JSX.Element => {
     customIcon,
   } = props
 
-  const renderCustomIcon = (icon: CustomIcon): JSX.Element => (
+  const renderCustomIcon = (
+    icon: React.SVGAttributes<SVGElement>
+  ): JSX.Element => (
     <span className={styles.icon}>
       {icon && <Icon icon={icon} role="presentation" />}
     </span>

--- a/draft-packages/tag/docs/Tag.stories.tsx
+++ b/draft-packages/tag/docs/Tag.stories.tsx
@@ -1,5 +1,7 @@
 import React from "react"
 import { Meta, StoryFn } from "@storybook/react"
+import { Icon } from "@kaizen/component-library"
+import lockIcon from "@kaizen/component-library/icons/lock.icon.svg"
 import { Avatar } from "@kaizen/draft-avatar"
 import { Tag } from "@kaizen/draft-tag"
 import { StoryWrapper } from "../../../storybook/components/StoryWrapper"
@@ -113,6 +115,14 @@ const StickerSheetTemplate: StoryFn<{ isReversed: boolean }> = ({
         </Tag>
         <Tag variant="validationCautionary" size="medium">
           Cautionary
+        </Tag>
+      </StoryWrapper.Row>
+    </StoryWrapper>
+    <StoryWrapper isReversed={isReversed}>
+      <StoryWrapper.RowHeader headings={["Private"]} gridColumns={1} />
+      <StoryWrapper.Row gridColumns={10} rowTitle="Custom Icon">
+        <Tag size="medium" variant="customIcon" customIcon={lockIcon}>
+          Private
         </Tag>
       </StoryWrapper.Row>
     </StoryWrapper>

--- a/draft-packages/tag/docs/Tag.stories.tsx
+++ b/draft-packages/tag/docs/Tag.stories.tsx
@@ -1,5 +1,6 @@
 import React from "react"
 import { Meta, StoryFn } from "@storybook/react"
+import { Icon } from "@kaizen/component-library"
 import lockIcon from "@kaizen/component-library/icons/lock.icon.svg"
 import { Avatar } from "@kaizen/draft-avatar"
 import { Tag } from "@kaizen/draft-tag"

--- a/draft-packages/tag/docs/Tag.stories.tsx
+++ b/draft-packages/tag/docs/Tag.stories.tsx
@@ -1,6 +1,5 @@
 import React from "react"
 import { Meta, StoryFn } from "@storybook/react"
-import { Icon } from "@kaizen/component-library"
 import lockIcon from "@kaizen/component-library/icons/lock.icon.svg"
 import { Avatar } from "@kaizen/draft-avatar"
 import { Tag } from "@kaizen/draft-tag"


### PR DESCRIPTION
Adds option to use any [icon](https://cultureamp.design/storybook/?path=/docs/components-icon--docs) available in [@kaizen/component-library](https://www.npmjs.com/package/@kaizen/component-library) as a custom icon in a tag.


<img width="254" alt="Screenshot 2023-06-26 at 4 48 54 PM" src="https://github.com/cultureamp/kaizen-design-system/assets/3740615/91f1f69f-79e6-49b9-847a-5091259ee753">
