### PR TITLE
test, no externals at all

### DIFF
--- a/.changeset/late-lobsters-know.md
+++ b/.changeset/late-lobsters-know.md
@@ -1,0 +1,5 @@
+---
+"@kaizen/components": patch
+---
+
+test

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -88,7 +88,7 @@
     "rollup-plugin-dts": "^5.3.0",
     "rollup-plugin-esbuild": "^5.0.0",
     "rollup-plugin-ignore": "^1.0.10",
-    "rollup-plugin-peer-deps-external": "^2.2.4",
+    "rollup-plugin-node-externals": "^6.1.1",
     "rollup-plugin-postcss": "^4.0.2",
     "sass": "^1.63.6",
     "serialize-query-params": "^2.0.2",

--- a/packages/components/rollup.config.mjs
+++ b/packages/components/rollup.config.mjs
@@ -6,10 +6,10 @@ import resolve from "@rollup/plugin-node-resolve"
 import typescript from "@rollup/plugin-typescript"
 import dts from "rollup-plugin-dts"
 import esbuild from "rollup-plugin-esbuild"
-import peerDepsExternal from "rollup-plugin-peer-deps-external"
+import ignore from "rollup-plugin-ignore"
+import nodeExternals from "rollup-plugin-node-externals"
 import postcss from "rollup-plugin-postcss"
 import ttypescript from "ttypescript"
-import ignore from "rollup-plugin-ignore"
 
 const TYPES_TEMP_DIR = "dts"
 const OUTPUT_DIR = "dist"
@@ -17,7 +17,9 @@ const OUTPUT_DIR = "dist"
 const getCompiledConfigByModuleType = format => ({
   input: { index: "./src/index.ts", future: "./src/__future__/index.ts" },
   plugins: [
-    peerDepsExternal(),
+    nodeExternals({
+      devDeps: true
+    }),
     // Has to be the same as packages/components/tsconfig.json -> compilerOptions -> paths
     alias({
       entries: [

--- a/yarn.lock
+++ b/yarn.lock
@@ -14586,10 +14586,10 @@ rollup-plugin-ignore@^1.0.10:
   resolved "https://registry.yarnpkg.com/rollup-plugin-ignore/-/rollup-plugin-ignore-1.0.10.tgz#0b8453ebf977fca1b4b0634062dded45288bf764"
   integrity sha512-VsbnfwwaTv2Dxl2onubetX/3RnSnplNnjdix0hvF8y2YpqdzlZrjIq6zkcuVJ08XysS8zqW3gt3ORBndFDgsrg==
 
-rollup-plugin-peer-deps-external@^2.2.4:
-  version "2.2.4"
-  resolved "https://registry.yarnpkg.com/rollup-plugin-peer-deps-external/-/rollup-plugin-peer-deps-external-2.2.4.tgz#8a420bbfd6dccc30aeb68c9bf57011f2f109570d"
-  integrity sha512-AWdukIM1+k5JDdAqV/Cxd+nejvno2FVLVeZ74NKggm3Q5s9cbbcOgUPGdbxPi4BXu7xGaZ8HG12F+thImYu/0g==
+rollup-plugin-node-externals@^6.1.1:
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-node-externals/-/rollup-plugin-node-externals-6.1.1.tgz#dff1a85073fe3c0b2c423b280259fe80392026a8"
+  integrity sha512-127OFMkpH5rBVlRHRBDUMk1m1sGuzbGy7so5aj/IkpUb2r3+wOWjR/erUzd2ChEQWPsxsyQG6xpYYvPBAdcBRA==
 
 rollup-plugin-postcss@^4.0.2:
   version "4.0.2"


### PR DESCRIPTION
## Why
Fixes an issue where `process is undefined` gets thrown whenever any KAIO component is used in non-next-template projects.


## What
Makes node builtins external.
