### PR TITLE
add fix for inputType issue in TextField

### DIFF
--- a/.changeset/spicy-scissors-allow.md
+++ b/.changeset/spicy-scissors-allow.md
@@ -1,0 +1,7 @@
+---
+"@kaizen/draft-form": patch
+---
+
+- Update Input components `type` condition to supersede the deprecated `inputType` prop
+- Add test coverage to ensure TextField components have the correct type
+- Update stories to use `type` instead of `inputType`

--- a/draft-packages/form/KaizenDraft/Form/Primitives/Input/Input.tsx
+++ b/draft-packages/form/KaizenDraft/Form/Primitives/Input/Input.tsx
@@ -57,7 +57,7 @@ export const Input = ({
   startIconAdornment,
   endIconAdornment,
   reversed = false,
-  type = "text",
+  type,
   inputType = "text",
   ariaLabel,
   ariaDescribedBy,
@@ -88,7 +88,7 @@ export const Input = ({
     <input
       ref={inputRef}
       data-automation-id={automationId}
-      type={inputType || type}
+      type={type || inputType}
       value={inputValue || value}
       defaultValue={defaultInputValue || defaultValue}
       aria-describedby={ariaDescribedBy} // will be replaced by `aria-describedby` in restProps

--- a/draft-packages/form/KaizenDraft/Form/Primitives/Input/Input.tsx
+++ b/draft-packages/form/KaizenDraft/Form/Primitives/Input/Input.tsx
@@ -15,7 +15,7 @@ export interface InputProps
   reversed?: boolean
   type?: InputType
   /**
-   * **Deprecated:** Use `type` instead
+   * **Deprecated:** Use `type` instead. If `inputType` is used, it will supersede the `type`
    * @deprecated
    */
   inputType?: InputType
@@ -57,8 +57,8 @@ export const Input = ({
   startIconAdornment,
   endIconAdornment,
   reversed = false,
-  type,
-  inputType = "text",
+  type = "text",
+  inputType,
   ariaLabel,
   ariaDescribedBy,
   value,
@@ -88,7 +88,7 @@ export const Input = ({
     <input
       ref={inputRef}
       data-automation-id={automationId}
-      type={type || inputType}
+      type={inputType || type}
       value={inputValue || value}
       defaultValue={defaultInputValue || defaultValue}
       aria-describedby={ariaDescribedBy} // will be replaced by `aria-describedby` in restProps

--- a/draft-packages/form/KaizenDraft/Form/TextField/TextField.spec.tsx
+++ b/draft-packages/form/KaizenDraft/Form/TextField/TextField.spec.tsx
@@ -92,34 +92,16 @@ describe("<TextField />", () => {
     expect(input).toBeInTheDocument()
   })
 
-  it("renders a TextField as a password field", () => {
-    render(<TextField {...defaultProps} labelText="Password" type="password" />)
-    const input = screen.getByLabelText("Password")
-    expect(input).toHaveAttribute("type", "password")
-  })
-
-  it("renders a TextField as an email field", () => {
-    render(<TextField {...defaultProps} labelText="Email" type="email" />)
-    const input = screen.getByLabelText("Email")
-    expect(input).toHaveAttribute("type", "email")
-  })
-
-  it("renders a TextField as an text field if no type is provided", () => {
-    render(<TextField {...defaultProps} labelText="Text" />)
-    const input = screen.getByLabelText("Text")
-    expect(input).toHaveAttribute("type", "text")
-  })
-
-  it("supersedes the deprecated inputType when `type` is passed in", () => {
+  it("renders a TextField with the correct input type", () => {
     render(
-      <TextField
-        {...defaultProps}
-        labelText="Password"
-        type="password"
-        inputType="text"
-      />
+      <TextField {...defaultProps} labelText="Password input" type="password" />
     )
-    const input = screen.getByLabelText("Password")
+    const input = screen.getByLabelText("Password input")
     expect(input).toHaveAttribute("type", "password")
+  })
+
+  it("If deprecated inputType is undefined it will fall back to the `type` default value", () => {
+    render(<TextField {...defaultProps} labelText="Default" />)
+    expect(screen.getByRole("textbox", { name: "Default" })).toBeInTheDocument()
   })
 })

--- a/draft-packages/form/KaizenDraft/Form/TextField/TextField.spec.tsx
+++ b/draft-packages/form/KaizenDraft/Form/TextField/TextField.spec.tsx
@@ -91,4 +91,35 @@ describe("<TextField />", () => {
 
     expect(input).toBeInTheDocument()
   })
+
+  it("renders a TextField as a password field", () => {
+    render(<TextField {...defaultProps} labelText="Password" type="password" />)
+    const input = screen.getByLabelText("Password")
+    expect(input).toHaveAttribute("type", "password")
+  })
+
+  it("renders a TextField as an email field", () => {
+    render(<TextField {...defaultProps} labelText="Email" type="email" />)
+    const input = screen.getByLabelText("Email")
+    expect(input).toHaveAttribute("type", "email")
+  })
+
+  it("renders a TextField as an text field if no type is provided", () => {
+    render(<TextField {...defaultProps} labelText="Text" />)
+    const input = screen.getByLabelText("Text")
+    expect(input).toHaveAttribute("type", "text")
+  })
+
+  it("supersedes the deprecated inputType when `type` is passed in", () => {
+    render(
+      <TextField
+        {...defaultProps}
+        labelText="Password"
+        type="password"
+        inputType="text"
+      />
+    )
+    const input = screen.getByLabelText("Password")
+    expect(input).toHaveAttribute("type", "password")
+  })
 })

--- a/draft-packages/form/docs/TextField.stories.tsx
+++ b/draft-packages/form/docs/TextField.stories.tsx
@@ -24,7 +24,7 @@ export const DefaultStory: StoryFn<typeof TextField> = args => (
 DefaultStory.args = {
   id: "kaizen-demo-text-field",
   labelText: "Label Text",
-  inputType: "text",
+  type: "text",
   defaultInputValue: "test",
   placeholder: "",
   description: "Example / description text",
@@ -62,25 +62,25 @@ const StickerSheetTemplate: StoryFn<{ isReversed: boolean }> = ({
   const DEFAULT__ROW_PROPS: TextFieldProps[] = [
     {
       id: "text-field--default",
-      inputType: "email",
+      type: "email",
       labelText: "Default",
     },
     {
       id: "text-field--description",
-      inputType: "email",
+      type: "email",
       labelText: "Description",
       description: "Description text",
     },
     {
       id: "text-field--placeholder",
-      inputType: "email",
+      type: "email",
       labelText: "Placeholder",
       description: "Description text",
       placeholder: "jane.doe@email.com",
     },
     {
       id: "text-field--positive",
-      inputType: "email",
+      type: "email",
       labelText: "Positive",
       status: "success",
       defaultInputValue: "Input Text",
@@ -88,7 +88,7 @@ const StickerSheetTemplate: StoryFn<{ isReversed: boolean }> = ({
     },
     {
       id: "text-field--negative",
-      inputType: "email",
+      type: "email",
       labelText: "Negative",
       status: "error",
       defaultInputValue: "Input Text",
@@ -97,7 +97,7 @@ const StickerSheetTemplate: StoryFn<{ isReversed: boolean }> = ({
     },
     {
       id: "text-field--cautionary",
-      inputType: "email",
+      type: "email",
       labelText: "Cautionary",
       status: "caution",
       defaultInputValue: "Input Text",
@@ -109,14 +109,14 @@ const StickerSheetTemplate: StoryFn<{ isReversed: boolean }> = ({
   const ICON__ROW_PROPS: TextFieldProps[] = [
     {
       id: "text-field--icon--default",
-      inputType: "email",
+      type: "email",
       labelText: "Default",
       defaultInputValue: "Input Text",
       description: "Description text",
     },
     {
       id: "text-field--icon--positive",
-      inputType: "email",
+      type: "email",
       labelText: "Positive",
       status: "success",
       defaultInputValue: "Input Text",
@@ -124,7 +124,7 @@ const StickerSheetTemplate: StoryFn<{ isReversed: boolean }> = ({
     },
     {
       id: "text-field--icon--negative",
-      inputType: "email",
+      type: "email",
       labelText: "Negative",
       status: "error",
       defaultInputValue: "Input Text",
@@ -133,7 +133,7 @@ const StickerSheetTemplate: StoryFn<{ isReversed: boolean }> = ({
     },
     {
       id: "text-field--icon--cautionary",
-      inputType: "email",
+      type: "email",
       labelText: "Cautionary",
       status: "caution",
       defaultInputValue: "Input Text",

--- a/draft-packages/form/docs/TextField.stories.tsx
+++ b/draft-packages/form/docs/TextField.stories.tsx
@@ -62,21 +62,33 @@ const StickerSheetTemplate: StoryFn<{ isReversed: boolean }> = ({
   const DEFAULT__ROW_PROPS: TextFieldProps[] = [
     {
       id: "text-field--default",
-      type: "email",
       labelText: "Default",
     },
     {
       id: "text-field--description",
-      type: "email",
       labelText: "Description",
       description: "Description text",
     },
     {
       id: "text-field--placeholder",
-      type: "email",
       labelText: "Placeholder",
       description: "Description text",
+      placeholder: "Enter some text here",
+    },
+    {
+      id: "text-field--placeholder",
+      type: "email",
+      labelText: "Email",
+      description: "Description text",
       placeholder: "jane.doe@email.com",
+    },
+    {
+      id: "text-field--placeholder",
+      type: "password",
+      labelText: "Password",
+      description: "Description text",
+      value: "abc123",
+      placeholder: "Enter a password...",
     },
     {
       id: "text-field--positive",


### PR DESCRIPTION
## Why
InputType prop was always superseding the type prop because it was passed in with a default value, ie:
```
...
  type = "text",
  inputType = "text",
...
<Input
  {...otherProps}
  type={inputType || type}
/>
```
This would mean that no matter what `type` passed in, the `inputType` would remain the same.


## What
- remove default value from `inputType` prop so it can be undefined
  - This means `type` can be passed without defaulting to the `inputType` value
- Add test coverage to ensure TextField components have the correct type
- Update stories to use `type` instead of `inputType`

