### PR TITLE
Update-changelog-change-to-datepicker

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -6,7 +6,6 @@
 
 - [#3852](https://github.com/cultureamp/kaizen-design-system/pull/3852) [`2e0a8db1d`](https://github.com/cultureamp/kaizen-design-system/commit/2e0a8db1db16f7a7bda4ab3c7dbad5691238facf) - **FilterDateRangePicker**
   - Fixed issue where validation was not returning the correct input value
-  - Minor fix to the types in `useDateInputHandlers` changing `setInputValue` from expecting a `SetStateAction` to just a `string`.
 - Updated dependencies [[`2e0a8db1d`](https://github.com/cultureamp/kaizen-design-system/commit/2e0a8db1db16f7a7bda4ab3c7dbad5691238facf), [`6621d8912`](https://github.com/cultureamp/kaizen-design-system/commit/6621d89125658392205963f89e230660bc6fddc2)]:
   - @kaizen/date-picker@6.2.2
   - @kaizen/draft-form@10.4.7

--- a/packages/date-picker/CHANGELOG.md
+++ b/packages/date-picker/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Patch Changes
 
-- [#3852](https://github.com/cultureamp/kaizen-design-system/pull/3852) [`2e0a8db1d`](https://github.com/cultureamp/kaizen-design-system/commit/2e0a8db1db16f7a7bda4ab3c7dbad5691238facf) - Update setInputValue to onValueChange to better reflect the functions being executed
+- [#3852](https://github.com/cultureamp/kaizen-design-system/pull/3852) [`2e0a8db1d`](https://github.com/cultureamp/kaizen-design-system/commit/2e0a8db1db16f7a7bda4ab3c7dbad5691238facf) - Minor fix to the types in `useDateInputHandlers` changing `setInputValue` from expecting a `SetStateAction` to just a `string`.
 
 - Updated dependencies [[`6621d8912`](https://github.com/cultureamp/kaizen-design-system/commit/6621d89125658392205963f89e230660bc6fddc2)]:
   - @kaizen/draft-form@10.4.7


### PR DESCRIPTION
Change was incorrectly attributed to KAIO, also a change to date-picker was incorrect