### PR TITLE
feat(filter-bar): allow consumer to open a filter from another filter's action

### DIFF
--- a/.changeset/chilled-beans-retire.md
+++ b/.changeset/chilled-beans-retire.md
@@ -1,0 +1,5 @@
+---
+"@kaizen/components": patch
+---
+
+Prevent infinite loop when calling `toggleOpenFilter` from selecting a value.

--- a/.changeset/chilled-beans-retire.md
+++ b/.changeset/chilled-beans-retire.md
@@ -1,6 +1,9 @@
 ---
-"@kaizen/components": patch
+"@kaizen/components": minor
 ---
+
+# FilterBar
 
 - Prevent infinite loop when calling `toggleOpenFilter` from selecting a value.
 - Deprecate `toggleOpenFilter`, and replace with `setFilterOpenState` for clearer function intent.
+- Add context util `openFilter` for consumers to be able to open a filter through an event from another filter.

--- a/.changeset/chilled-beans-retire.md
+++ b/.changeset/chilled-beans-retire.md
@@ -2,7 +2,7 @@
 "@kaizen/components": minor
 ---
 
-# FilterBar
+#### FilterBar
 
 - Prevent infinite loop when calling `toggleOpenFilter` from selecting a value.
 - Deprecate `toggleOpenFilter`, and replace with `setFilterOpenState` for clearer function intent.

--- a/.changeset/chilled-beans-retire.md
+++ b/.changeset/chilled-beans-retire.md
@@ -2,4 +2,5 @@
 "@kaizen/components": patch
 ---
 
-Prevent infinite loop when calling `toggleOpenFilter` from selecting a value.
+- Prevent infinite loop when calling `toggleOpenFilter` from selecting a value.
+- Deprecate `toggleOpenFilter`, and replace with `setFilterOpenState` for clearer function intent.

--- a/packages/components/src/FilterBar/FilterBar.spec.tsx
+++ b/packages/components/src/FilterBar/FilterBar.spec.tsx
@@ -906,83 +906,21 @@ describe("<FilterBar />", () => {
       })
     })
 
-    describe("setFilterOpenState()", () => {
+    describe("openFilter()", () => {
       type CycleFilterValues = {
         cycle: string
         customDate: Date
       }
 
       const CycleFilter = ({ id }: { id?: string }): JSX.Element => {
-        const { setFilterOpenState } = useFilterBarContext<
-          string,
-          CycleFilterValues
-        >()
+        const { openFilter } = useFilterBarContext<string, CycleFilterValues>()
 
         return (
           <FilterBar.Select
             id={id}
             items={[{ value: "custom", label: "Custom Date" }]}
             onSelectionChange={key => {
-              if (key === "custom") setFilterOpenState("customDate", true)
-            }}
-          />
-        )
-      }
-
-      const cycleFilters = [
-        {
-          id: "cycle",
-          name: "Cycle",
-          Component: <CycleFilter />,
-        },
-        {
-          id: "customDate",
-          name: "Custom Date",
-          Component: <FilterBar.DatePicker />,
-        },
-      ] satisfies Filters<CycleFilterValues>
-
-      it("opens the Custom Date filter when Cycle's 'custom' value is selected", async () => {
-        const { getByRole } = render(
-          <FilterBarWrapper<CycleFilterValues> filters={cycleFilters} />
-        )
-
-        const customDateButton = getByRole("button", { name: "Custom Date" })
-        expect(customDateButton).toHaveAttribute("aria-expanded", "false")
-
-        await user.click(getByRole("button", { name: "Cycle" }))
-
-        const customDateOption = getByRole("option", { name: "Custom Date" })
-        await waitFor(() => {
-          expect(customDateOption).toBeVisible()
-        })
-
-        await user.click(customDateOption)
-
-        await waitFor(() => {
-          expect(customDateButton).toHaveAttribute("aria-expanded", "true")
-        })
-      })
-    })
-
-    describe("DEPRECATED - toggleOpenFilter()", () => {
-      type CycleFilterValues = {
-        cycle: string
-        customDate: Date
-      }
-
-      const CycleFilter = ({ id }: { id?: string }): JSX.Element => {
-        const { toggleOpenFilter } = useFilterBarContext<
-          string,
-          CycleFilterValues
-        >()
-
-        return (
-          <FilterBar.Select
-            id={id}
-            items={[{ value: "custom", label: "Custom Date" }]}
-            onSelectionChange={key => {
-              if (key === "custom") toggleOpenFilter("customDate", true)
+              if (key === "custom") openFilter("customDate")
             }}
           />
         )

--- a/packages/components/src/FilterBar/FilterBar.spec.tsx
+++ b/packages/components/src/FilterBar/FilterBar.spec.tsx
@@ -756,134 +756,195 @@ describe("<FilterBar />", () => {
   })
 
   describe("Context use cases", () => {
-    type Items = Array<{ value: string; label: string }>
+    describe("getActiveFilterValues()", () => {
+      type Items = Array<{ value: string; label: string }>
 
-    type AsyncValues = {
-      city: string[]
-      hero: string[]
-    }
+      type AsyncValues = {
+        city: string[]
+        hero: string[]
+      }
 
-    const MockFilterAsyncComponent = ({
-      id,
-      fetcher,
-    }: {
-      id: string
-      fetcher: (args: Partial<AsyncValues>) => Promise<Items>
-    }): JSX.Element => {
-      const [items, setItems] = useState<Items>([])
-      const { getActiveFilterValues } = useFilterBarContext()
-      const activeFilterVals = getActiveFilterValues()
+      const MockFilterAsyncComponent = ({
+        id,
+        fetcher,
+      }: {
+        id: string
+        fetcher: (args: Partial<AsyncValues>) => Promise<Items>
+      }): JSX.Element => {
+        const [items, setItems] = useState<Items>([])
+        const { getActiveFilterValues } = useFilterBarContext()
+        const activeFilterVals = getActiveFilterValues()
 
-      useEffect(() => {
-        fetcher(activeFilterVals).then(fetchedItems => {
-          if (JSON.stringify(fetchedItems) !== JSON.stringify(items)) {
-            setItems(fetchedItems)
-          }
+        useEffect(() => {
+          fetcher(activeFilterVals).then(fetchedItems => {
+            if (JSON.stringify(fetchedItems) !== JSON.stringify(items)) {
+              setItems(fetchedItems)
+            }
+          })
+        }, [JSON.stringify(activeFilterVals)])
+
+        return (
+          <FilterBar.MultiSelect id={id} items={items}>
+            {() => (
+              <FilterMultiSelect.ListBox>
+                {({ allItems }) => (
+                  <FilterMultiSelect.ListBoxSection
+                    items={allItems}
+                    sectionName="All Items"
+                  >
+                    {item => (
+                      <FilterMultiSelect.Option key={item.key} item={item} />
+                    )}
+                  </FilterMultiSelect.ListBoxSection>
+                )}
+              </FilterMultiSelect.ListBox>
+            )}
+          </FilterBar.MultiSelect>
+        )
+      }
+
+      const fetchCityOptions = jest.fn((filterValues: Partial<AsyncValues>) => {
+        const isSupermanInFilterValue = filterValues.hero?.includes("superman")
+        const isBatmanInFilterValue = filterValues.hero?.includes("batman")
+
+        if (isBatmanInFilterValue && !isSupermanInFilterValue) {
+          return Promise.resolve([{ value: "gotham", label: "Gotham" }])
+        }
+
+        return Promise.resolve([
+          { value: "gotham", label: "Gotham" },
+          { value: "metro", label: "Metropolis" },
+        ])
+      })
+
+      const fetchHeroOptions = jest.fn((filterValues: Partial<AsyncValues>) => {
+        const isGothamInFilterValue = filterValues.city?.includes("gotham")
+        const isMetroInFilterValue = filterValues.city?.includes("metro")
+
+        if (isGothamInFilterValue && !isMetroInFilterValue) {
+          return Promise.resolve([{ value: "batman", label: "Batman" }])
+        }
+
+        return Promise.resolve([
+          { value: "superman", label: "Superman" },
+          { value: "batman", label: "Batman" },
+        ])
+      })
+
+      const config = [
+        {
+          id: "city",
+          name: "City",
+          Component: (
+            <MockFilterAsyncComponent id="city" fetcher={fetchCityOptions} />
+          ),
+        },
+        {
+          id: "hero",
+          name: "Hero",
+          Component: (
+            <MockFilterAsyncComponent id="Hero" fetcher={fetchHeroOptions} />
+          ),
+        },
+      ] satisfies Filters<AsyncValues>
+
+      it("can re-fetch options with all active filter values pulled off of the FilterBarContext", async () => {
+        const { getByRole, queryByRole } = render(
+          <FilterBarWrapper<AsyncValues> filters={config} defaultValues={{}} />
+        )
+
+        await user.click(getByRole("button", { name: "City" }))
+
+        await waitFor(() => {
+          expect(getByRole("option", { name: "Gotham" })).toBeVisible()
+          expect(getByRole("option", { name: "Metropolis" })).toBeVisible()
         })
-      }, [JSON.stringify(activeFilterVals)])
 
-      return (
-        <FilterBar.MultiSelect id={id} items={items}>
-          {() => (
-            <FilterMultiSelect.ListBox>
-              {({ allItems }) => (
-                <FilterMultiSelect.ListBoxSection
-                  items={allItems}
-                  sectionName="All Items"
-                >
-                  {item => (
-                    <FilterMultiSelect.Option key={item.key} item={item} />
-                  )}
-                </FilterMultiSelect.ListBoxSection>
-              )}
-            </FilterMultiSelect.ListBox>
-          )}
-        </FilterBar.MultiSelect>
-      )
-    }
+        await user.click(getByRole("option", { name: "Gotham" }))
 
-    const fetchCityOptions = jest.fn((filterValues: Partial<AsyncValues>) => {
-      const isSupermanInFilterValue = filterValues.hero?.includes("superman")
-      const isBatmanInFilterValue = filterValues.hero?.includes("batman")
+        // close city filter
+        await user.click(document.body)
 
-      if (isBatmanInFilterValue && !isSupermanInFilterValue) {
-        return Promise.resolve([{ value: "gotham", label: "Gotham" }])
-      }
+        await user.click(getByRole("button", { name: "Hero" }))
 
-      return Promise.resolve([
-        { value: "gotham", label: "Gotham" },
-        { value: "metro", label: "Metropolis" },
-      ])
+        await waitFor(() => {
+          expect(getByRole("option", { name: "Batman" })).toBeVisible()
+          expect(
+            queryByRole("option", { name: "Superman" })
+          ).not.toBeInTheDocument()
+        })
+
+        await user.click(getByRole("option", { name: "Batman" }))
+
+        await user.click(document.body)
+
+        await user.click(getByRole("button", { name: "City : Gotham" }))
+
+        await waitFor(() => {
+          expect(getByRole("option", { name: "Gotham" })).toBeVisible()
+          expect(
+            queryByRole("option", { name: "Metropolis" })
+          ).not.toBeInTheDocument()
+        })
+      })
     })
 
-    const fetchHeroOptions = jest.fn((filterValues: Partial<AsyncValues>) => {
-      const isGothamInFilterValue = filterValues.city?.includes("gotham")
-      const isMetroInFilterValue = filterValues.city?.includes("metro")
-
-      if (isGothamInFilterValue && !isMetroInFilterValue) {
-        return Promise.resolve([{ value: "batman", label: "Batman" }])
+    describe("toggleOpenFilter()", () => {
+      type CycleFilterValues = {
+        cycle: string
+        customDate: Date
       }
 
-      return Promise.resolve([
-        { value: "superman", label: "Superman" },
-        { value: "batman", label: "Batman" },
-      ])
-    })
+      const CycleFilter = ({ id }: { id?: string }): JSX.Element => {
+        const { toggleOpenFilter } = useFilterBarContext<
+          string,
+          CycleFilterValues
+        >()
 
-    const config = [
-      {
-        id: "city",
-        name: "City",
-        Component: (
-          <MockFilterAsyncComponent id="city" fetcher={fetchCityOptions} />
-        ),
-      },
-      {
-        id: "hero",
-        name: "Hero",
-        Component: (
-          <MockFilterAsyncComponent id="Hero" fetcher={fetchHeroOptions} />
-        ),
-      },
-    ] satisfies Filters<AsyncValues>
+        return (
+          <FilterBar.Select
+            id={id}
+            items={[{ value: "custom", label: "Custom Date" }]}
+            onSelectionChange={key => {
+              if (key === "custom") toggleOpenFilter("customDate", true)
+            }}
+          />
+        )
+      }
 
-    it("can re-fetch options with all active filter values pulled off of the FilterBarContext", async () => {
-      const { getByRole, queryByRole } = render(
-        <FilterBarWrapper<AsyncValues> filters={config} defaultValues={{}} />
-      )
+      const cycleFilters = [
+        {
+          id: "cycle",
+          name: "Cycle",
+          Component: <CycleFilter />,
+        },
+        {
+          id: "customDate",
+          name: "Custom Date",
+          Component: <FilterBar.DatePicker />,
+        },
+      ] satisfies Filters<CycleFilterValues>
 
-      await user.click(getByRole("button", { name: "City" }))
+      it("opens the Custom Date filter when Cycle's 'custom' value is selected", async () => {
+        const { getByRole } = render(
+          <FilterBarWrapper<CycleFilterValues> filters={cycleFilters} />
+        )
 
-      await waitFor(() => {
-        expect(getByRole("option", { name: "Gotham" })).toBeVisible()
-        expect(getByRole("option", { name: "Metropolis" })).toBeVisible()
-      })
+        const customDateButton = getByRole("button", { name: "Custom Date" })
+        expect(customDateButton).toHaveAttribute("aria-expanded", "false")
 
-      await user.click(getByRole("option", { name: "Gotham" }))
+        await user.click(getByRole("button", { name: "Cycle" }))
 
-      // close city filter
-      await user.click(document.body)
+        const customDateOption = getByRole("option", { name: "Custom Date" })
+        await waitFor(() => {
+          expect(customDateOption).toBeVisible()
+        })
 
-      await user.click(getByRole("button", { name: "Hero" }))
+        await user.click(customDateOption)
 
-      await waitFor(() => {
-        expect(getByRole("option", { name: "Batman" })).toBeVisible()
-        expect(
-          queryByRole("option", { name: "Superman" })
-        ).not.toBeInTheDocument()
-      })
-
-      await user.click(getByRole("option", { name: "Batman" }))
-
-      await user.click(document.body)
-
-      await user.click(getByRole("button", { name: "City : Gotham" }))
-
-      await waitFor(() => {
-        expect(getByRole("option", { name: "Gotham" })).toBeVisible()
-        expect(
-          queryByRole("option", { name: "Metropolis" })
-        ).not.toBeInTheDocument()
+        await waitFor(() => {
+          expect(customDateButton).toHaveAttribute("aria-expanded", "true")
+        })
       })
     })
   })

--- a/packages/components/src/FilterBar/FilterBar.spec.tsx
+++ b/packages/components/src/FilterBar/FilterBar.spec.tsx
@@ -125,12 +125,15 @@ const FilterBarWrapper = <T extends FiltersValues>({
   )
 
   return (
-    <FilterBar<T>
-      filters={filters}
-      values={activeValues}
-      onValuesChange={setActiveValues}
-      {...customProps}
-    />
+    <>
+      <FilterBar<T>
+        filters={filters}
+        values={activeValues}
+        onValuesChange={setActiveValues}
+        {...customProps}
+      />
+      <div data-testid="testid__values">{JSON.stringify(activeValues)}</div>
+    </>
   )
 }
 
@@ -269,6 +272,20 @@ describe("<FilterBar />", () => {
           queryByRole("button", { name: "Topping" })
         ).not.toBeInTheDocument()
         expect(getByRole("button", { name: "Add Filters" })).toBeDisabled()
+      })
+
+      it("clears the value if the filter is not usable", () => {
+        const { getByTestId } = render(
+          <FilterBarWrapper
+            filters={filtersDependent}
+            defaultValues={{
+              topping: "pearls",
+            }}
+          />
+        )
+        expect(getByTestId("testid__values").textContent).toEqual(
+          JSON.stringify({})
+        )
       })
     })
 

--- a/packages/components/src/FilterBar/FilterBar.spec.tsx
+++ b/packages/components/src/FilterBar/FilterBar.spec.tsx
@@ -906,7 +906,66 @@ describe("<FilterBar />", () => {
       })
     })
 
-    describe("toggleOpenFilter()", () => {
+    describe("setFilterOpenState()", () => {
+      type CycleFilterValues = {
+        cycle: string
+        customDate: Date
+      }
+
+      const CycleFilter = ({ id }: { id?: string }): JSX.Element => {
+        const { setFilterOpenState } = useFilterBarContext<
+          string,
+          CycleFilterValues
+        >()
+
+        return (
+          <FilterBar.Select
+            id={id}
+            items={[{ value: "custom", label: "Custom Date" }]}
+            onSelectionChange={key => {
+              if (key === "custom") setFilterOpenState("customDate", true)
+            }}
+          />
+        )
+      }
+
+      const cycleFilters = [
+        {
+          id: "cycle",
+          name: "Cycle",
+          Component: <CycleFilter />,
+        },
+        {
+          id: "customDate",
+          name: "Custom Date",
+          Component: <FilterBar.DatePicker />,
+        },
+      ] satisfies Filters<CycleFilterValues>
+
+      it("opens the Custom Date filter when Cycle's 'custom' value is selected", async () => {
+        const { getByRole } = render(
+          <FilterBarWrapper<CycleFilterValues> filters={cycleFilters} />
+        )
+
+        const customDateButton = getByRole("button", { name: "Custom Date" })
+        expect(customDateButton).toHaveAttribute("aria-expanded", "false")
+
+        await user.click(getByRole("button", { name: "Cycle" }))
+
+        const customDateOption = getByRole("option", { name: "Custom Date" })
+        await waitFor(() => {
+          expect(customDateOption).toBeVisible()
+        })
+
+        await user.click(customDateOption)
+
+        await waitFor(() => {
+          expect(customDateButton).toHaveAttribute("aria-expanded", "true")
+        })
+      })
+    })
+
+    describe("DEPRECATED - toggleOpenFilter()", () => {
       type CycleFilterValues = {
         cycle: string
         customDate: Date

--- a/packages/components/src/FilterBar/_docs/FilterBar.mdx
+++ b/packages/components/src/FilterBar/_docs/FilterBar.mdx
@@ -349,14 +349,11 @@ There may be a situation where you want to open a filter based on selecting a va
 To do so, call the `openFilter` function from `useFilterBarContext` in your event handler
 (you will need to create a custom component wrapping the Filter to access the context).
 
-**Note:** If your condition is based on the Source Filter (eg. Cycle)'s value and the Source Filter sits
-earlier in the list of active filters than the Dependent Filter (eg. Custom Range), we recommend you
-combine your implementation with an `isUsableWhen` for the Dependent Filter with a condition matching when
-you call `openFilter` (eg. in the following example, it is when Cycle has a value of "custom").
-While it is still usable without the dependency, you will likely see a misalignment with the
-popover of the Dependent Filter, as the position calculation of the popover will have run prior
-to the update of the Source Filter's button (which, when a value is selected, it is included in the button
-content, thus making it wider).
+**Note:**
+If you have a similar situation to below where _Custom Range_ appears later in the list than _Cycle_
+**and** it opens upon selecting a value from _Cycle_, we recommend you combine your implementation with an
+`isUsableWhen`, as the positioning calculation for _Custom Range_'s popover happens before the
+re-render of the Filter Buttons and _Cycle_'s button width will increase from having a selected value.
 
 ```tsx
 type Values = {

--- a/packages/components/src/FilterBar/_docs/FilterBar.mdx
+++ b/packages/components/src/FilterBar/_docs/FilterBar.mdx
@@ -349,8 +349,14 @@ There may be a situation where you want to open a filter based on selecting a va
 To do so, call the `openFilter` function from `useFilterBarContext` in your event handler
 (you will need to create a custom component wrapping the Filter to access the context).
 
-You may also want to combine the usage with an `isUsableWhen`, as a selected value increases the width of
-the Filter button (therefore pushing the others), potentially misaligning the popover of the one opened if it has relocated.
+**Note:** If your condition is based on the Source Filter (eg. Cycle)'s value and the Source Filter sits
+earlier in the list of active filters than the Dependent Filter (eg. Custom Range), we recommend you
+combine your implementation with an `isUsableWhen` for the Dependent Filter with a condition matching when
+you call `openFilter` (eg. in the following example, it is when Cycle has a value of "custom").
+While it is still usable without the dependency, you will likely see a misalignment with the
+popover of the Dependent Filter, as the position calculation of the popover will have run prior
+to the update of the Source Filter's button (which, when a value is selected, it is included in the button
+content, thus making it wider).
 
 ```tsx
 type Values = {

--- a/packages/components/src/FilterBar/_docs/FilterBar.mdx
+++ b/packages/components/src/FilterBar/_docs/FilterBar.mdx
@@ -346,7 +346,7 @@ packages.
 
 There may be a situation where you want to open a filter based on selecting a value from another filter.
 
-To do so, call the `setFilterOpenState` function from `useFilterBarContext` in your event handler
+To do so, call the `openFilter` function from `useFilterBarContext` in your event handler
 (you will need to create a custom component wrapping the Filter to access the context).
 
 You may also want to combine the usage with an `isUsableWhen`, as a selected value increases the width of
@@ -359,14 +359,14 @@ type Values = {
 }
 
 const CycleFilter = () => {
-  const { setFilterOpenState } = useFilterBarContext<Values["cycle"], Values>()
+  const { openFilter } = useFilterBarContext<Values["cycle"], Values>()
 
   return (
     <FilterBar.Select
       id="cycle"
       items={[{ value: "custom", label: "Custom Range" }]}
       onSelectionChange={key => {
-        if (key === "custom") setFilterOpenState("customRange", true)
+        if (key === "custom") openFilter("customRange")
       }}
     />
   )

--- a/packages/components/src/FilterBar/_docs/FilterBar.mdx
+++ b/packages/components/src/FilterBar/_docs/FilterBar.mdx
@@ -342,6 +342,44 @@ packages.
 
 <NoClipCanvas of={FilterBarStories.ExternalEventValuesUpdate} />
 
-### Open a sibling filter
+### Open a filter through selecting a value from another filter
+
+There may be a situation where you want to open a filter based on selecting a value from another filter.
+
+To do so, call the `toggleOpenFilter` function from `useFilterBarContext` in your event handler
+(you will need to create a custom component wrapping the Filter to access the context).
+
+You may also want to combine the usage with an `isUsableWhen`, as a selected value increases the width of
+the Filter button (therefore pushing the others), potentially misaligning the popover of the one opened if it has relocated.
+
+```tsx
+type Values = {
+  cycle: string
+  customRange: DateRange
+}
+
+const CycleFilter = () => {
+  const { toggleOpenFilter } = useFilterBarContext<Values["cycle"], Values>()
+
+  return (
+    <FilterBar.Select
+      id="cycle"
+      items={[{ value: "custom", label: "Custom Range" }]}
+      onSelectionChange={key => {
+        if (key === "custom") toggleOpenFilter("customRange", true)
+      }}
+    />
+  )
+}
+
+const CustomFilterBar = () => {
+  const filters = [
+    { id: "cycle", Component: <CycleFilter />, ...rest },
+    { id: "customRange", isUsableWhen: state => state.cycle.value === "custom", ...rest },
+  ] satisfies Filters<Values>
+
+  return <FilterBar<Values> filters={filters} {...rest} />
+}
+```
 
 <NoClipCanvas of={FilterBarStories.ExternalEventOpenFilter} />

--- a/packages/components/src/FilterBar/_docs/FilterBar.mdx
+++ b/packages/components/src/FilterBar/_docs/FilterBar.mdx
@@ -346,7 +346,7 @@ packages.
 
 There may be a situation where you want to open a filter based on selecting a value from another filter.
 
-To do so, call the `toggleOpenFilter` function from `useFilterBarContext` in your event handler
+To do so, call the `setFilterOpenState` function from `useFilterBarContext` in your event handler
 (you will need to create a custom component wrapping the Filter to access the context).
 
 You may also want to combine the usage with an `isUsableWhen`, as a selected value increases the width of
@@ -359,14 +359,14 @@ type Values = {
 }
 
 const CycleFilter = () => {
-  const { toggleOpenFilter } = useFilterBarContext<Values["cycle"], Values>()
+  const { setFilterOpenState } = useFilterBarContext<Values["cycle"], Values>()
 
   return (
     <FilterBar.Select
       id="cycle"
       items={[{ value: "custom", label: "Custom Range" }]}
       onSelectionChange={key => {
-        if (key === "custom") toggleOpenFilter("customRange", true)
+        if (key === "custom") setFilterOpenState("customRange", true)
       }}
     />
   )

--- a/packages/components/src/FilterBar/_docs/FilterBar.mdx
+++ b/packages/components/src/FilterBar/_docs/FilterBar.mdx
@@ -341,3 +341,7 @@ and <a href="https://www.npmjs.com/package/query-string">query-string</a>
 packages.
 
 <NoClipCanvas of={FilterBarStories.ExternalEventValuesUpdate} />
+
+### Open a sibling filter
+
+<NoClipCanvas of={FilterBarStories.ExternalEventOpenFilter} />

--- a/packages/components/src/FilterBar/_docs/FilterBar.stories.tsx
+++ b/packages/components/src/FilterBar/_docs/FilterBar.stories.tsx
@@ -670,3 +670,60 @@ export const ExternalEventValuesUpdate: StoryFn<typeof FilterBar> = () => {
     </>
   )
 }
+
+type CycleFilterValues = {
+  cycle: string
+  customRange: DateRange
+}
+
+const CycleFilter = ({ id }: { id?: string }): JSX.Element => {
+  const { toggleOpenFilter } = useFilterBarContext<string, CycleFilterValues>()
+
+  return (
+    <FilterBar.Select
+      id={id}
+      items={[
+        { value: "custom", label: "Custom Range" },
+        { value: "cycle-1", label: "Cycle 1" },
+        { value: "cycle-2", label: "Cycle 2" },
+      ]}
+      onSelectionChange={key => {
+        if (key === "custom") toggleOpenFilter("customRange", true)
+      }}
+    />
+  )
+}
+
+export const ExternalEventOpenFilter: StoryFn<typeof FilterBar> = () => {
+  const [values, setValues] = useState<Partial<CycleFilterValues>>({})
+
+  const cycleFilters = [
+    {
+      id: "cycle",
+      name: "Cycle",
+      Component: <CycleFilter />,
+    },
+    {
+      id: "customRange",
+      name: "Custom Range",
+      Component: <FilterBar.DateRangePicker />,
+    },
+  ] satisfies Filters<CycleFilterValues>
+
+  return (
+    <>
+      <FilterBar<CycleFilterValues>
+        filters={cycleFilters}
+        values={values}
+        onValuesChange={setValues}
+      />
+
+      <div className="mt-16">
+        <code>Values:</code>
+        <Highlight className="json">
+          {JSON.stringify(values, null, 4)}
+        </Highlight>
+      </div>
+    </>
+  )
+}

--- a/packages/components/src/FilterBar/_docs/FilterBar.stories.tsx
+++ b/packages/components/src/FilterBar/_docs/FilterBar.stories.tsx
@@ -677,7 +677,10 @@ type CycleFilterValues = {
 }
 
 const CycleFilter = ({ id }: { id?: string }): JSX.Element => {
-  const { toggleOpenFilter } = useFilterBarContext<string, CycleFilterValues>()
+  const { toggleOpenFilter } = useFilterBarContext<
+    CycleFilterValues["cycle"],
+    CycleFilterValues
+  >()
 
   return (
     <FilterBar.Select
@@ -707,6 +710,7 @@ export const ExternalEventOpenFilter: StoryFn<typeof FilterBar> = () => {
       id: "customRange",
       name: "Custom Range",
       Component: <FilterBar.DateRangePicker />,
+      isUsableWhen: state => state.cycle.value === "custom",
     },
   ] satisfies Filters<CycleFilterValues>
 
@@ -717,7 +721,6 @@ export const ExternalEventOpenFilter: StoryFn<typeof FilterBar> = () => {
         values={values}
         onValuesChange={setValues}
       />
-
       <div className="mt-16">
         <code>Values:</code>
         <Highlight className="json">

--- a/packages/components/src/FilterBar/_docs/FilterBar.stories.tsx
+++ b/packages/components/src/FilterBar/_docs/FilterBar.stories.tsx
@@ -677,7 +677,7 @@ type CycleFilterValues = {
 }
 
 const CycleFilter = ({ id }: { id?: string }): JSX.Element => {
-  const { setFilterOpenState } = useFilterBarContext<
+  const { openFilter } = useFilterBarContext<
     CycleFilterValues["cycle"],
     CycleFilterValues
   >()
@@ -691,7 +691,7 @@ const CycleFilter = ({ id }: { id?: string }): JSX.Element => {
         { value: "cycle-2", label: "Cycle 2" },
       ]}
       onSelectionChange={key => {
-        if (key === "custom") setFilterOpenState("customRange", true)
+        if (key === "custom") openFilter("customRange")
       }}
     />
   )

--- a/packages/components/src/FilterBar/_docs/FilterBar.stories.tsx
+++ b/packages/components/src/FilterBar/_docs/FilterBar.stories.tsx
@@ -677,7 +677,7 @@ type CycleFilterValues = {
 }
 
 const CycleFilter = ({ id }: { id?: string }): JSX.Element => {
-  const { toggleOpenFilter } = useFilterBarContext<
+  const { setFilterOpenState } = useFilterBarContext<
     CycleFilterValues["cycle"],
     CycleFilterValues
   >()
@@ -691,7 +691,7 @@ const CycleFilter = ({ id }: { id?: string }): JSX.Element => {
         { value: "cycle-2", label: "Cycle 2" },
       ]}
       onSelectionChange={key => {
-        if (key === "custom") toggleOpenFilter("customRange", true)
+        if (key === "custom") setFilterOpenState("customRange", true)
       }}
     />
   )

--- a/packages/components/src/FilterBar/context/FilterBarContext.tsx
+++ b/packages/components/src/FilterBar/context/FilterBarContext.tsx
@@ -16,7 +16,14 @@ export type FilterBarContextValue<
     id: Id
   ) => FilterState<keyof ValuesMap, ValuesMap[Id]>
   getActiveFilterValues: () => Partial<ValuesMap>
+  /**
+   * @deprecated Use `setFilterOpenState` instead.
+   */
   toggleOpenFilter: <Id extends keyof ValuesMap>(
+    id: Id,
+    isOpen: boolean
+  ) => void
+  setFilterOpenState: <Id extends keyof ValuesMap>(
     id: Id,
     isOpen: boolean
   ) => void
@@ -77,6 +84,12 @@ export const FilterBarProvider = <ValuesMap extends FiltersValues>({
     }),
     getActiveFilterValues: () => values,
     toggleOpenFilter: <Id extends keyof ValuesMap>(
+      id: Id,
+      isOpen: boolean
+    ): void => {
+      dispatch({ type: "update_single_filter", id, data: { isOpen } })
+    },
+    setFilterOpenState: <Id extends keyof ValuesMap>(
       id: Id,
       isOpen: boolean
     ): void => {

--- a/packages/components/src/FilterBar/context/FilterBarContext.tsx
+++ b/packages/components/src/FilterBar/context/FilterBarContext.tsx
@@ -113,9 +113,10 @@ export const FilterBarProvider = <ValuesMap extends FiltersValues>({
   }, [values])
 
   useEffect(() => {
-    const shouldUpdate =
-      state.values !== null && checkShouldUpdateValues<ValuesMap>(state, values)
-    if (shouldUpdate) onValuesChange({ ...state.values! })
+    if (state.hasUpdatedValues) {
+      onValuesChange({ ...state.values! })
+      dispatch({ type: "complete_update_values" })
+    }
   }, [state])
 
   const activeFilters = Array.from(

--- a/packages/components/src/FilterBar/context/FilterBarContext.tsx
+++ b/packages/components/src/FilterBar/context/FilterBarContext.tsx
@@ -27,6 +27,7 @@ export type FilterBarContextValue<
     id: Id,
     isOpen: boolean
   ) => void
+  openFilter: <Id extends keyof ValuesMap>(id: Id) => void
   updateValue: <Id extends keyof ValuesMap>(
     id: Id,
     value: ValuesMap[Id]
@@ -94,6 +95,9 @@ export const FilterBarProvider = <ValuesMap extends FiltersValues>({
       isOpen: boolean
     ): void => {
       dispatch({ type: "update_single_filter", id, data: { isOpen } })
+    },
+    openFilter: <Id extends keyof ValuesMap>(id: Id): void => {
+      dispatch({ type: "update_single_filter", id, data: { isOpen: true } })
     },
     updateValue: <Id extends keyof ValuesMap>(
       id: Id,

--- a/packages/components/src/FilterBar/context/FilterBarContext.tsx
+++ b/packages/components/src/FilterBar/context/FilterBarContext.tsx
@@ -66,7 +66,7 @@ export const FilterBarProvider = <ValuesMap extends FiltersValues>({
 
   const [state, dispatch] = useReducer(
     filterBarStateReducer<ValuesMap>,
-    setupFilterBarState<ValuesMap>(filters)
+    setupFilterBarState<ValuesMap>(filters, values)
   )
 
   const value = {
@@ -107,14 +107,13 @@ export const FilterBarProvider = <ValuesMap extends FiltersValues>({
   } satisfies FilterBarContextValue<any, ValuesMap>
 
   useEffect(() => {
-    const shouldUpdate =
-      state.values === null || checkShouldUpdateValues<ValuesMap>(state, values)
+    const shouldUpdate = checkShouldUpdateValues<ValuesMap>(state, values)
     if (shouldUpdate) dispatch({ type: "update_values", values: { ...values } })
   }, [values])
 
   useEffect(() => {
     if (state.hasUpdatedValues) {
-      onValuesChange({ ...state.values! })
+      onValuesChange({ ...state.values })
       dispatch({ type: "complete_update_values" })
     }
   }, [state])

--- a/packages/components/src/FilterBar/context/reducer/filterBarStateReducer.spec.ts
+++ b/packages/components/src/FilterBar/context/reducer/filterBarStateReducer.spec.ts
@@ -24,6 +24,24 @@ const stateFilters = {
 } satisfies FilterBarState<Values>["filters"]
 
 describe("filterBarStateReducer", () => {
+  describe("filterBarStateReducer: complete_update_values", () => {
+    it("sets hasUpdatedValues to false", () => {
+      const state = {
+        filters: stateFilters,
+        activeFilterIds: new Set<keyof Values>(["flavour"]),
+        values: {},
+        dependentFilterIds: new Set(),
+        hasUpdatedValues: true,
+      } satisfies FilterBarState<Values>
+
+      const newState = filterBarStateReducer<Values>(state, {
+        type: "complete_update_values",
+      })
+
+      expect(newState.hasUpdatedValues).toBe(false)
+    })
+  })
+
   describe("filterBarStateReducer: activate_filter", () => {
     it("sets a filter to active", () => {
       const state = {
@@ -31,6 +49,7 @@ describe("filterBarStateReducer", () => {
         activeFilterIds: new Set<keyof Values>(["flavour"]),
         values: {},
         dependentFilterIds: new Set(),
+        hasUpdatedValues: false,
       } satisfies FilterBarState<Values>
 
       const newState = filterBarStateReducer<Values>(state, {
@@ -51,6 +70,7 @@ describe("filterBarStateReducer", () => {
         activeFilterIds: new Set<keyof Values>(["flavour"]),
         values: { flavour: "jasmine" },
         dependentFilterIds: new Set(),
+        hasUpdatedValues: false,
       } satisfies FilterBarState<Values>
 
       const newState = filterBarStateReducer<Values>(state, {
@@ -59,7 +79,8 @@ describe("filterBarStateReducer", () => {
       })
 
       expect(newState.activeFilterIds).toEqual(new Set())
-      expect(newState.values!.flavour).toBeUndefined()
+      expect(newState.values.flavour).toBeUndefined()
+      expect(newState.hasUpdatedValues).toBe(true)
     })
   })
 })

--- a/packages/components/src/FilterBar/context/reducer/filterBarStateReducer.ts
+++ b/packages/components/src/FilterBar/context/reducer/filterBarStateReducer.ts
@@ -6,6 +6,7 @@ import { updateValues } from "./updateValues"
 
 type Actions<ValuesMap extends FiltersValues> =
   | { type: "update_values"; values: Partial<ValuesMap> }
+  | { type: "complete_update_values" }
   | {
       type: "update_single_filter"
       id: keyof ValuesMap
@@ -20,7 +21,16 @@ export const filterBarStateReducer = <ValuesMap extends FiltersValues>(
 ): FilterBarState<ValuesMap> => {
   switch (action.type) {
     case "update_values":
-      return { ...updateValues(state, action.values) }
+      return {
+        ...updateValues(state, action.values),
+        hasUpdatedValues: true,
+      }
+
+    case "complete_update_values":
+      return {
+        ...state,
+        hasUpdatedValues: false,
+      }
 
     case "update_single_filter":
       return {
@@ -35,6 +45,9 @@ export const filterBarStateReducer = <ValuesMap extends FiltersValues>(
     case "deactivate_filter":
       state.activeFilterIds.delete(action.id)
       state.values![action.id] = undefined
-      return { ...updateDependentFilters(state) }
+      return {
+        ...updateDependentFilters(state),
+        hasUpdatedValues: true,
+      }
   }
 }

--- a/packages/components/src/FilterBar/context/reducer/filterBarStateReducer.ts
+++ b/packages/components/src/FilterBar/context/reducer/filterBarStateReducer.ts
@@ -44,7 +44,7 @@ export const filterBarStateReducer = <ValuesMap extends FiltersValues>(
 
     case "deactivate_filter":
       state.activeFilterIds.delete(action.id)
-      state.values![action.id] = undefined
+      state.values[action.id] = undefined
       return {
         ...updateDependentFilters(state),
         hasUpdatedValues: true,

--- a/packages/components/src/FilterBar/context/reducer/filterBarStateReducer.ts
+++ b/packages/components/src/FilterBar/context/reducer/filterBarStateReducer.ts
@@ -21,10 +21,7 @@ export const filterBarStateReducer = <ValuesMap extends FiltersValues>(
 ): FilterBarState<ValuesMap> => {
   switch (action.type) {
     case "update_values":
-      return {
-        ...updateValues(state, action.values),
-        hasUpdatedValues: true,
-      }
+      return { ...updateValues(state, action.values) }
 
     case "complete_update_values":
       return {

--- a/packages/components/src/FilterBar/context/reducer/setupFilterBarState.spec.tsx
+++ b/packages/components/src/FilterBar/context/reducer/setupFilterBarState.spec.tsx
@@ -19,7 +19,8 @@ const filters = [
 
 describe("setupFilterBarState()", () => {
   it("sets up the base state correctly", () => {
-    expect(setupFilterBarState<Values>(filters)).toEqual({
+    const values = { flavour: "jasmine", sugarLevel: 50 }
+    expect(setupFilterBarState<Values>(filters, values)).toEqual({
       filters: {
         flavour: {
           id: "flavour",
@@ -36,9 +37,10 @@ describe("setupFilterBarState()", () => {
           isUsable: true,
         },
       },
-      activeFilterIds: new Set(),
-      values: null,
+      activeFilterIds: new Set(["flavour", "sugarLevel"]),
+      values,
       dependentFilterIds: new Set<keyof Values>(),
+      hasUpdatedValues: false,
     })
   })
 
@@ -54,9 +56,13 @@ describe("setupFilterBarState()", () => {
     ] satisfies Filters<Values>
 
     it("correctly sets up base for dependent filters", () => {
-      const state = setupFilterBarState<Values>(filtersDependent)
-      expect(state.filters.sugarLevel.isUsable).toBe(null)
+      const values = { sugarLevel: 50 }
+      const state = setupFilterBarState<Values>(filtersDependent, values)
+      expect(state.activeFilterIds).toEqual(new Set(["flavour"]))
       expect(state.dependentFilterIds).toEqual(new Set(["sugarLevel"]))
+      expect(state.filters.sugarLevel.isUsable).toBe(false)
+      expect(state.values).toEqual({})
+      expect(state.hasUpdatedValues).toBe(true)
     })
   })
 })

--- a/packages/components/src/FilterBar/context/reducer/setupFilterBarState.ts
+++ b/packages/components/src/FilterBar/context/reducer/setupFilterBarState.ts
@@ -9,7 +9,6 @@ export const setupFilterBarState = <ValuesMap extends FiltersValues>(
   const state = filters.reduce<FilterBarState<ValuesMap>>(
     (baseState, { id, name, isRemovable, isUsableWhen }) => {
       const hasDependency = isUsableWhen !== undefined
-      const isUsable = true
 
       baseState.filters[id] = {
         id,
@@ -17,14 +16,14 @@ export const setupFilterBarState = <ValuesMap extends FiltersValues>(
         isRemovable: isRemovable ?? false,
         isUsableWhen,
         isOpen: false,
-        isUsable,
+        isUsable: true,
       }
 
       if (hasDependency) {
         baseState.dependentFilterIds.add(id)
       }
 
-      if (isUsable && (!isRemovable || values[id] !== undefined)) {
+      if (!isRemovable || values[id] !== undefined) {
         baseState.activeFilterIds.add(id)
       }
 

--- a/packages/components/src/FilterBar/context/reducer/setupFilterBarState.ts
+++ b/packages/components/src/FilterBar/context/reducer/setupFilterBarState.ts
@@ -1,12 +1,15 @@
 import { Filters, FiltersValues } from "../../types"
 import { FilterBarState } from "../types"
+import { updateDependentFilters } from "../utils/updateDependentFilters"
 
 export const setupFilterBarState = <ValuesMap extends FiltersValues>(
-  filters: Filters<ValuesMap>
+  filters: Filters<ValuesMap>,
+  values: Partial<ValuesMap>
 ): FilterBarState<ValuesMap> => {
   const state = filters.reduce<FilterBarState<ValuesMap>>(
     (baseState, { id, name, isRemovable, isUsableWhen }) => {
       const hasDependency = isUsableWhen !== undefined
+      const isUsable = true
 
       baseState.filters[id] = {
         id,
@@ -14,29 +17,27 @@ export const setupFilterBarState = <ValuesMap extends FiltersValues>(
         isRemovable: isRemovable ?? false,
         isUsableWhen,
         isOpen: false,
-        // A dependent filter is set to `null` here as it
-        // will be re-evaluated in the `update_values` dispatch action.
-        isUsable: hasDependency ? null : true,
+        isUsable,
       }
 
       if (hasDependency) {
         baseState.dependentFilterIds.add(id)
       }
 
+      if (isUsable && (!isRemovable || values[id] !== undefined)) {
+        baseState.activeFilterIds.add(id)
+      }
+
       return baseState
     },
     {
-      hasUpdatedValues: false,
       filters: {},
-      // These will be set by the `update_values` dispatch action.
       activeFilterIds: new Set(),
-      // To prevent an infinite loop calculating dependent filters,
-      // `values` is set to `null` and default values will be
-      // set by the `update_values` dispatch action.
-      values: null,
+      values,
       dependentFilterIds: new Set(),
+      hasUpdatedValues: false,
     } as FilterBarState<ValuesMap>
   )
 
-  return state
+  return updateDependentFilters(state)
 }

--- a/packages/components/src/FilterBar/context/reducer/setupFilterBarState.ts
+++ b/packages/components/src/FilterBar/context/reducer/setupFilterBarState.ts
@@ -26,6 +26,7 @@ export const setupFilterBarState = <ValuesMap extends FiltersValues>(
       return baseState
     },
     {
+      hasUpdatedValues: false,
       filters: {},
       // These will be set by the `update_values` dispatch action.
       activeFilterIds: new Set(),

--- a/packages/components/src/FilterBar/context/reducer/updateSingleFilter.spec.ts
+++ b/packages/components/src/FilterBar/context/reducer/updateSingleFilter.spec.ts
@@ -30,6 +30,7 @@ describe("filterBarStateReducer: update_single_filter", () => {
       activeFilterIds: new Set<keyof Values>(["flavour"]),
       values: {},
       dependentFilterIds: new Set(),
+      hasUpdatedValues: false,
     } satisfies FilterBarState<Values>
 
     const newState = filterBarStateReducer<Values>(state, {
@@ -47,6 +48,7 @@ describe("filterBarStateReducer: update_single_filter", () => {
       activeFilterIds: new Set<keyof Values>(["flavour"]),
       values: {},
       dependentFilterIds: new Set(),
+      hasUpdatedValues: false,
     } satisfies FilterBarState<Values>
 
     expect(state.filters.flavour.isOpen).toBe(false)

--- a/packages/components/src/FilterBar/context/reducer/updateValues.spec.ts
+++ b/packages/components/src/FilterBar/context/reducer/updateValues.spec.ts
@@ -34,6 +34,7 @@ describe("filterBarStateReducer: update_values", () => {
         activeFilterIds: new Set<keyof Values>(["flavour"]),
         values: {},
         dependentFilterIds: new Set(),
+        hasUpdatedValues: false,
       } satisfies FilterBarState<Values>
 
       const newState = filterBarStateReducer<Values>(state, {
@@ -45,6 +46,7 @@ describe("filterBarStateReducer: update_values", () => {
         new Set(["flavour", "sugarLevel"])
       )
       expect(newState.values).toEqual({ sugarLevel: 50 })
+      expect(newState.hasUpdatedValues).toBe(true)
     })
   })
 
@@ -62,6 +64,7 @@ describe("filterBarStateReducer: update_values", () => {
           activeFilterIds: new Set<keyof Values>(["flavour"]),
           values: { sugarLevel: 50 },
           dependentFilterIds: new Set<keyof Values>(["sugarLevel"]),
+          hasUpdatedValues: false,
         } satisfies FilterBarState<Values>
 
         const newState = filterBarStateReducer<Values>(state, {
@@ -72,6 +75,7 @@ describe("filterBarStateReducer: update_values", () => {
         expect(newState.filters.sugarLevel.isUsable).toBe(false)
         expect(newState.activeFilterIds).toEqual(new Set(["flavour"]))
         expect(newState.values).toEqual({})
+        expect(newState.hasUpdatedValues).toBe(true)
       })
     })
 
@@ -88,6 +92,7 @@ describe("filterBarStateReducer: update_values", () => {
           activeFilterIds: new Set<keyof Values>(["flavour"]),
           values: {},
           dependentFilterIds: new Set<keyof Values>(["sugarLevel"]),
+          hasUpdatedValues: false,
         } satisfies FilterBarState<Values>
 
         const newState = filterBarStateReducer<Values>(state, {
@@ -100,6 +105,7 @@ describe("filterBarStateReducer: update_values", () => {
           new Set(["flavour", "sugarLevel"])
         )
         expect(newState.values).toEqual({ flavour: "jasmine", sugarLevel: 50 })
+        expect(newState.hasUpdatedValues).toBe(true)
       })
 
       it("does not activate a removable filter without a value", () => {
@@ -115,6 +121,7 @@ describe("filterBarStateReducer: update_values", () => {
           activeFilterIds: new Set<keyof Values>(["flavour"]),
           values: {},
           dependentFilterIds: new Set<keyof Values>(["sugarLevel"]),
+          hasUpdatedValues: false,
         } satisfies FilterBarState<Values>
 
         const newState = filterBarStateReducer<Values>(state, {
@@ -125,6 +132,7 @@ describe("filterBarStateReducer: update_values", () => {
         expect(newState.filters.sugarLevel.isUsable).toBe(true)
         expect(newState.activeFilterIds).toEqual(new Set(["flavour"]))
         expect(newState.values).toEqual({ flavour: "jasmine" })
+        expect(newState.hasUpdatedValues).toBe(true)
       })
 
       it("activates a removable filter with a value", () => {
@@ -140,6 +148,7 @@ describe("filterBarStateReducer: update_values", () => {
           activeFilterIds: new Set<keyof Values>(["flavour"]),
           values: {},
           dependentFilterIds: new Set<keyof Values>(["sugarLevel"]),
+          hasUpdatedValues: false,
         } satisfies FilterBarState<Values>
 
         const newState = filterBarStateReducer<Values>(state, {
@@ -152,6 +161,7 @@ describe("filterBarStateReducer: update_values", () => {
           new Set(["flavour", "sugarLevel"])
         )
         expect(newState.values).toEqual({ flavour: "jasmine", sugarLevel: 50 })
+        expect(newState.hasUpdatedValues).toBe(true)
       })
     })
   })

--- a/packages/components/src/FilterBar/context/reducer/updateValues.ts
+++ b/packages/components/src/FilterBar/context/reducer/updateValues.ts
@@ -6,13 +6,11 @@ export const updateValues = <ValuesMap extends FiltersValues>(
   state: FilterBarState<ValuesMap>,
   values: Partial<ValuesMap>
 ): FilterBarState<ValuesMap> => {
-  state.hasUpdatedValues = true
-
   Object.values(state.filters).forEach(({ id, isRemovable, isUsable }) => {
     if (isUsable && (!isRemovable || values[id] !== undefined)) {
       state.activeFilterIds.add(id)
     }
   })
 
-  return updateDependentFilters({ ...state, values })
+  return updateDependentFilters({ ...state, hasUpdatedValues: true, values })
 }

--- a/packages/components/src/FilterBar/context/reducer/updateValues.ts
+++ b/packages/components/src/FilterBar/context/reducer/updateValues.ts
@@ -6,6 +6,8 @@ export const updateValues = <ValuesMap extends FiltersValues>(
   state: FilterBarState<ValuesMap>,
   values: Partial<ValuesMap>
 ): FilterBarState<ValuesMap> => {
+  state.hasUpdatedValues = true
+
   Object.values(state.filters).forEach(({ id, isRemovable, isUsable }) => {
     if (isUsable && (!isRemovable || values[id] !== undefined)) {
       state.activeFilterIds.add(id)

--- a/packages/components/src/FilterBar/context/types.ts
+++ b/packages/components/src/FilterBar/context/types.ts
@@ -16,7 +16,7 @@ export type InternalFilterState<
   name: string
   isRemovable: boolean
   isUsableWhen?: FilterIsUsableWhen<ValuesMap>
-  isUsable: boolean | null
+  isUsable: boolean
   isOpen: boolean
   value?: never
   isActive?: never
@@ -30,7 +30,7 @@ export type FilterBarState<ValuesMap extends FiltersValues> = {
   hasUpdatedValues: boolean
   filters: FilterBarStateFilters<ValuesMap>
   activeFilterIds: Set<keyof ValuesMap>
-  values: Partial<ValuesMap> | null
+  values: Partial<ValuesMap>
   dependentFilterIds: Set<keyof ValuesMap>
 }
 

--- a/packages/components/src/FilterBar/context/types.ts
+++ b/packages/components/src/FilterBar/context/types.ts
@@ -27,6 +27,7 @@ export type FilterBarStateFilters<ValuesMap extends FiltersValues> = {
 }
 
 export type FilterBarState<ValuesMap extends FiltersValues> = {
+  hasUpdatedValues: boolean
   filters: FilterBarStateFilters<ValuesMap>
   activeFilterIds: Set<keyof ValuesMap>
   values: Partial<ValuesMap> | null

--- a/packages/components/src/FilterBar/context/utils/checkShouldUpdateValues.spec.ts
+++ b/packages/components/src/FilterBar/context/utils/checkShouldUpdateValues.spec.ts
@@ -26,6 +26,7 @@ const state = {
   activeFilterIds: new Set<keyof Values>(["flavour"]),
   values: {},
   dependentFilterIds: new Set(),
+  hasUpdatedValues: false,
 } satisfies FilterBarState<Values>
 
 describe("checkShouldUpdateValues()", () => {

--- a/packages/components/src/FilterBar/context/utils/checkShouldUpdateValues.ts
+++ b/packages/components/src/FilterBar/context/utils/checkShouldUpdateValues.ts
@@ -11,7 +11,7 @@ export const checkShouldUpdateValues = <ValuesMap extends FiltersValues>(
   values: Partial<ValuesMap>
 ): boolean =>
   Object.values(state.filters).some(({ id }) => {
-    const stateValue = state.values![id]
+    const stateValue = state.values[id]
     const value = values[id]
 
     if (Array.isArray(stateValue) && Array.isArray(value)) {

--- a/packages/components/src/FilterBar/context/utils/getInactiveFilters.spec.ts
+++ b/packages/components/src/FilterBar/context/utils/getInactiveFilters.spec.ts
@@ -30,6 +30,7 @@ describe("getInactiveFilters()", () => {
       activeFilterIds: new Set<keyof Values>(["flavour"]),
       values: {},
       dependentFilterIds: new Set(),
+      hasUpdatedValues: false,
     } satisfies FilterBarState<Values>
 
     expect(getInactiveFilters<Values>(state)).toEqual([
@@ -59,6 +60,7 @@ describe("getInactiveFilters()", () => {
       activeFilterIds: new Set<keyof Values>(),
       values: {},
       dependentFilterIds: new Set<keyof Values>(["sugarLevel"]),
+      hasUpdatedValues: false,
     } satisfies FilterBarState<Values>
 
     expect(getInactiveFilters<Values>(state)).toEqual([stateFilters.flavour])

--- a/packages/components/src/FilterBar/context/utils/getIsUsableWhenArgs.spec.ts
+++ b/packages/components/src/FilterBar/context/utils/getIsUsableWhenArgs.spec.ts
@@ -30,6 +30,7 @@ describe("getIsUsableWhenArgs()", () => {
       activeFilterIds: new Set<keyof Values>(["flavour"]),
       values: { flavour: "jasmine" },
       dependentFilterIds: new Set(),
+      hasUpdatedValues: false,
     } satisfies FilterBarState<Values>
 
     const usableArgs = getIsUsableWhenArgs<Values>(state)

--- a/packages/components/src/FilterBar/context/utils/getIsUsableWhenArgs.ts
+++ b/packages/components/src/FilterBar/context/utils/getIsUsableWhenArgs.ts
@@ -12,7 +12,7 @@ export const getIsUsableWhenArgs = <ValuesMap extends FiltersValues>({
         id,
         name,
         isActive: activeFilterIds.has(id),
-        value: values![id],
+        value: values[id],
       }
       return acc
     },

--- a/packages/components/src/FilterBar/context/utils/updateDependentFilters.spec.ts
+++ b/packages/components/src/FilterBar/context/utils/updateDependentFilters.spec.ts
@@ -39,6 +39,7 @@ describe("updateDependentFilters()", () => {
       activeFilterIds: new Set<keyof Values>(["flavour"]),
       values: { flavour: "jasmine" },
       dependentFilterIds: new Set(),
+      hasUpdatedValues: false,
     } satisfies FilterBarState<Values>
 
     const newState = updateDependentFilters<Values>(state)
@@ -53,6 +54,7 @@ describe("updateDependentFilters()", () => {
       activeFilterIds: new Set<keyof Values>(["flavour"]),
       values: { flavour: "jasmine" },
       dependentFilterIds: new Set<keyof Values>(["sugarLevel"]),
+      hasUpdatedValues: false,
     } satisfies FilterBarState<Values>
 
     const newState = updateDependentFilters<Values>(state)
@@ -76,6 +78,7 @@ describe("updateDependentFilters()", () => {
       activeFilterIds: new Set<keyof Values>(["flavour"]),
       values: { flavour: "jasmine" },
       dependentFilterIds: new Set<keyof Values>(["sugarLevel"]),
+      hasUpdatedValues: false,
     } satisfies FilterBarState<Values>
 
     updateDependentFilters<Values>(state)
@@ -96,6 +99,7 @@ describe("updateDependentFilters()", () => {
         activeFilterIds: new Set<keyof Values>(["flavour"]),
         values: { flavour: "jasmine" },
         dependentFilterIds: new Set<keyof Values>(["sugarLevel"]),
+        hasUpdatedValues: false,
       } satisfies FilterBarState<Values>
 
       const newState = updateDependentFilters<Values>(state)
@@ -114,6 +118,7 @@ describe("updateDependentFilters()", () => {
         activeFilterIds: new Set<keyof Values>(["flavour"]),
         values: { flavour: "jasmine" },
         dependentFilterIds: new Set<keyof Values>(["sugarLevel"]),
+        hasUpdatedValues: false,
       } satisfies FilterBarState<Values>
 
       const newState = updateDependentFilters<Values>(state)
@@ -135,6 +140,7 @@ describe("updateDependentFilters()", () => {
         activeFilterIds: new Set<keyof Values>(["flavour"]),
         values: { flavour: "jasmine", sugarLevel: 50 },
         dependentFilterIds: new Set<keyof Values>(["sugarLevel"]),
+        hasUpdatedValues: false,
       } satisfies FilterBarState<Values>
 
       const newState = updateDependentFilters<Values>(state)
@@ -156,6 +162,7 @@ describe("updateDependentFilters()", () => {
         activeFilterIds: new Set<keyof Values>(["flavour"]),
         values: { flavour: "jasmine" },
         dependentFilterIds: new Set<keyof Values>(["sugarLevel"]),
+        hasUpdatedValues: false,
       } satisfies FilterBarState<Values>
 
       const newState = updateDependentFilters<Values>(state)
@@ -170,11 +177,13 @@ describe("updateDependentFilters()", () => {
         activeFilterIds: new Set<keyof Values>(["flavour"]),
         values: { sugarLevel: 50 },
         dependentFilterIds: new Set<keyof Values>(["sugarLevel"]),
+        hasUpdatedValues: false,
       } satisfies FilterBarState<Values>
 
       const newState = updateDependentFilters<Values>(state)
       expect(newState.filters.sugarLevel.isUsable).toBe(false)
       expect(newState.values).toEqual({})
+      expect(newState.hasUpdatedValues).toBe(true)
     })
   })
 })

--- a/packages/components/src/FilterBar/context/utils/updateDependentFilters.ts
+++ b/packages/components/src/FilterBar/context/utils/updateDependentFilters.ts
@@ -22,16 +22,17 @@ export const updateDependentFilters = <ValuesMap extends FiltersValues>(
 
     if (!isUsable) {
       state.activeFilterIds.delete(id)
-      state.values![id] = undefined
+      state.values[id] = undefined
+      state.hasUpdatedValues = true
       return
     }
 
-    if (!state.filters[id].isRemovable || state.values![id] !== undefined) {
+    if (!state.filters[id].isRemovable || state.values[id] !== undefined) {
       state.activeFilterIds.add(id)
     }
   })
 
-  if (hasChange) updateDependentFilters({ ...state, hasUpdatedValues: true })
+  if (hasChange) updateDependentFilters(state)
 
   return state
 }

--- a/packages/components/src/FilterBar/context/utils/updateDependentFilters.ts
+++ b/packages/components/src/FilterBar/context/utils/updateDependentFilters.ts
@@ -31,7 +31,7 @@ export const updateDependentFilters = <ValuesMap extends FiltersValues>(
     }
   })
 
-  if (hasChange) updateDependentFilters(state)
+  if (hasChange) updateDependentFilters({ ...state, hasUpdatedValues: true })
 
   return state
 }

--- a/packages/components/src/FilterBar/subcomponents/FilterBarDatePicker/FilterBarDatePicker.tsx
+++ b/packages/components/src/FilterBar/subcomponents/FilterBarDatePicker/FilterBarDatePicker.tsx
@@ -28,9 +28,8 @@ export const FilterBarDatePicker = ({
   locale = "en-AU",
   ...props
 }: FilterBarDatePickerProps): JSX.Element => {
-  const { getFilterState, toggleOpenFilter, updateValue } = useFilterBarContext<
-    Date | undefined
-  >()
+  const { getFilterState, setFilterOpenState, updateValue } =
+    useFilterBarContext<Date | undefined>()
 
   if (!id) throw Error("Missing `id` prop in FilterBarDatePicker")
 
@@ -55,7 +54,7 @@ export const FilterBarDatePicker = ({
         onDateChange?.(key)
       }}
       isOpen={filterState.isOpen}
-      setIsOpen={(open): void => toggleOpenFilter(id, open)}
+      setIsOpen={(open): void => setFilterOpenState(id, open)}
     />
   )
 }

--- a/packages/components/src/FilterBar/subcomponents/FilterBarDateRangePicker/FilterBarDateRangePicker.tsx
+++ b/packages/components/src/FilterBar/subcomponents/FilterBarDateRangePicker/FilterBarDateRangePicker.tsx
@@ -29,9 +29,8 @@ export const FilterBarDateRangePicker = ({
   locale = "en-AU",
   ...props
 }: FilterBarDateRangePickerProps): JSX.Element => {
-  const { getFilterState, toggleOpenFilter, updateValue } = useFilterBarContext<
-    DateRange | undefined
-  >()
+  const { getFilterState, setFilterOpenState, updateValue } =
+    useFilterBarContext<DateRange | undefined>()
 
   if (!id) throw Error("Missing `id` prop in FilterBarDateRangePicker")
 
@@ -50,7 +49,7 @@ export const FilterBarDateRangePicker = ({
         />
       )}
       isOpen={filterState.isOpen}
-      setIsOpen={(open): void => toggleOpenFilter(id, open)}
+      setIsOpen={(open): void => setFilterOpenState(id, open)}
       selectedRange={filterState.value}
       onRangeChange={(range): void => {
         updateValue(id, range)

--- a/packages/components/src/FilterBar/subcomponents/FilterBarMultiSelect/FilterBarMultiSelect.tsx
+++ b/packages/components/src/FilterBar/subcomponents/FilterBarMultiSelect/FilterBarMultiSelect.tsx
@@ -46,7 +46,7 @@ export const FilterBarMultiSelect = ({
   onSelectionChange,
   ...props
 }: FilterBarMultiSelectProps): JSX.Element | null => {
-  const { getFilterState, toggleOpenFilter, updateValue, hideFilter } =
+  const { getFilterState, setFilterOpenState, updateValue, hideFilter } =
     useFilterBarContext<ConsumableSelection>()
   const [items, setItems] = useState<ItemType[]>(propsItems)
 
@@ -85,7 +85,7 @@ export const FilterBarMultiSelect = ({
       }}
       items={items}
       isOpen={filterState.isOpen}
-      onOpenChange={(open): void => toggleOpenFilter(id, open)}
+      onOpenChange={(open): void => setFilterOpenState(id, open)}
       trigger={(): JSX.Element => {
         const triggerProps = {
           selectedOptionLabels: filterState.value

--- a/packages/components/src/FilterBar/subcomponents/FilterBarSelect/FilterBarSelect.tsx
+++ b/packages/components/src/FilterBar/subcomponents/FilterBarSelect/FilterBarSelect.tsx
@@ -23,9 +23,8 @@ export const FilterBarSelect = <Option extends SelectOption = SelectOption>({
   onSelectionChange,
   ...props
 }: FilterBarSelectProps<Option>): JSX.Element => {
-  const { getFilterState, toggleOpenFilter, updateValue } = useFilterBarContext<
-    Option["value"] | undefined
-  >()
+  const { getFilterState, setFilterOpenState, updateValue } =
+    useFilterBarContext<Option["value"] | undefined>()
   const [items, setItems] = useState<Array<SelectItem<Option>>>(propsItems)
 
   if (!id) throw Error("Missing `id` prop in FilterBarSelect")
@@ -65,7 +64,7 @@ export const FilterBarSelect = <Option extends SelectOption = SelectOption>({
         onSelectionChange?.(key)
       }}
       isOpen={filterState.isOpen}
-      setIsOpen={(open): void => toggleOpenFilter(id, open)}
+      setIsOpen={(open): void => setFilterOpenState(id, open)}
     />
   )
 }


### PR DESCRIPTION
## Why
<!-- Why have you created this PR? - Is it a new feature, or a bug fix? Or something else? -->
<!-- Reference any relevant Jira tickets so your reviewer can find more context if needed. -->
<!-- Fixing a GitHub issue? Add "Fixes [issue URL]". -->
[KDS-1474](https://cultureamp.atlassian.net/jira/software/projects/KDS/boards/289?selectedIssue=KDS-1474)

Pathfinder have a use case where they want to open a DateRangePicker when they select a custom value from a Select.

## What
<!-- What do your changes do? How do they change/fix the current behavior? -->
<!-- Add screenshots, GIFs or videos to illustrate the changes.  -->

- Prevent infinite loop when calling `toggleOpenFilter` from selecting a value.
- Deprecate `toggleOpenFilter`, and replace with `setFilterOpenState` for clearer function intent.
- Add context util `openFilter` for consumers to be able to open a filter through an event from another filter.

[KDS-1474]: https://cultureamp.atlassian.net/browse/KDS-1474?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ