### PR TITLE
update stylelint rc following prettier v3 update

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -107,6 +107,7 @@
         "ignoreProperties": ["composes", "/font-family/"]
       }
     ],
-    "value-no-vendor-prefix": true
+    "value-no-vendor-prefix": true,
+    "scss/dollar-variable-colon-space-after": "always-single-line"
   }
 }

--- a/packages/select/package.json
+++ b/packages/select/package.json
@@ -15,7 +15,12 @@
   "bugs": {
     "url": "https://github.com/cultureamp/kaizen-design-system/issues"
   },
-  "files": ["**/*.js", "**/*.js.map", "**/*.d.ts", "**/*.scss"],
+  "files": [
+    "**/*.js",
+    "**/*.js.map",
+    "**/*.d.ts",
+    "**/*.scss"
+  ],
   "author": "",
   "private": false,
   "license": "MIT",


### PR DESCRIPTION
## Why
update stylelint rc following prettier v3 update


## What
- adds rule to allow no space after : in scss variables on multi-line declarations
