### PR TITLE
fix(filter-date-picker): only close popover when submitting value

### DIFF
--- a/.changeset/metal-beers-reflect.md
+++ b/.changeset/metal-beers-reflect.md
@@ -1,0 +1,5 @@
+---
+"@kaizen/components": patch
+---
+
+Fix bug in `FilterDatePicker` where popover would close when blurring input as soon as a value exists.

--- a/packages/components/src/FilterDatePicker/FilterDatePicker.playwright.spec.tsx
+++ b/packages/components/src/FilterDatePicker/FilterDatePicker.playwright.spec.tsx
@@ -1,0 +1,27 @@
+import { expect, test } from "@playwright/test"
+
+const iframePath = "iframe.html?args=&id="
+const storyId = "components-filter-date-picker--playground"
+test.beforeEach(async ({ page }) => {
+  // Go to the starting url before each test.
+  await page.goto(`./${iframePath}${storyId}`)
+})
+
+test.describe("<FilterDatePicker>", () => {
+  test("popover does not re-open after submitting using the Enter key", async ({
+    page,
+  }) => {
+    const triggerButton = page.getByRole("button", { name: "Date" })
+    await triggerButton.click()
+
+    await expect(page.getByRole("dialog")).toBeVisible()
+
+    const inputDate = page.getByLabel("Date")
+    await inputDate.click()
+    await inputDate.type("03/05/2022")
+    await page.keyboard.press("Enter")
+
+    // Ensure the popover didn't re-open.
+    await expect(page.getByRole("dialog")).not.toBeVisible()
+  })
+})

--- a/packages/components/src/FilterDatePicker/FilterDatePicker.spec.tsx
+++ b/packages/components/src/FilterDatePicker/FilterDatePicker.spec.tsx
@@ -164,6 +164,31 @@ describe("<FilterDatePicker />", () => {
       expect(dialog).toBeInTheDocument()
     })
   })
+  it("does not close the popover when there is a selected date and the user navigates months", async () => {
+    const { getByRole } = render(
+      <FilterDatePickerWrapper selectedDate={new Date("01/01/2022")} />
+    )
+    const triggerButton = getByRole("button", {
+      name: "Drank : 1 Jan 2022",
+    })
+
+    await user.click(triggerButton)
+    const dialog = getByRole("dialog")
+
+    await waitFor(() => {
+      expect(dialog).toBeInTheDocument()
+    })
+
+    const navigateMonthsButton = getByRole("button", {
+      name: "Go to next month",
+    })
+
+    await user.click(navigateMonthsButton)
+
+    await waitFor(() => {
+      expect(dialog).toBeInTheDocument()
+    })
+  })
 
   it("updates the selected value in the trigger button when typing a date", async () => {
     const { getByRole, getByLabelText } = render(

--- a/packages/components/src/FilterDatePicker/FilterDatePicker.spec.tsx
+++ b/packages/components/src/FilterDatePicker/FilterDatePicker.spec.tsx
@@ -86,53 +86,82 @@ describe("<FilterDatePicker />", () => {
     })
   })
 
-  it("closes the popover when a valid date has been submitted via the text input field", async () => {
-    const { getByRole, getByLabelText } = render(<FilterDatePickerWrapper />)
-    const triggerButton = getByRole("button", {
-      name: "Drank",
+  describe("Text input", () => {
+    it("validates the date on blur", async () => {
+      const { getByRole, getByLabelText, getByText } = render(
+        <FilterDatePickerWrapper />
+      )
+      const triggerButton = getByRole("button", {
+        name: "Drank",
+      })
+
+      await user.click(triggerButton)
+      const dialog = getByRole("dialog")
+
+      await waitFor(() => {
+        expect(dialog).toBeInTheDocument()
+      })
+
+      const inputDate = getByLabelText("Date")
+      await user.clear(inputDate)
+      await user.type(inputDate, "32/13/2022")
+      await user.tab()
+
+      await waitFor(() => {
+        expect(getByText("32/13/2022 is an invalid date")).toBeInTheDocument()
+      })
     })
 
-    await user.click(triggerButton)
-    const dialog = getByRole("dialog")
+    describe("Pressing Enter in the text input", () => {
+      it("closes the popover when a valid date has been submitted via the text input field", async () => {
+        const { getByRole, getByLabelText } = render(
+          <FilterDatePickerWrapper />
+        )
+        const triggerButton = getByRole("button", {
+          name: "Drank",
+        })
 
-    await waitFor(() => {
-      expect(dialog).toBeInTheDocument()
-    })
+        await user.click(triggerButton)
 
-    const inputDate = getByLabelText("Date")
-    await user.clear(inputDate)
-    await user.type(inputDate, "07/06/2022")
-    await user.tab()
+        const dialog = getByRole("dialog")
+        await waitFor(() => {
+          expect(dialog).toBeInTheDocument()
+        })
 
-    await waitFor(() => {
-      expect(dialog).not.toBeInTheDocument()
-    })
-  })
+        const inputDate = getByLabelText("Date")
+        await user.clear(inputDate)
+        await user.type(inputDate, "07/06/2022")
+        await user.keyboard("{Enter}")
 
-  it("does not close the popover when an invalid date has been submitted via the text input field", async () => {
-    const { getByRole, getByLabelText, getByText } = render(
-      <FilterDatePickerWrapper />
-    )
-    const triggerButton = getByRole("button", {
-      name: "Drank",
-    })
+        await waitFor(() => {
+          expect(dialog).not.toBeInTheDocument()
+        })
+      })
 
-    await user.click(triggerButton)
-    const dialog = getByRole("dialog")
+      it("does not close the popover when an invalid date has been submitted via the text input field", async () => {
+        const { getByRole, getByLabelText, getByText } = render(
+          <FilterDatePickerWrapper />
+        )
+        const triggerButton = getByRole("button", {
+          name: "Drank",
+        })
 
-    await waitFor(() => {
-      expect(dialog).toBeInTheDocument()
-    })
+        await user.click(triggerButton)
+        const dialog = getByRole("dialog")
 
-    const inputDate = getByLabelText("Date")
-    await user.clear(inputDate)
-    await user.type(inputDate, "32/13/2022")
-    await user.tab()
+        await waitFor(() => {
+          expect(dialog).toBeInTheDocument()
+        })
 
-    await waitFor(() => {
-      expect(getByText("32/13/2022 is an invalid date")).toBeInTheDocument()
-      // We are double checking that the popover has not closed
-      expect(dialog).toBeInTheDocument()
+        const inputDate = getByLabelText("Date")
+        await user.clear(inputDate)
+        await user.type(inputDate, "32/13/2022")
+        await user.keyboard("{Enter}")
+
+        await waitFor(() => {
+          expect(getByText("32/13/2022 is an invalid date")).toBeInTheDocument()
+        })
+      })
     })
   })
 
@@ -164,6 +193,7 @@ describe("<FilterDatePicker />", () => {
       expect(dialog).toBeInTheDocument()
     })
   })
+
   it("does not close the popover when there is a selected date and the user navigates months", async () => {
     const { getByRole } = render(
       <FilterDatePickerWrapper selectedDate={new Date("01/01/2022")} />

--- a/packages/components/src/FilterDatePicker/_docs/FilterDatePicker.stories.tsx
+++ b/packages/components/src/FilterDatePicker/_docs/FilterDatePicker.stories.tsx
@@ -300,8 +300,13 @@ export const Validation: StoryFn = () => {
   const submitRequest: React.FormEventHandler<HTMLFormElement> = e => {
     e.preventDefault()
 
-    setValidationMessage({ status: "error", message: "Error for date" })
-    return alert("Error")
+    const status = validationMessage?.status
+    if (status === "error" || status === "caution") {
+      setValidationMessage({ status: "error", message: "There is an error" })
+      return alert("Error")
+    }
+
+    alert("Success")
   }
 
   return (

--- a/packages/components/src/FilterDatePicker/hooks/useDateInputHandlers.spec.ts
+++ b/packages/components/src/FilterDatePicker/hooks/useDateInputHandlers.spec.ts
@@ -1,0 +1,355 @@
+import { ChangeEvent, FocusEvent, KeyboardEvent, SetStateAction } from "react"
+import { renderHook, act } from "@testing-library/react-hooks"
+import { enAU } from "date-fns/locale"
+import * as isSelectingDayInCalendar from "@kaizen/date-picker/src/utils/isSelectingDayInCalendar"
+import { useDateInputHandlers } from "./useDateInputHandlers"
+
+const locale = enAU
+const setInputValue = jest.fn<void, [SetStateAction<string>]>()
+const onDateChange = jest.fn<void, [Date | undefined]>()
+
+describe("useDateInputHandlers", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe("onChange", () => {
+    it("updates input value", () => {
+      const { result } = renderHook(() =>
+        useDateInputHandlers({
+          locale,
+          setInputValue,
+          onDateChange,
+        })
+      )
+      const { onChange } = result.current
+
+      act(() => {
+        onChange?.({
+          currentTarget: { value: "a" },
+        } as ChangeEvent<HTMLInputElement>)
+      })
+
+      expect(setInputValue).toHaveBeenCalledWith("a")
+    })
+
+    it("calls custom onChange when provided", () => {
+      const onChangeMock = jest.fn<void, [ChangeEvent]>()
+
+      const { result } = renderHook(() =>
+        useDateInputHandlers({
+          locale,
+          setInputValue,
+          onDateChange,
+          onChange: onChangeMock,
+        })
+      )
+      const { onChange } = result.current
+      const changeEvent = {
+        currentTarget: { value: "a" },
+      } as ChangeEvent<HTMLInputElement>
+
+      act(() => {
+        onChange?.(changeEvent)
+      })
+
+      expect(onChangeMock).toHaveBeenCalledWith(changeEvent)
+    })
+  })
+
+  describe("onFocus", () => {
+    it("transforms input value when it is a valid date", () => {
+      const { result } = renderHook(() =>
+        useDateInputHandlers({
+          locale,
+          setInputValue,
+          onDateChange,
+        })
+      )
+      const { onFocus } = result.current
+
+      act(() => {
+        onFocus?.({
+          currentTarget: { value: "1 May 2022" },
+        } as FocusEvent<HTMLInputElement>)
+      })
+
+      expect(setInputValue).toHaveBeenCalledWith("01/05/2022")
+    })
+
+    it("does not transform input value when it is an invalid date", () => {
+      const { result } = renderHook(() =>
+        useDateInputHandlers({
+          locale,
+          setInputValue,
+          onDateChange,
+        })
+      )
+      const { onFocus } = result.current
+
+      act(() => {
+        onFocus?.({
+          currentTarget: { value: "potato" },
+        } as FocusEvent<HTMLInputElement>)
+      })
+
+      expect(setInputValue).not.toHaveBeenCalled()
+    })
+
+    it("calls custom onFocus when provided", () => {
+      const onFocusMock = jest.fn<void, [FocusEvent<HTMLInputElement>]>()
+
+      const { result } = renderHook(() =>
+        useDateInputHandlers({
+          locale,
+          setInputValue,
+          onDateChange,
+          onFocus: onFocusMock,
+        })
+      )
+      const { onFocus } = result.current
+      const focusEvent = {
+        currentTarget: { value: "potato" },
+      } as FocusEvent<HTMLInputElement>
+
+      act(() => {
+        onFocus?.(focusEvent)
+      })
+
+      expect(onFocusMock).toHaveBeenCalledWith(focusEvent)
+    })
+  })
+
+  describe("onBlur", () => {
+    it("does not do anything when selecting a day in the calendar", () => {
+      const onBlurMock = jest.fn<void, [FocusEvent<HTMLInputElement>]>()
+      const { result } = renderHook(() =>
+        useDateInputHandlers({
+          locale,
+          setInputValue,
+          onDateChange,
+          onBlur: onBlurMock,
+        })
+      )
+      const { onBlur } = result.current
+      const blurEvent = {
+        currentTarget: { value: "" },
+      } as FocusEvent<HTMLInputElement>
+
+      const spy = jest.spyOn(
+        isSelectingDayInCalendar,
+        "isSelectingDayInCalendar"
+      )
+      spy.mockReturnValue(true)
+
+      act(() => {
+        onBlur?.(blurEvent)
+      })
+
+      expect(onBlurMock).not.toHaveBeenCalled()
+
+      spy.mockReset()
+    })
+
+    it("changes date to undefined when input is empty", () => {
+      const { result } = renderHook(() =>
+        useDateInputHandlers({
+          locale,
+          setInputValue,
+          onDateChange,
+        })
+      )
+      const { onBlur } = result.current
+      const blurEvent = {
+        currentTarget: { value: "" },
+      } as FocusEvent<HTMLInputElement>
+
+      act(() => {
+        onBlur?.(blurEvent)
+      })
+
+      expect(setInputValue).not.toHaveBeenCalled()
+      expect(onDateChange).toHaveBeenCalledWith(undefined)
+    })
+
+    it("transforms input value when it is a valid date", () => {
+      const { result } = renderHook(() =>
+        useDateInputHandlers({
+          locale,
+          setInputValue,
+          onDateChange,
+        })
+      )
+      const { onBlur } = result.current
+      const blurEvent = {
+        currentTarget: { value: "01/05/2022" },
+      } as FocusEvent<HTMLInputElement>
+
+      act(() => {
+        onBlur?.(blurEvent)
+      })
+
+      expect(setInputValue).toHaveBeenCalledWith("1 May 2022")
+      expect(onDateChange).toHaveBeenCalledWith(new Date("2022-05-1"))
+    })
+
+    it("does not transform input value when it is an invalid date", () => {
+      const { result } = renderHook(() =>
+        useDateInputHandlers({
+          locale,
+          setInputValue,
+          onDateChange,
+        })
+      )
+      const { onBlur } = result.current
+      const blurEvent = {
+        currentTarget: { value: "potato" },
+      } as FocusEvent<HTMLInputElement>
+
+      act(() => {
+        onBlur?.(blurEvent)
+      })
+
+      expect(setInputValue).not.toHaveBeenCalled()
+      // Called with the invalid Date object
+      expect(onDateChange).toHaveBeenCalledTimes(1)
+    })
+
+    it("does not transform input value when it is a disabled date", () => {
+      const { result } = renderHook(() =>
+        useDateInputHandlers({
+          locale,
+          disabledDays: new Date("2022-05-01"),
+          setInputValue,
+          onDateChange,
+        })
+      )
+      const { onBlur } = result.current
+      const blurEvent = {
+        currentTarget: { value: "01/05/2022" },
+      } as FocusEvent<HTMLInputElement>
+
+      act(() => {
+        onBlur?.(blurEvent)
+      })
+
+      expect(setInputValue).not.toHaveBeenCalled()
+      expect(onDateChange).toHaveBeenCalledWith(new Date("2022-05-01"))
+    })
+
+    it("calls custom onBlur when provided on input with value", () => {
+      const onBlurMock = jest.fn<void, [FocusEvent<HTMLInputElement>]>()
+      const { result } = renderHook(() =>
+        useDateInputHandlers({
+          locale,
+          setInputValue,
+          onDateChange,
+          onBlur: onBlurMock,
+        })
+      )
+      const { onBlur } = result.current
+      const blurEvent = {
+        currentTarget: { value: "1 May 2022" },
+      } as FocusEvent<HTMLInputElement>
+
+      act(() => {
+        onBlur?.(blurEvent)
+      })
+
+      expect(onBlurMock).toHaveBeenCalledWith(blurEvent)
+    })
+
+    it("calls custom onBlur when provided on empty", () => {
+      const onBlurMock = jest.fn<void, [FocusEvent<HTMLInputElement>]>()
+      const { result } = renderHook(() =>
+        useDateInputHandlers({
+          locale,
+          setInputValue,
+          onDateChange,
+          onBlur: onBlurMock,
+        })
+      )
+      const { onBlur } = result.current
+      const blurEvent = {
+        currentTarget: { value: "" },
+      } as FocusEvent<HTMLInputElement>
+
+      act(() => {
+        onBlur?.(blurEvent)
+      })
+
+      expect(onBlurMock).toHaveBeenCalledWith(blurEvent)
+    })
+  })
+
+  describe("onKeyDown - Enter", () => {
+    it("calls onDateChange with date", () => {
+      const { result } = renderHook(() =>
+        useDateInputHandlers({
+          locale,
+          setInputValue,
+          onDateChange,
+        })
+      )
+      const { onKeyDown } = result.current
+
+      act(() => {
+        onKeyDown?.({
+          preventDefault: (): void => undefined,
+          currentTarget: { value: "01/05/2022" },
+          key: "Enter",
+        } as KeyboardEvent<HTMLInputElement>)
+      })
+
+      expect(onDateChange).toBeCalledWith(new Date("2022-05-01"))
+    })
+
+    it("calls onDateSubmit when provided", () => {
+      const onDateSubmit = jest.fn<void, [Date]>()
+
+      const { result } = renderHook(() =>
+        useDateInputHandlers({
+          locale,
+          setInputValue,
+          onDateChange,
+          onDateSubmit,
+        })
+      )
+      const { onKeyDown } = result.current
+      const keyboardEvent = {
+        preventDefault: (): void => undefined,
+        currentTarget: { value: "01/05/2022" },
+        key: "Enter",
+      } as KeyboardEvent<HTMLInputElement>
+
+      act(() => {
+        onKeyDown?.(keyboardEvent)
+      })
+
+      expect(onDateSubmit).toBeCalledWith(new Date("2022-05-01"))
+    })
+
+    it("calls custom onKeyDown when provided", () => {
+      const onKeyDownMock = jest.fn<void, [KeyboardEvent]>()
+
+      const { result } = renderHook(() =>
+        useDateInputHandlers({
+          locale,
+          setInputValue,
+          onDateChange,
+          onKeyDown: onKeyDownMock,
+        })
+      )
+      const { onKeyDown } = result.current
+      const keyboardEvent = {
+        currentTarget: { value: "potato" },
+      } as KeyboardEvent<HTMLInputElement>
+
+      act(() => {
+        onKeyDown?.(keyboardEvent)
+      })
+
+      expect(onKeyDownMock).toBeCalledWith(keyboardEvent)
+    })
+  })
+})

--- a/packages/components/src/FilterDatePicker/hooks/useDateInputHandlers.ts
+++ b/packages/components/src/FilterDatePicker/hooks/useDateInputHandlers.ts
@@ -1,0 +1,99 @@
+import {
+  DateInputProps,
+  formatDateAsText,
+  isInvalidDate,
+} from "@kaizen/date-picker"
+import { formatDateAsNumeral } from "@kaizen/date-picker/src/utils/formatDateAsNumeral"
+import { isDisabledDate } from "@kaizen/date-picker/src/utils/isDisabledDate"
+import { isSelectingDayInCalendar } from "@kaizen/date-picker/src/utils/isSelectingDayInCalendar"
+import { parseDateFromNumeralFormatValue } from "@kaizen/date-picker/src/utils/parseDateFromNumeralFormatValue"
+import { parseDateFromTextFormatValue } from "@kaizen/date-picker/src/utils/parseDateFromTextFormatValue"
+import { DisabledDays } from "~types/DatePicker"
+
+type UseDateInputHandlersArgs = {
+  locale: Locale
+  disabledDays?: DisabledDays
+  setInputValue: (value: string) => void
+  onDateChange: (date: Date | undefined) => void
+  onDateSubmit?: (date: Date) => void
+  onChange?: DateInputProps["onChange"]
+  onFocus?: DateInputProps["onFocus"]
+  onBlur?: DateInputProps["onBlur"]
+  onKeyDown?: DateInputProps["onKeyDown"]
+}
+
+type UseDateInputHandlersValue = {
+  onChange: DateInputProps["onChange"]
+  onFocus: DateInputProps["onFocus"]
+  onBlur: DateInputProps["onBlur"]
+  onKeyDown: DateInputProps["onKeyDown"]
+}
+
+export const useDateInputHandlers = ({
+  locale,
+  disabledDays,
+  setInputValue,
+  onDateChange,
+  onDateSubmit,
+  onChange,
+  onFocus,
+  onBlur,
+  onKeyDown,
+}: UseDateInputHandlersArgs): UseDateInputHandlersValue => {
+  const isValidDate = (date: Date): boolean =>
+    !isInvalidDate(date) && !isDisabledDate(date, disabledDays)
+
+  const handleChange: DateInputProps["onChange"] = e => {
+    setInputValue(e.currentTarget.value)
+    onChange?.(e)
+  }
+
+  const handleFocus: DateInputProps["onFocus"] = e => {
+    const date = parseDateFromTextFormatValue(e.currentTarget.value, locale)
+    if (!isInvalidDate(date)) {
+      const newInputValue = formatDateAsNumeral(date, locale)
+      setInputValue(newInputValue)
+    }
+    onFocus?.(e)
+  }
+
+  const handleBlur: DateInputProps["onBlur"] = e => {
+    if (isSelectingDayInCalendar(e.relatedTarget)) return
+
+    if (e.currentTarget.value === "") {
+      onDateChange(undefined)
+      onBlur?.(e)
+      return
+    }
+
+    const date = parseDateFromNumeralFormatValue(e.currentTarget.value, locale)
+
+    if (isValidDate(date)) {
+      const newInputValue = formatDateAsText(date, disabledDays, locale)
+      setInputValue(newInputValue)
+    }
+
+    onDateChange(date)
+    onBlur?.(e)
+  }
+
+  const handleKeyDown: DateInputProps["onKeyDown"] = e => {
+    if (e.key === "Enter") {
+      e.preventDefault()
+      const date = parseDateFromNumeralFormatValue(
+        e.currentTarget.value,
+        locale
+      )
+      onDateChange(date)
+      onDateSubmit?.(date)
+    }
+    onKeyDown?.(e)
+  }
+
+  return {
+    onChange: handleChange,
+    onFocus: handleFocus,
+    onBlur: handleBlur,
+    onKeyDown: handleKeyDown,
+  }
+}

--- a/packages/components/src/FilterDatePicker/subcomponents/FilterDatePickerField/FilterDatePickerField.spec.tsx
+++ b/packages/components/src/FilterDatePicker/subcomponents/FilterDatePickerField/FilterDatePickerField.spec.tsx
@@ -91,8 +91,49 @@ describe("<FilterDatePickerField />", () => {
         await waitFor(() => {
           expect(inputDate).toHaveValue("1 May 2022")
           expect(inputDateOnBlur).toHaveBeenCalled()
-          expect(inputDateOnSubmit).toHaveBeenCalledWith(new Date("2022-05-01"))
           expect(targetDay).toHaveAttribute("aria-pressed", "true")
+        })
+      })
+    })
+
+    describe("Press Enter key", () => {
+      it("updates calendar values and calls submit when the date is valid", async () => {
+        render(
+          <FilterDatePickerFieldWrapper selectedDate={new Date("2022-05-02")} />
+        )
+
+        const inputDate = screen.getByLabelText("Date")
+        expect(inputDate).toHaveValue("2 May 2022")
+
+        const targetDay = screen.getByRole("button", {
+          name: "1st May (Sunday)",
+        })
+        expect(targetDay).not.toHaveAttribute("aria-pressed")
+
+        await user.click(inputDate)
+        await user.clear(inputDate)
+        await user.type(inputDate, "01/05/2022")
+        await user.keyboard("{Enter}")
+
+        await waitFor(() => {
+          expect(targetDay).toHaveAttribute("aria-pressed", "true")
+          expect(inputDateOnSubmit).toHaveBeenCalledWith(new Date("2022-05-01"))
+        })
+      })
+
+      it("does not call submit when the date is invalid", async () => {
+        render(
+          <FilterDatePickerFieldWrapper selectedDate={new Date("2022-05-02")} />
+        )
+
+        const inputDate = screen.getByLabelText("Date")
+        await user.click(inputDate)
+        await user.clear(inputDate)
+        await user.type(inputDate, "32/05/2022")
+        await user.keyboard("{Enter}")
+
+        await waitFor(() => {
+          expect(inputDateOnSubmit).not.toHaveBeenCalled()
         })
       })
     })
@@ -114,7 +155,6 @@ describe("<FilterDatePickerField />", () => {
 
       await waitFor(() => {
         expect(screen.queryByText("May 2022")).not.toBeInTheDocument()
-        expect(inputDateOnSubmit).toHaveBeenCalledWith(new Date("2020-02-19"))
       })
     })
   })

--- a/packages/components/src/FilterDatePicker/subcomponents/FilterDatePickerField/FilterDatePickerField.tsx
+++ b/packages/components/src/FilterDatePicker/subcomponents/FilterDatePickerField/FilterDatePickerField.tsx
@@ -133,12 +133,13 @@ export const FilterDatePickerField = ({
         date: newDate,
       })
 
-      // Only provide consumers with a valid date to the `onDateSubmit` function
-      if (newDate && !isInvalidDate(newDate)) {
-        onDateSubmit?.(newDate)
-      }
-
       handleDateChange(newDate)
+    },
+    onDateSubmit: date => {
+      // Only provide consumers with a valid date to the `onDateSubmit` function
+      if (!isInvalidDate(date)) {
+        onDateSubmit?.(date)
+      }
     },
     ...inputProps,
   })

--- a/packages/components/src/FilterDatePicker/subcomponents/FilterDatePickerField/FilterDatePickerField.tsx
+++ b/packages/components/src/FilterDatePicker/subcomponents/FilterDatePickerField/FilterDatePickerField.tsx
@@ -3,7 +3,6 @@ import classnames from "classnames"
 import {
   CalendarSingle,
   CalendarSingleProps,
-  useDateInputHandlers,
   isInvalidDate,
   getLocale,
 } from "@kaizen/date-picker"
@@ -14,6 +13,7 @@ import { DateInputDescriptionProps } from "~components/FilterDateRangePicker/sub
 import { DataAttributes } from "~types/DataAttributes"
 import { DisabledDays, FilterDateSupportedLocales } from "~types/DatePicker"
 import { OverrideClassName } from "~types/OverrideClassName"
+import { useDateInputHandlers } from "../../hooks/useDateInputHandlers"
 import { DateValidationResponse, ValidationMessage } from "../../types"
 import { DateInputField, DateInputFieldProps } from "../DateInputField"
 import { filterDatePickerFieldReducer } from "./filterDatePickerFieldReducer"

--- a/packages/components/src/FilterDatePicker/subcomponents/FilterDatePickerField/filterDatePickerFieldReducer.tsx
+++ b/packages/components/src/FilterDatePicker/subcomponents/FilterDatePickerField/filterDatePickerFieldReducer.tsx
@@ -37,12 +37,14 @@ export const filterDatePickerFieldReducer = (
         startMonth:
           action.date && !isInvalidDate(action.date) ? action.date : new Date(),
       }
+
     case "navigate_months":
       return {
         ...state,
         startMonth:
           action.date && !isInvalidDate(action.date) ? action.date : new Date(),
       }
+
     case "update_input_field":
       return {
         ...state,

--- a/packages/components/src/FilterDateRangePicker/subcomponents/FilterDateRangePickerField/FilterDateRangePickerField.tsx
+++ b/packages/components/src/FilterDateRangePicker/subcomponents/FilterDateRangePickerField/FilterDateRangePickerField.tsx
@@ -5,12 +5,12 @@ import {
   CalendarRange,
   CalendarRangeProps,
 } from "@kaizen/date-picker/src/_subcomponents/Calendar"
-import { useDateInputHandlers } from "@kaizen/date-picker/src/hooks/useDateInputHandlers"
 import { formatDateAsText } from "@kaizen/date-picker/src/utils/formatDateAsText"
 import { getLocale } from "@kaizen/date-picker/src/utils/getLocale"
 import { isInvalidDate } from "@kaizen/date-picker/src/utils/isInvalidDate"
 import { parseDateFromTextFormatValue } from "@kaizen/date-picker/src/utils/parseDateFromTextFormatValue"
 import { DateValidationResponse } from "~components/FilterDatePicker"
+import { useDateInputHandlers } from "~components/FilterDatePicker/hooks/useDateInputHandlers"
 import { DataAttributes } from "~types/DataAttributes"
 import {
   DateRange,

--- a/packages/date-picker/src/hooks/useDateInputHandlers.spec.ts
+++ b/packages/date-picker/src/hooks/useDateInputHandlers.spec.ts
@@ -283,7 +283,7 @@ describe("useDateInputHandlers", () => {
   })
 
   describe("onKeyDown - Enter", () => {
-    it("calls onDateChange with date", () => {
+    it("returns a date when date is valid", () => {
       const { result } = renderHook(() =>
         useDateInputHandlers({
           locale,
@@ -295,7 +295,6 @@ describe("useDateInputHandlers", () => {
 
       act(() => {
         onKeyDown?.({
-          preventDefault: (): void => undefined,
           currentTarget: { value: "01/05/2022" },
           key: "Enter",
         } as KeyboardEvent<HTMLInputElement>)
@@ -304,29 +303,24 @@ describe("useDateInputHandlers", () => {
       expect(onDateChange).toBeCalledWith(new Date("2022-05-01"))
     })
 
-    it("calls onDateSubmit when provided", () => {
-      const onDateSubmit = jest.fn<void, [Date]>()
-
+    it("returns undefined when date is invalid", () => {
       const { result } = renderHook(() =>
         useDateInputHandlers({
           locale,
           setInputValue,
           onDateChange,
-          onDateSubmit,
         })
       )
       const { onKeyDown } = result.current
-      const keyboardEvent = {
-        preventDefault: (): void => undefined,
-        currentTarget: { value: "01/05/2022" },
-        key: "Enter",
-      } as KeyboardEvent<HTMLInputElement>
 
       act(() => {
-        onKeyDown?.(keyboardEvent)
+        onKeyDown?.({
+          currentTarget: { value: "potato" },
+          key: "Enter",
+        } as KeyboardEvent<HTMLInputElement>)
       })
 
-      expect(onDateSubmit).toBeCalledWith(new Date("2022-05-01"))
+      expect(onDateChange).toBeCalledWith(undefined)
     })
 
     it("calls custom onKeyDown when provided", () => {

--- a/packages/date-picker/src/hooks/useDateInputHandlers.spec.ts
+++ b/packages/date-picker/src/hooks/useDateInputHandlers.spec.ts
@@ -283,7 +283,7 @@ describe("useDateInputHandlers", () => {
   })
 
   describe("onKeyDown - Enter", () => {
-    it("returns a date when date is valid", () => {
+    it("calls onDateChange with date", () => {
       const { result } = renderHook(() =>
         useDateInputHandlers({
           locale,
@@ -295,6 +295,7 @@ describe("useDateInputHandlers", () => {
 
       act(() => {
         onKeyDown?.({
+          preventDefault: (): void => undefined,
           currentTarget: { value: "01/05/2022" },
           key: "Enter",
         } as KeyboardEvent<HTMLInputElement>)
@@ -303,24 +304,29 @@ describe("useDateInputHandlers", () => {
       expect(onDateChange).toBeCalledWith(new Date("2022-05-01"))
     })
 
-    it("returns undefined when date is invalid", () => {
+    it("calls onDateSubmit when provided", () => {
+      const onDateSubmit = jest.fn<void, [Date]>()
+
       const { result } = renderHook(() =>
         useDateInputHandlers({
           locale,
           setInputValue,
           onDateChange,
+          onDateSubmit,
         })
       )
       const { onKeyDown } = result.current
+      const keyboardEvent = {
+        preventDefault: (): void => undefined,
+        currentTarget: { value: "01/05/2022" },
+        key: "Enter",
+      } as KeyboardEvent<HTMLInputElement>
 
       act(() => {
-        onKeyDown?.({
-          currentTarget: { value: "potato" },
-          key: "Enter",
-        } as KeyboardEvent<HTMLInputElement>)
+        onKeyDown?.(keyboardEvent)
       })
 
-      expect(onDateChange).toBeCalledWith(undefined)
+      expect(onDateSubmit).toBeCalledWith(new Date("2022-05-01"))
     })
 
     it("calls custom onKeyDown when provided", () => {

--- a/packages/date-picker/src/hooks/useDateInputHandlers.ts
+++ b/packages/date-picker/src/hooks/useDateInputHandlers.ts
@@ -14,6 +14,7 @@ export type UseDateInputHandlersArgs = {
   disabledDays?: DisabledDays
   setInputValue: Dispatch<string>
   onDateChange: (date: Date | undefined) => void
+  onDateSubmit?: (date: Date) => void
   onChange?: DateInputProps["onChange"]
   onFocus?: DateInputProps["onFocus"]
   onBlur?: DateInputProps["onBlur"]
@@ -32,6 +33,7 @@ export const useDateInputHandlers = ({
   disabledDays,
   setInputValue,
   onDateChange,
+  onDateSubmit,
   onChange,
   onFocus,
   onBlur,
@@ -76,11 +78,13 @@ export const useDateInputHandlers = ({
 
   const handleKeyDown: DateInputProps["onKeyDown"] = e => {
     if (e.key === "Enter") {
+      e.preventDefault()
       const date = parseDateFromNumeralFormatValue(
         e.currentTarget.value,
         locale
       )
-      onDateChange(isValidDate(date) ? date : undefined)
+      onDateChange(date)
+      onDateSubmit?.(date)
     }
     onKeyDown?.(e)
   }

--- a/packages/date-picker/src/hooks/useDateInputHandlers.ts
+++ b/packages/date-picker/src/hooks/useDateInputHandlers.ts
@@ -14,7 +14,6 @@ export type UseDateInputHandlersArgs = {
   disabledDays?: DisabledDays
   setInputValue: Dispatch<string>
   onDateChange: (date: Date | undefined) => void
-  onDateSubmit?: (date: Date) => void
   onChange?: DateInputProps["onChange"]
   onFocus?: DateInputProps["onFocus"]
   onBlur?: DateInputProps["onBlur"]
@@ -33,7 +32,6 @@ export const useDateInputHandlers = ({
   disabledDays,
   setInputValue,
   onDateChange,
-  onDateSubmit,
   onChange,
   onFocus,
   onBlur,
@@ -78,13 +76,11 @@ export const useDateInputHandlers = ({
 
   const handleKeyDown: DateInputProps["onKeyDown"] = e => {
     if (e.key === "Enter") {
-      e.preventDefault()
       const date = parseDateFromNumeralFormatValue(
         e.currentTarget.value,
         locale
       )
-      onDateChange(date)
-      onDateSubmit?.(date)
+      onDateChange(isValidDate(date) ? date : undefined)
     }
     onKeyDown?.(e)
   }

--- a/packages/date-picker/src/hooks/useDateInputHandlers.ts
+++ b/packages/date-picker/src/hooks/useDateInputHandlers.ts
@@ -27,6 +27,9 @@ export type UseDateInputHandlersValue = {
   onKeyDown: DateInputProps["onKeyDown"]
 }
 
+/**
+ * @deprecated Moved to @kaizen/components.
+ */
 export const useDateInputHandlers = ({
   locale,
   disabledDays,


### PR DESCRIPTION
## Why
<!-- Why have you created this PR? - Is it a new feature, or a bug fix? Or something else? -->
<!-- Reference any relevant Jira tickets so your reviewer can find more context if needed. -->
<!-- Fixing a GitHub issue? Add "Fixes [issue URL]". -->
[KDS-1621](https://cultureamp.atlassian.net/jira/software/projects/KDS/boards/289?selectedIssue=KDS-1621)

Team Pathfinder reported that the popover closed when attempting to navigate months after having selected a value.

After investigation, it was actually found to be due to the blur event of the input when a valid date exists.

## What
<!-- What do your changes do? How do they change/fix the current behavior? -->
<!-- Add screenshots, GIFs or videos to illustrate the changes.  -->

- Fix the logic so that the popover only closes when submitting a value.
- Add more tests
- Move `useDateInputHandlers` from `@kaizen/date-picker` to KAIO as the only usages of it are within KAIO (to prevent needing a release for date-picker for this fix)

[KDS-1621]: https://cultureamp.atlassian.net/browse/KDS-1621?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ