### PR TITLE
feat(filter-select): change the popover width to be more flexible

### DIFF
--- a/.changeset/gold-rings-remember.md
+++ b/.changeset/gold-rings-remember.md
@@ -1,0 +1,5 @@
+---
+"@kaizen/components": minor
+---
+
+Change the FilterSelect popover width to be between 196-400px.

--- a/packages/components/src/FilterSelect/FilterSelect.module.scss
+++ b/packages/components/src/FilterSelect/FilterSelect.module.scss
@@ -1,7 +1,9 @@
 @import "~@kaizen/design-tokens/sass/spacing";
 
 .filterContents {
-  width: 224px; // @todo: check this value
+  box-sizing: border-box;
+  min-width: 12.25rem; // 196px
+  max-width: 25rem; // 400px
   overflow: auto;
   padding: $spacing-12;
 }

--- a/packages/components/src/FilterSelect/_docs/FilterSelect.mdx
+++ b/packages/components/src/FilterSelect/_docs/FilterSelect.mdx
@@ -1,7 +1,8 @@
-import { ArgTypes, Controls, Description, Meta } from "@storybook/blocks"
+import { ArgTypes, Canvas, Controls, Description, Meta } from "@storybook/blocks"
 import { ResourceLinks, KaioNotification, Installation, NoClipCanvas } from "../../../../../storybook/components"
 import { LinkTo } from "../../../../../storybook/components/LinkTo"
 import * as FilterSelectStories from "./FilterSelect.stories"
+import * as FilterSelectStickerSheet from "./FilterSelect.stickersheet.stories"
 
 <Meta of={FilterSelectStories} />
 
@@ -22,11 +23,17 @@ import * as FilterSelectStories from "./FilterSelect.stories"
 />
 
 ## Playground
+
 <NoClipCanvas of={FilterSelectStories.Playground} />
 <Controls of={FilterSelectStories.Playground} />
 
 ## API
 
-### Additional Option Properties (generic)
+### Additional option properties (generic)
+
 <Description of={FilterSelectStories.AdditionalProperties} />
 <NoClipCanvas of={FilterSelectStories.AdditionalProperties} />
+
+## Sticker sheet
+
+<Canvas of={FilterSelectStickerSheet.StickerSheetDefault} />

--- a/packages/components/src/FilterSelect/_docs/FilterSelect.stickersheet.stories.tsx
+++ b/packages/components/src/FilterSelect/_docs/FilterSelect.stickersheet.stories.tsx
@@ -108,7 +108,7 @@ const StickerSheetTemplate: StoryFn = () => {
 
       <StickerSheet
         heading="Customised options"
-        style={{ paddingBottom: IS_CHROMATIC ? "26rem" : undefined }}
+        style={{ paddingTop: IS_CHROMATIC ? "26rem" : undefined }}
       >
         <StickerSheet.Header
           headings={[

--- a/packages/components/src/FilterSelect/_docs/FilterSelect.stickersheet.stories.tsx
+++ b/packages/components/src/FilterSelect/_docs/FilterSelect.stickersheet.stories.tsx
@@ -282,7 +282,7 @@ const StickerSheetTemplate: StoryFn = () => {
 
       <StickerSheet
         heading="Min/Max"
-        style={{ paddingBottom: IS_CHROMATIC ? "26rem" : undefined }}
+        style={{ paddingTop: IS_CHROMATIC ? "26rem" : undefined }}
       >
         <StickerSheet.Header headings={["Min size", "Max size"]} />
         <StickerSheet.Body>

--- a/packages/components/src/FilterSelect/_docs/FilterSelect.stickersheet.stories.tsx
+++ b/packages/components/src/FilterSelect/_docs/FilterSelect.stickersheet.stories.tsx
@@ -1,4 +1,4 @@
-import React from "react"
+import React, { useState } from "react"
 import { Meta, StoryFn } from "@storybook/react"
 import isChromatic from "chromatic"
 import { StickerSheet } from "../../../../../storybook/components/StickerSheet"
@@ -26,22 +26,25 @@ const StickerSheetTemplate: StoryFn = () => {
   // Only open the dropdowns in Chromatic as the focus locks clash with
   // each other in Storybook.
   const [isOpenDefaultSingle, setIsOpenDefaultSingle] =
-    React.useState<boolean>(IS_CHROMATIC)
+    useState<boolean>(IS_CHROMATIC)
   const [isOpenDefaultGroup, setIsOpenDefaultGroup] =
-    React.useState<boolean>(IS_CHROMATIC)
+    useState<boolean>(IS_CHROMATIC)
   const [isOpenDefaultExisting, setIsOpenDefaultExisting] =
-    React.useState<boolean>(IS_CHROMATIC)
+    useState<boolean>(IS_CHROMATIC)
   const [isOpenDefaultDisabled, setIsOpenDefaultDisabled] =
-    React.useState<boolean>(IS_CHROMATIC)
+    useState<boolean>(IS_CHROMATIC)
 
   const [isOpenCustomSingle, setIsOpenCustomSingle] =
-    React.useState<boolean>(IS_CHROMATIC)
+    useState<boolean>(IS_CHROMATIC)
   const [isOpenCustomPartial, setIsOpenCustomPartial] =
-    React.useState<boolean>(IS_CHROMATIC)
+    useState<boolean>(IS_CHROMATIC)
   const [isOpenCustomDividerMixed, setIsOpenCustomDividerMixed] =
-    React.useState<boolean>(IS_CHROMATIC)
+    useState<boolean>(IS_CHROMATIC)
   const [isOpenCustomDividerSpecific, setIsOpenCustomDividerSpecific] =
-    React.useState<boolean>(IS_CHROMATIC)
+    useState<boolean>(IS_CHROMATIC)
+
+  const [isOpenMin, setIsOpenMin] = useState<boolean>(IS_CHROMATIC)
+  const [isOpenMax, setIsOpenMax] = useState<boolean>(IS_CHROMATIC)
 
   return (
     <>
@@ -59,7 +62,7 @@ const StickerSheetTemplate: StoryFn = () => {
                 label="Label"
                 isOpen={isOpenDefaultSingle}
                 setIsOpen={setIsOpenDefaultSingle}
-                renderTrigger={(triggerProps): JSX.Element => (
+                renderTrigger={triggerProps => (
                   <FilterButton {...triggerProps} />
                 )}
                 items={singleMockItems}
@@ -70,7 +73,7 @@ const StickerSheetTemplate: StoryFn = () => {
                 label="Label"
                 isOpen={isOpenDefaultGroup}
                 setIsOpen={setIsOpenDefaultGroup}
-                renderTrigger={(triggerProps): JSX.Element => (
+                renderTrigger={triggerProps => (
                   <FilterButton {...triggerProps} />
                 )}
                 items={groupedMockItems}
@@ -81,7 +84,7 @@ const StickerSheetTemplate: StoryFn = () => {
                 label="Label"
                 isOpen={isOpenDefaultExisting}
                 setIsOpen={setIsOpenDefaultExisting}
-                renderTrigger={(triggerProps): JSX.Element => (
+                renderTrigger={triggerProps => (
                   <FilterButton {...triggerProps} />
                 )}
                 items={singleMockItems}
@@ -93,7 +96,7 @@ const StickerSheetTemplate: StoryFn = () => {
                 label="Label"
                 isOpen={isOpenDefaultDisabled}
                 setIsOpen={setIsOpenDefaultDisabled}
-                renderTrigger={(triggerProps): JSX.Element => (
+                renderTrigger={triggerProps => (
                   <FilterButton {...triggerProps} />
                 )}
                 items={mixedMockItemsDisabled}
@@ -105,7 +108,7 @@ const StickerSheetTemplate: StoryFn = () => {
 
       <StickerSheet
         heading="Customised options"
-        style={{ paddingTop: IS_CHROMATIC ? "26rem" : undefined }}
+        style={{ paddingBottom: IS_CHROMATIC ? "26rem" : undefined }}
       >
         <StickerSheet.Header
           headings={[
@@ -122,7 +125,7 @@ const StickerSheetTemplate: StoryFn = () => {
                 label="Label"
                 isOpen={isOpenCustomSingle}
                 setIsOpen={setIsOpenCustomSingle}
-                renderTrigger={(triggerProps): JSX.Element => (
+                renderTrigger={triggerProps => (
                   <FilterButton {...triggerProps} />
                 )}
                 items={singleMockItems}
@@ -166,7 +169,7 @@ const StickerSheetTemplate: StoryFn = () => {
                 label="Label"
                 isOpen={isOpenCustomPartial}
                 setIsOpen={setIsOpenCustomPartial}
-                renderTrigger={(triggerProps): JSX.Element => (
+                renderTrigger={triggerProps => (
                   <FilterButton {...triggerProps} />
                 )}
                 items={mixedMockItemsUngroupedFirst}
@@ -218,7 +221,7 @@ const StickerSheetTemplate: StoryFn = () => {
                 label="Label"
                 isOpen={isOpenCustomDividerMixed}
                 setIsOpen={setIsOpenCustomDividerMixed}
-                renderTrigger={(triggerProps): JSX.Element => (
+                renderTrigger={triggerProps => (
                   <FilterButton {...triggerProps} />
                 )}
                 items={mixedMockItemsUnordered}
@@ -244,7 +247,7 @@ const StickerSheetTemplate: StoryFn = () => {
                 label="Label"
                 isOpen={isOpenCustomDividerSpecific}
                 setIsOpen={setIsOpenCustomDividerSpecific}
-                renderTrigger={(triggerProps): JSX.Element => (
+                renderTrigger={triggerProps => (
                   <FilterButton {...triggerProps} />
                 )}
                 items={[
@@ -272,6 +275,51 @@ const StickerSheetTemplate: StoryFn = () => {
                   })
                 }
               </FilterSelect>
+            </div>
+          </StickerSheet.Row>
+        </StickerSheet.Body>
+      </StickerSheet>
+
+      <StickerSheet
+        heading="Min/Max"
+        style={{ paddingBottom: IS_CHROMATIC ? "26rem" : undefined }}
+      >
+        <StickerSheet.Header headings={["Min size", "Max size"]} />
+        <StickerSheet.Body>
+          <StickerSheet.Row>
+            <div style={{ width: "250px" }}>
+              <FilterSelect
+                label="Label"
+                isOpen={isOpenMin}
+                setIsOpen={setIsOpenMin}
+                renderTrigger={triggerProps => (
+                  <FilterButton {...triggerProps} />
+                )}
+                items={[{ value: "a", label: "A" }]}
+              />
+            </div>
+            <div>
+              <FilterSelect
+                label="Label"
+                isOpen={isOpenMax}
+                setIsOpen={setIsOpenMax}
+                renderTrigger={triggerProps => (
+                  <FilterButton {...triggerProps} />
+                )}
+                items={[
+                  {
+                    value: "long-1",
+                    label:
+                      "Super long option where the container is fixed width and the selected option goes multiline",
+                  },
+                  {
+                    value: "long-2",
+                    label:
+                      "Another super long option where the container is fixed width and the selected option goes multiline",
+                  },
+                  ...singleMockItems,
+                ]}
+              />
             </div>
           </StickerSheet.Row>
         </StickerSheet.Body>


### PR DESCRIPTION
## Why
<!-- Why have you created this PR? - Is it a new feature, or a bug fix? Or something else? -->
<!-- Reference any relevant Jira tickets so your reviewer can find more context if needed. -->
<!-- Fixing a GitHub issue? Add "Fixes [issue URL]". -->
[KDS-1635](https://cultureamp.atlassian.net/jira/software/projects/KDS/boards/289?selectedIssue=KDS-1635)

The popover width has been set to an arbitrary value of 224px. No one really knows why.
Update it to be more flexible as per https://www.figma.com/file/hANEprZKom5Br1IBXhE8mr/%F0%9F%A7%AA-Kaizen-Labs?type=design&node-id=28873-184759&mode=design&t=tLDLiMNpxcYRO1wI-0

## What
<!-- What do your changes do? How do they change/fix the current behavior? -->
<!-- Add screenshots, GIFs or videos to illustrate the changes.  -->

- Update FilterSelect to have width range 196px-400px (rem equivalent)
- Add extra examples to stickersheet
- Expose stickersheet in docs (rewriting would take too long, so this is the quicker option)

![image](https://github.com/cultureamp/kaizen-design-system/assets/25891850/439f2e29-ff70-447a-9a25-27cd8d2160d0)



[KDS-1635]: https://cultureamp.atlassian.net/browse/KDS-1635?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ