### PR TITLE
fix(filter-ms): move classNameOverride to removable button container

### DIFF
--- a/.changeset/shaggy-carrots-rest.md
+++ b/.changeset/shaggy-carrots-rest.md
@@ -1,0 +1,6 @@
+---
+"@kaizen/components": patch
+"@kaizen/select": patch
+---
+
+Move `classNameOverride` to outer container of FilterMultiSelect removable trigger button.

--- a/packages/components/src/FilterMultiSelect/subcomponents/Trigger/RemovableFilterTrigger/RemovableFilterTrigger.tsx
+++ b/packages/components/src/FilterMultiSelect/subcomponents/Trigger/RemovableFilterTrigger/RemovableFilterTrigger.tsx
@@ -22,6 +22,7 @@ export const RemovableFilterTrigger = ({
   return (
     <FilterButtonRemovable
       ref={ref}
+      classNameOverride={classNameOverride}
       triggerButtonProps={{
         ...buttonProps,
         label,
@@ -30,7 +31,6 @@ export const RemovableFilterTrigger = ({
           labelCharacterLimitBeforeTruncate
         ),
         isOpen: menuTriggerState.isOpen,
-        classNameOverride,
       }}
       removeButtonProps={{
         onClick: onRemove,

--- a/packages/select/src/FilterMultiSelect/components/Trigger/RemovableFilterTrigger/RemovableFilterTrigger.tsx
+++ b/packages/select/src/FilterMultiSelect/components/Trigger/RemovableFilterTrigger/RemovableFilterTrigger.tsx
@@ -14,11 +14,12 @@ export type RemovableFilterTriggerProps = {
 
 export const RemovableFilterTrigger = ({
   onRemove,
+  classNameOverride,
   ...filterTriggerProps
 }: RemovableFilterTriggerProps): JSX.Element => {
   const removeButtonLabel = `Remove filter - ${filterTriggerProps.label}`
   return (
-    <div className={styles.trigger}>
+    <div className={`${styles.trigger} ${classNameOverride}`}>
       <FilterTriggerButton
         classNameOverride={styles.triggerButton}
         {...filterTriggerProps}


### PR DESCRIPTION
## Why
<!-- Why have you created this PR? - Is it a new feature, or a bug fix? Or something else? -->
<!-- Reference any relevant Jira tickets so your reviewer can find more context if needed. -->
<!-- Fixing a GitHub issue? Add "Fixes [issue URL]". -->
[KDS-1658](https://cultureamp.atlassian.net/jira/software/projects/KDS/boards/289?selectedIssue=KDS-1658)

Applying `classNameOverride` only applied to the trigger button as opposed to the button as a whole.
![image](https://github.com/cultureamp/kaizen-design-system/assets/25891850/60096ec4-0d6f-46e0-a284-7d9bb94f71e9)

## What
<!-- What do your changes do? How do they change/fix the current behavior? -->
<!-- Add screenshots, GIFs or videos to illustrate the changes.  -->

Move `classNameOverride` to container of removable button for FilterMultiSelect (kaizen/select and KAIO)

[KDS-1658]: https://cultureamp.atlassian.net/browse/KDS-1658?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ