### PR TITLE
ci: run and skip workflows on release branch automerge

### DIFF
--- a/.github/workflows/check-files.yml
+++ b/.github/workflows/check-files.yml
@@ -4,10 +4,22 @@ on:
   push:
     branches-ignore:
       - "main"
-      - "changeset-release/*"
+
+  # When Changesets opens a PR it does not trigger GitHub actions,
+  # because its token does not have permission to. This is a hack
+  # to allow one of us to trigger GitHub actions for a changesets PR
+  # by enabling automerge on the PR.
+  pull_request_target:
+    types:
+      - auto_merge_enabled
+    branches:
+      - main # the target branch of the PR
+    paths:
+      - "**/CHANGELOG.md" # only changesets releases touch changelogs
 
 jobs:
   changesets-exists:
+    if: github.head_ref != 'changeset-release/main'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -16,13 +28,17 @@ jobs:
           fetch-depth: 0
       - uses: ./.github/actions/setup
       - run: yarn changeset status --since=origin/main
+
   yarn-integrity:
+    if: github.head_ref != 'changeset-release/main'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup
       - run: yarn check --integrity
+
   verify-build:
+    if: github.head_ref != 'changeset-release/main'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ on:
 
 jobs:
   typescript:
+    if: github.head_ref != 'changeset-release/main'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -27,6 +28,7 @@ jobs:
       - run: yarn compile
 
   eslint:
+    if: github.head_ref != 'changeset-release/main'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -35,6 +37,7 @@ jobs:
       - run: yarn lint:ts
 
   prettier:
+    if: github.head_ref != 'changeset-release/main'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -43,6 +46,7 @@ jobs:
       - run: yarn lint:format
 
   stylelint:
+    if: github.head_ref != 'changeset-release/main'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -52,6 +56,7 @@ jobs:
 
   jest-react-16--1:
     name: jest-react-16
+    if: github.head_ref != 'changeset-release/main'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -61,6 +66,7 @@ jobs:
 
   jest-react-16--2:
     name: jest-react-16
+    if: github.head_ref != 'changeset-release/main'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -70,6 +76,7 @@ jobs:
 
   jest-react-16--aio:
     name: jest-react-16
+    if: github.head_ref != 'changeset-release/main'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -79,6 +86,7 @@ jobs:
 
   jest-react-17--1:
     name: jest-react-17
+    if: github.head_ref != 'changeset-release/main'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -88,6 +96,7 @@ jobs:
 
   jest-react-17--2:
     name: jest-react-17
+    if: github.head_ref != 'changeset-release/main'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -97,6 +106,7 @@ jobs:
 
   jest-react-17--aio:
     name: jest-react-17
+    if: github.head_ref != 'changeset-release/main'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -106,6 +116,7 @@ jobs:
 
   jest-react-18--1:
     name: jest-react-18
+    if: github.head_ref != 'changeset-release/main'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -115,6 +126,7 @@ jobs:
 
   jest-react-18--2:
     name: jest-react-18
+    if: github.head_ref != 'changeset-release/main'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -124,6 +136,7 @@ jobs:
 
   jest-react-18--aio:
     name: jest-react-18
+    if: github.head_ref != 'changeset-release/main'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -20,8 +20,21 @@ on:
   schedule:
     - cron: "27 1 * * 3"
 
+  # When Changesets opens a PR it does not trigger GitHub actions,
+  # because its token does not have permission to. This is a hack
+  # to allow one of us to trigger GitHub actions for a changesets PR
+  # by enabling automerge on the PR.
+  pull_request_target:
+    types:
+      - auto_merge_enabled
+    branches:
+      - main # the target branch of the PR
+    paths:
+      - "**/CHANGELOG.md" # only changesets releases touch changelogs
+
 jobs:
   analyze:
+    if: github.head_ref != 'changeset-release/main'
     name: Analyze
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Why
<!-- Why have you created this PR? - Is it a new feature, or a bug fix? Or something else? -->
<!-- Reference any relevant Jira tickets so your reviewer can find more context if needed. -->
<!-- Fixing a GitHub issue? Add "Fixes [issue URL]". -->
Allow the whole team to do releases.

## What
<!-- What do your changes do? How do they change/fix the current behavior? -->
<!-- Add screenshots, GIFs or videos to illustrate the changes.  -->

Update required CI workflows to run but skip all steps on the release branch.