### PR TITLE
add canary release workflow

### DIFF
--- a/.github/workflows/canary-release.yml
+++ b/.github/workflows/canary-release.yml
@@ -17,14 +17,11 @@ jobs:
       LABEL: ${{ github.event.inputs.label }}
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
-        with:
-          node-version-file: ".nvmrc"
-          cache: yarn
-      - run: |
-          npm config set "//npm.pkg.github.com/:_authToken" "$PACKAGE_REGISTRY_ACCESS_TOKEN"
-          yarn install --frozen-lockfile --ignore-scripts
-          npm config set "//npm.pkg.github.com/:_authToken" "$GITHUB_TOKEN"
+      - uses: ./.github/actions/setup
+      - name: Create Release Pull Request or Publish to npm
+        id: changesets
+        run: |
+          npm config set "//registry.npmjs.org/:_authToken" "$NPM_TOKEN"
       - run: |
           git config --global user.email "cultureamp-ci@cultureamp.com"
           git config --global user.name "cultureamp-ci"

--- a/.github/workflows/canary-release.yml
+++ b/.github/workflows/canary-release.yml
@@ -1,0 +1,34 @@
+name: "Canary release"
+
+on:
+  workflow_dispatch:
+    inputs:
+      label:
+        description: "Pick a label for the release, to be included in the version number — e.g. '1.0.0-\\${label}.x' (note: can't contain slashes!)"
+        required: true
+        type: string
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ github.token }}
+      PACKAGE_REGISTRY_ACCESS_TOKEN: ${{ secrets.PACKAGE_REGISTRY_ACCESS_TOKEN }}
+      LABEL: ${{ github.event.inputs.label }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version-file: ".nvmrc"
+          cache: yarn
+      - run: |
+          npm config set "//npm.pkg.github.com/:_authToken" "$PACKAGE_REGISTRY_ACCESS_TOKEN"
+          yarn install --frozen-lockfile --ignore-scripts
+          npm config set "//npm.pkg.github.com/:_authToken" "$GITHUB_TOKEN"
+      - run: |
+          git config --global user.email "cultureamp-ci@cultureamp.com"
+          git config --global user.name "cultureamp-ci"
+      - run: |
+          yarn compile
+          yarn changeset version --snapshot "$LABEL"
+          yarn changeset publish --tag "$LABEL"

--- a/.github/workflows/canary-release.yml
+++ b/.github/workflows/canary-release.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       label:
-        description: "Pick a label for the release, to be included in the version number — e.g. "fix-button-focus" will released as "@kaizen/button@1.0.0-fix-button-focus-20230719002814"
+        description: 'Pick a label for the release, to be included in the version number — e.g. "fix-button-focus" will released as "@kaizen/button@1.0.0-fix-button-focus-20230719002814"'
         required: true
         type: string
 

--- a/.github/workflows/canary-release.yml
+++ b/.github/workflows/canary-release.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       label:
-        description: "Pick a label for the release, to be included in the version number — e.g. '1.0.0-\\${label}.x' (note: can't contain slashes!)"
+        description: "Pick a label for the release, to be included in the version number — e.g. "fix-button-focus" will released as "@kaizen/button@1.0.0-fix-button-focus-20230719002814"
         required: true
         type: string
 
@@ -22,10 +22,9 @@ jobs:
         id: changesets
         run: |
           npm config set "//registry.npmjs.org/:_authToken" "$NPM_TOKEN"
-      - run: |
-          git config --global user.email "cultureamp-ci@cultureamp.com"
-          git config --global user.name "cultureamp-ci"
-      - run: |
-          yarn compile
-          yarn changeset version --snapshot "$LABEL"
-          yarn changeset publish --tag "$LABEL"
+      - uses: changesets/action@v1
+        with:
+          title: "Changeset: Version packages"
+          commit: "version packages"
+          version: yarn ci:version --snapshot "$LABEL"
+          publish: yarn ci:publish --tag "$LABEL"

--- a/.github/workflows/canary-release.yml
+++ b/.github/workflows/canary-release.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GITHUB_TOKEN: ${{ github.token }}
-      PACKAGE_REGISTRY_ACCESS_TOKEN: ${{ secrets.PACKAGE_REGISTRY_ACCESS_TOKEN }}
+      PACKAGE_REGISTRY_ACCESS_TOKEN: ${{ secrets.NPM_TOKEN }}
       LABEL: ${{ github.event.inputs.label }}
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
## Why
Since the switch to changeset we have not had a release strategy for canary's and relied on yalc to test new release features in consuming repos. This PR aims to adopt the [Front Ops canary release workflow
](https://github.com/cultureamp/frontend-ops/blob/master/.github/workflows/release.yml) tailored to our environments.

## What
- adds a canary release workflow