### PR TITLE
Skip running chromatic flow again on reopen of PR

### DIFF
--- a/.github/workflows/test-stories.yaml
+++ b/.github/workflows/test-stories.yaml
@@ -28,7 +28,6 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       storybookUrl: ${{ steps.publishChromatic.outputs.storybookUrl }}
-      skip: ${{ steps.publishChromatic.outputs.code }} == 0
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -78,7 +77,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     needs: chromatic
-    if: needs.chromatic.outputs.skip
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup
@@ -92,7 +90,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     needs: chromatic
-    if: needs.chromatic.outputs.skip
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup
@@ -106,7 +103,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     needs: chromatic
-    if: needs.chromatic.outputs.skip
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup

--- a/.github/workflows/test-stories.yaml
+++ b/.github/workflows/test-stories.yaml
@@ -79,7 +79,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     needs: chromatic
-    if: needs.chromatic.outputs.code != 0
+    if: needs.chromatic.outputs.code != "0"
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup
@@ -93,7 +93,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     needs: chromatic
-    if: needs.chromatic.outputs.code != 0
+    if: needs.chromatic.outputs.code != "0"
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup
@@ -107,7 +107,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     needs: chromatic
-    if: needs.chromatic.outputs.code != 0
+    if: needs.chromatic.outputs.code != "0"
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup

--- a/.github/workflows/test-stories.yaml
+++ b/.github/workflows/test-stories.yaml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       storybookUrl: ${{ steps.publishChromatic.outputs.storybookUrl }}
-      skip: ${{ steps.publishChromatic.outputs.code == 0 }}
+      skip: ${{ steps.publishChromatic.outputs.code == "0" }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/.github/workflows/test-stories.yaml
+++ b/.github/workflows/test-stories.yaml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       storybookUrl: ${{ steps.publishChromatic.outputs.storybookUrl }}
-      skip: ${{ steps.publishChromatic.outputs.code == "0" }}
+      skip: ${{ steps.publishChromatic.outputs.code }} == 0
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/.github/workflows/test-stories.yaml
+++ b/.github/workflows/test-stories.yaml
@@ -29,6 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       storybookUrl: ${{ steps.publishChromatic.outputs.storybookUrl }}
+      code: ${{ steps.publishChromatic.outputs.code }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -78,6 +79,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     needs: chromatic
+    if: needs.chromatic.outputs.code != 0
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup
@@ -91,6 +93,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     needs: chromatic
+    if: needs.chromatic.outputs.code != 0
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup
@@ -104,6 +107,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     needs: chromatic
+    if: needs.chromatic.outputs.code != 0
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup

--- a/.github/workflows/test-stories.yaml
+++ b/.github/workflows/test-stories.yaml
@@ -7,7 +7,6 @@ on:
   pull_request:
     types:
       - opened
-      - reopened
       - synchronize
       - ready_for_review
 

--- a/.github/workflows/test-stories.yaml
+++ b/.github/workflows/test-stories.yaml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       storybookUrl: ${{ steps.publishChromatic.outputs.storybookUrl }}
-      code: ${{ steps.publishChromatic.outputs.code }}
+      skip: ${{ steps.publishChromatic.outputs.code == 0 }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -79,7 +79,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     needs: chromatic
-    if: needs.chromatic.outputs.code != "0"
+    if: needs.chromatic.outputs.skip
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup
@@ -93,7 +93,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     needs: chromatic
-    if: needs.chromatic.outputs.code != "0"
+    if: needs.chromatic.outputs.skip
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup
@@ -107,7 +107,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     needs: chromatic
-    if: needs.chromatic.outputs.code != "0"
+    if: needs.chromatic.outputs.skip
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup


### PR DESCRIPTION
## Why
Weird edge case where if your chromatic ci step has previously built and passed all tests, and you close/re-open your branch, it will skip the publishing of chromatic (since nothing has changed) causing the subsequent test steps to fail


## What
Remove the "reopened" type of pull request event