### PR TITLE
ci: set up cache for playwright

### DIFF
--- a/.github/actions/playwright/action.yml
+++ b/.github/actions/playwright/action.yml
@@ -1,0 +1,21 @@
+# this is composite workflow that gets the repo ready for actions
+# for docs how composite workflows work see https://wallis.dev/blog/composite-github-actions
+
+name: Install Playwright
+description: Dependency for storybook/test-runner
+
+runs:
+  using: composite
+  steps:
+    - name: Cache Playwright
+      id: playwright-cache
+      uses: actions/cache@v3
+      with:
+        path: ~/.cache/ms-playwright
+        key: kaizen-${{ runner.os }}-playwright-${{ hashFiles('./yarn.lock') }}
+    - if: steps.playwright-cache.outputs.cache-hit != 'true'
+      run: npx playwright install --with-deps
+      shell: bash
+    - if: steps.playwright-cache.outputs.cache-hit == 'true'
+      run: npx playwright install-deps
+      shell: bash

--- a/.github/workflows/test-stories.yaml
+++ b/.github/workflows/test-stories.yaml
@@ -80,8 +80,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup
-      - name: Install Playwright
-        run: npx playwright install --with-deps
+      - uses: ./.github/actions/playwright
       - name: Storybook tests (1/3)
         run: yarn ci:test:storybook --url ${{ needs.chromatic.outputs.storybookUrl }} --shard 1/3
 
@@ -93,8 +92,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup
-      - name: Install Playwright
-        run: npx playwright install --with-deps
+      - uses: ./.github/actions/playwright
       - name: Storybook tests (2/3)
         run: yarn ci:test:storybook --url ${{ needs.chromatic.outputs.storybookUrl }} --shard 2/3
 
@@ -106,7 +104,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup
-      - name: Install Playwright
-        run: npx playwright install --with-deps
+      - uses: ./.github/actions/playwright
       - name: Storybook tests (3/3)
         run: yarn ci:test:storybook --url ${{ needs.chromatic.outputs.storybookUrl }} --shard 3/3


### PR DESCRIPTION
## Why
<!-- Why have you created this PR? - Is it a new feature, or a bug fix? Or something else? -->
<!-- Reference any relevant Jira tickets so your reviewer can find more context if needed. -->
<!-- Fixing a GitHub issue? Add "Fixes [issue URL]". -->

Sometimes the Playwright install step lags for many minutes, which causes the storybook tests to timeout (eg. https://github.com/cultureamp/kaizen-design-system/actions/runs/5745672429/job/15574123956?pr=3948)

## What
<!-- What do your changes do? How do they change/fix the current behavior? -->
<!-- Add screenshots, GIFs or videos to illustrate the changes.  -->

Cache the Playwright binary to try and stabilise the workflows.

## Notes

The speed seems to be slower given the need to search through cache first, but perhaps it's more stable?

|With cache|Without cache|
|---|---|
|![image](https://github.com/cultureamp/kaizen-design-system/assets/25891850/509d6443-3b49-47c9-bc1a-7ef59a491168)|![image](https://github.com/cultureamp/kaizen-design-system/assets/25891850/31f03ee6-cf11-4496-8ffa-f4e3511a3a32)|