### PR TITLE
add canary prefix, push tags and clean up steps

### DIFF
--- a/.github/workflows/canary-release.yml
+++ b/.github/workflows/canary-release.yml
@@ -11,8 +11,6 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
-    outputs:
-      published: ${{ steps.changesets.outputs.published }}
     env:
       GITHUB_TOKEN: ${{ github.token }}
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/canary-release.yml
+++ b/.github/workflows/canary-release.yml
@@ -4,13 +4,15 @@ on:
   workflow_dispatch:
     inputs:
       label:
-        description: 'Pick a label for the release, to be included in the version number — e.g. "fix-button-focus" will released as "@kaizen/button@1.0.0-fix-button-focus-20230719002814"'
+        description: 'Pick a label for the release, to be included in the version number — e.g. "fix-button-focus" will released as "@kaizen/button@0.0.0-canary-fix-button-focus-20230719002814"'
         required: true
         type: string
 
 jobs:
   release:
     runs-on: ubuntu-latest
+    outputs:
+      published: ${{ steps.changesets.outputs.published }}
     env:
       GITHUB_TOKEN: ${{ github.token }}
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
@@ -18,12 +20,17 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup
-      - name: Create Release Pull Request or Publish to npm
-        id: changesets
+      - name: Set npm token
         run: |
           npm config set "//registry.npmjs.org/:_authToken" "$NPM_TOKEN"
-      - run: |
-          echo "Releasing canary for $LABEL"
+      - name: Create canary release and publish to npm
+        id: changesets
+        run: |
+          echo "🥚 Building canary-$LABEL"
           yarn build
-          yarn changeset version --snapshot "$LABEL"
-          yarn changeset publish --tag "$LABEL"
+          echo "🐣 Releasing canary-$LABEL"
+          yarn changeset version --snapshot "canary-$LABEL"
+          yarn changeset publish --tag "canary-$LABEL"
+      - name: Push tags
+        run: |
+          git push --follow-tags


### PR DESCRIPTION
## Why
Some minor tweaks to the canary workflow just to clean up the build logs, prefix the release with `canary` and push the tags 


## What
- updates canary-release.yml 