### PR TITLE
fix(AsyncSelect): add ClearIndicator to AsyncSelect when isClearable is true

### DIFF
--- a/.changeset/nervous-ghosts-carry.md
+++ b/.changeset/nervous-ghosts-carry.md
@@ -1,0 +1,5 @@
+---
+"@kaizen/draft-select": patch
+---
+
+fix ClearIndicator display when isClearable is true on AsyncSelect

--- a/draft-packages/select/KaizenDraft/Select/Select.tsx
+++ b/draft-packages/select/KaizenDraft/Select/Select.tsx
@@ -141,7 +141,7 @@ export const AsyncSelect = React.forwardRef(
         MultiValue,
         IndicatorsContainer,
         ValueContainer,
-        ClearIndicator: undefined,
+        ClearIndicator,
         IndicatorSeparator: null,
         LoadingMessage,
       }}


### PR DESCRIPTION
## Why
Add the `ClearIndicator` component to `AsyncSelect` so that `isClearable` (an accepted prop) will actually render the clear button.


## What
Before: 
![Screenshot 2023-08-03 at 4 48 03 pm](https://github.com/cultureamp/kaizen-design-system/assets/5242169/c8fd6679-0962-4b15-a006-1d29d04d3102)

After:
![Screenshot 2023-08-03 at 4 48 09 pm](https://github.com/cultureamp/kaizen-design-system/assets/5242169/1ceaab6a-c96d-4985-8bc9-82b60913e133)

