### PR TITLE
Fix incorrect usage of role=rowheader in TableHeaderRow

### DIFF
--- a/.changeset/eighty-monkeys-beam.md
+++ b/.changeset/eighty-monkeys-beam.md
@@ -1,0 +1,7 @@
+---
+"@kaizen/draft-table": patch
+---
+
+Changes the role of TableHeaderRow from "rowheader" to "row" due to incorrect usage of the role.
+
+Also deprecates the component, because it is now a direct replica of TableRow

--- a/draft-packages/table/KaizenDraft/Table/Table.spec.tsx
+++ b/draft-packages/table/KaizenDraft/Table/Table.spec.tsx
@@ -28,7 +28,6 @@ enum AriaRoles {
   cell = "cell",
   columnheader = "columnheader",
   rowgroup = "rowgroup",
-  rowheader = "rowheader",
 }
 
 /**

--- a/draft-packages/table/KaizenDraft/Table/Table.spec.tsx
+++ b/draft-packages/table/KaizenDraft/Table/Table.spec.tsx
@@ -21,15 +21,6 @@ enum TestId {
   tableRowCell = "table-row-cell",
 }
 
-// eslint-disable-next-line @typescript-eslint/no-shadow
-enum AriaRoles {
-  table = "table",
-  row = "row",
-  cell = "cell",
-  columnheader = "columnheader",
-  rowgroup = "rowgroup",
-}
-
 /**
  * Simple Wrapper with absolute bare basics.
  * Although we use data-automation-id in practice,
@@ -75,17 +66,6 @@ describe("<Table />", () => {
         const { getByTestId } = render(<Wrapper />)
 
         expect(getByTestId(value)).toBeTruthy()
-      })
-    }
-  })
-
-  describe("Accessibility", () => {
-    // simple check for roles
-    for (const [role] of Object.entries(AriaRoles)) {
-      it(`contains ARIA compliant table role ${role}`, () => {
-        const { queryByRole } = render(<Wrapper />)
-
-        expect(queryByRole(role)).toBeTruthy()
       })
     }
   })

--- a/draft-packages/table/KaizenDraft/Table/Table.tsx
+++ b/draft-packages/table/KaizenDraft/Table/Table.tsx
@@ -68,11 +68,17 @@ export type TableHeaderRowProps = {
   children?: React.ReactNode
 }
 
+/**
+ * **Deprecated:** Please replace any usages of this with TableRow
+ * This was incorrectly implementing role="rowheader" when this should just be role="row"
+ * It's now an exact replica of TableRow
+ * @deprecated
+ */
 export const TableHeaderRow = ({
   children,
   ...otherProps
 }: TableHeaderRowProps): JSX.Element => (
-  <div className={styles.row} role="rowheader" {...otherProps}>
+  <div className={styles.row} role="row" {...otherProps}>
     {children}
   </div>
 )


### PR DESCRIPTION
## Why
All of our examples of how to compose a Table with our components (and all of the usages that exist out there now) do something like this (noting the placement of `TableHeaderRow`):
<img width="543" alt="image" src="https://github.com/cultureamp/kaizen-design-system/assets/1811583/f230a34e-1b34-4588-9fda-5117b220892d">

Which creates mark up like this
```
<div role="table">
  <div role="rowgroup">
    <div role="rowheader">
      <div role="columnheader" />
      <div role="columnheader" />
      <div role="columnheader" />
    </div>
  </div>
</div>
```

If you look at [documentation for role=rowheader](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/rowheader_role), this is not how the role is meant to be used. It's basically a `<th scope="row">`, whereas it's being used as a `<tr>`. 

The way `TableHeaderRow` is being used, the correct role is just "row". There doesn't appear to be such a thing as a `<tr>` that's header specific.

## What
* Changes the role in the `TableHeaderRow` component from `rowheader` to `row`
* Deprecates the `TableHeaderRow` component, because it is now a direct replica of `TableRow`

Credit to @caitlinmwillington for raising this issue.
