### PR TITLE
ci(release): added condition to check if publish is true before pushing tags

### DIFF
--- a/.github/workflows/changeset.yaml
+++ b/.github/workflows/changeset.yaml
@@ -26,7 +26,9 @@ jobs:
           commit: "version packages"
           version: yarn ci:version
           publish: yarn ci:publish
-      - run: git push --follow-tags
+      - name: Push git tags
+        if: steps.changesets.outputs.published == 'true'
+        run: git push --follow-tags
   slack-notify:
     runs-on: ubuntu-latest
     needs: version


### PR DESCRIPTION
## Why
Github Actions have been trying to push tags despite not needing to


## What
Only push the git tags if there's been a publish