### PR TITLE
Fix-published-flag

### DIFF
--- a/.changeset/dull-donuts-promise.md
+++ b/.changeset/dull-donuts-promise.md
@@ -1,0 +1,5 @@
+---
+"@kaizen/components": patch
+---
+
+tester release

--- a/.changeset/nine-jobs-rush.md
+++ b/.changeset/nine-jobs-rush.md
@@ -1,0 +1,5 @@
+---
+"@kaizen/components": patch
+---
+
+tester publish

--- a/.github/workflows/changeset.yaml
+++ b/.github/workflows/changeset.yaml
@@ -9,7 +9,9 @@ jobs:
   version:
     runs-on: ubuntu-latest
     outputs:
-      published: ${{ steps.changesets.outputs.published }}
+      # Determine if there's a changeset present to infer that a publish is happening
+      # since changesets itself could either be creating a PR or publishing.
+      hasPublished: ${{ steps.changesets.outputs.hasChangesets == 'false' && steps.changesets.outputs.published == 'true' }}
     env:
       GITHUB_TOKEN: ${{ github.token }}
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
@@ -26,8 +28,14 @@ jobs:
           commit: "version packages"
           version: yarn ci:version
           publish: yarn ci:publish
+  notify-slack:
+    runs-on: ubuntu-latest
+    needs: version
+    env:
+      PUBLISHED: ${{ needs.version.outputs.hasPublished }}
+    steps:
       - name: Publish successful
-        if: steps.changesets.outputs.published == 'true'
+        if: ${{ env.PUBLISHED }}
         uses: slackapi/slack-github-action@v1.24.0
         with:
           channel-id: "C02NUQ27G56"
@@ -35,7 +43,7 @@ jobs:
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
       - name: Publish failed
-        if: steps.changesets.outputs.published == 'false'
+        if: ${{ env.PUBLISHED == 'false' }}
         uses: slackapi/slack-github-action@v1.24.0
         with:
           channel-id: "C02NUQ27G56"

--- a/.github/workflows/changeset.yaml
+++ b/.github/workflows/changeset.yaml
@@ -35,7 +35,7 @@ jobs:
       PUBLISHED: ${{ needs.version.outputs.hasPublished }}
     steps:
       - name: Publish successful
-        if: ${{ env.PUBLISHED }}
+        if: ${{ env.PUBLISHED == 'true' }}
         uses: slackapi/slack-github-action@v1.24.0
         with:
           channel-id: "C02NUQ27G56"

--- a/.github/workflows/changeset.yaml
+++ b/.github/workflows/changeset.yaml
@@ -17,20 +17,17 @@ jobs:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup
       - name: Create Release Pull Request or Publish to npm
-        id: changesets
         run: |
           npm config set "//registry.npmjs.org/:_authToken" "$NPM_TOKEN"
       - uses: changesets/action@v1
+        id: changesets
         with:
           title: "Changeset: Version packages"
           commit: "version packages"
           version: yarn ci:version
           publish: yarn ci:publish
-      - name: Push git tags
-        if: ${{ steps.changesets.outputs.published }} == 'true'
-        run: git push --follow-tags
       - name: Publish successful
-        if: ${{ steps.changesets.outputs.published }} == 'true'
+        if: steps.changesets.outputs.published == 'true'
         uses: slackapi/slack-github-action@v1.24.0
         with:
           channel-id: "C02NUQ27G56"
@@ -38,7 +35,7 @@ jobs:
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
       - name: Publish failed
-        if: ${{ steps.changesets.outputs.published }} == 'false'
+        if: steps.changesets.outputs.published == 'false'
         uses: slackapi/slack-github-action@v1.24.0
         with:
           channel-id: "C02NUQ27G56"


### PR DESCRIPTION
## Why

So that we only get notified when changesets starts to publish.

## What

Using the outputs of changesets action we detect if there's a changeset, if there isn't then we can assume that this is the publishing action, and if the published status is`true`, then we are successful.