### PR TITLE
add hook to apply css vars to html element

### DIFF
--- a/.changeset/shiny-hotels-enjoy.md
+++ b/.changeset/shiny-hotels-enjoy.md
@@ -1,0 +1,5 @@
+---
+"@kaizen/components": patch
+---
+
+Fix asignment of CSS vars to load onto the `html` element.

--- a/.changeset/shiny-hotels-enjoy.md
+++ b/.changeset/shiny-hotels-enjoy.md
@@ -2,4 +2,4 @@
 "@kaizen/components": patch
 ---
 
-Fix asignment of CSS vars to load onto the `html` element.
+Fix assignment of CSS vars to load onto the `html` element.

--- a/packages/components/src/KaizenProvider/ThemeProvider/ThemeProvider.spec.tsx
+++ b/packages/components/src/KaizenProvider/ThemeProvider/ThemeProvider.spec.tsx
@@ -21,7 +21,7 @@ describe("<ThemeProvider />", () => {
   it("activates initial theme on construction", () => {
     render(<ThemeProvider>hello</ThemeProvider>)
 
-    const rootElement = document.getElementById("kaizen--theme-root")
+    const rootElement = document.documentElement
     assertThemeIsActive(heartTheme, rootElement)
     expect(rootElement?.style.getPropertyValue("--color-purple-800")).toBe(
       "#2f2438"
@@ -39,7 +39,7 @@ describe("<ThemeProvider />", () => {
 
     render(<ThemeProvider theme={customTheme}>hello</ThemeProvider>)
 
-    const rootElement = document.getElementById("kaizen--theme-root")
+    const rootElement = document.documentElement
     assertThemeIsActive(customTheme, rootElement)
     expect(rootElement?.style.getPropertyValue("--color-pancake")).toBe("#000")
   })

--- a/packages/components/src/KaizenProvider/ThemeProvider/ThemeProvider.tsx
+++ b/packages/components/src/KaizenProvider/ThemeProvider/ThemeProvider.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useContext } from "react"
+import React, { createContext, useContext, useEffect } from "react"
 import { makeCssVariableDefinitionsMap } from "@kaizen/design-tokens"
 import { defaultTheme, Theme as BaseTheme } from "./themes"
 
@@ -20,14 +20,21 @@ export const ThemeProvider = <Theme extends BaseTheme = BaseTheme>({
   children: React.ReactNode
 }): JSX.Element => {
   const theme = userTheme ?? defaultTheme
-  const themeVariables = makeCssVariableDefinitionsMap(theme)
+
+  useEffect(() => {
+    // Add the Theme CSS vars to the document HTML element
+    if (typeof window !== "undefined") {
+      const cssVariableDefinitions = makeCssVariableDefinitionsMap(theme)
+      Object.entries(cssVariableDefinitions).forEach(([key, value]) => {
+        document.documentElement.style.setProperty(key, value)
+      })
+    }
+  }, [])
 
   return (
     <>
       <ThemeContext.Provider value={theme}>
-        <div id="kaizen--theme-root" style={themeVariables}>
-          {props.children}
-        </div>
+        {props.children}
       </ThemeContext.Provider>
       <link
         rel="preload"


### PR DESCRIPTION
## Why
Previously thought applying CSS vars to a consistent node would work for all cases, however elements whch sit outside the root node (eg. portals) will not have access to the variables.


## What
Introduce a hook to load the variables onto the `html` element (as per original functionality)