### PR TITLE
KDS-1868 add styles.css to sideeffects

### DIFF
--- a/.changeset/afraid-knives-approve.md
+++ b/.changeset/afraid-knives-approve.md
@@ -1,0 +1,5 @@
+---
+"@kaizen/components": patch
+---
+
+Fixes issue where styles.css was being tree-shaken by Webpack

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -21,7 +21,9 @@
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",
   "types": "dist/index.d.ts",
-  "sideEffects": false,
+  "sideEffects": [
+    "styles.css"
+  ],
   "scripts": {
     "prepublishOnly": "yarn build:components && yarn postBuild && yarn dist:clean",
     "build": "yarn clean && yarn prepublishOnly",


### PR DESCRIPTION
Fixes this same issue detailed here: https://github.com/ng-select/ng-select/issues/1717

Kaizen CSS was being tree-shaken by Webpack as it is part of a package marked with no side effects and our styles are imported via JS yet not directly used. This fix adds our styles to the side effects parameter to prevent webpack from shaking it out.