### PR TITLE
fix: update CloseIcon to be able to inherit color

### DIFF
--- a/.changeset/cool-spies-mix.md
+++ b/.changeset/cool-spies-mix.md
@@ -1,0 +1,5 @@
+---
+"@kaizen/components": patch
+---
+
+Fix colour inheritance for CloseIcon.

--- a/packages/components/assets/svgs/icons/close.icon.svg
+++ b/packages/components/assets/svgs/icons/close.icon.svg
@@ -1,1 +1,3 @@
-<svg width="20" height="20" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><title>Icons/Actions/close</title><defs><path id="a" d="M14.654 4.167 10 8.82 5.346 4.167l-1.18 1.18L8.823 10l-4.655 4.655 1.179 1.178L10 11.18l4.654 4.654 1.18-1.178L11.18 10l4.655-4.653z"/></defs><use fill="#000" xlink:href="#a" fill-rule="evenodd"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20" fill="none">
+  <path fill-rule="evenodd" clip-rule="evenodd" d="M14.6542 4.16669L10 8.82085L5.34584 4.16669L4.16667 5.34669L8.82167 10L4.16667 14.655L5.34584 15.8334L10 11.1792L14.6542 15.8334L15.8342 14.655L11.1792 10L15.8342 5.34669L14.6542 4.16669Z" fill="#2F2438"/>
+</svg>

--- a/packages/components/src/Icon/CloseIcon.tsx
+++ b/packages/components/src/Icon/CloseIcon.tsx
@@ -2,20 +2,18 @@
 // Changes to this file will be overwritten
 
 import React from "react"
-import { v4 as uuidv4 } from "uuid"
+
 import { SVG, IconProps } from "~components/Icon/subcomponents/SVG"
 
 export const CloseIcon = (props: IconProps): JSX.Element => {
-  const uniqueId = uuidv4()
   const svgContent = (
     <>
-      <defs>
-        <path
-          id={uniqueId}
-          d="M14.654 4.167 10 8.82 5.346 4.167l-1.18 1.18L8.823 10l-4.655 4.655 1.179 1.178L10 11.18l4.654 4.654 1.18-1.178L11.18 10l4.655-4.653z"
-        />
-      </defs>
-      <use href={`#${uniqueId}`} fillRule="evenodd" />
+      <path
+        fill="currentColor"
+        d="M14.654 4.167 10 8.82 5.346 4.167l-1.18 1.18L8.823 10l-4.655 4.655 1.179 1.178L10 11.18l4.654 4.654 1.18-1.178L11.18 10l4.655-4.653-1.18-1.18Z"
+        fillRule="evenodd"
+        clipRule="evenodd"
+      />
     </>
   )
   return <SVG {...props}>{svgContent}</SVG>

--- a/packages/components/src/Icon/_docs/Icon.stickersheet.stories.tsx
+++ b/packages/components/src/Icon/_docs/Icon.stickersheet.stories.tsx
@@ -17,14 +17,24 @@ export default {
 const StickerSheetTemplate: StickerSheetStory = {
   render: () => (
     <StickerSheet heading="Icons">
-      <StickerSheet.Header headings={["Icon", "Name"]} />
+      <StickerSheet.Header
+        headings={["Default", "Color"]}
+        hasVerticalHeadings
+      />
       <StickerSheet.Body>
-        {Object.keys(ICONS as { [key: string]: any }).map(iconKey => (
-          <StickerSheet.Row key={iconKey}>
-            {ICONS[iconKey as keyof typeof ICONS]({ role: "presentation" })}
-            <p className="font-family-heading">{iconKey}</p>
-          </StickerSheet.Row>
-        ))}
+        {Object.keys(ICONS).map(iconName => {
+          const icon = ICONS[iconName as keyof typeof ICONS]({
+            role: "presentation",
+          })
+          return (
+            <StickerSheet.Row key={iconName} rowTitle={iconName}>
+              {icon}
+              <StickerSheet.Cell className="text-green-400">
+                {icon}
+              </StickerSheet.Cell>
+            </StickerSheet.Row>
+          )
+        })}
       </StickerSheet.Body>
     </StickerSheet>
   ),

--- a/packages/components/svgoUtils.js
+++ b/packages/components/svgoUtils.js
@@ -44,13 +44,17 @@ const replaceAttrKeys = child => {
 // Figma/ Sketch don't allow us to set 'currentColor' when exporting SVGs.
 // We have a convention to export the color as #000 or #0000000, then change it here.
 const replaceColor = child => {
-  if (child.attributes.fill === "#000" || child.attributes.fill === "#000000") {
+  const hexCodesToReplace = [
+    "#000",
+    "#000000",
+    "#2F2438", // Purple-800 from Figma export
+  ]
+
+  if (hexCodesToReplace.includes(child.attributes.fill)) {
     child.attributes.fill = "currentColor"
   }
-  if (
-    child.attributes.stroke === "#000" ||
-    child.attributes.stroke === "#000000"
-  ) {
+
+  if (hexCodesToReplace.includes(child.attributes.stroke)) {
     child.attributes.stroke = "currentColor"
   }
 }


### PR DESCRIPTION
## Why
<!-- Why have you created this PR? - Is it a new feature, or a bug fix? Or something else? -->
<!-- Reference any relevant Jira tickets so your reviewer can find more context if needed. -->
<!-- Fixing a GitHub issue? Add "Fixes [issue URL]". -->

`CloseIcon` does not inherit colour.

## What
<!-- What do your changes do? How do they change/fix the current behavior? -->
<!-- Add screenshots, GIFs or videos to illustrate the changes.  -->

- Update stickersheet for Icon to show colour inheritance
- Update icon script to also replace Purple 800 hex (as UI Kit stores them as such - easier moving forward)
- Regenerate `CloseIcon`
	- Note: There are some other icons which are broken, but will fix them separately as they have other issues (eg. doesn't exist in UI Kit or has a complex svg) 