### PR TITLE
fix(ErrorPage): 404 fing typo

### DIFF
--- a/.changeset/wise-rivers-begin.md
+++ b/.changeset/wise-rivers-begin.md
@@ -1,0 +1,5 @@
+---
+"@kaizen/components": patch
+---
+
+fix: fing typo

--- a/packages/components/src/ErrorPage/hooks/useErrorMessages.ts
+++ b/packages/components/src/ErrorPage/hooks/useErrorMessages.ts
@@ -68,7 +68,7 @@ export const useErrorMessages = (
       message: formatMessage({
         id: "kzErrorPage.404.message",
         defaultMessage:
-          "Sorry but we can't fing the page you're looking for. Go back and try again, or head to Home",
+          "Sorry but we can't find the page you're looking for. Go back and try again, or head to Home",
         description: "Call to action instructions for the user",
       }),
     },


### PR DESCRIPTION
## Why
This PR fixes a typo on the Kaizen 404 Error Page.

## What
Fixes the typo "fing" instead of "find".