### PR TITLE
fix: add the TitleBlock types file to index

### DIFF
--- a/.changeset/old-kangaroos-wonder.md
+++ b/.changeset/old-kangaroos-wonder.md
@@ -1,0 +1,5 @@
+---
+"@kaizen/components": patch
+---
+
+Add the TitleBlock types file to index

--- a/packages/components/src/TitleBlockZen/index.ts
+++ b/packages/components/src/TitleBlockZen/index.ts
@@ -1,2 +1,3 @@
 export * from "./TitleBlockZen"
 export * from "./subcomponents/NavigationTabs"
+export * from "./types"


### PR DESCRIPTION
## Why
This PR adds the TitleBlock types file to index so that barreling will work for types.

## What
With this change, TitleBlockProps will now be accessible.

[KDS-1968](https://cultureamp.atlassian.net/browse/KDS-1968).

[KDS-1968]: https://cultureamp.atlassian.net/browse/KDS-1968?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ