### PR TITLE
Add conditional check for release tag in Buildkite pipeline

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -15,7 +15,7 @@ steps:
     key: "is_released"
     branches: "main"
     # we assume that all releases with have a tag and that tag with have a @ version format
-    if: build.tag =~ /@(\d+\.\d+\.\d+)/
+    if: build.tag =~ /@(\d+\.\d+\.\d+)/ && build.tag =~ /^(?:(?!canary).)*$/
 
   - wait
 

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -11,8 +11,17 @@ x-defaults: &defaults
         run: build
 
 steps:
+  - name: ":sleuth_or_spy: Checking for release tag"
+    key: "is_released"
+    branches: "main"
+    # we assume that all releases with have a tag and that tag with have a @ version format
+    if: build.tag =~ /@(\d+\.\d+\.\d+)/
+
+  - wait
+
   - name: ":package: Build (storybook)"
     branches: "main"
+    depends_on: "is_released"
     command: ".buildkite/scripts/build-storybook.sh"
     timeout_in_minutes: 15
     artifact_paths: "./storybook.tar.gz"


### PR DESCRIPTION

## Why
This aims to stop all buildkite builds and publishing if a merge to the main brain does not have a release tag


## What
- adds a conditional in the Buildkite steps to check for the existance of a tag and that it is in release format, ie: `blah@12.3.4`
  - Theoretically this means that it should fail on the initial step, which should early exit of the pipeline
  - This also mean we don't have to supply any more information since all releases should have tags (hopefully!)