### PR TITLE
Revert Buildkite pipeline changes

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -11,17 +11,8 @@ x-defaults: &defaults
         run: build
 
 steps:
-  - name: ":sleuth_or_spy: Checking for release tag"
-    key: "is_released"
-    branches: "main"
-    # we assume that all releases with have a tag and that tag with have a @ version format
-    if: ((build.tag =~ /@(\d+\.\d+\.\d+)/) && (build.tag =~ /^(?:(?!canary).)*$/))
-
-  - wait
-
   - name: ":package: Build (storybook)"
     branches: "main"
-    depends_on: "is_released"
     command: ".buildkite/scripts/build-storybook.sh"
     timeout_in_minutes: 15
     artifact_paths: "./storybook.tar.gz"


### PR DESCRIPTION
## Why
Reverting this because it was breaking the pipeline and I'm exploring an alternative method using github labels


## What
- reverts pipeline.yml to original state