### PR TITLE
ci(Buildkite): add base branch for bk tests

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -3,6 +3,8 @@ env:
   KAIZEN_DOMAIN_NAME: ${BRANCH_DOMAIN_NAME}
   KAIZEN_DISTRIBUTION_ID: ${BRANCH_DISTRIBUTION_ID}
   GITHUB_REGISTRY_TOKEN: ${GITHUB_REGISTRY_TOKEN}
+  GITHUB_CURRENT_BUILD: build.commit
+  # assuming that build.commit is the commit hash
 
 x-defaults: &defaults
   agent_query_rules: ["queue=build-unrestricted"]
@@ -11,6 +13,13 @@ x-defaults: &defaults
         run: build
 
 steps:
+  - name: ":sleuth_or_spy: Checking for release label"
+    key: "should_publish"
+    branches: "test-buildkite-pipeline"
+    command: ".buildkite/scripts/check-build-for-publish.sh"
+    <<: *defaults
+    agent_query_rules: ["queue=build-unrestricted-large"]
+
   - name: ":package: Build (storybook)"
     branches: "main"
     command: ".buildkite/scripts/build-storybook.sh"

--- a/.buildkite/scripts/check-build-for-publish.sh
+++ b/.buildkite/scripts/check-build-for-publish.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -e
+
+echo "Query Github with the current commit $GITHUB_CURRENT_BUILD"


### PR DESCRIPTION
## Why
Testing to see if this triggers a bk build


## What
- adds initial shell script - may break because it is partially finished
