### PR TITLE
ci(buildkite): update shell script

### DIFF
--- a/.buildkite/scripts/check-build-for-publish.sh
+++ b/.buildkite/scripts/check-build-for-publish.sh
@@ -2,3 +2,21 @@
 set -e
 
 echo "Query Github with the current commit $GITHUB_CURRENT_BUILD"
+
+VALID_LABEL="release"
+
+# Stores the labels object in a variable
+LABELS=$(curl --request GET \
+  --url "https://api.github.com/repos/cultureamp/kaizen-design-system/commits/$GITHUB_CURRENT_BUILD/pulls?=" \
+  --header "Authorization: Bearer $GITHUB_REGISTRY_TOKEN" | jq '[] | .labels.name')
+
+echo "Latest commit labels: $LABELS"
+
+if [ -n "$LABELS" ]; then
+    echo "I have labels, let's see it they match!"
+    # Does something when labels exist
+    exit 0  # Return true
+else
+    echo "I have no labels"
+    exit 1  # Return false
+fi


### PR DESCRIPTION
## Important: Request PR reviews on Slack
Please reach out to the design system team on Slack in `#prod_design_system` for PR reviews. GitHub notifications (e.g. from tagging a person) are not actively monitored.

## Why
Testing if updating the pipeline yml will reflect in buildkite

## What
- adds basic shell script to check for labels
