### PR TITLE
Update bk shell script to catch and handle errors

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -3,7 +3,7 @@ env:
   KAIZEN_DOMAIN_NAME: ${BRANCH_DOMAIN_NAME}
   KAIZEN_DISTRIBUTION_ID: ${BRANCH_DISTRIBUTION_ID}
   GITHUB_REGISTRY_TOKEN: ${GITHUB_REGISTRY_TOKEN}
-  # assuming that build.commit is the commit hash
+  CURRENT_COMMIT: ${BUILDKITE_COMMIT}
 
 x-defaults: &defaults
   agent_query_rules: ["queue=build-unrestricted"]
@@ -16,9 +16,6 @@ steps:
     key: "should_publish"
     branches: "test-buildkite-pipeline"
     command: ".buildkite/scripts/check-build-for-publish.sh"
-    env:
-      CURRENT_COMMIT: ${BUILDKITE_COMMIT}
-      # assuming that build.commit is the commit hash
     <<: *defaults
     plugins:
       - docker-compose#v3.9.0:

--- a/.buildkite/scripts/check-build-for-publish.sh
+++ b/.buildkite/scripts/check-build-for-publish.sh
@@ -1,22 +1,26 @@
 #!/bin/sh
 set -e
 
-echo "Query Github with the current commit ${CURRENT_COMMIT}"
-
 VALID_LABEL="pipeline test label"
+
+echo "⏩ Querying Github for current commit: ${CURRENT_COMMIT} and retriving labels"
 
 # Stores the labels object in a variable
 LABELS=$(curl --request GET \
   --url "https://api.github.com/repos/cultureamp/kaizen-design-system/commits/${CURRENT_COMMIT}/pulls?=" \
-  --header "Authorization: Bearer ${GITHUB_REGISTRY_TOKEN}" | jq '[] | .labels.name')
+  --header "Authorization: Bearer ${GITHUB_REGISTRY_TOKEN}" | jq 'try .[0] .labels [] .name catch .')
 
-echo "Latest commit labels: ${LABELS}"
 
 if [ -n "${LABELS}" ]; then
-    echo "I have labels, let's see it they match!!!"
-    # Does something when labels exist
-    exit 0  # Return true
+    echo "🔍 Labels were found! Checking for \"${VALID_LABEL}\" label"
+    if [[ $LABELS =~ "${VALID_LABEL}" ]]; then
+        echo "🔮 \"${VALID_LABEL}\" was found! Commencing build..."
+      exit 0  
+    else
+      echo "🤷‍♀️ \"${VALID_LABEL}\" label was not found. Exiting build"
+      exit 1  
+    fi
 else
-    echo "I have no labels"
-    exit 1  # Return false
+    echo "⛔️ No labels were found in this commit. Exiting build"
+    exit 1  
 fi

--- a/.buildkite/scripts/check-build-for-publish.sh
+++ b/.buildkite/scripts/check-build-for-publish.sh
@@ -10,9 +10,9 @@ LABELS=$(curl --request GET \
   --url "https://api.github.com/repos/cultureamp/kaizen-design-system/commits/${CURRENT_COMMIT}/pulls?=" \
   --header "Authorization: Bearer ${GITHUB_REGISTRY_TOKEN}" | jq '[] | .labels.name')
 
-echo "Latest commit labels: $LABELS"
+echo "Latest commit labels: ${LABELS}"
 
-if [ -n "$LABELS" ]; then
+if [ -n "${LABELS}" ]; then
     echo "I have labels, let's see it they match!!!"
     # Does something when labels exist
     exit 0  # Return true

--- a/.buildkite/scripts/check-build-for-publish.sh
+++ b/.buildkite/scripts/check-build-for-publish.sh
@@ -10,10 +10,10 @@ LABELS=$(curl --request GET \
   --url "https://api.github.com/repos/cultureamp/kaizen-design-system/commits/${CURRENT_COMMIT}/pulls?=" \
   --header "Authorization: Bearer ${GITHUB_REGISTRY_TOKEN}" | jq '[] | .labels.name')
 
-echo "Latest commit labels: ${LABELS}"
+echo "Latest commit labels: $LABELS"
 
-if [ -n "${LABELS}" ]; then
-    echo "I have labels, let's see it they match!!!"
+if [ -n "$LABELS" ]; then
+    echo "I have labels, let's see it they match!"
     # Does something when labels exist
     exit 0  # Return true
 else

--- a/.buildkite/scripts/check-build-for-publish.sh
+++ b/.buildkite/scripts/check-build-for-publish.sh
@@ -13,7 +13,7 @@ LABELS=$(curl --request GET \
 echo "Latest commit labels: $LABELS"
 
 if [ -n "$LABELS" ]; then
-    echo "I have labels, let's see it they match!"
+    echo "I have labels, let's see it they match!!!"
     # Does something when labels exist
     exit 0  # Return true
 else

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,7 @@ x-defaults: &defaults
     - KAIZEN_BASE_PATH
     - GITHUB_STATUS_TOKEN
     - BUILDKITE_BRANCH
+    - BUILDKITE_COMMIT
     - GITHUB_REGISTRY_TOKEN
 
 services:


### PR DESCRIPTION
## Why
While the step may still not continue, this update is to handle when jq is unable to find the label property

## What
- adds try catch and handle failed exit conditions with feedback
