### PR TITLE
Allow a soft fail on the bk shell script

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -4,6 +4,7 @@ env:
   KAIZEN_DISTRIBUTION_ID: ${BRANCH_DISTRIBUTION_ID}
   GITHUB_REGISTRY_TOKEN: ${GITHUB_REGISTRY_TOKEN}
   CURRENT_COMMIT: ${BUILDKITE_COMMIT}
+  SHOULD_PUBLISH: false
 
 x-defaults: &defaults
   agent_query_rules: ["queue=build-unrestricted"]
@@ -16,10 +17,21 @@ steps:
     key: "should_publish"
     branches: "test-buildkite-pipeline"
     command: ".buildkite/scripts/check-build-for-publish.sh"
+    soft_fail: true
     <<: *defaults
     plugins:
       - docker-compose#v3.9.0:
           run: prepublish
+
+  - wait
+
+  - name: ":seedling: Mock publishing if release label found"
+    key: "mock_publish"
+    skip: ${SHOULD_PUBLISH}
+    branches: "test-buildkite-pipeline"
+    command: echo("hello should I be here ${SHOULD_PUBLISH}")
+
+  - wait
 
   - name: ":package: Build (storybook)"
     branches: "main"

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -3,7 +3,7 @@ env:
   KAIZEN_DOMAIN_NAME: ${BRANCH_DOMAIN_NAME}
   KAIZEN_DISTRIBUTION_ID: ${BRANCH_DISTRIBUTION_ID}
   GITHUB_REGISTRY_TOKEN: ${GITHUB_REGISTRY_TOKEN}
-  # assuming that build.commit is the commit hash
+  CURRENT_COMMIT: ${BUILDKITE_COMMIT}
 
 x-defaults: &defaults
   agent_query_rules: ["queue=build-unrestricted"]
@@ -16,9 +16,6 @@ steps:
     key: "should_publish"
     branches: "test-buildkite-pipeline"
     command: ".buildkite/scripts/check-build-for-publish.sh"
-    env:
-      CURRENT_COMMIT: ${BUILDKITE_COMMIT}
-      # assuming that build.commit is the commit hash
     <<: *defaults
     plugins:
       - docker-compose#v3.9.0:

--- a/.buildkite/scripts/check-build-for-publish.sh
+++ b/.buildkite/scripts/check-build-for-publish.sh
@@ -1,22 +1,26 @@
 #!/bin/sh
 set -e
 
-echo "Query Github with the current commit ${CURRENT_COMMIT}"
-
 VALID_LABEL="pipeline test label"
+
+echo "⏩ Querying Github for current commit: ${CURRENT_COMMIT} and retriving labels"
 
 # Stores the labels object in a variable
 LABELS=$(curl --request GET \
   --url "https://api.github.com/repos/cultureamp/kaizen-design-system/commits/${CURRENT_COMMIT}/pulls?=" \
-  --header "Authorization: Bearer ${GITHUB_REGISTRY_TOKEN}" | jq '[] | .labels.name')
+  --header "Authorization: Bearer ${GITHUB_REGISTRY_TOKEN}" | jq 'try .[0] .labels [] .name catch .')
 
-echo "Latest commit labels: ${LABELS}"
 
 if [ -n "${LABELS}" ]; then
-    echo "I have labels, let's see it they match!!!"
-    # Does something when labels exist
-    exit 0  # Return true
+    echo "🔍 Labels were found! Checking for \"${VALID_LABEL}\" label"
+    if [[ $LABELS =~ "${VALID_LABEL}" ]]; then
+        echo "🔮 \"${VALID_LABEL}\" was found! Commencing build..."
+      exit 0  
+    else
+      echo "🤷‍♀️ \"${VALID_LABEL}\" label was not found. Exiting build"
+      exit 1  
+    fi
 else
-    echo "I have no labels"
-    exit 1  # Return false
+    echo "⛔️ No labels were found in this commit. Exiting build"
+    exit 1  
 fi

--- a/.buildkite/scripts/check-build-for-publish.sh
+++ b/.buildkite/scripts/check-build-for-publish.sh
@@ -10,9 +10,9 @@ LABELS=$(curl --request GET \
   --url "https://api.github.com/repos/cultureamp/kaizen-design-system/commits/${CURRENT_COMMIT}/pulls?=" \
   --header "Authorization: Bearer ${GITHUB_REGISTRY_TOKEN}" | jq '[] | .labels.name')
 
-echo "Latest commit labels: $LABELS"
+echo "Latest commit labels: ${LABELS}"
 
-if [ -n "$LABELS" ]; then
+if [ -n "${LABELS}" ]; then
     echo "I have labels, let's see it they match!!!"
     # Does something when labels exist
     exit 0  # Return true

--- a/.buildkite/scripts/check-build-for-publish.sh
+++ b/.buildkite/scripts/check-build-for-publish.sh
@@ -3,11 +3,11 @@ set -e
 
 VALID_LABEL="pipeline test label"
 
-echo "⏩ Querying Github for current commit: ${CURRENT_COMMIT} and retriving labels"
+echo "⏩ Querying Github for current commit: ${BUILDKITE_COMMIT} and retriving labels"
 
 # Stores the labels object in a variable
 LABELS=$(curl --request GET \
-  --url "https://api.github.com/repos/cultureamp/kaizen-design-system/commits/${CURRENT_COMMIT}/pulls?=" \
+  --url "https://api.github.com/repos/cultureamp/kaizen-design-system/commits/${BUILDKITE_COMMIT}/pulls?=" \
   --header "Authorization: Bearer ${GITHUB_REGISTRY_TOKEN}" | jq 'try .[0] .labels [] .name catch .')
 
 
@@ -15,7 +15,8 @@ if [ -n "${LABELS}" ]; then
     echo "🔍 Labels were found! Checking for \"${VALID_LABEL}\" label"
     if [[ $LABELS =~ "${VALID_LABEL}" ]]; then
         echo "🔮 \"${VALID_LABEL}\" was found! Commencing build..."
-      exit 0  
+        SHOULD_PUBLISH=true
+      exit 0
     else
       echo "🤷‍♀️ \"${VALID_LABEL}\" label was not found. Exiting build"
       exit 1  

--- a/.buildkite/scripts/check-build-for-publish.sh
+++ b/.buildkite/scripts/check-build-for-publish.sh
@@ -10,10 +10,10 @@ LABELS=$(curl --request GET \
   --url "https://api.github.com/repos/cultureamp/kaizen-design-system/commits/${CURRENT_COMMIT}/pulls?=" \
   --header "Authorization: Bearer ${GITHUB_REGISTRY_TOKEN}" | jq '[] | .labels.name')
 
-echo "Latest commit labels: ${LABELS}"
+echo "Latest commit labels: $LABELS"
 
-if [ -n "${LABELS}" ]; then
-    echo "I have labels, let's see it they match!!!"
+if [ -n "$LABELS" ]; then
+    echo "I have labels, let's see it they match!"
     # Does something when labels exist
     exit 0  # Return true
 else

--- a/.buildkite/scripts/check-build-for-publish.sh
+++ b/.buildkite/scripts/check-build-for-publish.sh
@@ -13,7 +13,7 @@ LABELS=$(curl --request GET \
 echo "Latest commit labels: $LABELS"
 
 if [ -n "$LABELS" ]; then
-    echo "I have labels, let's see it they match!"
+    echo "I have labels, let's see it they match!!!"
     # Does something when labels exist
     exit 0  # Return true
 else

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,7 @@ x-defaults: &defaults
     - KAIZEN_BASE_PATH
     - GITHUB_STATUS_TOKEN
     - BUILDKITE_BRANCH
+    - BUILDKITE_COMMIT
     - GITHUB_REGISTRY_TOKEN
 
 services:


### PR DESCRIPTION

## Why
Need some way to allow for the BK script to exit gracefully since a lot of failed builds would mess out our stability metrics.

## What
- allows for soft fail on the label check
- add test step to validation using an env var to skip steps
