### PR TITLE
Increase opacity on placeholder in Select

### DIFF
--- a/.changeset/honest-weeks-sniff.md
+++ b/.changeset/honest-weeks-sniff.md
@@ -1,0 +1,5 @@
+---
+"@kaizen/components": patch
+---
+
+Change placeholder opacity on Select

--- a/packages/components/src/Select/Select.module.scss
+++ b/packages/components/src/Select/Select.module.scss
@@ -5,7 +5,7 @@
 
 // Should match the values for the Input component
 $input-height: 48px;
-$input-placeholder-opacity: 0.5;
+$input-placeholder-opacity: 0.7;
 
 $focus-border-color: $color-blue-500;
 

--- a/packages/components/src/Select/_docs/Select.stickersheet.stories.tsx
+++ b/packages/components/src/Select/_docs/Select.stickersheet.stories.tsx
@@ -15,11 +15,6 @@ export default {
       config: {
         rules: [
           {
-            // Placeholders do not pass color contrast
-            id: "color-contrast",
-            enabled: false,
-          },
-          {
             // React-select's list structure missing when there are no options (third-party a11y issue)
             id: "aria-required-children",
             enabled: false,

--- a/packages/components/src/Select/_docs/Select.stories.tsx
+++ b/packages/components/src/Select/_docs/Select.stories.tsx
@@ -41,19 +41,6 @@ const meta = {
     options: OPTIONS,
     label: "Select",
   },
-  parameters: {
-    a11y: {
-      config: {
-        rules: [
-          {
-            // Placeholders do not pass color contrast
-            id: "color-contrast",
-            enabled: false,
-          },
-        ],
-      },
-    },
-  },
 } satisfies Meta<typeof Select>
 
 export default meta


### PR DESCRIPTION
## Why
Team Athena is using the Select component in Anytime Feedback. We are running the storybook tests and are addressing all accessibility issues that are raised. The Select had a placeholder opacity of 0.5 (whereas other placeholders were 0.7 in Kaizen) and this was failing the minimum contrast rule.

We've not been able to override this using react-select properties as it's overridden by these styles from what I can see.

## What
1. Change placeholder opacity from 0.5 to 0.7
2. Remove override of a11y test as it should now pass the rule