### PR TITLE
Include minimum KAIO compatible template versions

### DIFF
--- a/docs/app-starter.mdx
+++ b/docs/app-starter.mdx
@@ -11,9 +11,17 @@ This guide is all about how to introduce the Kaizen Design System to your app.
 Whilst the Kaizen Design System mainly focuses on the more atomic components in your app, some of the components have a high level of complexity requiring various global components to be present in order for them to function.
 
 <InlineNotification persistent type="informative">You won't need to apply any of the below if you have the latest <a href="https://github.com/cultureamp/next-template">next-template</a>.</InlineNotification>
+
+## Prerequisites
+- React v18
+- Node v18
+- `@cultureamp/next-services` v2.0.7+
+- `@cultureamp/next-storybook` v3.0.1+
+
 ## 1. Add the KaizenProvider
 
 The <LinkTo pageId="components-kaizen-provider-installation">KaizenProvider</LinkTo> feeds your entire app with Kaizen defaults so it's important that it goes at the very root of your application.
+
 ```tsx
 import { KaizenProvider } from "@kaizen/components";
 <KaizenProvider>


### PR DESCRIPTION
## Why
We need to let consumers know what the minimum versions of CultureAmp's shared config are compatible with KAIO

## What
Updating Storybook docs