### PR TITLE
fix(TitleBlockZen): migrate positiveSentiment fix from kaizen-legacy

### DIFF
--- a/.changeset/green-vans-fold.md
+++ b/.changeset/green-vans-fold.md
@@ -1,0 +1,5 @@
+---
+"@kaizen/components": patch
+---
+
+Add sentimentPositive TitleBlockZen fix from kaizen-legacy

--- a/packages/components/src/TitleBlockZen/TitleBlockZen.spec.tsx
+++ b/packages/components/src/TitleBlockZen/TitleBlockZen.spec.tsx
@@ -712,6 +712,8 @@ describe("<TitleBlockZen />", () => {
       ["live", "statusLive"],
       ["closed", "statusClosed"],
       ["scheduled", "statusClosed"],
+      ["sentimentPositive", "sentimentPositive"],
+      ["default", "default"],
     ])(
       "renders tag with correct text and variant when %s status",
       async (status, expectedClassName) => {
@@ -725,6 +727,7 @@ describe("<TitleBlockZen />", () => {
                 | "live"
                 | "scheduled"
                 | "closed"
+                | "sentimentPositive"
                 | "default",
             }}
           >

--- a/packages/components/src/TitleBlockZen/TitleBlockZen.tsx
+++ b/packages/components/src/TitleBlockZen/TitleBlockZen.tsx
@@ -51,6 +51,10 @@ const renderTag = (surveyStatus: SurveyStatus): JSX.Element | void => {
     tagVariant = "statusClosed"
   }
 
+  if (surveyStatus.status === "sentimentPositive") {
+    tagVariant = "sentimentPositive"
+  }
+
   if (surveyStatus.status === "default") {
     tagVariant = "default"
   }

--- a/packages/components/src/TitleBlockZen/types.ts
+++ b/packages/components/src/TitleBlockZen/types.ts
@@ -181,7 +181,13 @@ export type TextDirection = "ltr" | "rtl"
 
 export type SurveyStatus = {
   text: string
-  status: "draft" | "live" | "scheduled" | "closed" | "default"
+  status:
+    | "draft"
+    | "live"
+    | "scheduled"
+    | "closed"
+    | "sentimentPositive"
+    | "default"
 }
 
 export type TitleBlockBreadcrumbType = {


### PR DESCRIPTION

## Why
There was a fix on [kaizen legacy repo](https://github.com/cultureamp/kaizen-legacy/commit/70c568412abb13f7617cab2f7cc50ef380982ec6) that we need to bring across to KAIO


## What
- adds sentimentPositive to survey status variants

