### PR TITLE
fix(MultiSelect Popover): Use :focus-visible instead of :focus for focus ring

### DIFF
--- a/.changeset/beige-cups-hug.md
+++ b/.changeset/beige-cups-hug.md
@@ -1,0 +1,5 @@
+---
+"@kaizen/components": patch
+---
+
+Use :focus-visible instead of :focus for popover focus ring

--- a/packages/components/src/MultiSelect/subcomponents/Popover/Popover.module.scss
+++ b/packages/components/src/MultiSelect/subcomponents/Popover/Popover.module.scss
@@ -11,7 +11,7 @@
   background: $color-white;
   overflow: auto;
 
-  &:focus {
+  &:focus-visible {
     outline: none;
     border-color: $color-blue-500;
   }

--- a/packages/components/src/MultiSelect/subcomponents/Popover/Popover.module.scss
+++ b/packages/components/src/MultiSelect/subcomponents/Popover/Popover.module.scss
@@ -11,8 +11,11 @@
   background: $color-white;
   overflow: auto;
 
-  &:focus-visible {
+  &:focus {
     outline: none;
+  }
+
+  &:focus-visible {
     border-color: $color-blue-500;
   }
 }


### PR DESCRIPTION
Having this styling on `:focus` means we get this happening:

https://github.com/cultureamp/kaizen-design-system/assets/1811583/cb748bbb-1f07-4547-9808-b82c88dc7f75

Switching to `:focus-visible`, we still lose focus on the checkbox on mouse down for some reason (happens on our regular CheckboxField as well) but at least it's no longer as obviously janky.

Focus rings are ideally only set on `:focus-visible` as well anyway.