### PR TITLE
Fix TabList classNameOverride usage

### DIFF
--- a/.changeset/silly-snails-drive.md
+++ b/.changeset/silly-snails-drive.md
@@ -1,0 +1,5 @@
+---
+"@kaizen/components": patch
+---
+
+TabList now uses classNameOverride correctly

--- a/packages/components/src/Tabs/subcomponents/TabList.tsx
+++ b/packages/components/src/Tabs/subcomponents/TabList.tsx
@@ -24,12 +24,17 @@ export const TabList = (props: TabListProps): JSX.Element => {
     "aria-label": ariaLabel,
     noPadding = false,
     children,
+    classNameOverride,
     ...restProps
   } = props
   return (
     <ReachTabList
       aria-label={ariaLabel}
-      className={classnames(styles.tabList, noPadding && styles.noPadding)}
+      className={classnames(
+        styles.tabList,
+        classNameOverride,
+        noPadding && styles.noPadding
+      )}
       {...restProps}
     >
       {children}


### PR DESCRIPTION
`TabList` was accepting a `classNameOverride` prop but it wasn't actually doing anything.