### PR TITLE
Fix SSR hydration warning when using Illustration

### DIFF
--- a/.changeset/stupid-apples-sneeze.md
+++ b/.changeset/stupid-apples-sneeze.md
@@ -1,0 +1,5 @@
+---
+"@kaizen/components": patch
+---
+
+Fix SSR support for video player

--- a/packages/components/src/Illustration/subcomponents/VideoPlayer/VideoPlayer.spec.tsx
+++ b/packages/components/src/Illustration/subcomponents/VideoPlayer/VideoPlayer.spec.tsx
@@ -65,24 +65,7 @@ describe("<VideoPlayer />", () => {
         />
       )
       const videoPlayer = screen.getByTestId("kz-video-player")
-      expect(videoPlayer).toMatchSnapshot(`
-        <video
-          aria-hidden="true"
-          class="wrapper"
-          data-testid="kz-video-player"
-          muted=""
-          playsinline=""
-          poster="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/heart/spot/moods-cautionary.svg.png"
-          preload="metadata"
-          tabindex="-1"
-          width="100%"
-        >
-          <source
-            src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/heart/spot/moods-cautionary.webm.mp4"
-            type="video/mp4"
-          />
-        </video>
-      `)
+      expect(videoPlayer).toMatchSnapshot()
       expect(mockPause).toBeCalled()
     })
 
@@ -98,25 +81,7 @@ describe("<VideoPlayer />", () => {
         />
       )
       const videoPlayer = screen.getByTestId("kz-video-player")
-      expect(videoPlayer).toMatchSnapshot(`
-        <video
-          aria-hidden="true"
-          autoplay=""
-          class="wrapper"
-          data-testid="kz-video-player"
-          muted=""
-          playsinline=""
-          poster="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/heart/spot/moods-cautionary.svg.png"
-          preload="metadata"
-          tabindex="-1"
-          width="100%"
-        >
-          <source
-            src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/heart/spot/moods-cautionary.webm.mp4"
-            type="video/mp4"
-          />
-        </video>
-      `)
+      expect(videoPlayer).toMatchSnapshot()
       expect(mockPlay).toBeCalled()
     })
   })

--- a/packages/components/src/Illustration/subcomponents/VideoPlayer/VideoPlayer.spec.tsx
+++ b/packages/components/src/Illustration/subcomponents/VideoPlayer/VideoPlayer.spec.tsx
@@ -65,7 +65,7 @@ describe("<VideoPlayer />", () => {
         />
       )
       const videoPlayer = screen.getByTestId("kz-video-player")
-      expect(videoPlayer).toMatchInlineSnapshot(`
+      expect(videoPlayer).toMatchSnapshot(`
         <video
           aria-hidden="true"
           class="wrapper"
@@ -98,7 +98,7 @@ describe("<VideoPlayer />", () => {
         />
       )
       const videoPlayer = screen.getByTestId("kz-video-player")
-      expect(videoPlayer).toMatchInlineSnapshot(`
+      expect(videoPlayer).toMatchSnapshot(`
         <video
           aria-hidden="true"
           autoplay=""

--- a/packages/components/src/Illustration/subcomponents/VideoPlayer/VideoPlayer.tsx
+++ b/packages/components/src/Illustration/subcomponents/VideoPlayer/VideoPlayer.tsx
@@ -51,6 +51,7 @@ export const VideoPlayer = ({
   const videoRef = useRef<HTMLVideoElement>(null)
   const [prefersReducedMotion, setPrefersReducedMotion] =
     React.useState<boolean>(true)
+  const [sourceEl, setSourceEl] = React.useState<React.ReactNode>()
 
   useEffect(() => {
     /**
@@ -149,6 +150,24 @@ export const VideoPlayer = ({
     }
   }, [videoRef])
 
+  useEffect(() => {
+    /**
+     * This seems counter-intuitive, but webm support is codec specific.
+     * Only offer webm if we are positive the browser supports it.
+     * Reference: https://bugs.webkit.org/show_bug.cgi?id=216652#c1
+     */
+    canPlayWebm() ? (
+      setSourceEl(
+        <>
+          <source src={assetUrl(`${source}.webm`)} type="video/webm" />
+          <source src={assetUrl(`${source}.mp4`)} type="video/mp4" />
+        </>
+      )
+    ) : (
+      <source src={assetUrl(`${source}.mp4`)} type="video/mp4" />
+    )
+  }, [setSourceEl])
+
   const pausePlay = usePausePlay(videoRef)
 
   return (
@@ -172,15 +191,7 @@ export const VideoPlayer = ({
         playsInline={true}
         tabIndex={-1}
       >
-        {/**
-         * This seems counter-intuitive, but webm support is codec specific.
-         * Only offer webm if we are positive the browser supports it.
-         * Reference: https://bugs.webkit.org/show_bug.cgi?id=216652#c1
-         */}
-        {canPlayWebm() && (
-          <source src={assetUrl(`${source}.webm`)} type="video/webm" />
-        )}
-        <source src={assetUrl(`${source}.mp4`)} type="video/mp4" />
+        {sourceEl}
       </video>
       <IconButton
         onClick={(): void => pausePlay.toggle()}

--- a/packages/components/src/Illustration/subcomponents/VideoPlayer/__snapshots__/VideoPlayer.spec.tsx.snap
+++ b/packages/components/src/Illustration/subcomponents/VideoPlayer/__snapshots__/VideoPlayer.spec.tsx.snap
@@ -1,24 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`<VideoPlayer /> use-reduced-motion defaults to autoplay when user does not set use-reduced-motion preferences: 
-        <video
-          aria-hidden="true"
-          autoplay=""
-          class="wrapper"
-          data-testid="kz-video-player"
-          muted=""
-          playsinline=""
-          poster="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/heart/spot/moods-cautionary.svg.png"
-          preload="metadata"
-          tabindex="-1"
-          width="100%"
-        >
-          <source
-            src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/heart/spot/moods-cautionary.webm.mp4"
-            type="video/mp4"
-          />
-        </video>
-       1`] = `
+exports[`<VideoPlayer /> use-reduced-motion defaults to autoplay when user does not set use-reduced-motion preferences 1`] = `
 <video
   aria-hidden="true"
   autoplay=""
@@ -33,24 +15,7 @@ exports[`<VideoPlayer /> use-reduced-motion defaults to autoplay when user does 
 />
 `;
 
-exports[`<VideoPlayer /> use-reduced-motion respects the use-reduced-motion preferences of the user: 
-        <video
-          aria-hidden="true"
-          class="wrapper"
-          data-testid="kz-video-player"
-          muted=""
-          playsinline=""
-          poster="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/heart/spot/moods-cautionary.svg.png"
-          preload="metadata"
-          tabindex="-1"
-          width="100%"
-        >
-          <source
-            src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/heart/spot/moods-cautionary.webm.mp4"
-            type="video/mp4"
-          />
-        </video>
-       1`] = `
+exports[`<VideoPlayer /> use-reduced-motion respects the use-reduced-motion preferences of the user 1`] = `
 <video
   aria-hidden="true"
   class="wrapper"

--- a/packages/components/src/Illustration/subcomponents/VideoPlayer/__snapshots__/VideoPlayer.spec.tsx.snap
+++ b/packages/components/src/Illustration/subcomponents/VideoPlayer/__snapshots__/VideoPlayer.spec.tsx.snap
@@ -1,0 +1,65 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<VideoPlayer /> use-reduced-motion defaults to autoplay when user does not set use-reduced-motion preferences: 
+        <video
+          aria-hidden="true"
+          autoplay=""
+          class="wrapper"
+          data-testid="kz-video-player"
+          muted=""
+          playsinline=""
+          poster="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/heart/spot/moods-cautionary.svg.png"
+          preload="metadata"
+          tabindex="-1"
+          width="100%"
+        >
+          <source
+            src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/heart/spot/moods-cautionary.webm.mp4"
+            type="video/mp4"
+          />
+        </video>
+       1`] = `
+<video
+  aria-hidden="true"
+  autoplay=""
+  class="wrapper"
+  data-testid="kz-video-player"
+  muted=""
+  playsinline=""
+  poster="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/heart/spot/moods-cautionary.svg.png"
+  preload="metadata"
+  tabindex="-1"
+  width="100%"
+/>
+`;
+
+exports[`<VideoPlayer /> use-reduced-motion respects the use-reduced-motion preferences of the user: 
+        <video
+          aria-hidden="true"
+          class="wrapper"
+          data-testid="kz-video-player"
+          muted=""
+          playsinline=""
+          poster="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/heart/spot/moods-cautionary.svg.png"
+          preload="metadata"
+          tabindex="-1"
+          width="100%"
+        >
+          <source
+            src="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/heart/spot/moods-cautionary.webm.mp4"
+            type="video/mp4"
+          />
+        </video>
+       1`] = `
+<video
+  aria-hidden="true"
+  class="wrapper"
+  data-testid="kz-video-player"
+  muted=""
+  playsinline=""
+  poster="https://d1e7r7b0lb8p4d.cloudfront.net/illustrations/heart/spot/moods-cautionary.svg.png"
+  preload="metadata"
+  tabindex="-1"
+  width="100%"
+/>
+`;


### PR DESCRIPTION
## Why
When using the Illustration component either directly or through another component (BrandMoment for instance), you will receive a hydration warning in the console:
![image](https://github.com/cultureamp/kaizen-design-system/assets/4666090/6f2abafc-c92b-40d3-93b6-7fd5e94f830d)

Without this fix, every consumer that uses a component with VideoPlayer in it needs to dynamically import it into their Next.js app and disable prerendering for it.

## What
This PR moves the source element logic into a `useEffect` so we can ensure that it only runs once on the client - thus keeping the server HTML and initial client render consistent.

I encountered an issue with updating the inline snapshots as that feature is no longer compatible with prettier 3.0. I have converted these to external snapshots after [confirming with the DS team.](https://cultureamp.slack.com/archives/C0189KBPM4Y/p1702857404345209)

Tested it fixed the issue via canary release