### PR TITLE
Add readonly input state

### DIFF
--- a/.changeset/two-cooks-fetch.md
+++ b/.changeset/two-cooks-fetch.md
@@ -1,0 +1,5 @@
+---
+"@kaizen/components": minor
+---
+
+add: readOnly state (visual and functional) to Input, TextField, TextArea and TextAreaField components

--- a/packages/components/src/Input/Input/Input.module.scss
+++ b/packages/components/src/Input/Input/Input.module.scss
@@ -300,6 +300,11 @@ $input-with-icon-padding: calc(
       border-color: rgba($color-yellow-600-rgb, $input-disabled-opacity);
     }
   }
+
+  &.readOnly {
+    background: $color-gray-200;
+    border: none;
+  }
 }
 
 // Reversed (Dark Backgrounds)
@@ -355,5 +360,10 @@ $input-with-icon-padding: calc(
     &.disabled {
       border-color: rgba($color-yellow-400-rgb, $input-disabled-opacity);
     }
+  }
+
+  &.readOnly {
+    background: rgba($color-white-rgb, 0.1);
+    border: none;
   }
 }

--- a/packages/components/src/Input/Input/Input.tsx
+++ b/packages/components/src/Input/Input/Input.tsx
@@ -27,6 +27,7 @@ export const Input = ({
   defaultValue,
   classNameOverride,
   disabled,
+  readOnly,
   ...restProps
 }: InputProps): JSX.Element => (
   <div
@@ -48,12 +49,14 @@ export const Input = ({
       type={type}
       value={value}
       defaultValue={defaultValue}
+      readOnly={readOnly}
       disabled={disabled}
       className={classnames(
         styles.input,
         styles[status],
         classNameOverride,
         reversed ? styles.reversed : styles.default,
+        readOnly && styles.readOnly,
         disabled && styles.disabled
       )}
       {...restProps}

--- a/packages/components/src/Input/Input/Input.tsx
+++ b/packages/components/src/Input/Input/Input.tsx
@@ -13,6 +13,7 @@ export type InputProps = {
   startIconAdornment?: React.ReactNode
   endIconAdornment?: React.ReactNode
   reversed?: boolean
+  readOnly?: boolean
   type?: InputType
 } & OverrideClassName<InputHTMLAttributes<HTMLInputElement>>
 

--- a/packages/components/src/Input/Input/_docs/Input.stickersheet.stories.tsx
+++ b/packages/components/src/Input/Input/_docs/Input.stickersheet.stories.tsx
@@ -61,7 +61,14 @@ const StickerSheetTemplate: StickerSheetStory = {
   render: ({ isReversed }) => (
     <StickerSheet isReversed={isReversed}>
       <StickerSheet.Header
-        headings={["Default", "Hover", "Active", "Focus", "Disabled"]}
+        headings={[
+          "Default",
+          "Hover",
+          "Active",
+          "Focus",
+          "Read only",
+          "Disabled",
+        ]}
         hasVerticalHeadings
       />
       <StickerSheet.Body>
@@ -83,6 +90,7 @@ const StickerSheetTemplate: StickerSheetStory = {
               reversed={isReversed}
               data-sb-pseudo-styles="focus"
             />
+            <InputExampleGroup status={status} reversed={isReversed} readOnly />
             <InputExampleGroup
               status={status}
               reversed={isReversed}

--- a/packages/components/src/TextArea/TextArea.module.scss
+++ b/packages/components/src/TextArea/TextArea.module.scss
@@ -90,7 +90,11 @@ $input-disabled-border-alpha: 50%;
 
   &.readOnly {
     background-color: $color-gray-200;
-    border: none;
+    border-color: $color-gray-200;
+
+    @include form-input-focus-state {
+      border-color: $color-gray-200;
+    }
   }
 }
 
@@ -142,6 +146,10 @@ $input-disabled-border-alpha: 50%;
 
   &.readOnly {
     background: rgba($color-white-rgb, 0.1);
-    border: none;
+    border-color: rgba($color-white-rgb, 0);
+
+    @include form-input-focus-state {
+      border-color: rgba($color-white-rgb, 0);
+    }
   }
 }

--- a/packages/components/src/TextArea/TextArea.module.scss
+++ b/packages/components/src/TextArea/TextArea.module.scss
@@ -87,6 +87,11 @@ $input-disabled-border-alpha: 50%;
       opacity: $input-disabled-opacity;
     }
   }
+
+  &.readOnly {
+    background-color: $color-gray-200;
+    border: none;
+  }
 }
 
 // Reversed (Dark Backgrounds)
@@ -133,5 +138,10 @@ $input-disabled-border-alpha: 50%;
     @include form-input-placeholder {
       opacity: $input-disabled-opacity;
     }
+  }
+
+  &.readOnly {
+    background: rgba($color-white-rgb, 0.1);
+    border: none;
   }
 }

--- a/packages/components/src/TextArea/TextArea.tsx
+++ b/packages/components/src/TextArea/TextArea.tsx
@@ -12,6 +12,7 @@ export type TextAreaProps = {
   textAreaRef?: React.RefObject<HTMLTextAreaElement>
   status?: "default" | "error" | "caution"
   autogrow?: boolean
+  readOnly?: boolean
   reversed?: boolean
 } & OverrideClassName<TextareaHTMLAttributes<HTMLTextAreaElement>>
 
@@ -24,6 +25,7 @@ export const TextArea = ({
   defaultValue,
   value,
   disabled,
+  readOnly,
   onChange: propsOnChange,
   ...restProps
 }: TextAreaProps): JSX.Element => {
@@ -78,6 +80,7 @@ export const TextArea = ({
           styles.textarea,
           styles[status],
           reversed ? styles.reversed : styles.default,
+          readOnly && styles.readOnly,
           disabled && styles.disabled
         )}
         rows={rows}
@@ -87,6 +90,7 @@ export const TextArea = ({
         // ^ React throws a warning if you specify both a value and a defaultValue
         ref={textAreaRef}
         style={getTextAreaStyle()}
+        readOnly={readOnly}
         disabled={disabled}
         {...restProps}
       />

--- a/packages/components/src/TextArea/_docs/TextArea.stickersheet.stories.tsx
+++ b/packages/components/src/TextArea/_docs/TextArea.stickersheet.stories.tsx
@@ -39,6 +39,24 @@ const StickerSheetTemplate: StickerSheetStory = {
           <TextArea reversed={isReversed} data-sb-pseudo-styles="active" />
           <TextArea reversed={isReversed} data-sb-pseudo-styles="focus" />
         </StickerSheet.Row>
+        <StickerSheet.Row rowTitle="Read only">
+          <TextArea readOnly reversed={isReversed} />
+          <TextArea
+            readOnly
+            reversed={isReversed}
+            data-sb-pseudo-styles="hover"
+          />
+          <TextArea
+            readOnly
+            reversed={isReversed}
+            data-sb-pseudo-styles="active"
+          />
+          <TextArea
+            readOnly
+            reversed={isReversed}
+            data-sb-pseudo-styles="focus"
+          />
+        </StickerSheet.Row>
         <StickerSheet.Row rowTitle="Disabled">
           <TextArea reversed={isReversed} disabled />
           <TextArea

--- a/packages/components/src/TextAreaField/TextAreaField.tsx
+++ b/packages/components/src/TextAreaField/TextAreaField.tsx
@@ -9,6 +9,7 @@ import styles from "./TextAreaField.module.scss"
 export type TextAreaFieldProps = {
   labelText: string | React.ReactNode
   inline?: boolean
+  readOnly?: boolean
   validationMessage?: string | React.ReactNode
   description?: string | React.ReactNode
   variant?: "default" | "prominent"
@@ -27,6 +28,7 @@ export const TextAreaField = ({
   id: propsId,
   reversed = false,
   status = "default",
+  readOnly,
   disabled,
   ...restProps
 }: TextAreaFieldProps): JSX.Element => {
@@ -88,6 +90,7 @@ export const TextAreaField = ({
         data-testid={`${id}-field-textarea`}
         reversed={reversed}
         status={status}
+        readOnly={readOnly}
         disabled={disabled}
         aria-describedby={ariaDescribedBy}
         {...restProps}

--- a/packages/components/src/TextAreaField/_docs/TextAreaField.stickersheet.stories.tsx
+++ b/packages/components/src/TextAreaField/_docs/TextAreaField.stickersheet.stories.tsx
@@ -83,6 +83,27 @@ const StickerSheetTemplate: StickerSheetStory = {
         </StickerSheet.Body>
       </StickerSheet>
       <Heading variant="heading-2" color={isReversed ? "white" : "dark"}>
+        Read only
+      </Heading>
+      <StickerSheet isReversed={isReversed}>
+        <StickerSheet.Header
+          headings={["Default", "Hover", "Active", "Focus"]}
+          hasVerticalHeadings
+        />
+        <StickerSheet.Body>
+          <TAFieldStatusGroup
+            readOnly
+            isReversed={isReversed}
+            variant="default"
+          />
+          <TAFieldStatusGroup
+            readOnly
+            isReversed={isReversed}
+            variant="prominent"
+          />
+        </StickerSheet.Body>
+      </StickerSheet>
+      <Heading variant="heading-2" color={isReversed ? "white" : "dark"}>
         Disabled
       </Heading>
       <StickerSheet isReversed={isReversed}>

--- a/packages/components/src/TextField/TextField.tsx
+++ b/packages/components/src/TextField/TextField.tsx
@@ -19,6 +19,7 @@ export type TextFieldProps = {
    */
   labelText: React.ReactNode
   inline?: boolean
+  readOnly?: boolean
   icon?: JSX.Element
   /**
    * A descriptive message for `error` or `caution` states
@@ -43,6 +44,7 @@ export const TextField = ({
   description,
   status,
   reversed = false,
+  readOnly,
   disabled,
   ...restProps
 }: TextFieldProps): JSX.Element => {
@@ -80,6 +82,7 @@ export const TextField = ({
         data-testid={`${id}-field-input`}
         aria-describedby={ariaDescribedBy}
         classNameOverride={styles.input}
+        readOnly={readOnly}
         disabled={disabled}
         reversed={reversed}
         status={status}

--- a/packages/components/src/TextField/_docs/TextField.stickersheet.stories.tsx
+++ b/packages/components/src/TextField/_docs/TextField.stickersheet.stories.tsx
@@ -34,7 +34,7 @@ const StickerSheetTemplate: StickerSheetStory = {
   render: ({ isReversed }) => (
     <StickerSheet isReversed={isReversed}>
       <StickerSheet.Header
-        headings={["Default", "Hover", "Active", "Focus"]}
+        headings={["Default", "Hover", "Active", "Focus", "Read only"]}
         hasVerticalHeadings
       />
       <StickerSheet.Body>
@@ -70,6 +70,14 @@ const StickerSheetTemplate: StickerSheetStory = {
               status={status}
               validationMessage="A valid question"
               data-sb-pseudo-styles="focus"
+            />
+            <TextFieldExampleGroup
+              reversed={isReversed}
+              readOnly
+              labelText="TextField"
+              description="A short description"
+              status={status}
+              validationMessage="A valid question"
             />
           </StickerSheet.Row>
         ))}


### PR DESCRIPTION
## Why
Noticed that the email input on the Login screen became `disabled` when stepping through to the choice between Google and SSO. Should be read only instead.

![image](https://github.com/cultureamp/kaizen-design-system/assets/1561116/a054c500-6e60-4e3d-a3af-e556dd180ea4)

Also seems like useful functionality for elsewhere in the platform.


## What
Adds a `readOnly` prop to the Input and TextArea components – flowing up to TextField and TextAreaField as well.

![readonly](https://github.com/cultureamp/kaizen-design-system/assets/1561116/09c9612b-d50e-4782-aca0-35f0d49a0e9e)
