### PR TITLE
Clean up remnants of TitleBlock's action prop on menu items

### DIFF
--- a/.changeset/pink-donkeys-crash.md
+++ b/.changeset/pink-donkeys-crash.md
@@ -1,0 +1,5 @@
+---
+"@kaizen/components": patch
+---
+
+Remove required action prop on TitleBlockZen menu items that does nothing

--- a/packages/components/src/TitleBlockZen/_docs/TitleBlockZen.stories.tsx
+++ b/packages/components/src/TitleBlockZen/_docs/TitleBlockZen.stories.tsx
@@ -51,12 +51,10 @@ const meta = {
     secondaryActions: SECONDARY_ACTIONS,
     secondaryOverflowMenuItems: [
       {
-        action: (): void => alert("test"),
         label: "Overflow action 1",
         icon: <StarOnIcon role="presentation" />,
       },
       {
-        action: "#",
         label: "Overflow link 1",
         icon: <StarOnIcon role="presentation" />,
       },

--- a/packages/components/src/TitleBlockZen/subcomponents/MainActions.tsx
+++ b/packages/components/src/TitleBlockZen/subcomponents/MainActions.tsx
@@ -2,12 +2,13 @@ import React from "react"
 import { Button, IconButton } from "~components/Button"
 import { ChevronDownIcon, MeatballsIcon } from "~components/Icon"
 import { Menu, MenuList } from "~components/Menu"
-import { DefaultActionProps, PrimaryActionProps } from "../types"
-import { isMenuGroupNotButton } from "../utils"
 import {
-  TitleBlockMenuItem,
+  DefaultActionProps,
+  PrimaryActionProps,
   TitleBlockMenuItemProps,
-} from "./TitleBlockMenuItem"
+} from "../types"
+import { isMenuGroupNotButton } from "../utils"
+import { TitleBlockMenuItem } from "./TitleBlockMenuItem"
 import { Toolbar } from "./Toolbar"
 import styles from "./MainActions.module.scss"
 

--- a/packages/components/src/TitleBlockZen/subcomponents/MainActions.tsx
+++ b/packages/components/src/TitleBlockZen/subcomponents/MainActions.tsx
@@ -33,7 +33,7 @@ export const MainActions = ({
       <TitleBlockMenuItem
         {...item}
         key={`main-action-primary-menu-item-${idx}`}
-        automationId={`main-action-primary-menu-item-${idx}`}
+        data-automation-id={`main-action-primary-menu-item-${idx}`}
         data-testid={`main-action-primary-menu-item-${idx}`}
       />
     ))

--- a/packages/components/src/TitleBlockZen/subcomponents/MobileActions.spec.tsx
+++ b/packages/components/src/TitleBlockZen/subcomponents/MobileActions.spec.tsx
@@ -8,11 +8,11 @@ const user = userEvent.setup()
 const MENU_LINKS = [
   {
     label: "Primary menu link 1",
-    action: "#",
+    href: "#",
   },
   {
     label: "Primary menu action 2",
-    action: (): void => alert("test"),
+    onClick: (): void => alert("test"),
   },
 ]
 

--- a/packages/components/src/TitleBlockZen/subcomponents/MobileActions.tsx
+++ b/packages/components/src/TitleBlockZen/subcomponents/MobileActions.tsx
@@ -55,7 +55,7 @@ const renderPrimaryActionDrawerContent = (
         <TitleBlockMenuItem
           {...item}
           key={`title-block-mobile-actions-primary-${itemType}-${idx}`}
-          automationId={`title-block-mobile-actions-primary-${itemType}-${idx}`}
+          data-automation-id={`title-block-mobile-actions-primary-${itemType}-${idx}`}
           data-testid={`title-block-mobile-actions-primary-${itemType}-${idx}`}
         />
       )
@@ -74,7 +74,7 @@ const renderDefaultLink = (
       <TitleBlockMenuItem
         {...defaultAction}
         key="title-block-mobile-actions-default-link"
-        automationId="title-block-mobile-actions-default-link"
+        data-automation-id="title-block-mobile-actions-default-link"
         data-testid="title-block-mobile-actions-default-link"
       />
     )
@@ -86,7 +86,7 @@ const renderDefaultLink = (
       icon={defaultAction.icon}
       disabled={defaultAction.disabled}
       key="title-block-mobile-actions-default-link"
-      automationId="title-block-mobile-actions-default-link"
+      data-automation-id="title-block-mobile-actions-default-link"
       data-testid="title-block-mobile-actions-default-link"
     />
   )
@@ -100,7 +100,7 @@ const renderDefaultAction = (
       <TitleBlockMenuItem
         {...defaultAction}
         key="title-block-mobile-actions-default-action"
-        automationId="title-block-mobile-actions-default-action"
+        data-automation-id="title-block-mobile-actions-default-action"
         data-testid="title-block-mobile-actions-default-action"
       />
     )

--- a/packages/components/src/TitleBlockZen/subcomponents/MobileActions.tsx
+++ b/packages/components/src/TitleBlockZen/subcomponents/MobileActions.tsx
@@ -10,15 +10,13 @@ import {
   SecondaryActionsProps,
   TitleBlockButtonProps,
   TitleBlockMenuGroup,
+  TitleBlockMenuItemProps,
 } from "../types"
 import {
   convertSecondaryActionsToMenuItems,
   isMenuGroupNotButton,
 } from "../utils"
-import {
-  TitleBlockMenuItem,
-  TitleBlockMenuItemProps,
-} from "./TitleBlockMenuItem"
+import { TitleBlockMenuItem } from "./TitleBlockMenuItem"
 
 import styles from "./MobileActions.module.scss"
 

--- a/packages/components/src/TitleBlockZen/subcomponents/TitleBlockMenuItem.tsx
+++ b/packages/components/src/TitleBlockZen/subcomponents/TitleBlockMenuItem.tsx
@@ -1,14 +1,8 @@
 import React from "react"
 import classnames from "classnames"
-import { CustomButtonProps } from "~components/Button"
-import { MenuItem, MenuItemProps } from "~components/Menu"
+import { MenuItem } from "~components/Menu"
+import { TitleBlockMenuItemProps } from "../types"
 import styles from "./TitleBlockMenuItem.module.scss"
-
-export type TitleBlockMenuItemProps =
-  | ({
-      component: (props: CustomButtonProps) => JSX.Element
-    } & MenuItemProps)
-  | MenuItemProps
 
 export const TitleBlockMenuItem = (
   props: TitleBlockMenuItemProps

--- a/packages/components/src/TitleBlockZen/types.ts
+++ b/packages/components/src/TitleBlockZen/types.ts
@@ -124,11 +124,7 @@ export type TitleBlockCustomButtonProps = TitleBlockDistributiveOmit<
   component: (props: CustomButtonProps) => JSX.Element
 }
 
-export type TitleBlockMenuItemProps =
-  | (Omit<MenuItemProps, "action"> & {
-      action: ((e: any) => void) | string
-    })
-  | TitleBlockCustomButtonProps
+export type TitleBlockMenuItemProps = MenuItemProps | TitleBlockCustomButtonProps
 
 export type ButtonWithHrefNotOnClick = TitleBlockDistributiveOmit<
   ButtonProps,

--- a/packages/components/src/TitleBlockZen/types.ts
+++ b/packages/components/src/TitleBlockZen/types.ts
@@ -124,7 +124,9 @@ export type TitleBlockCustomButtonProps = TitleBlockDistributiveOmit<
   component: (props: CustomButtonProps) => JSX.Element
 }
 
-export type TitleBlockMenuItemProps = MenuItemProps | TitleBlockCustomButtonProps
+export type TitleBlockMenuItemProps =
+  | MenuItemProps
+  | TitleBlockCustomButtonProps
 
 export type ButtonWithHrefNotOnClick = TitleBlockDistributiveOmit<
   ButtonProps,

--- a/packages/components/src/TitleBlockZen/utils.ts
+++ b/packages/components/src/TitleBlockZen/utils.ts
@@ -1,4 +1,3 @@
-import { MenuItemProps } from "~components/Menu"
 import {
   TitleBlockButtonProps,
   TitleBlockCustomButtonProps,
@@ -7,10 +6,6 @@ import {
   SecondaryActionsProps,
   TitleBlockMenuItemProps,
 } from "./types"
-
-export const isMenuItemNotButton = (
-  value: TitleBlockButtonProps | MenuItemProps
-): value is MenuItemProps => "action" in value
 
 export const isMenuGroupNotButton = (
   value:


### PR DESCRIPTION
Bit of a confusing mess here in typical TitleBlockZen fashion:
We had 2x `TitleBlockMenuItemProps` type definitions being exported, one which had an old and required `action` prop.

I've consolidated those into one (living in types.ts) and cleaned up any remnants of the old `action` prop in stories.