### PR TITLE
Revert alpine update

### DIFF
--- a/.buildkite/dockerfiles/publish.Dockerfile
+++ b/.buildkite/dockerfiles/publish.Dockerfile
@@ -1,14 +1,16 @@
-FROM alpine:3.18
+FROM alpine:3.11
 
 RUN apk update && apk add --no-cache \
   git \
   openssh \
-  python3 \
+  python \
   py-pip \
   curl \ 
   gcc \ 
   alpine-sdk \ 
-  python3-dev
+  python-dev
 
 RUN pip install \
+  wheel \
+  "Cython<3.0" "pyyaml<6" --no-build-isolation \
   awscli


### PR DESCRIPTION
Alpine was updated in a dep refresh and subsequently broke the build.

We then tried updating python: https://github.com/cultureamp/kaizen-design-system/pull/4421
and then removing things from the pip install: https://github.com/cultureamp/kaizen-design-system/pull/4423 

but they still failed, so we're reverting everything here.