### PR TITLE
fix: add className to checkIcon

### DIFF
--- a/.changeset/ten-cycles-approve.md
+++ b/.changeset/ten-cycles-approve.md
@@ -1,0 +1,5 @@
+---
+"@kaizen/components": patch
+---
+
+Address ToggleSwitch bug - CheckIcon now hidden when toggle set to false.

--- a/packages/components/src/ToggleSwitch/ToggleSwitch/ToggleSwitch.tsx
+++ b/packages/components/src/ToggleSwitch/ToggleSwitch/ToggleSwitch.tsx
@@ -39,7 +39,7 @@ export const ToggleSwitch = ({
       />
       <span className={styles.track}>
         <span className={styles.thumb}>
-          <CheckIcon role="presentation" />
+          <CheckIcon classNameOverride={styles.checkIcon} role="presentation" />
         </span>
       </span>
     </span>


### PR DESCRIPTION
## Why
<!-- Why have you created this PR? - Is it a new feature, or a bug fix? Or something else? -->
<!-- Reference any relevant Jira tickets so your reviewer can find more context if needed. -->
<!-- Fixing a GitHub issue? Add "Fixes [issue URL]". -->

Bug identified where ToggleSwitch CheckIcon stayed visible regardless of true/false state of toggle - due to missing className.
Addressed this to keep ToggleSwitch behaviour inline with preKAIO component.


## What
<!-- What do your changes do? How do they change/fix the current behavior? -->
<!-- Add screenshots, GIFs or videos to illustrate the changes.  -->
Added className to component - checkIcon now appears when ToggleSwitch set to true, fades when ToggleSwitch set to false.
