### PR TITLE
Timefield label and accessibility fix

### DIFF
--- a/.changeset/blue-seals-argue.md
+++ b/.changeset/blue-seals-argue.md
@@ -1,0 +1,5 @@
+---
+"@kaizen/components": patch
+---
+
+TimeField: added conditional aria-describeby to fix accessibility

--- a/packages/components/src/TimeField/TimeField.module.scss
+++ b/packages/components/src/TimeField/TimeField.module.scss
@@ -18,7 +18,8 @@ $input-height: 48px;
   color: $color-purple-800;
 }
 
-.heading {
+.label {
+  display: block;
   margin-bottom: $spacing-6;
 }
 

--- a/packages/components/src/TimeField/TimeField.tsx
+++ b/packages/components/src/TimeField/TimeField.tsx
@@ -9,6 +9,7 @@ import {
 import classnames from "classnames"
 import { FieldMessage } from "~components/FieldMessage"
 import { Heading } from "~components/Heading"
+import { Label } from "~components/Label"
 import { OverrideClassName } from "~types/OverrideClassName"
 import { TimeSegment } from "./subcomponents/TimeSegment"
 import { StatusType, TimeValue, ValueType } from "./types"
@@ -79,7 +80,9 @@ const TimeFieldComponent = ({
     locale,
     validationState: status === "default" ? "valid" : "invalid",
   })
-  const descriptionId = `${id}-field-message`
+
+  const hasError = !!validationMessage && status === "error"
+  const descriptionId = hasError ? `${id}-field-message` : undefined
 
   const inputRef = React.useRef(null)
   const { fieldProps, labelProps } = useTimeField(
@@ -94,17 +97,15 @@ const TimeFieldComponent = ({
   )
   return (
     <div className={classNameOverride}>
-      <Heading
-        tag="div"
-        variant="heading-6"
+      <Label
         {...labelProps}
         classNameOverride={classnames(
-          styles.heading,
+          styles.label,
           state.isDisabled && styles.isDisabled
         )}
       >
         {label}
-      </Heading>
+      </Label>
       <div className={styles.wrapper}>
         {/* eslint-disable-next-line jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events */}
         <div
@@ -123,7 +124,7 @@ const TimeFieldComponent = ({
           <div className={styles.focusRing} />
         </div>
       </div>
-      {validationMessage && status === "error" && (
+      {hasError && (
         <FieldMessage
           id={descriptionId}
           message={validationMessage}

--- a/packages/components/src/TimeField/TimeField.tsx
+++ b/packages/components/src/TimeField/TimeField.tsx
@@ -8,7 +8,6 @@ import {
 } from "@react-stately/datepicker"
 import classnames from "classnames"
 import { FieldMessage } from "~components/FieldMessage"
-import { Heading } from "~components/Heading"
 import { Label } from "~components/Label"
 import { OverrideClassName } from "~types/OverrideClassName"
 import { TimeSegment } from "./subcomponents/TimeSegment"

--- a/packages/components/src/TimeField/TimeField.tsx
+++ b/packages/components/src/TimeField/TimeField.tsx
@@ -98,11 +98,9 @@ const TimeFieldComponent = ({
   return (
     <div className={classNameOverride}>
       <Label
+        disabled={state.isDisabled}
         {...labelProps}
-        classNameOverride={classnames(
-          styles.label,
-          state.isDisabled && styles.isDisabled
-        )}
+        classNameOverride={styles.label}
       >
         {label}
       </Label>


### PR DESCRIPTION
## Important: Request PR reviews on Slack
Please reach out to the design system team on Slack in `#prod_design_system` for PR reviews. GitHub notifications (e.g. from tagging a person) are not actively monitored.

## Why
<!-- Why have you created this PR? - Is it a new feature, or a bug fix? Or something else? -->
<!-- Reference any relevant Jira tickets so your reviewer can find more context if needed. -->
<!-- Fixing a GitHub issue? Add "Fixes [issue URL]". -->
There is currently an issue with aria-describedby and FieldMessage, this PR add a conditional to only add the "aria-describedby" if there is a `FieldMessage`

Also updated Label for consistency


## What
<!-- What do your changes do? How do they change/fix the current behavior? -->
<!-- Add screenshots, GIFs or videos to illustrate the changes.  -->

![Screenshot 2024-01-08 at 11 39 04 am](https://github.com/cultureamp/kaizen-design-system/assets/12579379/6c73b108-8f57-47e5-ba1d-4cb62a761d9c)


