### PR TITLE
ci: separate SB build for chromatic

### DIFF
--- a/.github/workflows/test-stories.yaml
+++ b/.github/workflows/test-stories.yaml
@@ -106,7 +106,9 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - run: pnpm storybook:build:prod --webpack-stats-json
+      - uses: ./.github/actions/setup
+      - name: Build Storybook for Chromatic
+        run: pnpm storybook:build:prod --webpack-stats-json
       - id: publishChromatic
         name: Publish to Chromatic
         uses: chromaui/action@v1

--- a/.github/workflows/test-stories.yaml
+++ b/.github/workflows/test-stories.yaml
@@ -26,8 +26,15 @@ env:
   ARTIFACT_NAME: artifact--storybook-build
 
 jobs:
-  build-storybook:
+  run-check:
+    name: Check if we should run Storybook tests
     if: github.head_ref != 'changeset-release/main' && github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Run the Storybook tests"
+
+  build-storybook:
+    needs: run-check
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -90,7 +97,7 @@ jobs:
         run: pnpm test:storybook --shard 3/3
 
   chromatic:
-    needs: build-storybook
+    needs: run-check
     runs-on: ubuntu-latest
     outputs:
       storybookUrl: ${{ steps.publishChromatic.outputs.storybookUrl }}
@@ -99,12 +106,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Download Storybook build artifact
-        id: download
-        uses: actions/download-artifact@v3
-        with:
-          name: ${{ env.ARTIFACT_NAME }}
-          path: "./storybook/public"
+      - run: pnpm storybook:build:prod --webpack-stats-json
       - id: publishChromatic
         name: Publish to Chromatic
         uses: chromaui/action@v1

--- a/.github/workflows/test-stories.yaml
+++ b/.github/workflows/test-stories.yaml
@@ -108,7 +108,8 @@ jobs:
           fetch-depth: 0
       - uses: ./.github/actions/setup
       - name: Build Storybook for Chromatic
-        run: pnpm storybook:build:prod --webpack-stats-json
+        # We want both stories and docs for the branch preview
+        run: pnpm storybook:build --webpack-stats-json
       - id: publishChromatic
         name: Publish to Chromatic
         uses: chromaui/action@v1

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "storybook:preview": "NODE_ENV=production pnpm storybook --docs",
     "storybook:clean": "rm -rf storybook/public",
     "storybook:build": "storybook build -c storybook -o storybook/public",
-    "storybook:build:test": "pnpm storybook:build --test --webpack-stats-json",
+    "storybook:build:test": "pnpm storybook:build --test",
     "storybook:build:prod": "pnpm storybook:build --docs",
     "test:storybook": "test-storybook --config-dir storybook",
     "jest:debug": "node --inspect-brk node_modules/.bin/jest --runInBand --no-cache",


### PR DESCRIPTION
## Why
<!-- Why have you created this PR? - Is it a new feature, or a bug fix? Or something else? -->
<!-- Reference any relevant Jira tickets so your reviewer can find more context if needed. -->
<!-- Fixing a GitHub issue? Add "Fixes [issue URL]". -->
Branch preview uses Chromatic, but we were not providing Docs in the build, therefore we only see stories.

## What
<!-- What do your changes do? How do they change/fix the current behavior? -->
<!-- Add screenshots, GIFs or videos to illustrate the changes.  -->

Separate the build for SB tests (stories only) and Chromatic (stories + docs).