### PR TITLE
fix: unscrollable style remains when modal is unmounted

### DIFF
--- a/.changeset/fluffy-spies-thank.md
+++ b/.changeset/fluffy-spies-thank.md
@@ -2,4 +2,6 @@
 "@kaizen/components": patch
 ---
 
-Fix the unscrollable problem when a modal is unmounted after confirmation
+Bug fix for modals: ensure clean up runs when the modal is unmounted.
+
+This bug created unscrollable pages if the modal was removed from the DOM before its `onAfterLeave` callback was able to run.

--- a/.changeset/fluffy-spies-thank.md
+++ b/.changeset/fluffy-spies-thank.md
@@ -1,0 +1,5 @@
+---
+"@kaizen/components": patch
+---
+
+Fix the unscrollable problem when a modal is unmounted after confirmation

--- a/packages/components/src/Modal/GenericModal/GenericModal.tsx
+++ b/packages/components/src/Modal/GenericModal/GenericModal.tsx
@@ -1,4 +1,4 @@
-import React, { useId, useState } from "react"
+import React, { useEffect, useId, useState } from "react"
 import { createPortal } from "react-dom"
 import { Transition } from "@headlessui/react"
 import FocusLock from "react-focus-lock"
@@ -102,7 +102,7 @@ export const GenericModal = ({
     }
   }
 
-  const onAfterLeaveHandler = (): void => {
+  const cleanUpAfterClose = (): void => {
     document.documentElement.classList.remove(
       styles.unscrollable,
       styles.pseudoScrollbar
@@ -111,7 +111,13 @@ export const GenericModal = ({
     if (onEscapeKeyup) {
       document.removeEventListener("keyup", onEscapeKeyup)
     }
+  }
 
+  /* Ensure sure add-on styles (e.g. unscrollable) and key event is cleaned up when the modal is unmounted*/
+  useEffect(() => () => cleanUpAfterClose(), [])
+
+  const onAfterLeaveHandler = (): void => {
+    cleanUpAfterClose()
     propsOnAfterLeave?.()
   }
 


### PR DESCRIPTION
## Important: Request PR reviews on Slack
Please reach out to the design system team on Slack in `#prod_design_system` for PR reviews. GitHub notifications (e.g. from tagging a person) are not actively monitored.

## Why
<!-- Why have you created this PR? - Is it a new feature, or a bug fix? Or something else? -->
<!-- Reference any relevant Jira tickets so your reviewer can find more context if needed. -->
<!-- Fixing a GitHub issue? Add "Fixes [issue URL]". -->
There is a bug when modal is unmounted (e.g. navigation, parent unmounted) after onConfirm, the unscrollable style remains which stops user from scrolling unless refresh.

## What
<!-- What do your changes do? How do they change/fix the current behavior? -->
<!-- Add screenshots, GIFs or videos to illustrate the changes.  -->
Include the clean up code in onAfterLeave to a useEffect's return block.

Before

https://github.com/cultureamp/kaizen-design-system/assets/8596435/4741bc9b-a7f4-44d2-94fa-32609ba72e70


After

https://github.com/cultureamp/kaizen-design-system/assets/8596435/3c398b56-d210-4696-bc38-9fc727140ba6



