### PR TITLE
Improve SplitButton dropdown accessible label

### DIFF
--- a/.changeset/few-seas-notice.md
+++ b/.changeset/few-seas-notice.md
@@ -1,0 +1,7 @@
+---
+"@kaizen/components": patch
+---
+
+Improve the SplitButton dropdown accessible label (from "Open menu" to "Additional actions")
+
+Also adds internationalisation to the label

--- a/packages/components/locales/en.json
+++ b/packages/components/locales/en.json
@@ -112,5 +112,9 @@
   "kzErrorPage.goToHome": {
     "description": "Home button label",
     "message": "Go to Home"
+  },
+  "splitButton.dropdownButton.label": {
+    "description": "Label for a dropdown menu holding additional actions",
+    "message": "Additional actions"
   }
 }

--- a/packages/components/src/SplitButton/subcomponents/DropdownButton/DropdownButton.spec.tsx
+++ b/packages/components/src/SplitButton/subcomponents/DropdownButton/DropdownButton.spec.tsx
@@ -9,8 +9,8 @@ const DropdownButtonWrapper = (
 describe("<DropdownButton />", () => {
   it("renders icon with default aria-label", () => {
     render(<DropdownButtonWrapper />)
-    const button = screen.getByRole("button", { name: "Open menu" })
-    expect(button.getAttribute("aria-label")).toBe("Open menu")
+    const button = screen.getByRole("button", { name: "Additional actions" })
+    expect(button.getAttribute("aria-label")).toBe("Additional actions")
     expect(button.firstChild?.nodeName).toEqual("svg")
   })
 

--- a/packages/components/src/SplitButton/subcomponents/DropdownButton/DropdownButton.tsx
+++ b/packages/components/src/SplitButton/subcomponents/DropdownButton/DropdownButton.tsx
@@ -1,4 +1,5 @@
 import React from "react"
+import { useIntl } from "@cultureamp/i18n-react-intl"
 import classnames from "classnames"
 import { ChevronDownIcon } from "~components/Icon"
 import { BaseButton, BaseButtonProps } from "../BaseButton"
@@ -10,13 +11,23 @@ export const DropdownButton = ({
   classNameOverride,
   "aria-label": ariaLabel,
   ...restProps
-}: DropdownButtonProps): JSX.Element => (
-  <BaseButton
-    label={ariaLabel || "Open menu"}
-    icon={<ChevronDownIcon role="presentation" />}
-    classNameOverride={classnames(styles.dropdownButton, classNameOverride)}
-    {...restProps}
-  />
-)
+}: DropdownButtonProps): JSX.Element => {
+  const { formatMessage } = useIntl()
+  return (
+    <BaseButton
+      label={
+        ariaLabel ||
+        formatMessage({
+          id: "splitButton.dropdownButton.label",
+          defaultMessage: "Additional actions",
+          description: "Label for a dropdown menu holding additional actions",
+        })
+      }
+      icon={<ChevronDownIcon role="presentation" />}
+      classNameOverride={classnames(styles.dropdownButton, classNameOverride)}
+      {...restProps}
+    />
+  )
+}
 
 DropdownButton.displayName = "DropdownButton"


### PR DESCRIPTION
## Why
The label "Open menu" doesn't do a good job of describing this button because:
- It doesn't give you any indication of what the menu holds or is for
- It remains as "_Open_ menu" even when the action would be to close the menu.

The `aria-haspopup` and `aria-expanded` attributes already cover communicating that this is a menu and whether it's open or not.

## What
Change the aria-label on the dropdown button on SplitButton from "Open menu" to "More actions"

Also adds internationalisation while I was here.