### PR TITLE
feature: Allow label and trigger props in FilterBarMultiSelect

### DIFF
--- a/.changeset/moody-hotels-drive.md
+++ b/.changeset/moody-hotels-drive.md
@@ -1,0 +1,5 @@
+---
+"@kaizen/components": patch
+---
+
+Allow `label` and `trigger` props to `FilterBarMultiSelect`, ensuring the tooltip for the removable button still displays the filter name. Also, translates the `Remove filter` tooltip.

--- a/packages/components/locales/en.json
+++ b/packages/components/locales/en.json
@@ -14,6 +14,10 @@
     "description": "Label for the 'Input format' field",
     "message": "Input format"
   },
+  "filterButtonRemovable.tooltipText": {
+    "description": "Label for the tooltip used in a filter remove button",
+    "message": "Remove filter - {filter}"
+  },
   "filterDateRangePicker.dateFrom": {
     "description": "Label for the 'Date from' field",
     "message": "Date from"

--- a/packages/components/src/Filter/FilterBar/_docs/FilterBar.stories.tsx
+++ b/packages/components/src/Filter/FilterBar/_docs/FilterBar.stories.tsx
@@ -148,6 +148,7 @@ const filters = [
     name: "Toppings",
     Component: (
       <FilterBar.MultiSelect
+        label="Group by Toppings"
         items={[
           { value: "none", label: "None" },
           { value: "pearls", label: "Pearls" },

--- a/packages/components/src/Filter/FilterBar/_docs/FilterBar.stories.tsx
+++ b/packages/components/src/Filter/FilterBar/_docs/FilterBar.stories.tsx
@@ -148,7 +148,6 @@ const filters = [
     name: "Toppings",
     Component: (
       <FilterBar.MultiSelect
-        label="Group by Toppings"
         items={[
           { value: "none", label: "None" },
           { value: "pearls", label: "Pearls" },

--- a/packages/components/src/Filter/FilterBar/subcomponents/FilterBarMultiSelect/FilterBarMultiSelect.tsx
+++ b/packages/components/src/Filter/FilterBar/subcomponents/FilterBarMultiSelect/FilterBarMultiSelect.tsx
@@ -4,6 +4,7 @@ import {
   FilterMultiSelect,
   FilterMultiSelectProps,
   ItemType,
+  MenuTriggerProviderContextType,
   getSelectedOptionLabels,
 } from "~components/Filter/FilterMultiSelect"
 import { useFilterBarContext } from "../../context/FilterBarContext"
@@ -11,14 +12,11 @@ import { checkArraysMatch } from "../../utils/checkArraysMatch"
 
 export type FilterBarMultiSelectProps = Omit<
   FilterMultiSelectProps,
-  | "isOpen"
-  | "setIsOpen"
-  | "renderTrigger"
-  | "label"
-  | "selectedKeys"
-  | "trigger"
+  "isOpen" | "selectedKeys" | "label" | "trigger"
 > & {
   id?: string
+  label?: string
+  trigger?: (value?: MenuTriggerProviderContextType) => React.ReactNode
 }
 
 // This should technically be handled within the FilterMultiSelect
@@ -44,6 +42,7 @@ export const FilterBarMultiSelect = ({
   items: propsItems,
   children,
   onSelectionChange,
+  label,
   ...props
 }: FilterBarMultiSelectProps): JSX.Element | null => {
   const { getFilterState, setFilterOpenState, updateValue, hideFilter } =
@@ -94,12 +93,13 @@ export const FilterBarMultiSelect = ({
                 items
               )
             : [],
-          label: filterState.name,
+          label: label || filterState.name,
         }
 
         return filterState.isRemovable ? (
           <FilterMultiSelect.RemovableTrigger
             {...triggerProps}
+            removeButtonTooltipText={filterState.name}
             onRemove={() => hideFilter(id)}
           />
         ) : (

--- a/packages/components/src/Filter/FilterButton/FilterButtonRemovable/FilterButtonRemovable.tsx
+++ b/packages/components/src/Filter/FilterButton/FilterButtonRemovable/FilterButtonRemovable.tsx
@@ -1,4 +1,5 @@
 import React, { forwardRef } from "react"
+import { useIntl } from "@cultureamp/i18n-react-intl"
 import { ButtonGroup, ButtonGroupProps } from "~components/ButtonGroup"
 import { FilterTriggerRef } from "~components/Filter/Filter"
 import { ClearIcon } from "~components/Icon"
@@ -25,12 +26,20 @@ export const FilterButtonRemovable = forwardRef<
   FilterButtonRemovableRefs,
   FilterButtonRemovableProps
 >(({ triggerButtonProps, removeButtonProps, ...restProps }, ref) => {
+  const { formatMessage } = useIntl()
   const customRefObject = isRefObject(ref) ? ref.current : null
   const removeButtonRef = customRefObject?.removeButtonRef
 
-  const removeButtonLabel =
-    removeButtonProps?.tooltipText ??
-    `Remove filter - ${triggerButtonProps?.label}`
+  const removeButtonLabel = formatMessage(
+    {
+      id: "filterButtonRemovable.tooltipText",
+      defaultMessage: "Remove filter - {filter}",
+      description: "Label for the tooltip used in a filter remove button",
+    },
+    {
+      filter: removeButtonProps?.tooltipText || triggerButtonProps?.label,
+    }
+  )
 
   return (
     <ButtonGroup {...restProps}>

--- a/packages/components/src/Filter/FilterMultiSelect/subcomponents/Trigger/RemovableFilterTrigger/RemovableFilterTrigger.tsx
+++ b/packages/components/src/Filter/FilterMultiSelect/subcomponents/Trigger/RemovableFilterTrigger/RemovableFilterTrigger.tsx
@@ -7,6 +7,7 @@ import { FilterTriggerButtonProps } from "../FilterTriggerButton"
 
 export type RemovableFilterTriggerProps = FilterTriggerButtonProps & {
   onRemove: () => void
+  removeButtonTooltipText: string
 }
 
 export const RemovableFilterTrigger = ({
@@ -14,6 +15,7 @@ export const RemovableFilterTrigger = ({
   selectedOptionLabels,
   labelCharacterLimitBeforeTruncate = 50,
   classNameOverride,
+  removeButtonTooltipText,
   onRemove,
 }: RemovableFilterTriggerProps): JSX.Element => {
   const { buttonProps, buttonRef, menuTriggerState } = useMenuTriggerContext()
@@ -33,6 +35,7 @@ export const RemovableFilterTrigger = ({
         isOpen: menuTriggerState.isOpen,
       }}
       removeButtonProps={{
+        tooltipText: removeButtonTooltipText,
         onClick: onRemove,
       }}
     />


### PR DESCRIPTION
## Important: Request PR reviews on Slack
Please reach out to the design system team on Slack in `#prod_design_system` for PR reviews. GitHub notifications (e.g. from tagging a person) are not actively monitored.

## Why
`FilterBarMultiSelect` types were not allowing a `label` or a `trigger` to be passed, even though they were being spread. Also, the label prop was not being used at all.

## What
We are now allowing the `label` to be customised, but also making sure we are still using the filter's name in the remove button's tooltip. This way, we can achieve something like this:


https://github.com/cultureamp/kaizen-design-system/assets/4048660/3c25bcb6-7914-4bf4-b8b7-6e19dfe78fe5

As part of this PR, we are now also localising the `Remove filter` tooltip text.
