### PR TITLE
fix: use named export for CJS default exports

### DIFF
--- a/.changeset/gold-beers-marry.md
+++ b/.changeset/gold-beers-marry.md
@@ -1,0 +1,5 @@
+---
+"@kaizen/components": patch
+---
+
+Fix CJS bundling and moved type declarations into dist/types.

--- a/packages/components/future/package.json
+++ b/packages/components/future/package.json
@@ -1,5 +1,5 @@
 {
   "main": "../dist/cjs/future.cjs",
   "module": "../dist/esm/future.mjs",
-  "types": "../dist/esm/dts/__future__/index.d.ts"
+  "types": "../dist/types/__future__/index.d.ts"
 }

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -32,7 +32,7 @@
     "test:ci": "pnpm test -- --ci",
     "test:treeshake": "agadoo ./dist/esm/index.mjs",
     "clean": "rimraf dist",
-    "build:components": "rollup -c",
+    "build:components": "rollup -c && pnpm build:types",
     "build:styles": "postcss styles/global.css --output dist/global.css",
     "build:types": "tspc --project tsconfig.types.json",
     "compile": "tsc",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -21,7 +21,7 @@
   ],
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",
-  "types": "dist/index.d.ts",
+  "types": "dist/types/index.d.ts",
   "sideEffects": [
     "styles.css"
   ],
@@ -34,6 +34,7 @@
     "clean": "rimraf dist",
     "build:components": "rollup -c",
     "build:styles": "postcss styles/global.css --output dist/global.css",
+    "build:types": "tspc --project tsconfig.types.json",
     "compile": "tsc",
     "dist:clean": "rm ./dist/global.css ./dist/raw-styles.css",
     "dist:combine-styles": "concat-cli -f ./dist/*.css ./dist/esm/*.css -o ./dist/raw-styles.css",

--- a/packages/components/rollup.config.mjs
+++ b/packages/components/rollup.config.mjs
@@ -50,7 +50,13 @@ const cjsConfig = {
   ...sharedConfig,
   plugins: [
     ...sharedConfig.plugins,
-    typescript({ tsconfig: "./tsconfig.cjs.json" }),
+    typescript({
+      tsconfig: "./tsconfig.dist.json",
+      compilerOptions: {
+        esModuleInterop: false,
+        allowSyntheticDefaultImports: true
+      }
+    }),
     commonjs(),
   ],
   output: {
@@ -66,7 +72,7 @@ const esmConfig = {
   ...sharedConfig,
   plugins: [
     ...sharedConfig.plugins,
-    typescript({ tsconfig: "./tsconfig.esm.json" })
+    typescript({ tsconfig: "./tsconfig.dist.json" })
   ],
   output: {
     dir: "dist/esm",

--- a/packages/components/rollup.config.mjs
+++ b/packages/components/rollup.config.mjs
@@ -58,6 +58,7 @@ const cjsConfig = {
     format: "cjs",
     preserveModules: true,
     entryFileNames: "[name].cjs",
+    interop: "auto",
   }
 }
 

--- a/packages/components/src/TitleBlockZen/TitleBlockZen.module.scss
+++ b/packages/components/src/TitleBlockZen/TitleBlockZen.module.scss
@@ -269,7 +269,7 @@ $tab-container-height-medium-and-small-collapsed: 0;
     text-overflow: ellipsis;
     overflow: hidden;
     max-width: none;
-    margin: ($ca-grid / 5) 0;
+    margin: calc(#{$ca-grid} / 5) 0;
   }
 }
 
@@ -289,7 +289,7 @@ $tab-container-height-medium-and-small-collapsed: 0;
 .sectionTitleContainer {
   display: flex;
   align-items: center;
-  padding: ($ca-grid * 3/4) 0;
+  padding: calc(#{$ca-grid} * 3 / 4) 0;
 }
 
 .sectionTitleInner {
@@ -331,7 +331,7 @@ $tab-container-height-medium-and-small-collapsed: 0;
 
 .sectionTitleDescription {
   .sectionTitle + & {
-    margin-top: $ca-grid / 4;
+    margin-top: calc(#{$ca-grid} / 4);
   }
 
   color: $color-white;

--- a/packages/components/src/TitleBlockZen/subcomponents/Toolbar.module.scss
+++ b/packages/components/src/TitleBlockZen/subcomponents/Toolbar.module.scss
@@ -7,10 +7,10 @@
   align-items: center;
 
   .toolbarItem {
-    margin: 0 ($ca-grid / 4);
+    margin: 0 calc(#{$ca-grid} / 4);
 
     @include title-block-under-1024 {
-      margin: 0 ($ca-grid / 8);
+      margin: 0 calc(#{$ca-grid} / 8);
     }
 
     &.noGap {
@@ -19,10 +19,10 @@
   }
 
   .toolbarItem:first-of-type {
-    @include ca-margin($start: 0, $end: $ca-grid / 4);
+    @include ca-margin($start: 0, $end: calc(#{$ca-grid} / 4));
 
     @include title-block-under-1024 {
-      @include ca-margin($start: 0, $end: $ca-grid / 8);
+      @include ca-margin($start: 0, $end: calc(#{$ca-grid} / 8));
     }
 
     &.noGap {
@@ -31,10 +31,10 @@
   }
 
   .toolbarItem:last-of-type {
-    @include ca-margin($start: $ca-grid / 4, $end: 0);
+    @include ca-margin($start: calc(#{$ca-grid} / 4), $end: 0);
 
     @include title-block-under-1024 {
-      @include ca-margin($start: $ca-grid / 8, $end: 0);
+      @include ca-margin($start: calc(#{$ca-grid} / 8), $end: 0);
     }
 
     &.noGap {

--- a/packages/components/tsconfig.cjs.json
+++ b/packages/components/tsconfig.cjs.json
@@ -1,7 +1,0 @@
-{
-  "extends": "./tsconfig.dist.json",
-  "compilerOptions": {
-    "esModuleInterop": false,
-    "allowSyntheticDefaultImports": true
-  }
-}

--- a/packages/components/tsconfig.cjs.json
+++ b/packages/components/tsconfig.cjs.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.dist.json",
   "compilerOptions": {
-    "declarationDir": "dist/cjs/dts"
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true
   }
 }

--- a/packages/components/tsconfig.dist.json
+++ b/packages/components/tsconfig.dist.json
@@ -3,13 +3,11 @@
   "compilerOptions": {
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": true,
-    // Note: To transform paths for both the output .js and .d.ts files, you need both of the below entries
+    "declaration": false,
+    "noEmit": false,
     "plugins": [
       // Transform paths in output .js files
-      { "transform": "typescript-transform-paths" },
-      // Transform paths in output .d.ts files (Include this line if you output declarations files)
-      { "transform": "typescript-transform-paths", "afterDeclarations": true }
+      { "transform": "typescript-transform-paths" }
     ]
   },
   "exclude": [

--- a/packages/components/tsconfig.esm.json
+++ b/packages/components/tsconfig.esm.json
@@ -1,3 +1,0 @@
-{
-  "extends": "./tsconfig.dist.json"
-}

--- a/packages/components/tsconfig.esm.json
+++ b/packages/components/tsconfig.esm.json
@@ -1,6 +1,3 @@
 {
-  "extends": "./tsconfig.dist.json",
-  "compilerOptions": {
-    "declarationDir": "dist/esm/dts"
-  }
+  "extends": "./tsconfig.dist.json"
 }

--- a/packages/components/tsconfig.types.json
+++ b/packages/components/tsconfig.types.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.dist.json",
+  "compilerOptions": {
+    "declaration": true,
+    "declarationDir": "dist/types",
+    "emitDeclarationOnly": true,
+    "plugins": [
+      // Transform paths in output .d.ts files (Include this line if you output declarations files)
+      { "transform": "typescript-transform-paths", "afterDeclarations": true }
+    ]
+  }
+}

--- a/turbo.json
+++ b/turbo.json
@@ -25,7 +25,7 @@
     },
     "@kaizen/components#build": {
       "dependsOn": ["@kaizen/design-tokens#build"],
-      "inputs": ["src/**"],
+      "inputs": ["src/**", "rollup.config.mjs", "tsconfig*.json"],
       "outputs": ["dist/**"]
     },
     "@kaizen/components#test:treeshake": {


### PR DESCRIPTION
## Why
<!-- Why have you created this PR? - Is it a new feature, or a bug fix? Or something else? -->
<!-- Reference any relevant Jira tickets so your reviewer can find more context if needed. -->
<!-- Fixing a GitHub issue? Add "Fixes [issue URL]". -->

[KZN-2208](https://cultureamp.atlassian.net/jira/software/c/projects/KZN/boards/634?selectedIssue=KZN-2208)

It was found that when our components consume packages with a default export, our CJS does not use a namespace and cannot resolve the imported element, thus throwing a(n ambiguous) error in consuming repos as [seen here](https://github.com/cultureamp/survey-configuration/actions/runs/8445271914/job/23132220436?pr=599)
<img width="984" alt="image" src="https://github.com/cultureamp/kaizen-design-system/assets/25891850/d0dd1fcb-1ee6-4ad7-a0e3-4868129eef0d">

## What
<!-- What do your changes do? How do they change/fix the current behavior? -->
<!-- Add screenshots, GIFs or videos to illustrate the changes.  -->

- Update our rollup config to use the default typescript compiler instead of ts-patch, then update our CJS config to allow for default exports
- Separated compiling the TS declaration files to use ts-patch (tspc - cannot use tsc as it won't resolve aliases) instead of using rollup+dts
- Fixed the CSS division warnings