### PR TITLE
Update link to docs for GitHub Package Registry setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ To learn more, see the designer section of the [Contributing guidelines](./CONTR
 ## Getting started
 
 ### Setup
-Set up access to private Culture Amp packages on your laptop. You will need to update `~.npmrc` with a Github token linked to your account. Refer to the [instructions here](https://github.com/cultureamp/node-packages/blob/master/how-to-setup-a-project-to-use-private-cultureamp-packages.md).
+Set up access to private Culture Amp packages on your laptop. You will need to update `~/.npmrc` with a Github token linked to your account. Refer to the [instructions here](https://cultureamp.atlassian.net/wiki/spaces/TV/pages/2776629375/Working+with+our+private+GitHub+package+registry).
 
 ### Installation
 To begin developing the design system locally, run the following from the repository root:


### PR DESCRIPTION
The previously-linked docs are obsolete.

## Why
Our new team members in Serbia are looking at possibly using some parts of Kaizen in their initial reskinning efforts. The setup instructions for GitHub Package Registry have been an initial stumbling block, as they reference outdated information from the node-packages repo.

## What
Link to our current Confluence docs for setting up GitHub Package Registry.