### PR TITLE
fix(SplitButton): Add node resolve back into the rollup config

### DIFF
--- a/.changeset/odd-roses-punch.md
+++ b/.changeset/odd-roses-punch.md
@@ -1,0 +1,5 @@
+---
+"@kaizen/components": patch
+---
+
+Update rollup config to re-add node resolver

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -103,6 +103,7 @@
     "@kaizen/design-tokens": "workspace:*",
     "@kaizen/tailwind": "workspace:*",
     "@rollup/plugin-alias": "^5.1.0",
+    "@rollup/plugin-node-resolve": "^15.2.3",
     "@rollup/plugin-babel": "^6.0.4",
     "@rollup/plugin-commonjs": "^25.0.7",
     "@rollup/plugin-typescript": "^11.1.6",

--- a/packages/components/rollup.config.mjs
+++ b/packages/components/rollup.config.mjs
@@ -1,10 +1,12 @@
 import alias from "@rollup/plugin-alias"
 import { babel, getBabelOutputPlugin } from "@rollup/plugin-babel";
 import commonjs from "@rollup/plugin-commonjs"
+import resolve from "@rollup/plugin-node-resolve"
 import typescript from "@rollup/plugin-typescript"
 import ignore from "rollup-plugin-ignore"
 import nodeExternals from "rollup-plugin-node-externals"
 import postcss from "rollup-plugin-postcss"
+
 
 const sharedConfig = {
   input: { index: "./src/index.ts", future: "./src/__future__/index.ts" },
@@ -26,6 +28,15 @@ const sharedConfig = {
           replacement: "locales",
         },
       ],
+    }),
+    resolve({
+      preferBuiltins: true,
+      extensions: [".js", ".jsx", ".ts", ".tsx"
+     // This is needed to ensure that css is compiled correctly.
+     // Without this there is an alphabetised order in the dist CSS for subcomponents.
+     // This can cause styles being overwritten by primitives, ie: BaseButton overwriting DropdownButton
+     // https://cultureamp.slack.com/archives/C02NUQ27G56/p1713157055178419
+    ],
     }),
     // These libraries aren't used in KAIO, and require polyfills to be set up
     // in consuming repos. Ignoring them here removes the need for extra setup in

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -457,6 +457,9 @@ importers:
       '@rollup/plugin-commonjs':
         specifier: ^25.0.7
         version: 25.0.7(rollup@4.13.2)
+      '@rollup/plugin-node-resolve':
+        specifier: ^15.2.3
+        version: 15.2.3(rollup@4.13.2)
       '@rollup/plugin-typescript':
         specifier: ^11.1.6
         version: 11.1.6(rollup@4.13.2)(tslib@2.6.2)(typescript@5.4.3)
@@ -4413,6 +4416,24 @@ packages:
       rollup: 4.13.2
     dev: true
 
+  /@rollup/plugin-node-resolve@15.2.3(rollup@4.13.2):
+    resolution: {integrity: sha512-j/lym8nf5E21LwBT4Df1VD6hRO2L2iwUeUmP7litikRsVp1H6NWx20NEp0Y7su+7XGc476GnXXc4kFeZNGmaSQ==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^2.78.0||^3.0.0||^4.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+    dependencies:
+      '@rollup/pluginutils': 5.1.0(rollup@4.13.2)
+      '@types/resolve': 1.20.2
+      deepmerge: 4.3.1
+      is-builtin-module: 3.2.1
+      is-module: 1.0.0
+      resolve: 1.22.8
+      rollup: 4.13.2
+    dev: true
+
   /@rollup/plugin-typescript@11.1.6(rollup@4.13.2)(tslib@2.6.2)(typescript@5.4.3):
     resolution: {integrity: sha512-R92yOmIACgYdJ7dJ97p4K69I8gg6IEHt8M7dUBxN3W6nrO8uUxX5ixl0yU/N3aZTi8WhPuICvOHXQvF6FaykAA==}
     engines: {node: '>=14.0.0'}
@@ -6365,6 +6386,10 @@ packages:
       '@types/prop-types': 15.7.11
       csstype: 3.1.3
 
+  /@types/resolve@1.20.2:
+    resolution: {integrity: sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==}
+    dev: true
+
   /@types/resolve@1.20.6:
     resolution: {integrity: sha512-A4STmOXPhMUtHH+S6ymgE2GiBSMqf4oTvcQZMcHzokuTLVYzXTB8ttjcgxOVaAp2lGwEdzZ0J+cRbbeevQj1UQ==}
     dev: true
@@ -7779,6 +7804,11 @@ packages:
     dependencies:
       base64-js: 1.5.1
       ieee754: 1.2.1
+    dev: true
+
+  /builtin-modules@3.3.0:
+    resolution: {integrity: sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==}
+    engines: {node: '>=6'}
     dev: true
 
   /bytes@3.0.0:
@@ -11607,6 +11637,13 @@ packages:
     resolution: {integrity: sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==}
     dev: true
 
+  /is-builtin-module@3.2.1:
+    resolution: {integrity: sha512-BSLE3HnV2syZ0FK0iMA/yUGplUeMmNz4AW5fnTunbCIqZi4vG3WjJT9FHMy5D69xmAYBHXQhJdALdpwVxV501A==}
+    engines: {node: '>=6'}
+    dependencies:
+      builtin-modules: 3.3.0
+    dev: true
+
   /is-callable@1.2.7:
     resolution: {integrity: sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==}
     engines: {node: '>= 0.4'}
@@ -11719,6 +11756,10 @@ packages:
 
   /is-map@2.0.2:
     resolution: {integrity: sha512-cOZFQQozTha1f4MxLFzlgKYPTyj26picdZTx82hbc/Xf4K/tZOOXSCkMvU4pKioRXGDLJRn0GM7Upe7kR721yg==}
+    dev: true
+
+  /is-module@1.0.0:
+    resolution: {integrity: sha512-51ypPSPCoTEIN9dy5Oy+h4pShgJmPCygKfyRCISBI+JoWT/2oJvK8QPxmwv7b/p239jXrm9M1mlQbyKJ5A152g==}
     dev: true
 
   /is-nan@1.3.2:


### PR DESCRIPTION
## Why
As of release `1.42.3` the SplitButton styles have cause visual regression in consuming repos. This appears to have been caused by the recent update to the Rollup config, whereby the compile CSS is causing the BaseButton styles to override the DropdownButton. It appears that this may have been caused by the removal of rollup plugin`plugin-node-resolve`, which impact where in the cascade the styles are declared.

### Visual regression
![image](https://github.com/cultureamp/kaizen-design-system/assets/36558508/f0206c85-2f89-4e59-a238-0259a0ba86a2)


### Dist comparison
**@kaizen/components v1.42.3**
The `BaseButton` styles will supersede the `DropdownButton`

![Screenshot 2024-04-15 at 1 45 33 pm (3)](https://github.com/cultureamp/kaizen-design-system/assets/36558508/31b5c854-5ed8-4f7a-ac51-ba24b47225f6)
![Screenshot 2024-04-15 at 1 45 52 pm (3)](https://github.com/cultureamp/kaizen-design-system/assets/36558508/5a6f56cf-a9d9-45b0-8299-128d8f68eb42)

**@kaizen/components v1.42.1**
The `DropdownButton` styles will supersede the `BaseButton`

![Screenshot 2024-04-15 at 1 43 23 pm (1)](https://github.com/cultureamp/kaizen-design-system/assets/36558508/fe97b46b-e86b-4330-8695-9eae171a72ba)
![Screenshot 2024-04-15 at 1 43 08 pm (1)](https://github.com/cultureamp/kaizen-design-system/assets/36558508/b5803950-f835-472d-8734-a360fca9537f)


## What
- Adds the resolve config back into rollup with a comment explaining why it is there... for now

## More context
[See thread](https://cultureamp.slack.com/archives/C02NUQ27G56/p1713157055178419)