### PR TITLE
Fix TitleBlockZen breadcrumbs focus styles

### DIFF
--- a/.changeset/ninety-gifts-run.md
+++ b/.changeset/ninety-gifts-run.md
@@ -1,0 +1,5 @@
+---
+"@kaizen/components": patch
+---
+
+Add focus styles to TitleBlockZen Breadcrumb link

--- a/packages/components/src/TitleBlockZen/TitleBlockZen.module.scss
+++ b/packages/components/src/TitleBlockZen/TitleBlockZen.module.scss
@@ -550,6 +550,25 @@ $tab-container-height-medium-and-small-collapsed: 0;
     text-decoration: underline;
   }
 
+  &:focus {
+    outline: none;
+
+    &::after {
+      $focus-ring-offset: calc(
+        (-2 * #{$border-focus-ring-border-width}) - #{$border-focus-ring-border-width}
+      );
+
+      content: "";
+      position: absolute;
+      background: transparent;
+      border-color: $color-blue-200;
+      border-radius: 50%;
+      border-width: $border-focus-ring-border-width;
+      border-style: $border-focus-ring-border-style;
+      inset: $focus-ring-offset;
+    }
+  }
+
   @media only screen and (max-width: $breadcrumb-breakpoint-width) {
     position: relative;
 

--- a/packages/components/src/TitleBlockZen/_docs/TitleBlockZen.stories.tsx
+++ b/packages/components/src/TitleBlockZen/_docs/TitleBlockZen.stories.tsx
@@ -108,9 +108,11 @@ export const StickerSheetDefault: Story = {
     pseudo: {
       hover: [
         '#tab-hover-example [class^="TitleBlockZen-TitleBlockZen-module__navigationTabsList"] li:nth-child(2) a',
+        '#Breadcrumbs-hover-example [class^="TitleBlockZen-TitleBlockZen-module__breadcrumb"]',
       ],
       focus: [
         '#tab-focus-example [class^="TitleBlockZen-TitleBlockZen-module__navigationTabsList"] li:nth-child(2) a',
+        '#Breadcrumbs-focus-example [class^="TitleBlockZen-TitleBlockZen-module__breadcrumb"]',
       ],
     },
   },
@@ -121,6 +123,12 @@ export const StickerSheetDefault: Story = {
       </StickerSheet.Row>
       <StickerSheet.Row rowTitle="Tab focus">
         <TitleBlockZen {...args} id="tab-focus-example" />
+      </StickerSheet.Row>
+      <StickerSheet.Row rowTitle="Breadcrumbs hover">
+        <TitleBlockZen {...args} id="Breadcrumbs-hover-example" />
+      </StickerSheet.Row>
+      <StickerSheet.Row rowTitle="Breadcrumbs focus">
+        <TitleBlockZen {...args} id="Breadcrumbs-focus-example" />
       </StickerSheet.Row>
     </StickerSheet>
   ),


### PR DESCRIPTION
## Why
The breadcrumbs was using the browser default `outline` property for focus styles.

![Screenshot 2024-04-22 at 4 30 55 pm](https://github.com/cultureamp/kaizen-design-system/assets/36558508/37cc0a1a-4ed7-4a5a-8fe0-44a31747588d)

This creates a contrast issue in Safari as the default outline is dark blue.

## After

The focus ring will now high the back breadcrumb anchor on focus.

![Screenshot 2024-04-24 at 2 53 50 pm](https://github.com/cultureamp/kaizen-design-system/assets/36558508/8d5efde5-c8ef-44ff-b4c5-635649f729b7)

Note that this is slightly different to the hover state that underlines the text.  Give the text is a span and not actually focus-able I chose not to include a that style - see example below

![Screenshot 2024-04-24 at 2 58 08 pm](https://github.com/cultureamp/kaizen-design-system/assets/36558508/4446f891-af26-4825-8209-c1b55d76d6c0)

## What
- adds focus ring to breadcrumbs anchor and story coverage
