### PR TITLE
Fix Windows high contrast Radio select state issue

### DIFF
--- a/.changeset/stupid-teachers-admire.md
+++ b/.changeset/stupid-teachers-admire.md
@@ -1,0 +1,5 @@
+---
+"@kaizen/components": patch
+---
+
+Adds forced-colors @media query to show selected Radio state

--- a/packages/components/src/Radio/Radio/Radio.module.scss
+++ b/packages/components/src/Radio/Radio/Radio.module.scss
@@ -29,6 +29,14 @@ $dt-color-radio-border-color-focus-reversed: $color-blue-300;
   &.reversed {
     background: $color-white;
   }
+
+  @media (forced-colors: active) {
+      // High contrast mode with remove the background color so we have to use border to create the selected icon state.
+      // Transparent is used so the user defined colors for borders will be used here
+      border: $icon-offset solid transparent;
+      width: 0;
+      height: 0;
+  }
 }
 
 .box {

--- a/packages/components/src/Radio/Radio/Radio.module.scss
+++ b/packages/components/src/Radio/Radio/Radio.module.scss
@@ -31,11 +31,11 @@ $dt-color-radio-border-color-focus-reversed: $color-blue-300;
   }
 
   @media (forced-colors: active) {
-      // High contrast mode with remove the background color so we have to use border to create the selected icon state.
-      // Transparent is used so the user defined colors for borders will be used here
-      border: $icon-offset solid transparent;
-      width: 0;
-      height: 0;
+    // High contrast mode with remove the background color so we have to use border to create the selected icon state.
+    // Transparent is used so the user defined colors for borders will be used here
+    border: $icon-offset solid transparent;
+    width: 0;
+    height: 0;
   }
 }
 


### PR DESCRIPTION
## Why
High contrast mode removes the selected state background color.


## What
Adds a `forced-color` media query to fall back to a transparent border for the selected Icon that will render as a full circle

### Before

![before-radio-whc](https://github.com/cultureamp/kaizen-design-system/assets/36558508/8a0c650d-c355-4c73-9b14-a5a78ed70931)


### After
![radio_with_contrast](https://github.com/cultureamp/kaizen-design-system/assets/36558508/44263c67-5423-4ad8-882c-028634c99ce3)

This screenshot is from a Windows machine.