### PR TITLE
Fix TitleBlockZen active tab state on High Contrast

### DIFF
--- a/.changeset/rude-toes-tap.md
+++ b/.changeset/rude-toes-tap.md
@@ -1,0 +1,5 @@
+---
+"@kaizen/components": patch
+---
+
+Fix the TitleBlockZen Windows High Contrast Mode Bug and obscured the active NavigationTab

--- a/packages/components/src/TitleBlockZen/subcomponents/NavigationTabs.module.scss
+++ b/packages/components/src/TitleBlockZen/subcomponents/NavigationTabs.module.scss
@@ -115,11 +115,11 @@
   }
 
   @media (forced-colors: active) {
-    &.active, &:focus {
-
+    &.active,
+    &:focus {
       &::before {
         background: transparent;
-        // instead of height we're using the border to create a active tab mark to make it friendlier for Windows High Contrast Mode. 
+        // instead of height we're using the border to create a active tab mark to make it friendlier for Windows High Contrast Mode.
         border: $active-tab-marker-height solid transparent;
         height: 0;
       }

--- a/packages/components/src/TitleBlockZen/subcomponents/NavigationTabs.module.scss
+++ b/packages/components/src/TitleBlockZen/subcomponents/NavigationTabs.module.scss
@@ -113,6 +113,18 @@
       }
     }
   }
+
+  @media (forced-colors: active) {
+    &.active, &:focus {
+
+      &::before {
+        background: transparent;
+        // instead of height we're using the border to create a active tab mark to make it friendlier for Windows High Contrast Mode. 
+        border: $active-tab-marker-height solid transparent;
+        height: 0;
+      }
+    }
+  }
 }
 
 .linkAnchor.lightBackground {


### PR DESCRIPTION
## Why
The active `NavigationTab` was obscured on Windows High Contrast Mode (WHCM). This makes it hard for the end user to determine the relationship with the active Tab.

## What
- Use `forced-colors` media query to replace the background color in the tabs pseudo `after` element with a transparent border. This will now render on a user's page if high contrast mode is active.

## Before
While the focus state showed the active tab was obscured.
![before-tabs-high-contrast](https://github.com/cultureamp/kaizen-design-system/assets/36558508/962a0186-0c45-402c-be73-f91cac4883eb)


## After (Tested on windows machine)
Behavior now matches the current tab experience but with the user's preferred color scheme in WHCM 
![tabs-high-contrast](https://github.com/cultureamp/kaizen-design-system/assets/36558508/f5a214b3-803b-40c1-9473-735ac7921912)
