### PR TITLE
RichTextEditor LinkModal focus fix

### DIFF
--- a/.changeset/short-bears-train.md
+++ b/.changeset/short-bears-train.md
@@ -1,0 +1,5 @@
+---
+"@kaizen/components": patch
+---
+
+Fix to intercept keydown event for pasting content into the RTE's LinkModal

--- a/packages/components/src/RichTextEditor/utils/plugins/LinkManager/components/LinkModal/LinkModal.tsx
+++ b/packages/components/src/RichTextEditor/utils/plugins/LinkManager/components/LinkModal/LinkModal.tsx
@@ -35,6 +35,16 @@ export const LinkModal = ({
     onSubmit(href)
   }
 
+  /** * This covers the scenario for pasting directly after a link modal is opened */
+  const interceptKeyDown = (e: React.KeyboardEvent<HTMLDivElement>): void => {
+    const modifierDown = e.ctrlKey || e.metaKey
+    const vKey = e.code === "KeyV"
+
+    if (modifierDown && vKey) {
+      inputRef.current?.focus()
+    }
+  }
+
   return (
     <InputEditModal
       submitLabel={defaultHref ? "Save" : "Add"}
@@ -44,6 +54,7 @@ export const LinkModal = ({
       onSubmit={handleSubmit}
       onDismiss={onDismiss}
       onAfterLeave={onAfterLeave}
+      onKeyDown={e => interceptKeyDown(e)}
     >
       <TextField
         id="href"


### PR DESCRIPTION
## Why
A bug was reported that pasting (`ctrl + v`) immediately after opening the link's `InputEditModal` in the `RichTextEditor` (RTE), would cause the modal to close and paste the content back into the RTE input field.

## Replication
1. Copy a link into your clipboard
2. Find an RTE with the ability to add links 
3. Write some text in an [RTE](https://cultureamp.design/?path=/docs/components-richtexteditor-richtexteditor--docs#controls)
4. Highlight the text
5. Open the link modal from the toolbar
6. Without moving focus, paste your URL, it ends up in the RTE

## Possible underlying issue
Despite the active element in the DOM being shifted to the `InputEditModal` title, as is standard with out modals, it appears that ProseMirrors still tracks the active cursor position despite being focused to the new input.

## Current fix
The current fix is to add an key down listener to intercept the scenario of a user immediately pasting content when the modal is opened. 

## A11Y concerns
I have tested this with assistive technologies and think there may be enough context for a user. While the paste shortcut will refocus them to the input when the modal is open, they will still initially land on the modal title and can follow standard tab order.

## Divergent behaviour
This will diverge slightly from the current `InputEditModal`, whereby pasting as soon as its open will not refocus to the input. There is a chance that this will cause confusion in the long run

## What
- Adds a keydown listener to intercept `ctrl + v` or `cmd + v` and refocus on the input.
