### PR TITLE
Add onAfterEnter callback to Modals 

### DIFF
--- a/.changeset/short-bears-train.md
+++ b/.changeset/short-bears-train.md
@@ -1,5 +1,5 @@
 ---
-"@kaizen/components": patch
+"@kaizen/components": minor
 ---
 
-Fix to intercept keydown event for pasting content into the RTE's LinkModal
+Add onAferEnter callback to GenericModal and expose in InputEditModal, ContextModal, ConfirmationModal to allow for focus management after open.

--- a/.changeset/short-bears-train.md
+++ b/.changeset/short-bears-train.md
@@ -1,0 +1,5 @@
+---
+"@kaizen/components": patch
+---
+
+Fix to intercept keydown event for pasting content into the RTE's LinkModal

--- a/packages/components/src/Modal/ConfirmationModal/ConfirmationModal.tsx
+++ b/packages/components/src/Modal/ConfirmationModal/ConfirmationModal.tsx
@@ -39,6 +39,9 @@ export type ConfirmationModalProps = {
   title: string
   onConfirm?: () => void
   onDismiss: () => void
+  /** A callback that is triggered after the modal is opened. */
+  onAfterEnter?: () => void
+  /** A callback that is triggered after the modal is closed. */
   onAfterLeave?: () => void
   confirmLabel?: string
   dismissLabel?: string
@@ -99,6 +102,7 @@ export const ConfirmationModal = ({
   title,
   onConfirm,
   onAfterLeave,
+  onAfterEnter,
   confirmLabel = "Confirm",
   dismissLabel = "Cancel",
   confirmWorking,
@@ -134,6 +138,7 @@ export const ConfirmationModal = ({
       onEscapeKeyup={onDismiss}
       onOutsideModalClick={onDismiss}
       onAfterLeave={onAfterLeave}
+      onAfterEnter={onAfterEnter}
     >
       <div className={styles.modal} data-modal {...props}>
         <ModalHeader onDismiss={onDismiss}>

--- a/packages/components/src/Modal/ContextModal/ContextModal.tsx
+++ b/packages/components/src/Modal/ContextModal/ContextModal.tsx
@@ -32,6 +32,9 @@ export type ContextModalProps = Readonly<
     title: string
     onConfirm?: () => void
     onDismiss: () => void
+    /** A callback that is triggered after the modal is opened. */
+    onAfterEnter?: () => void
+    /** A callback that is triggered after the modal is closed. */
     onAfterLeave?: () => void
     confirmLabel?: string
     confirmWorking?: { label: string; labelHidden?: boolean }
@@ -59,6 +62,7 @@ export const ContextModal = ({
   onConfirm,
   onDismiss: propsOnDismiss,
   onAfterLeave,
+  onAfterEnter,
   confirmLabel = "Confirm",
   confirmWorking,
   renderBackground,
@@ -100,6 +104,7 @@ export const ContextModal = ({
       onEscapeKeyup={onDismiss}
       onOutsideModalClick={onDismiss}
       onAfterLeave={onAfterLeave}
+      onAfterEnter={onAfterEnter}
     >
       <div className={styles.modal} data-modal {...props}>
         {renderBackground && renderBackground()}

--- a/packages/components/src/Modal/GenericModal/GenericModal.tsx
+++ b/packages/components/src/Modal/GenericModal/GenericModal.tsx
@@ -14,6 +14,8 @@ export type GenericModalProps = {
   onEscapeKeyup?: (event: KeyboardEvent) => void
   onOutsideModalClick?: (event: React.MouseEvent) => void
   onAfterLeave?: () => void
+  /** Override default focus to the modal title and shift focus to this element after the modal is opened */
+  onOpenFocusTo?: HTMLElement | null
 }
 
 export const GenericModal = ({
@@ -24,6 +26,7 @@ export const GenericModal = ({
   onEscapeKeyup,
   onOutsideModalClick,
   onAfterLeave: propsOnAfterLeave,
+  onOpenFocusTo,
 }: GenericModalProps): JSX.Element => {
   const reactId = useId()
   const id = propsId ?? reactId
@@ -50,8 +53,10 @@ export const GenericModal = ({
     }
   }
 
-  const focusAccessibleLabel = (): void => {
-    if (modalLayer) {
+  const focusToElement = (): void => {
+    if (onOpenFocusTo) {
+      onOpenFocusTo.focus()
+    } else {
       const labelElement: HTMLElement | null =
         document.getElementById(labelledByID)
       if (labelElement) {
@@ -61,7 +66,6 @@ export const GenericModal = ({
   }
 
   const a11yWarn = (): void => {
-    if (!modalLayer) return
     // Ensure that consumers have provided an element that labels the modal
     // to meet ARIA accessibility guidelines.
     if (!document.getElementById(labelledByID)) {
@@ -86,8 +90,10 @@ export const GenericModal = ({
 
   const onAfterEnterHandler = (): void => {
     scrollModalToTop()
-    focusAccessibleLabel()
-    a11yWarn()
+    if (modalLayer) {
+      focusToElement()
+      a11yWarn()
+    }
   }
 
   const onBeforeEnterHandler = (): void => {

--- a/packages/components/src/Modal/GenericModal/GenericModal.tsx
+++ b/packages/components/src/Modal/GenericModal/GenericModal.tsx
@@ -13,9 +13,10 @@ export type GenericModalProps = {
   focusLockDisabled?: boolean
   onEscapeKeyup?: (event: KeyboardEvent) => void
   onOutsideModalClick?: (event: React.MouseEvent) => void
+  /** A callback that is triggered after the modal is opened. */
+  onAfterEnter?: () => void
+  /** A callback that is triggered after the modal is closed. */
   onAfterLeave?: () => void
-  /** A callback that is triggered after the modal is open. This can be used to shift focus to an element within the modal. */
-  onAfterOpen?: () => void
 }
 
 export const GenericModal = ({
@@ -25,8 +26,8 @@ export const GenericModal = ({
   focusLockDisabled,
   onEscapeKeyup,
   onOutsideModalClick,
+  onAfterEnter,
   onAfterLeave: propsOnAfterLeave,
-  onAfterOpen,
 }: GenericModalProps): JSX.Element => {
   const reactId = useId()
   const id = propsId ?? reactId
@@ -91,7 +92,7 @@ export const GenericModal = ({
   const onAfterEnterHandler = (): void => {
     scrollModalToTop()
     if (modalLayer) {
-      onAfterOpen && onAfterOpen()
+      onAfterEnter?.()
       focusOnAccessibleLabel()
       a11yWarn()
     }

--- a/packages/components/src/Modal/GenericModal/GenericModal.tsx
+++ b/packages/components/src/Modal/GenericModal/GenericModal.tsx
@@ -14,8 +14,8 @@ export type GenericModalProps = {
   onEscapeKeyup?: (event: KeyboardEvent) => void
   onOutsideModalClick?: (event: React.MouseEvent) => void
   onAfterLeave?: () => void
-  /** Override default focus to the modal title and shift focus to this element after the modal is opened */
-  onOpenFocusTo?: HTMLElement | null
+  /** A callback that is triggered after the modal is open. This can be used to shift focus to an element within the modal. */
+  onAfterOpen?: () => void
 }
 
 export const GenericModal = ({
@@ -26,7 +26,7 @@ export const GenericModal = ({
   onEscapeKeyup,
   onOutsideModalClick,
   onAfterLeave: propsOnAfterLeave,
-  onOpenFocusTo,
+  onAfterOpen,
 }: GenericModalProps): JSX.Element => {
   const reactId = useId()
   const id = propsId ?? reactId
@@ -53,16 +53,16 @@ export const GenericModal = ({
     }
   }
 
-  const focusToElement = (): void => {
-    if (onOpenFocusTo) {
-      onOpenFocusTo.focus()
-    } else {
-      const labelElement: HTMLElement | null =
-        document.getElementById(labelledByID)
-      if (labelElement) {
-        labelElement.focus()
-      }
+  const focusOnAccessibleLabel = (): void => {
+    // Check if focus already exists within the modal
+    if (modalLayer?.contains(document.activeElement)) {
+      return
     }
+
+    const labelElement: HTMLElement | null =
+      document.getElementById(labelledByID)
+
+    labelElement?.focus()
   }
 
   const a11yWarn = (): void => {
@@ -91,7 +91,8 @@ export const GenericModal = ({
   const onAfterEnterHandler = (): void => {
     scrollModalToTop()
     if (modalLayer) {
-      focusToElement()
+      onAfterOpen && onAfterOpen()
+      focusOnAccessibleLabel()
       a11yWarn()
     }
   }

--- a/packages/components/src/Modal/GenericModal/_docs/GenericModal.spec.stories.tsx
+++ b/packages/components/src/Modal/GenericModal/_docs/GenericModal.spec.stories.tsx
@@ -1,0 +1,124 @@
+import React from "react"
+import { action } from "@storybook/addon-actions"
+import { Meta, StoryObj } from "@storybook/react"
+import { expect, userEvent, within, waitFor } from "@storybook/test"
+
+import {
+  GenericModal,
+  ModalAccessibleLabel,
+  ModalBody,
+  ModalHeader,
+} from "../index"
+
+const meta: Meta<typeof GenericModal> = {
+  title: "Components/Modals/Generic Modal/Tests",
+  component: GenericModal,
+}
+
+export default meta
+
+type Story = StoryObj<typeof GenericModal>
+
+export const TestBase: Story = {
+  render: ({ isOpen: propsIsOpen, ...args }) => {
+    const [isOpen, setIsOpen] = React.useState<boolean>(propsIsOpen)
+    const handleDismiss = (): void => setIsOpen(false)
+
+    return (
+      <>
+        <button
+          type="button"
+          className="border border-gray-500"
+          onClick={() => setIsOpen(true)}
+        >
+          Open Modal
+        </button>
+        <GenericModal
+          {...args}
+          isOpen={isOpen}
+          onOutsideModalClick={handleDismiss}
+          onEscapeKeyup={handleDismiss}
+          id="GenericModalTestId"
+        >
+          <ModalHeader>
+            <ModalAccessibleLabel>Test Modal</ModalAccessibleLabel>
+          </ModalHeader>
+          <ModalBody>
+            <form>
+              <label htmlFor="modal-input-play-test">Add link</label>
+              <input type="text" id="modal-input-play-test" />
+            </form>
+          </ModalBody>
+        </GenericModal>
+      </>
+    )
+  },
+  play: async ({ canvasElement, step }) => {
+    const { getByRole } = within(canvasElement)
+
+    const openModalButton = getByRole("button", { name: "Open Modal" })
+
+    await step("Open modal", async () => {
+      await userEvent.click(openModalButton)
+    })
+
+    await step("Default focus is shifted to the Accessible title", async () => {
+      await waitFor(() => {
+        // document has to be use as Modal will append to document body
+        expect(document.activeElement).toHaveTextContent("Test Modal")
+      })
+    })
+  },
+}
+
+export const ModalAccessibleLabelRetainsFocus: Story = {
+  ...TestBase,
+  name: "ModalAccessibleLabel retains focus if onAfterEnter is called",
+  args: {
+    onAfterEnter: () => action("openCallBack"),
+  },
+  play: async ({ canvasElement, step }) => {
+    const { getByRole } = within(canvasElement)
+
+    const openModalButton = getByRole("button", { name: "Open Modal" })
+
+    await step("Open modal", async () => {
+      await userEvent.click(openModalButton)
+    })
+
+    await step("Accessible title still has focus", async () => {
+      await waitFor(() => {
+        expect(document.activeElement).toHaveTextContent("Test Modal")
+      })
+    })
+  },
+}
+
+export const TriggerOnAfterEnterFocus: Story = {
+  ...TestBase,
+  args: {
+    onAfterEnter: () =>
+      document.getElementById("modal-input-play-test")?.focus(),
+  },
+  name: "onAfterEnter can shift focus to internal elements of the modal",
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement)
+    const openModalButton = canvas.getByRole("button", { name: "Open Modal" })
+
+    await step("Open modal", async () => {
+      await userEvent.click(openModalButton)
+    })
+
+    await step("Expect activeElement to be the Input", async () => {
+      await waitFor(() => {
+        expect(document.activeElement).toHaveAccessibleName("Add link")
+      })
+    })
+
+    await step("Expect to be able to type without shifting focus", async () => {
+      await userEvent.keyboard(
+        "All lorem and no ipsum make dolar a dull boy..."
+      )
+    })
+  },
+}

--- a/packages/components/src/Modal/InputEditModal/InputEditModal.tsx
+++ b/packages/components/src/Modal/InputEditModal/InputEditModal.tsx
@@ -30,6 +30,7 @@ export type InputEditModalProps = {
   automationId?: string
   children: React.ReactNode
   submitWorking?: { label: string; labelHidden?: boolean }
+  onOpenFocusTo?: HTMLElement | null
 } & Omit<HTMLAttributes<HTMLDivElement>, "onSubmit">
 
 /**
@@ -51,6 +52,7 @@ export const InputEditModal = ({
   children,
   unpadded = false,
   onDismiss: propsOnDismiss,
+  onOpenFocusTo,
   ...props
 }: InputEditModalProps): JSX.Element => {
   const onDismiss = submitWorking ? undefined : propsOnDismiss
@@ -79,6 +81,7 @@ export const InputEditModal = ({
       isOpen={isOpen}
       onEscapeKeyup={onDismiss}
       onAfterLeave={onAfterLeave}
+      onOpenFocusTo={onOpenFocusTo}
     >
       <div className={styles.modal} dir={localeDirection} data-modal {...props}>
         <ModalHeader onDismiss={onDismiss}>

--- a/packages/components/src/Modal/InputEditModal/InputEditModal.tsx
+++ b/packages/components/src/Modal/InputEditModal/InputEditModal.tsx
@@ -19,6 +19,9 @@ export type InputEditModalProps = {
   onSubmit: () => void
   onSecondaryAction?: () => void
   onDismiss: () => void
+  /** A callback that is triggered after the modal is opened. */
+  onAfterEnter?: () => void
+  /** A callback that is triggered after the modal is closed. */
   onAfterLeave?: () => void
   localeDirection?: "rtl" | "ltr"
   submitLabel?: string
@@ -30,7 +33,6 @@ export type InputEditModalProps = {
   automationId?: string
   children: React.ReactNode
   submitWorking?: { label: string; labelHidden?: boolean }
-  onAfterOpen?: () => void
 } & Omit<HTMLAttributes<HTMLDivElement>, "onSubmit">
 
 /**
@@ -52,7 +54,7 @@ export const InputEditModal = ({
   children,
   unpadded = false,
   onDismiss: propsOnDismiss,
-  onAfterOpen,
+  onAfterEnter,
   ...props
 }: InputEditModalProps): JSX.Element => {
   const onDismiss = submitWorking ? undefined : propsOnDismiss
@@ -81,7 +83,7 @@ export const InputEditModal = ({
       isOpen={isOpen}
       onEscapeKeyup={onDismiss}
       onAfterLeave={onAfterLeave}
-      onAfterOpen={onAfterOpen}
+      onAfterEnter={onAfterEnter}
     >
       <div className={styles.modal} dir={localeDirection} data-modal {...props}>
         <ModalHeader onDismiss={onDismiss}>

--- a/packages/components/src/Modal/InputEditModal/InputEditModal.tsx
+++ b/packages/components/src/Modal/InputEditModal/InputEditModal.tsx
@@ -30,7 +30,7 @@ export type InputEditModalProps = {
   automationId?: string
   children: React.ReactNode
   submitWorking?: { label: string; labelHidden?: boolean }
-  onOpenFocusTo?: HTMLElement | null
+  onAfterOpen?: () => void
 } & Omit<HTMLAttributes<HTMLDivElement>, "onSubmit">
 
 /**
@@ -52,7 +52,7 @@ export const InputEditModal = ({
   children,
   unpadded = false,
   onDismiss: propsOnDismiss,
-  onOpenFocusTo,
+  onAfterOpen,
   ...props
 }: InputEditModalProps): JSX.Element => {
   const onDismiss = submitWorking ? undefined : propsOnDismiss
@@ -81,7 +81,7 @@ export const InputEditModal = ({
       isOpen={isOpen}
       onEscapeKeyup={onDismiss}
       onAfterLeave={onAfterLeave}
-      onOpenFocusTo={onOpenFocusTo}
+      onAfterOpen={onAfterOpen}
     >
       <div className={styles.modal} dir={localeDirection} data-modal {...props}>
         <ModalHeader onDismiss={onDismiss}>

--- a/packages/components/src/Modal/InputEditModal/_docs/InputEditModal.mdx
+++ b/packages/components/src/Modal/InputEditModal/_docs/InputEditModal.mdx
@@ -39,3 +39,14 @@ When your modal is preforming a destructive action eg. delete customer data.
 ### Unpadded
 
 <Canvas of={InputEditModalStories.Unpadded} />
+
+## onAfterEnter and shifting focus
+
+It is an important accessibility consideration that any time we shift focus on the page, no important content is skipped that may provide context to assistive technologies. This is why the default behaviour for our modals is to shift focus to the accessible title.
+
+There are instances, such as single input modals, where shifting focus may not impact the users context. In these instances, we can leverage the `onAfterEnter` callback to shift focus to an input.
+
+<Canvas of={InputEditModalStories.OnAfterEnter} sourceState="shown" />
+
+As both the button and input label have clear intent and the focus does not skip past crucial content, this should provide enough context for an end user.
+

--- a/packages/components/src/Modal/InputEditModal/_docs/InputEditModal.stories.tsx
+++ b/packages/components/src/Modal/InputEditModal/_docs/InputEditModal.stories.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react"
+import React, { useRef, useState } from "react"
 import { Meta, StoryObj } from "@storybook/react"
 import { fn } from "@storybook/test"
 import isChromatic from "chromatic"
@@ -100,4 +100,66 @@ export const Unpadded: Story = {
   ...InputModalTemplate,
   args: { unpadded: true },
   ...chromaticModalSettings,
+}
+
+export const OnAfterEnter: Story = {
+  ...chromaticModalSettings,
+  args: {
+    title: "Create new link",
+    submitLabel: "Add link",
+  },
+  render: args => {
+    const [isOpen, setIsOpen] = useState(IS_CHROMATIC)
+    const inputRef = useRef<HTMLInputElement>(null)
+    const handleOpen = (): void => setIsOpen(true)
+    const handleClose = (): void => setIsOpen(false)
+
+    return (
+      <>
+        <button
+          type="button"
+          className="border border-gray-500"
+          onClick={handleOpen}
+        >
+          Create a link
+        </button>
+        <InputEditModal
+          {...args}
+          isOpen={isOpen}
+          onSubmit={handleClose}
+          onDismiss={handleClose}
+          onAfterEnter={() => inputRef.current?.focus()}
+        >
+          <form>
+            <TextField inputRef={inputRef} labelText="Link URL" />
+          </form>
+        </InputEditModal>
+      </>
+    )
+  },
+  parameters: {
+    docs: {
+      source: {
+        code: `
+        // The label of the button and the input it is focused to may provide enough context.
+        <button
+          onClick={handleOpen}
+        >
+          Create a link
+        </button>
+        <InputEditModal
+          {...args}
+          isOpen={isOpen}
+          onSubmit={handleClose}
+          onDismiss={handleClose}
+          onAfterEnter={() => inputRef.current?.focus()}
+        >
+          <form>
+            <TextField inputRef={inputRef} labelText="Link URL" />
+          </form>
+        </InputEditModal>
+        `,
+      },
+    },
+  },
 }

--- a/packages/components/src/RichTextEditor/utils/plugins/LinkManager/components/LinkModal/LinkModal.tsx
+++ b/packages/components/src/RichTextEditor/utils/plugins/LinkManager/components/LinkModal/LinkModal.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from "react"
+import React, { useRef, useState } from "react"
 import { InputEditModal } from "~components/Modal"
 import { TextField } from "~components/TextField"
 import { ValidationResponse, validateLink } from "../../validation"
@@ -22,7 +22,6 @@ export const LinkModal = ({
   const [validationStatus, setValidationStatus] = useState<ValidationResponse>({
     status: "default",
   })
-  const [inputEl, setInputEl] = useState<HTMLInputElement | null>(null)
   const inputRef = useRef<HTMLInputElement>(null)
 
   const handleSubmit = (): void => {
@@ -36,12 +35,6 @@ export const LinkModal = ({
     onSubmit(href)
   }
 
-  useEffect(() => {
-    if (inputRef.current) {
-      setInputEl(inputRef.current)
-    }
-  }, [])
-
   return (
     <InputEditModal
       submitLabel={defaultHref ? "Save" : "Add"}
@@ -51,7 +44,7 @@ export const LinkModal = ({
       onSubmit={handleSubmit}
       onDismiss={onDismiss}
       onAfterLeave={onAfterLeave}
-      onOpenFocusTo={inputEl}
+      onAfterOpen={() => inputRef.current?.focus()}
     >
       <TextField
         id="href"

--- a/packages/components/src/RichTextEditor/utils/plugins/LinkManager/components/LinkModal/LinkModal.tsx
+++ b/packages/components/src/RichTextEditor/utils/plugins/LinkManager/components/LinkModal/LinkModal.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from "react"
+import React, { useEffect, useRef, useState } from "react"
 import { InputEditModal } from "~components/Modal"
 import { TextField } from "~components/TextField"
 import { ValidationResponse, validateLink } from "../../validation"
@@ -22,6 +22,7 @@ export const LinkModal = ({
   const [validationStatus, setValidationStatus] = useState<ValidationResponse>({
     status: "default",
   })
+  const [inputEl, setInputEl] = useState<HTMLInputElement | null>(null)
   const inputRef = useRef<HTMLInputElement>(null)
 
   const handleSubmit = (): void => {
@@ -35,15 +36,11 @@ export const LinkModal = ({
     onSubmit(href)
   }
 
-  /** * This covers the scenario for pasting directly after a link modal is opened */
-  const interceptKeyDown = (e: React.KeyboardEvent<HTMLDivElement>): void => {
-    const modifierDown = e.ctrlKey || e.metaKey
-    const vKey = e.code === "KeyV"
-
-    if (modifierDown && vKey) {
-      inputRef.current?.focus()
+  useEffect(() => {
+    if (inputRef.current) {
+      setInputEl(inputRef.current)
     }
-  }
+  }, [])
 
   return (
     <InputEditModal
@@ -54,7 +51,7 @@ export const LinkModal = ({
       onSubmit={handleSubmit}
       onDismiss={onDismiss}
       onAfterLeave={onAfterLeave}
-      onKeyDown={e => interceptKeyDown(e)}
+      onOpenFocusTo={inputEl}
     >
       <TextField
         id="href"

--- a/packages/components/src/RichTextEditor/utils/plugins/LinkManager/components/LinkModal/LinkModal.tsx
+++ b/packages/components/src/RichTextEditor/utils/plugins/LinkManager/components/LinkModal/LinkModal.tsx
@@ -44,7 +44,7 @@ export const LinkModal = ({
       onSubmit={handleSubmit}
       onDismiss={onDismiss}
       onAfterLeave={onAfterLeave}
-      onAfterOpen={() => inputRef.current?.focus()}
+      onAfterEnter={() => inputRef.current?.focus()}
     >
       <TextField
         id="href"

--- a/packages/components/src/RichTextEditor/utils/plugins/LinkManager/components/LinkModal/LinkModal.tsx
+++ b/packages/components/src/RichTextEditor/utils/plugins/LinkManager/components/LinkModal/LinkModal.tsx
@@ -35,6 +35,16 @@ export const LinkModal = ({
     onSubmit(href)
   }
 
+  /** * This covers the scenario for pasting directly after a link modal is opened */
+  const interceptKeyDown = (e: React.KeyboardEvent<HTMLDivElement>): void => {
+    const modifierDown = e.ctrlKey || e.metaKey
+    const vKey = e.code === "KeyV"
+
+    if (modifierDown && vKey) {
+      inputRef.current?.focus()
+    }
+  }
+
   return (
     <InputEditModal
       submitLabel={defaultHref ? "Save" : "Add"}
@@ -44,6 +54,7 @@ export const LinkModal = ({
       onSubmit={handleSubmit}
       onDismiss={onDismiss}
       onAfterLeave={onAfterLeave}
+      onKeyDown={e => interceptKeyDown(e)}
     >
       <TextField
         id="href"


### PR DESCRIPTION
## Why
This update to the modals is a more holistic way of addressing the issue raised by Will regarding the RTE's Link modal (see thread [here](https://cultureamp.slack.com/archives/C0189KBPM4Y/p1713422268454219))

## Original issue overview
https://github.com/cultureamp/kaizen-design-system/assets/36558508/ebd5d18d-559f-4935-96bb-60bf5669b9c1

## Background
Initially, to resolve this we were going to intercept the onKeyDown event for a `paste` and shift focus to the input. This was more a monkey patch that a long term solution. Instead we opted to provide an `onAfterEnter` callback that is triggered when the Modal is opened.

## Maintaining a11y
The default behaviour that we have baked into our modals is to focus on the accessible title. This is to ensure that screen reader users have context to where there focus has been shifted. This guard rail still exists if the onAfterEnter callback does not shift focus to a child of the modal. 

Additional documentation has been added to the InputEditModal docs since this is where it would be likely used most.

## What
- Adds `onAfterEnter` callback to GenericModal
  - `onAfterEnter` to other modals to allow for callbacks to be consumed
- Update RTE's LinkModal to shift focus after open 
- Adds storybook play tests to GenericModal to simulate the focus management