### PR TITLE
Expose ref for IconButton

### DIFF
--- a/.changeset/angry-ants-know.md
+++ b/.changeset/angry-ants-know.md
@@ -1,0 +1,5 @@
+---
+"@kaizen/components": minor
+---
+
+Expose ref for IconButton

--- a/packages/components/src/Button/IconButton/IconButton.tsx
+++ b/packages/components/src/Button/IconButton/IconButton.tsx
@@ -1,4 +1,4 @@
-import React from "react"
+import React, { forwardRef, Ref } from "react"
 import {
   GenericButton,
   GenericProps,
@@ -6,6 +6,7 @@ import {
   WorkingProps,
   WorkingUndefinedProps,
   ButtonBadgeProps,
+  ButtonRef,
 } from "../GenericButton"
 
 export type IconButtonProps = GenericProps &
@@ -28,8 +29,10 @@ export type IconButtonProps = GenericProps &
  * {@link https://cultureamp.atlassian.net/wiki/spaces/DesignSystem/pages/3062890984/Button Guidance} |
  * {@link https://cultureamp.design/?path=/docs/components-iconbutton--docs Storybook}
  */
-export const IconButton = (props: IconButtonProps): JSX.Element => (
-  <GenericButton iconButton {...props} />
+export const IconButton = forwardRef(
+  (props: IconButtonProps, ref: Ref<ButtonRef | undefined>): JSX.Element => (
+    <GenericButton iconButton {...props} ref={ref} />
+  )
 )
 
 IconButton.defaultProps = {


### PR DESCRIPTION
## Important: Request PR reviews on Slack
Please reach out to the design system team on Slack in `#prod_design_system` for PR reviews. GitHub notifications (e.g. from tagging a person) are not actively monitored.

## Why
<!-- Why have you created this PR? - Is it a new feature, or a bug fix? Or something else? -->
<!-- Reference any relevant Jira tickets so your reviewer can find more context if needed. -->
<!-- Fixing a GitHub issue? Add "Fixes [issue URL]". -->
In conversations-ui, we are using `Menu` `MenuItem` and `IconButton` for our meatball. This meatball allows user to switch to edit mode and once user have either decided to cancel or submit the edit, we want to return their focus back to the IconButton of the Menu
![image](https://github.com/cultureamp/kaizen-design-system/assets/23372284/4cf1d1ad-accf-4ee7-a458-f6a7b0d39be7)
![image](https://github.com/cultureamp/kaizen-design-system/assets/23372284/090e1017-5bc9-4dbf-9e13-f0c716ba137a)




## What
<!-- What do your changes do? How do they change/fix the current behavior? -->
<!-- Add screenshots, GIFs or videos to illustrate the changes.  -->
To enable the above, we are exposing the ref of IconButton so that we can focus on it
