### PR TITLE
fix(RTE): duplicate id, added optional id

### DIFF
--- a/.changeset/new-adults-rescue.md
+++ b/.changeset/new-adults-rescue.md
@@ -1,0 +1,5 @@
+---
+"@kaizen/components": minor
+---
+
+fixed duplicate id on RTE, added optional id to RTE

--- a/.changeset/tame-geckos-exercise.md
+++ b/.changeset/tame-geckos-exercise.md
@@ -1,5 +1,5 @@
 ---
-"@kaizen/components": minor
+"@kaizen/components": patch
 ---
 
 fixed duplicate id on RTE, added optional id to RTE

--- a/packages/components/src/RichTextEditor/RichTextEditor/RichTextEditor.tsx
+++ b/packages/components/src/RichTextEditor/RichTextEditor/RichTextEditor.tsx
@@ -87,12 +87,12 @@ export const RichTextEditor = ({
   status = "default",
   ...restProps
 }: RichTextEditorProps): JSX.Element => {
-  const reactId = useId()
+  const generatedId = useId()
   const [schema] = useState<ProseMirrorModel.Schema>(
     createSchemaFromControls(controls)
   )
 
-  const [editorId] = useState<string>(id || reactId)
+  const editorId = id || generatedId
   const labelId = labelledBy || `${editorId}-rte-label`
   const validationMessageAria = validationMessage
     ? `${editorId}-rte-validation-message`

--- a/packages/components/src/RichTextEditor/RichTextEditor/RichTextEditor.tsx
+++ b/packages/components/src/RichTextEditor/RichTextEditor/RichTextEditor.tsx
@@ -30,6 +30,7 @@ import { buildKeymap } from "./utils/keymap"
 import styles from "./RichTextEditor.module.scss"
 
 type BaseRichTextEditorProps = {
+  id?: string
   onChange: (content: ProseMirrorState.EditorState) => void
   defaultValue: EditorContentArray
   controls?: ToolbarItems[]
@@ -70,6 +71,7 @@ export type RichTextEditorProps = BaseRichTextEditorProps &
  * {@link https://cultureamp.design/?path=/docs/components-richtexteditor--docs Storybook}
  */
 export const RichTextEditor = ({
+  id,
   onChange,
   defaultValue,
   labelText,
@@ -89,8 +91,9 @@ export const RichTextEditor = ({
   const [schema] = useState<ProseMirrorModel.Schema>(
     createSchemaFromControls(controls)
   )
-  const [labelId] = useState<string>(labelledBy || reactId)
-  const [editorId] = useState<string>(reactId)
+
+  const [editorId] = useState<string>(id || reactId)
+  const labelId = labelledBy || `${editorId}-rte-label`
   const validationMessageAria = validationMessage
     ? `${editorId}-rte-validation-message`
     : ""


### PR DESCRIPTION
## Important: Request PR reviews on Slack
Please reach out to the design system team on Slack in `#prod_design_system` for PR reviews. GitHub notifications (e.g. from tagging a person) are not actively monitored.

## Why
While reviewing a11y on RTE, I noticed a duplicate id issue, It was also difficult to target the RTE without being able to control the id, so I have added an optional id props to override the generated Id inside the RTE component, this will allow to use `describedBy` or `labelledBy` on components that are related to the RTE


## What
- Fixed duplicate Id on RTE
- Added optional id prop

Before :
![Screenshot 2024-05-08 at 12 34 55 pm](https://github.com/cultureamp/kaizen-design-system/assets/12579379/a1189573-12d7-40f1-a146-527aca24476e)

After :
![Screenshot 2024-05-08 at 12 33 18 pm](https://github.com/cultureamp/kaizen-design-system/assets/12579379/be129d43-9b2a-49dd-81f1-69fe00689f71)
