### PR TITLE
Kzn 2334/table a11y fixes

### DIFF
--- a/packages/components/src/Table/Table.module.scss
+++ b/packages/components/src/Table/Table.module.scss
@@ -185,6 +185,28 @@ $row-height-data-variant: 48px;
     will-change: box-shadow, border-color, margin, padding, width;
   }
 
+  &:focus-visible {
+    outline: none;
+    position: relative;
+    &::after {
+      // This offset provide enough gap on on reverse for contrast ratios
+      $focus-ring-offset: calc(#{$border-focus-ring-border-width} + 2px);
+
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%);
+      width: calc(100% + #{$focus-ring-offset});
+      height: calc(100% + #{$focus-ring-offset});
+      content: "";
+      position: absolute;
+      background: transparent;
+      border-color: $color-blue-500;
+      border-width: $border-focus-ring-border-width;
+      border-style: $border-focus-ring-border-style;
+      border-radius: inherit;
+    }
+  }
+
   &.well {
     margin-top: $spacing-sm;
   }

--- a/packages/components/src/Table/Table.module.scss
+++ b/packages/components/src/Table/Table.module.scss
@@ -20,10 +20,6 @@ $row-height-data-variant: 48px;
   &:focus {
     text-decoration: none;
   }
-
-  &.headerRowCellButtonReversed {
-    color: $color-white;
-  }
 }
 
 // Special Table-only button reset
@@ -90,9 +86,44 @@ $row-height-data-variant: 48px;
 .headerRowCellButton {
   @include button-reset;
   @include anchor-reset;
+
+  display: flex;
+  align-items: stretch;
+  width: 100%;
+  // Ensures that the 100% doesn't go outside of the `headerRowCell` width
+  box-sizing: border-box;
+
+  &:focus-visible {
+    outline: none;
+
+    &::after {
+      // This offset provide enough gap on on reverse for contrast ratios
+      $focus-ring-offset: calc(#{$border-focus-ring-border-width} + 6px);
+
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%);
+      width: calc(100% - #{$border-focus-ring-border-width});
+      height: calc(100% - #{$focus-ring-offset});
+      content: "";
+      position: absolute;
+      background: transparent;
+      border-color: $color-blue-500;
+      border-width: $border-focus-ring-border-width;
+      border-style: $border-focus-ring-border-style;
+      border-radius: $border-focus-ring-border-radius;
+    }
+  }
 }
 
-.headerRowCellButton,
+.headerRowCellButtonReversed {
+  color: $color-white;
+
+  &:focus-visible::after {
+    border-color: $color-blue-100;
+  }
+}
+
 .headerRowCellNoButton {
   display: flex;
   align-items: stretch;

--- a/packages/components/src/Table/Table.tsx
+++ b/packages/components/src/Table/Table.tsx
@@ -13,6 +13,7 @@ import styles from "./Table.module.scss"
 
 export type TableContainerProps = {
   children?: React.ReactNode
+  /** @default "compact" */
   variant?: "compact" | "default" | "data"
 }
 /**
@@ -135,6 +136,7 @@ export const TableHeaderRowCell = ({
 }: TableHeaderRowCellProps): JSX.Element => {
   const sorting = sortingRaw
   const [isHovered, setIsHovered] = React.useState(false)
+
   const updateHoverState = (hoverState: boolean): void => {
     if (sortingArrowsOnHover && hoverState != isHovered)
       setIsHovered(hoverState)
@@ -151,7 +153,11 @@ export const TableHeaderRowCell = ({
     <div className={styles.headerRowCellLabelAndIcons}>
       {icon && (
         <span className={styles.headerRowCellIcon}>
-          {cloneElement(icon, { title: labelText, role: "img" })}
+          {cloneElement(icon, {
+            title: labelText,
+            ["aria-label"]: labelText, // title is unreliable so this is a sensible fallback for tables with icons as headers without aria-labels
+            role: "img",
+          })}
         </span>
       )}
       {checkable && (

--- a/packages/components/src/Table/Table.tsx
+++ b/packages/components/src/Table/Table.tsx
@@ -56,6 +56,15 @@ export type TableHeaderRowProps = {
 const ratioToPercent = (width?: number): string | number | undefined =>
   width != null ? `${width * 100}%` : width
 
+//
+export type TableHeaderRowCellCheckboxProps = {
+  checkable?: boolean
+  checkedStatus?: CheckedStatus
+  /** This will be passed into the aria-label for the checkbox to provide context to the user */
+  checkboxLabel?: string
+  onCheck?: (event: React.ChangeEvent<HTMLInputElement>) => any
+}
+
 /**
  * @param width value between 1 and 0, to be calculated as a percentage
  * @param flex CSS flex shorthand as a string. Be sure to specify the flex grow,
@@ -71,9 +80,6 @@ export type TableHeaderRowCellProps = {
   flex?: string
   href?: string
   icon?: ReactElement
-  checkable?: boolean
-  checkedStatus?: CheckedStatus
-  onCheck?: (event: React.ChangeEvent<HTMLInputElement>) => any
   reversed?: boolean
   /**
    * Shows an up or down arrow, to show that the column is sorted.
@@ -82,13 +88,19 @@ export type TableHeaderRowCellProps = {
   wrapping?: "nowrap" | "wrap"
   align?: "start" | "center" | "end"
   tooltipInfo?: string
+  /** If set, this will hide the tooltip exclamation icon. Useful in situations where
+   the table header does not have enough space. This should be done with caution as tooltips
+   should have a visual indicator to users */
   isTooltipIconHidden?: boolean
   /**
    * Specify where the tooltip should be rendered.
    */
   tooltipPortalSelector?: string | undefined
+  /** If set, this will show the arrow in the direction provided
+  when the header cell is hovered over. */
   sortingArrowsOnHover?: "ascending" | "descending" | undefined
-} & OverrideClassName<HTMLAttributes<HTMLElement>>
+} & TableHeaderRowCellCheckboxProps &
+  OverrideClassName<HTMLAttributes<HTMLElement>>
 
 export const TableHeaderRowCell = ({
   labelText,
@@ -99,6 +111,7 @@ export const TableHeaderRowCell = ({
   icon,
   checkable,
   checkedStatus,
+  checkboxLabel,
   onCheck,
   reversed,
   sorting: sortingRaw,
@@ -111,13 +124,9 @@ export const TableHeaderRowCell = ({
   wrapping = "nowrap",
   align = "start",
   tooltipInfo,
-  // If set, this will hide the tooltip exclamation icon. Useful in situations where
-  // the table header does not have enough space. However, we should always show a
-  // tooltip icon as the default based on design system tooltip guidelines.
   isTooltipIconHidden = false,
   tooltipPortalSelector,
-  // If set, this will show the arrow in the direction provided
-  // when the header cell is hovered over.
+
   sortingArrowsOnHover,
   classNameOverride,
   // There aren't any other props in the type definition, so I'm unsure why we
@@ -126,7 +135,6 @@ export const TableHeaderRowCell = ({
 }: TableHeaderRowCellProps): JSX.Element => {
   const sorting = sortingRaw
   const [isHovered, setIsHovered] = React.useState(false)
-
   const updateHoverState = (hoverState: boolean): void => {
     if (sortingArrowsOnHover && hoverState != isHovered)
       setIsHovered(hoverState)
@@ -148,7 +156,11 @@ export const TableHeaderRowCell = ({
       )}
       {checkable && (
         <div className={styles.headerRowCellCheckbox}>
-          <Checkbox checkedStatus={checkedStatus} onCheck={onCheck} />
+          <Checkbox
+            checkedStatus={checkedStatus}
+            onCheck={onCheck}
+            aria-label={checkboxLabel}
+          />
         </div>
       )}
       {tooltipInfo != null && !isTooltipIconHidden ? (

--- a/packages/components/src/Table/_docs/Table.mdx
+++ b/packages/components/src/Table/_docs/Table.mdx
@@ -27,7 +27,7 @@ A table displays rows of data, including all data in a set, making it efficient 
 
 ### Variant
 
-Controls the spacing in each cell within the table. Options available are `compact`, `default` and `data`
+Controls the spacing in each cell within the table. Options available are `compact`, `default` and `data`.
 
 #### Compact
 <Canvas of={TableStories.Data} />
@@ -75,6 +75,9 @@ You can read more about the Tooltip component and accessibility limitation [here
 <Canvas of={TableStories.LinkVariant} />
 
 ### Expandable
+
+The `expandable` prop introduces known accessibility issues with nesting interactive elements as children of a `button` or `anchor` tag. We recommend avoiding this pattern if possible, or creating a tier 3 component that adheres to correct WCAG hierarchy.
+
 <Canvas of={TableStories.Expandable} />
 
 

--- a/packages/components/src/Table/_docs/Table.mdx
+++ b/packages/components/src/Table/_docs/Table.mdx
@@ -23,34 +23,56 @@ A table displays rows of data, including all data in a set, making it efficient 
 
 <Canvas of={TableStories.Playground} />
 
-## API
+## TableContainer API
 
-### Compact tables
-<Canvas of={TableStories.Compact} />
+### Variant
 
-### Data tables
+Controls the spacing in each cell within the table. Options available are `compact`, `default` and `data`
+
+#### Compact
 <Canvas of={TableStories.Data} />
 
-#### Sorting headers
+#### Default
+<Canvas of={TableStories.Default} />
+
+#### Data
+<Canvas of={TableStories.Data} />
+
+## TableHeaderRowCell API
+
+### Sorting
 <Canvas of={TableStories.Sorting} />
 
-### Checkbox header
+### Checkbox
+
+To ensure there appropriate context for users of assistive technologies, when using a `checkable` `TableHeaderRowCell`, we advise in the `checkboxLabel`. This will be passed to the a checkbox aria-label and be announce to screen reader users when focused.
+
 <Canvas of={TableStories.CheckboxVariant} />
 
-### Icon headers
+### Icon
+
+When using providing `icon` to `TableHeaderRowCell` the `labelText` will be passed to the `aria-label` of the SVG.
+
 <Canvas of={TableStories.IconVariant} />
 
-### Align and wrapping headers
+### Align and wrapping
 <Canvas of={TableStories.HeaderAlignmentAndWrapping} />
 
-### Tooltip headers
+### Tooltips
+
+While Tooltip content can be passed to any table header via the `tooltipInfo` prop, it is strong advised to avoid this if the header is not an interactive element as the tooltip content will be unreadable to keyboard users or those that use assistive technologies.
+
 <Canvas of={TableStories.Tooltip} />
+
+You can read more about the Tooltip component and accessibility limitation [here](https://cultureamp.design/?path=/docs/components-tooltip--docs#screen-reader-accessibility).
 
 ### Reversed
 <Canvas of={TableStories.Reversed} />
 
-### Link TableCards
+## TableCard API
+
+### Link
 <Canvas of={TableStories.LinkVariant} />
 
-### Expandable TableCards
+### Expandable
 <Canvas of={TableStories.Expandable} />

--- a/packages/components/src/Table/_docs/Table.mdx
+++ b/packages/components/src/Table/_docs/Table.mdx
@@ -76,3 +76,5 @@ You can read more about the Tooltip component and accessibility limitation [here
 
 ### Expandable
 <Canvas of={TableStories.Expandable} />
+
+

--- a/packages/components/src/Table/_docs/Table.mdx
+++ b/packages/components/src/Table/_docs/Table.mdx
@@ -25,29 +25,32 @@ A table displays rows of data, including all data in a set, making it efficient 
 
 ## API
 
-### Data
-<Canvas of={TableStories.Data} />
-
-### Compact
+### Compact tables
 <Canvas of={TableStories.Compact} />
 
-### LinkVariant
-<Canvas of={TableStories.LinkVariant} />
+### Data tables
+<Canvas of={TableStories.Data} />
 
-### CheckboxVariant
+#### Sorting headers
+<Canvas of={TableStories.Sorting} />
+
+### Checkbox header
 <Canvas of={TableStories.CheckboxVariant} />
 
-### IconVariant
+### Icon headers
 <Canvas of={TableStories.IconVariant} />
 
-### Expandable
-<Canvas of={TableStories.Expandable} />
-
-### HeaderAlignmentAndWrapping
+### Align and wrapping headers
 <Canvas of={TableStories.HeaderAlignmentAndWrapping} />
 
-### Tooltip
+### Tooltip headers
 <Canvas of={TableStories.Tooltip} />
 
 ### Reversed
 <Canvas of={TableStories.Reversed} />
+
+### Link TableCards
+<Canvas of={TableStories.LinkVariant} />
+
+### Expandable TableCards
+<Canvas of={TableStories.Expandable} />

--- a/packages/components/src/Table/_docs/Table.stories.tsx
+++ b/packages/components/src/Table/_docs/Table.stories.tsx
@@ -27,12 +27,6 @@ export type TableStoryProps = {
   card: TableCardProps
 }
 
-// <TableRowCell width={3 / 12} {...rowCell}>
-// <Text tag="div" variant="body">
-//   Today
-// </Text>
-// </TableRowCell>
-
 const Table = ({
   container,
   row,
@@ -235,11 +229,13 @@ export const Reversed: Story = {
     headerRowCells: [
       {
         labelText: "Resource name",
+        sorting: "ascending",
+        onClick: action("Sort Resource name by ascending"),
         width: 3 / 12,
         reversed: true,
       },
       {
-        labelText: "Resource name",
+        labelText: "Supplementary information",
         width: 3 / 12,
         reversed: true,
       },
@@ -272,6 +268,16 @@ export const Reversed: Story = {
 export const Compact: Story = {
   render: Table,
   args: { container: { variant: "compact" } },
+  parameters: {
+    docs: {
+      source: { type: "dynamic" },
+    },
+  },
+}
+
+export const Default: Story = {
+  render: Table,
+  args: { container: { variant: "default" } },
   parameters: {
     docs: {
       source: { type: "dynamic" },
@@ -355,9 +361,8 @@ export const IconVariant: Story = {
       },
       {
         icon: <EffectivenessIcon role="presentation" />,
-        labelText: "Resource name",
+        labelText: "Supplementary information",
         width: 3 / 12,
-        sorting: "ascending",
       },
       {
         labelText: "Date",
@@ -431,7 +436,9 @@ export const Tooltip: Story = {
     headerRowCells: [
       {
         labelText: "Resource name",
-        tooltipInfo: "This is a resource",
+        tooltipInfo: "Sort this by ascending",
+        sorting: "ascending",
+        onClick: action("Sort Resource name by ascending"),
         width: 3 / 12,
       },
       {

--- a/packages/components/src/Table/_docs/Table.stories.tsx
+++ b/packages/components/src/Table/_docs/Table.stories.tsx
@@ -1,8 +1,9 @@
 import React from "react"
+import { action } from "@storybook/addon-actions"
 import { Meta, StoryObj } from "@storybook/react"
-import { IconButton } from "~components/Button"
+import { Checkbox } from "~components/Checkbox"
 import { Divider } from "~components/Divider"
-import { ChevronUpIcon, EffectivenessIcon } from "~components/Icon"
+import { EffectivenessIcon } from "~components/Icon"
 import { Text } from "~components/Text"
 import {
   TableCard,
@@ -21,48 +22,33 @@ import {
 export type TableStoryProps = {
   container?: TableContainerProps
   row?: TableRowProps
-  rowCell?: TableRowCellProps
-  headerRowCell: Partial<TableHeaderRowCellProps>
+  rowCells: TableRowCellProps[]
+  headerRowCells: TableHeaderRowCellProps[]
   card: TableCardProps
 }
+
+// <TableRowCell width={3 / 12} {...rowCell}>
+// <Text tag="div" variant="body">
+//   Today
+// </Text>
+// </TableRowCell>
 
 const Table = ({
   container,
   row,
-  rowCell,
-  headerRowCell,
+  rowCells,
+  headerRowCells,
   card,
 }: TableStoryProps): JSX.Element => {
   const { expanded, ...restCardProps } = card
-  const { checkable, ...restHeaderRowCellProps } = headerRowCell
 
   return (
     <TableContainer {...container}>
       <TableHeader>
         <TableRow>
-          <TableHeaderRowCell
-            labelText="Resource name"
-            width={3 / 12}
-            checkable={checkable}
-            sorting="descending"
-            {...restHeaderRowCellProps}
-          />
-          <TableHeaderRowCell
-            labelText="Supplementary information"
-            width={3 / 12}
-            sorting="ascending"
-            {...restHeaderRowCellProps}
-          />
-          <TableHeaderRowCell
-            labelText="Date"
-            width={3 / 12}
-            {...restHeaderRowCellProps}
-          />
-          <TableHeaderRowCell
-            labelText="Price"
-            width={3 / 12}
-            {...restHeaderRowCellProps}
-          />
+          {headerRowCells.map((headerRowCellProps, index) => (
+            <TableHeaderRowCell key={index} {...headerRowCellProps} />
+          ))}
         </TableRow>
       </TableHeader>
       <TableCard
@@ -71,34 +57,13 @@ const Table = ({
         onClick={expanded ? (): void => undefined : undefined}
       >
         <TableRow {...row}>
-          <TableRowCell width={3 / 12} {...rowCell}>
-            <Text tag="div" variant="body">
-              Resource
-            </Text>
-          </TableRowCell>
-          <TableRowCell width={3 / 12} {...rowCell}>
-            <Text tag="div" variant="body">
-              Supplementary
-            </Text>
-          </TableRowCell>
-          <TableRowCell width={3 / 12} {...rowCell}>
-            <Text tag="div" variant="body">
-              Today
-            </Text>
-          </TableRowCell>
-          <TableRowCell width={3 / 12} {...rowCell}>
-            <Text tag="div" variant="body" classNameOverride="mr-24">
-              100
-            </Text>
-            {expanded && (
-              <TableRowCell width={3 / 12} {...rowCell}>
-                <IconButton
-                  label="Expand"
-                  icon={<ChevronUpIcon role="presentation" />}
-                />
-              </TableRowCell>
-            )}
-          </TableRowCell>
+          {rowCells.map(({ children, ...otherProps }, rowCellIndex) => (
+            <TableRowCell {...otherProps} key={rowCellIndex}>
+              <Text tag="div" variant="body">
+                {children}
+              </Text>
+            </TableRowCell>
+          ))}
         </TableRow>
         {expanded && (
           <>
@@ -111,26 +76,13 @@ const Table = ({
       </TableCard>
       <TableCard {...restCardProps}>
         <TableRow {...row}>
-          <TableRowCell width={3 / 12} {...rowCell}>
-            <Text tag="div" variant="body">
-              Resource
-            </Text>
-          </TableRowCell>
-          <TableRowCell width={3 / 12} {...rowCell}>
-            <Text tag="div" variant="body">
-              Supplementary
-            </Text>
-          </TableRowCell>
-          <TableRowCell width={3 / 12} {...rowCell}>
-            <Text tag="div" variant="body">
-              Today
-            </Text>
-          </TableRowCell>
-          <TableRowCell width={3 / 12} {...rowCell}>
-            <Text tag="div" variant="body">
-              100
-            </Text>
-          </TableRowCell>
+          {rowCells.map(({ children, ...otherProps }, rowCellIndex) => (
+            <TableRowCell {...otherProps} key={rowCellIndex}>
+              <Text tag="div" variant="body">
+                {children}
+              </Text>
+            </TableRowCell>
+          ))}
         </TableRow>
       </TableCard>
     </TableContainer>
@@ -142,6 +94,9 @@ const meta = {
   component: Table,
   parameters: {
     chromatic: { disable: false },
+    docs: {
+      source: { type: "dynamic" },
+    },
     a11y: {
       config: {
         rules: [
@@ -171,7 +126,42 @@ const meta = {
   },
   args: {
     card: { expanded: false },
-    headerRowCell: { checkable: false },
+    headerRowCells: [
+      {
+        labelText: "Resource name",
+        width: 3 / 12,
+      },
+      {
+        labelText: "Supplementary information",
+        width: 3 / 12,
+      },
+      {
+        labelText: "Date",
+        width: 3 / 12,
+      },
+      {
+        labelText: "Price",
+        width: 3 / 12,
+      },
+    ],
+    rowCells: [
+      {
+        width: 3 / 12,
+        children: "Resource",
+      },
+      {
+        width: 3 / 12,
+        children: "Supplementary",
+      },
+      {
+        width: 3 / 12,
+        children: "Today",
+      },
+      {
+        width: 3 / 12,
+        children: "100",
+      },
+    ],
   },
   decorators: [
     Story => (
@@ -195,6 +185,39 @@ export const Playground: Story = {
   },
 }
 
+export const Sorting: Story = {
+  render: Table,
+  parameters: {
+    docs: {
+      source: { type: "dynamic" },
+    },
+  },
+  args: {
+    headerRowCells: [
+      {
+        labelText: "Resource name",
+        sorting: "ascending",
+        onClick: action("Sort Resource name"),
+        width: 3 / 12,
+      },
+      {
+        labelText: "Supplementary information",
+        sorting: "descending",
+        onClick: action("Sort Supplementary information"),
+        width: 3 / 12,
+      },
+      {
+        labelText: "Date",
+        width: 3 / 12,
+      },
+      {
+        labelText: "Price",
+        width: 3 / 12,
+      },
+    ],
+  },
+}
+
 export const Data: Story = {
   render: Table,
   args: { container: { variant: "data" } },
@@ -207,7 +230,31 @@ export const Data: Story = {
 
 export const Reversed: Story = {
   render: Table,
-  args: { headerRowCell: { reversed: true } },
+  args: {
+    card: { expanded: false },
+    headerRowCells: [
+      {
+        labelText: "Resource name",
+        width: 3 / 12,
+        reversed: true,
+      },
+      {
+        labelText: "Resource name",
+        width: 3 / 12,
+        reversed: true,
+      },
+      {
+        labelText: "Date",
+        width: 3 / 12,
+        reversed: true,
+      },
+      {
+        labelText: "Price",
+        width: 3 / 12,
+        reversed: true,
+      },
+    ],
+  },
   parameters: {
     docs: {
       source: { type: "dynamic" },
@@ -234,7 +281,52 @@ export const Compact: Story = {
 
 export const CheckboxVariant: Story = {
   render: Table,
-  args: { headerRowCell: { checkable: true } },
+  args: {
+    headerRowCells: [
+      {
+        checkable: true,
+        onCheck: action("onCheck header-1"),
+        checkboxLabel: "Select all Employees",
+        labelText: "Employee",
+        width: 5 / 12,
+      },
+      {
+        labelText: "Job title",
+        width: 3 / 12,
+      },
+      {
+        labelText: "Date",
+        width: 2 / 12,
+      },
+      {
+        labelText: "Score",
+        width: 2 / 12,
+      },
+    ],
+    rowCells: [
+      {
+        width: 5 / 12,
+        children: (
+          <span className="flex gap-12">
+            <Checkbox aria-label="Employee x" />
+            <span>Employee name</span>
+          </span>
+        ),
+      },
+      {
+        width: 3 / 12,
+        children: "Engineer",
+      },
+      {
+        width: 2 / 12,
+        children: "Today",
+      },
+      {
+        width: 2 / 12,
+        children: "100",
+      },
+    ],
+  },
   parameters: {
     docs: {
       source: { type: "dynamic" },
@@ -255,9 +347,27 @@ export const LinkVariant: Story = {
 export const IconVariant: Story = {
   render: Table,
   args: {
-    headerRowCell: {
-      icon: <EffectivenessIcon role="presentation" />,
-    },
+    headerRowCells: [
+      {
+        icon: <EffectivenessIcon role="presentation" />,
+        labelText: "Resource name",
+        width: 3 / 12,
+      },
+      {
+        icon: <EffectivenessIcon role="presentation" />,
+        labelText: "Resource name",
+        width: 3 / 12,
+        sorting: "ascending",
+      },
+      {
+        labelText: "Date",
+        width: 3 / 12,
+      },
+      {
+        labelText: "Price",
+        width: 3 / 12,
+      },
+    ],
   },
   parameters: {
     docs: {
@@ -284,11 +394,28 @@ export const Expandable: Story = {
 export const HeaderAlignmentAndWrapping: Story = {
   render: Table,
   args: {
-    headerRowCell: {
-      labelText: "Right header align with wrapping",
-      wrapping: "wrap",
-      align: "end",
-    },
+    headerRowCells: [
+      {
+        labelText: "Header align start with wrapping",
+        wrapping: "wrap",
+        align: "start",
+      },
+      {
+        labelText: "Default alignment",
+        width: 3 / 12,
+      },
+      {
+        labelText: "Header center",
+        align: "center",
+        width: 3 / 12,
+      },
+      {
+        labelText: "Header align with end with wrapping",
+        wrapping: "wrap",
+        align: "end",
+        width: 3 / 12,
+      },
+    ],
   },
   parameters: {
     docs: {
@@ -300,9 +427,26 @@ export const HeaderAlignmentAndWrapping: Story = {
 export const Tooltip: Story = {
   render: Table,
   args: {
-    headerRowCell: {
-      tooltipInfo: "This is a tooltip",
-    },
+    card: { expanded: false },
+    headerRowCells: [
+      {
+        labelText: "Resource name",
+        tooltipInfo: "This is a resource",
+        width: 3 / 12,
+      },
+      {
+        labelText: "Supplementary information",
+        width: 3 / 12,
+      },
+      {
+        labelText: "Date",
+        width: 3 / 12,
+      },
+      {
+        labelText: "Price",
+        width: 3 / 12,
+      },
+    ],
   },
   parameters: {
     docs: {

--- a/packages/components/src/Table/_docs/Table.stories.tsx
+++ b/packages/components/src/Table/_docs/Table.stories.tsx
@@ -109,11 +109,6 @@ const meta = {
             id: "aria-required-parent",
             enabled: false,
           },
-          {
-            // Fixing this in a rebuild
-            id: "label",
-            enabled: false,
-          },
         ],
       },
     },


### PR DESCRIPTION
## Why
This PR addresses several accessibility issue with the existing table implementation in Kaizen, reported in the last round of Intopia and during development of these fixes. While we accept that the Table in Kaizen is an imperfect solution, this PR seeks address as many of these accessibility issues without the need for a rebuild or breaking change.

## a11y issues
- Focus indicators on table headings and row links are browser default.
- Wherever there is a table with checkboxes, the checkboxes aren’t linked to anything, resulting in inputs with no label linked.
- Expandable pattern creates invalid HTML and likely issues for screen readers - consideration for the Tier 3.
- Icon headings passing the labetText into the SVG title, which was not accessible to screen readers

## Fixes
- Added default focus ring widths and colors to interactive  variants of the `TableHeaderRowCell` and interactive table cards
- Added a `checkboxLabel` prop as a mean to resolving the unlinked checkbox label in the `checkable` variant of the `TableHeaderRowCell`
  - I opted not to use the `labelText` as a default for this since it would not communicate to a user what it's intention was. This I think should explicitly be called out, i.e: `Select all *Resource name*`. This way translations and intent can be handled by the consumer.
- Updated the `TableHeaderRowCell` to pass labelText in the an aria-label for the `icon` variant
- Update the documentation with some clearer guidance on the APIs and sub components
  - I left these all as a one pager but am not appose to splitting them into individual pages, I just didn't want to spend too long fussing over the IA of this old component

