### PR TITLE
Fix tsconfig types to resolve broken types build

### DIFF
--- a/.changeset/curvy-boxes-clap.md
+++ b/.changeset/curvy-boxes-clap.md
@@ -1,0 +1,5 @@
+---
+"@kaizen/components": patch
+---
+
+fix tsConfig jest-dom types

--- a/packages/components/tsconfig.json
+++ b/packages/components/tsconfig.json
@@ -9,10 +9,13 @@
       "~types/*": ["./src/types/*"],
       "~utils/*": ["./src/utils/*"],
       "~components/*": ["./src/*"]
-    }
+    },
+    "types": [
+      "@testing-library/jest-dom"
+    ]
   },
-  "files": ["types.d.ts"],
-  "include": ["src/**/*", "../../jest.setup.ts"],
+  "files": ["types.d.ts" ],
+  "include": ["src/**/*"],
   "exclude": ["node_modules"],
   "ts-node": {
     "moduleTypes": {

--- a/packages/components/tsconfig.json
+++ b/packages/components/tsconfig.json
@@ -10,11 +10,9 @@
       "~utils/*": ["./src/utils/*"],
       "~components/*": ["./src/*"]
     },
-    "types": [
-      "@testing-library/jest-dom"
-    ]
+    "types": ["@testing-library/jest-dom"]
   },
-  "files": ["types.d.ts" ],
+  "files": ["types.d.ts"],
   "include": ["src/**/*"],
   "exclude": ["node_modules"],
   "ts-node": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,15 +19,9 @@
       "~components/*": ["packages/components/src/*"],
       "~design-tokens/*": ["packages/design-tokens/src/*"]
     },
-    "types": [
-      "@testing-library/jest-dom"
-    ]
+    "types": ["@testing-library/jest-dom"]
   },
   "files": ["./types.d.ts"],
-  "include": [
-    "packages/**/*",
-    "storybook/**/*",
-    "docs/**/*.tsx"
-  ],
+  "include": ["packages/**/*", "storybook/**/*", "docs/**/*.tsx"],
   "exclude": ["**/node_modules"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,14 +18,16 @@
       "~utils/*": ["packages/components/src/utils/*"],
       "~components/*": ["packages/components/src/*"],
       "~design-tokens/*": ["packages/design-tokens/src/*"]
-    }
+    },
+    "types": [
+      "@testing-library/jest-dom"
+    ]
   },
   "files": ["./types.d.ts"],
   "include": [
     "packages/**/*",
     "storybook/**/*",
-    "docs/**/*.tsx",
-    "./jest.setup.ts"
+    "docs/**/*.tsx"
   ],
   "exclude": ["**/node_modules"]
 }


### PR DESCRIPTION
## Why
We made some changes to our tsconfig attempting to resolve TS errors including the `jest.setup`. This resulted in our distributed types being bundle incorrectly.

## What
- update tsconfig to pull types from @testing-library/jest-dom instead of including our local `jest.setup` file
