### PR TITLE
Fix bundling and package version

### DIFF
--- a/.buildkite/scripts/build-storybook.sh
+++ b/.buildkite/scripts/build-storybook.sh
@@ -5,7 +5,7 @@ set -e
 . ".buildkite/scripts/helpers/setup-registry.sh"
 
 pnpm install --frozen-lockfile
-pnpm -F @kaizen/design-tokens prepublishOnly
-pnpm -F @kaizen/tailwind prepublishOnly
+pnpm -F @kaizen/design-tokens build
+pnpm -F @kaizen/tailwind build
 pnpm storybook:build:prod
 tar -czf ./storybook.tar.gz ./storybook/public

--- a/.changeset/late-dragons-switch.md
+++ b/.changeset/late-dragons-switch.md
@@ -1,0 +1,5 @@
+---
+"@kaizen/package-bundler": patch
+---
+
+Update fs.rmdirSync to fs.rmSync

--- a/.changeset/swift-stingrays-travel.md
+++ b/.changeset/swift-stingrays-travel.md
@@ -2,4 +2,5 @@
 "@kaizen/package-bundler": patch
 ---
 
-Fix version number from v2 to v1
+- Fix version number from v2 to v1
+- Fix missing bundle in KAIO and `package-bundler`

--- a/.changeset/swift-stingrays-travel.md
+++ b/.changeset/swift-stingrays-travel.md
@@ -1,0 +1,5 @@
+---
+"@kaizen/package-bundler": patch
+---
+
+Fix version number from v2 to v1

--- a/package.json
+++ b/package.json
@@ -35,8 +35,8 @@
     "changeset": "changeset",
     "plop": "plop",
     "pkg:aio": "pnpm -F @kaizen/components",
-    "ci:version": "pnpm turbo prepublishOnly && pnpm changeset version",
-    "ci:publish": "pnpm turbo prepublishOnly && pnpm changeset publish",
+    "ci:version": "pnpm turbo build && pnpm changeset version",
+    "ci:publish": "pnpm turbo build && pnpm changeset publish",
     "update-icons": "pnpm pkg:aio update-icons",
     "i18n:extract": "pnpm pkg:aio i18n:extract",
     "i18n:extract:remove-obsolete": "pnpm pkg:aio i18n:extract --deleteObsoleteTranslations"

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -26,8 +26,10 @@
     "styles.css"
   ],
   "scripts": {
-    "build": "pnpm package-bundler build-shared-ui && pnpm build:global-styles",
+    "prepublishOnly": "pnpm package-bundler build-shared-ui && pnpm build:global-styles",
+    "build": "pnpm clean && pnpm prepublishOnly",
     "build:global-styles": "postcss ./styles/global.css --output dist/styles.css",
+    "clean": "rm -rf dist",
     "test": "FORCE_COLOR=1 jest",
     "test:ci": "pnpm test -- --ci",
     "test:treeshake": "agadoo ./dist/esm/index.mjs",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -26,8 +26,7 @@
     "styles.css"
   ],
   "scripts": {
-    "prepublishOnly": "pnpm package-bundler build-shared-ui && pnpm build:global-styles",
-    "build": "pnpm clean && pnpm prepublishOnly",
+    "build": "pnpm package-bundler build-shared-ui && pnpm build:global-styles",
     "build:global-styles": "postcss ./styles/global.css --output dist/styles.css",
     "clean": "rm -rf dist",
     "test": "FORCE_COLOR=1 jest",

--- a/packages/design-tokens/package.json
+++ b/packages/design-tokens/package.json
@@ -24,13 +24,12 @@
   "scripts": {
     "test": "FORCE_COLOR=1 jest",
     "test:ci": "pnpm test -- --ci",
-    "build": "pnpm clean && pnpm prepublishOnly",
+    "build": "pnpm clean && pnpm build:json && pnpm build:less && pnpm build:sass && pnpm build:ts",
     "build:json": "tsx ./bin/buildCssVarTokens.ts",
     "build:ts": "tsc --project tsconfig.dist.json",
     "build:less": "json-to-flat-sass './tokens/*.json' 'less' --extension 'less' --caseType 'kebab' && prettier less/* --write",
     "build:sass": "json-to-flat-sass './tokens/*.json' 'sass' --extension 'scss' --caseType 'kebab' && prettier sass/* --write",
-    "clean": "rimraf dist",
-    "prepublishOnly": "pnpm build:json && pnpm build:less && pnpm build:sass && pnpm build:ts"
+    "clean": "rimraf dist"
   },
   "devDependencies": {
     "@types/lodash.flatmap": "^4.5.9",

--- a/packages/hosted-assets/package.json
+++ b/packages/hosted-assets/package.json
@@ -18,7 +18,6 @@
     "_index.scss"
   ],
   "scripts": {
-    "prepublishOnly": "tsc --project tsconfig.dist.json",
     "build": "pnpm clean && pnpm prepublishOnly",
     "clean": "rm -rf dist && rimraf '*.d.ts' '*.js'"
   }

--- a/packages/hosted-assets/package.json
+++ b/packages/hosted-assets/package.json
@@ -18,7 +18,7 @@
     "_index.scss"
   ],
   "scripts": {
-    "build": "pnpm clean && pnpm prepublishOnly",
+    "build": "pnpm clean && tsc --project tsconfig.dist.json",
     "clean": "rm -rf dist && rimraf '*.d.ts' '*.js'"
   }
 }

--- a/packages/package-bundler/CHANGELOG.md
+++ b/packages/package-bundler/CHANGELOG.md
@@ -1,6 +1,6 @@
 # @kaizen/package-bundler
 
-## 2.0.0
+## 1.0.0
 
 ### Major Changes
 

--- a/packages/package-bundler/package.json
+++ b/packages/package-bundler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kaizen/package-bundler",
-  "version": "2.0.0",
+  "version": "1.0.0",
   "description": "Bundles libraries",
   "main": "dist/index.js",
   "type": "module",

--- a/packages/package-bundler/package.json
+++ b/packages/package-bundler/package.json
@@ -9,7 +9,6 @@
   },
   "scripts": {
     "build": "rm -rf dist && tsc --build",
-    "prepublishOnly": "tsc --build",
     "prepare": "ts-patch install -s"
   },
   "files": [

--- a/packages/package-bundler/package.json
+++ b/packages/package-bundler/package.json
@@ -9,6 +9,7 @@
   },
   "scripts": {
     "build": "rm -rf dist && tsc --build",
+    "prepublishOnly": "tsc --build",
     "prepare": "ts-patch install -s"
   },
   "files": [

--- a/packages/package-bundler/src/presets/shared-ui/bin/postBuild.ts
+++ b/packages/package-bundler/src/presets/shared-ui/bin/postBuild.ts
@@ -6,5 +6,5 @@ const args = getArgs()
 const destination = `${args.packagePath}/src/__build-tools`
 
 if (fs.existsSync(destination)) {
-  fs.rmdirSync(destination, { recursive: true })
+  fs.rmSync(destination, { recursive: true })
 }

--- a/packages/tailwind/package.json
+++ b/packages/tailwind/package.json
@@ -3,9 +3,7 @@
   "version": "1.2.7",
   "description": "Kaizen Tailwind presets",
   "scripts": {
-    "build": "pnpm clean && pnpm prepublishOnly",
-    "build:ts": "tsc --project tsconfig.dist.json",
-    "prepublishOnly": "tsc --project tsconfig.dist.json",
+    "build": "pnpm clean && tsc --project tsconfig.dist.json",
     "clean": "rimraf -g '**/*.d.ts' '**/*.js' '**/*.map'"
   },
   "repository": {

--- a/turbo.json
+++ b/turbo.json
@@ -15,11 +15,6 @@
       "dependsOn": ["^build"],
       "inputs": ["dist/**"]
     },
-    "prepublishOnly": {
-      "dependsOn": ["^prepublishOnly"],
-      "inputs": ["packages/**"],
-      "outputs": ["dist/**"]
-    },
     "clean": {
       "cache": false
     },


### PR DESCRIPTION
## Why
We accidentally published a 2.0 instead of 1.0 for `package-bundler` and the publish script failed to bundle all the code, making `package-bundler` and  the latest `KAIO` unusable.


## What
- Revert and publish `package-bunlder` to `1.0.0`
- Remove all `prepublishOnly` scripts
- Change the publishing process to use `build` instead