### PR TITLE
fix(EmptyState): Blank out alt text for illustrations in EmptyState

### DIFF
--- a/.changeset/flat-eyes-wash.md
+++ b/.changeset/flat-eyes-wash.md
@@ -1,0 +1,5 @@
+---
+"@kaizen/components": patch
+---
+
+Blank out alt text for illustrations in EmptyState

--- a/packages/components/src/EmptyState/EmptyState.tsx
+++ b/packages/components/src/EmptyState/EmptyState.tsx
@@ -84,10 +84,7 @@ export const EmptyState = ({
             classNameOverride={styles.illustration}
           />
         ) : (
-          <IllustrationComponent
-            alt={illustrationType}
-            classNameOverride={styles.illustration}
-          />
+          <IllustrationComponent classNameOverride={styles.illustration} />
         )}
       </div>
       <div className={styles.textSide}>


### PR DESCRIPTION
Illustrations in Empty States have alt text at the moment, when `isAnimated` is false. It uses the string of the `mood` prop. e.g. `positive` or `action`.

We want these blank because they're decorative

## Before
![image](https://github.com/cultureamp/kaizen-design-system/assets/1811583/3e971295-a3bc-4ed7-9541-e94053f330f0)

## After
![image](https://github.com/cultureamp/kaizen-design-system/assets/1811583/a58c2b4f-1007-4011-b43e-ab5b590e6cd6)

