### PR TITLE
fix(FilterBarMultiSelect): allow consumer to override more props

### DIFF
--- a/.changeset/long-cheetahs-serve.md
+++ b/.changeset/long-cheetahs-serve.md
@@ -1,0 +1,5 @@
+---
+"@kaizen/components": patch
+---
+
+Fix `FilterBarMultiSelectProps` to allow consumer to override `label`, `trigger` and `selectedKeys`

--- a/packages/components/src/Filter/FilterBar/subcomponents/FilterBarMultiSelect/FilterBarMultiSelect.tsx
+++ b/packages/components/src/Filter/FilterBar/subcomponents/FilterBarMultiSelect/FilterBarMultiSelect.tsx
@@ -11,14 +11,11 @@ import { checkArraysMatch } from "../../utils/checkArraysMatch"
 
 export type FilterBarMultiSelectProps = Omit<
   FilterMultiSelectProps,
-  | "isOpen"
-  | "setIsOpen"
-  | "renderTrigger"
-  | "label"
-  | "selectedKeys"
-  | "trigger"
+  "label" | "trigger"
 > & {
   id?: string
+  label?: FilterMultiSelectProps["label"]
+  trigger?: FilterMultiSelectProps["trigger"]
 }
 
 // This should technically be handled within the FilterMultiSelect


### PR DESCRIPTION
## Why
<!-- Why have you created this PR? - Is it a new feature, or a bug fix? Or something else? -->
<!-- Reference any relevant Jira tickets so your reviewer can find more context if needed. -->
<!-- Fixing a GitHub issue? Add "Fixes [issue URL]". -->

[KZN-2441](https://cultureamp.atlassian.net/jira/software/c/projects/KZN/boards/634?selectedIssue=KZN-2441)
Perf have a requirement for overriding the shape of selected values where they wish to access the label in the parent `FilterBar` level prior to loading their full list of async options.

## What
<!-- What do your changes do? How do they change/fix the current behavior? -->
<!-- Add screenshots, GIFs or videos to illustrate the changes.  -->

Update the props for `FilterBarMultiSelect` to allow the consumer to override default behaviour
- No functionality change as the spread props is already working - just addressing the TS error

[KZN-2441]: https://cultureamp.atlassian.net/browse/KZN-2441?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ