### PR TITLE
ci(renovate): disable for peerDeps

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -8,6 +8,10 @@
   ],
   "packageRules": [
     {
+      "depTypeList": ["peerDependencies"],
+      "enabled": false
+    },
+    {
       // Any peerDep or dep within the publishable packages triggers a
       // patch release as a _sensible default_. Merger should use their
       // discretion to determine whether a major change is more appropriate


### PR DESCRIPTION
## Why
<!-- Why have you created this PR? - Is it a new feature, or a bug fix? Or something else? -->
<!-- Reference any relevant Jira tickets so your reviewer can find more context if needed. -->
<!-- Fixing a GitHub issue? Add "Fixes [issue URL]". -->

Peer dependencies have been receiving renovate version bumps, even when we list the version as `>= {version}`.

As discussed with @gyfchong, our peer dep versions should be deliberate and allow for a broader range of compatible versions, and only bumped when it becomes incompatible.

## What
<!-- What do your changes do? How do they change/fix the current behavior? -->
<!-- Add screenshots, GIFs or videos to illustrate the changes.  -->

Disable renovate for peer dependencies.