### PR TITLE
feat(TitleBlockZen): update title font to match composable header

### DIFF
--- a/.changeset/forty-games-battle.md
+++ b/.changeset/forty-games-battle.md
@@ -1,0 +1,5 @@
+---
+"@kaizen/components": minor
+---
+
+Update TitleBlockZen title font to match composable header.

--- a/packages/components/src/TitleBlockZen/TitleBlockZen.module.scss
+++ b/packages/components/src/TitleBlockZen/TitleBlockZen.module.scss
@@ -171,12 +171,6 @@ $tab-container-height-medium-and-small-collapsed: 0;
 .titleTextOverride.titleTextOverride {
   padding: 4px 0;
 
-  @media (max-width: $breadcrumb-breakpoint-width) {
-    font-size: $typography-heading-2-font-size;
-    line-height: $typography-heading-2-line-height;
-    letter-spacing: $typography-heading-2-letter-spacing;
-  }
-
   @include title-block-under-1366 {
     font-size: $typography-heading-2-font-size;
     line-height: $typography-heading-2-line-height;

--- a/packages/components/src/TitleBlockZen/TitleBlockZen.module.scss
+++ b/packages/components/src/TitleBlockZen/TitleBlockZen.module.scss
@@ -172,16 +172,12 @@ $tab-container-height-medium-and-small-collapsed: 0;
   padding: 4px 0;
 
   @media (max-width: $breadcrumb-breakpoint-width) {
-    font-family: $typography-heading-2-font-family;
-    font-weight: $typography-heading-2-font-weight;
     font-size: $typography-heading-2-font-size;
     line-height: $typography-heading-2-line-height;
     letter-spacing: $typography-heading-2-letter-spacing;
   }
 
   @include title-block-under-1366 {
-    font-family: $typography-heading-2-font-family;
-    font-weight: $typography-heading-2-font-weight;
     font-size: $typography-heading-2-font-size;
     line-height: $typography-heading-2-line-height;
     letter-spacing: $typography-heading-2-letter-spacing;
@@ -190,8 +186,6 @@ $tab-container-height-medium-and-small-collapsed: 0;
 
   .hasLongTitle & {
     @include title-block-under-1366 {
-      font-family: $typography-heading-3-font-family;
-      font-weight: $typography-heading-3-font-weight;
       font-size: $typography-heading-3-font-size;
       line-height: $typography-heading-3-line-height;
       letter-spacing: $typography-heading-3-letter-spacing;
@@ -200,8 +194,6 @@ $tab-container-height-medium-and-small-collapsed: 0;
   }
 
   @include title-block-medium-and-small {
-    font-family: $typography-heading-4-font-family;
-    font-weight: $typography-heading-4-font-weight;
     font-size: $typography-heading-4-font-size;
     line-height: $typography-heading-4-line-height;
     letter-spacing: $typography-heading-4-letter-spacing;

--- a/packages/components/src/TitleBlockZen/TitleBlockZen.tsx
+++ b/packages/components/src/TitleBlockZen/TitleBlockZen.tsx
@@ -329,7 +329,7 @@ export const TitleBlockZen = ({
                       <div className={styles.titleAndSubtitleInner}>
                         <div className={styles.title}>
                           <Heading
-                            variant="heading-1"
+                            variant="composable-header-title"
                             color={isReversed(variant) ? "white" : "dark"}
                             classNameOverride={styles.titleTextOverride}
                             data-automation-id={titleAutomationId}

--- a/packages/components/src/TitleBlockZen/_docs/TitleBlockZen.stories.tsx
+++ b/packages/components/src/TitleBlockZen/_docs/TitleBlockZen.stories.tsx
@@ -98,6 +98,65 @@ export const Playground: Story = {
   },
 }
 
+export const Viewports: Story = {
+  parameters: {
+    viewport: {
+      viewports: {
+        default: {
+          name: "Default",
+          styles: { width: "1800px", height: "800px" },
+          type: "desktop",
+        },
+        breadcrumbBreakpoint: {
+          name: "Breadcrumb breakpoint",
+          styles: { width: "1644px", height: "800px" },
+          type: "desktop",
+        },
+        under1366: {
+          name: "Under 1366",
+          styles: { width: "1365px", height: "800px" },
+          type: "desktop",
+        },
+        mediumSmall: {
+          name: "Medium and small",
+          styles: { width: "1079px", height: "800px" },
+          type: "desktop",
+        },
+      },
+      defaultViewport: "default",
+    },
+    chromatic: {
+      disable: false,
+      viewports: [1079, 1365, 1644, 1800],
+    },
+  },
+}
+
+export const HasLongTitle: Story = {
+  parameters: {
+    viewport: {
+      viewports: {
+        default: {
+          name: "Default",
+          styles: { width: "1800px", height: "800px" },
+          type: "desktop",
+        },
+        under1366: {
+          name: "Under 1366",
+          styles: { width: "1365px", height: "800px" },
+          type: "desktop",
+        },
+      },
+      defaultViewport: "default",
+    },
+    chromatic: {
+      disable: false,
+      viewports: [1365, 1800],
+    },
+  },
+  args: { title: "A long title with over thirty characters" },
+}
+
 export const StickerSheetDefault: Story = {
   parameters: {
     docs: {

--- a/packages/components/src/TitleBlockZen/_docs/TitleBlockZen.stories.tsx
+++ b/packages/components/src/TitleBlockZen/_docs/TitleBlockZen.stories.tsx
@@ -104,7 +104,7 @@ export const Viewports: Story = {
       viewports: {
         default: {
           name: "Default",
-          styles: { width: "1800px", height: "800px" },
+          styles: { width: "1645px", height: "800px" },
           type: "desktop",
         },
         breadcrumbBreakpoint: {
@@ -127,7 +127,7 @@ export const Viewports: Story = {
     },
     chromatic: {
       disable: false,
-      viewports: [1079, 1365, 1644, 1800],
+      viewports: [1079, 1365, 1644, 1645],
     },
   },
 }
@@ -136,9 +136,9 @@ export const HasLongTitle: Story = {
   parameters: {
     viewport: {
       viewports: {
-        default: {
-          name: "Default",
-          styles: { width: "1800px", height: "800px" },
+        aboveEqual1366: {
+          name: "Above or equal to 1366",
+          styles: { width: "1366px", height: "800px" },
           type: "desktop",
         },
         under1366: {
@@ -151,7 +151,7 @@ export const HasLongTitle: Story = {
     },
     chromatic: {
       disable: false,
-      viewports: [1365, 1800],
+      viewports: [1365, 1366],
     },
   },
   args: { title: "A long title with over thirty characters" },

--- a/packages/components/src/TitleBlockZen/_docs/TitleBlockZen.stories.tsx
+++ b/packages/components/src/TitleBlockZen/_docs/TitleBlockZen.stories.tsx
@@ -103,13 +103,8 @@ export const Viewports: Story = {
     viewport: {
       viewports: {
         default: {
-          name: "Default",
-          styles: { width: "1645px", height: "800px" },
-          type: "desktop",
-        },
-        breadcrumbBreakpoint: {
-          name: "Breadcrumb breakpoint",
-          styles: { width: "1644px", height: "800px" },
+          name: "Above or equal to 1366",
+          styles: { width: "1366px", height: "800px" },
           type: "desktop",
         },
         under1366: {
@@ -127,7 +122,7 @@ export const Viewports: Story = {
     },
     chromatic: {
       disable: false,
-      viewports: [1079, 1365, 1644, 1645],
+      viewports: [1079, 1365, 1366],
     },
   },
 }
@@ -136,7 +131,7 @@ export const HasLongTitle: Story = {
   parameters: {
     viewport: {
       viewports: {
-        aboveEqual1366: {
+        default: {
           name: "Above or equal to 1366",
           styles: { width: "1366px", height: "800px" },
           type: "desktop",


### PR DESCRIPTION
## What
<!-- What do your changes do? How do they change/fix the current behavior? -->
<!-- Add screenshots, GIFs or videos to illustrate the changes.  -->

Update `TitleBlockZen`'s title font to match the composable header.

## Why
<!-- Why have you created this PR? - Is it a new feature, or a bug fix? Or something else? -->
<!-- Reference any relevant Jira tickets so your reviewer can find more context if needed. -->
<!-- Fixing a GitHub issue? Add "Fixes [issue URL]". -->

Match the font family of the composable header.

After discussion with Dave, removed breadcrumb breakpoint title font scaling given:
- We don't know the actual use case it was solving
- The change of font changes the width of the text - therefore may already be solving initial reason for it
- The breakpoint being at 1644 means most users never actually see the proper visual hierarchy, which isn't ideal