### PR TITLE
feat: translate embedded text within FMS SearchInput

### DIFF
--- a/.changeset/heavy-humans-provide.md
+++ b/.changeset/heavy-humans-provide.md
@@ -1,0 +1,5 @@
+---
+"@kaizen/components": minor
+---
+
+Translate embedded text within `FilterMultiSelect.SearchInput` and `InputSearch`.

--- a/packages/components/locales/en.json
+++ b/packages/components/locales/en.json
@@ -22,6 +22,18 @@
     "description": "Label for the 'date to' field",
     "message": "Date to"
   },
+  "filterMultiSelectSearchInput.label": {
+    "description": "Label for the search input",
+    "message": "Filter options by search query"
+  },
+  "filterMultiSelectSearchInput.placeholder": {
+    "description": "Placeholder for the search input",
+    "message": "Search…"
+  },
+  "inputSearch.clear": {
+    "description": "Label for the clear search button",
+    "message": "Clear search"
+  },
   "kzErrorPage": {
     "description": "Label for contact button",
     "message": "Contact support"

--- a/packages/components/src/Filter/FilterMultiSelect/subcomponents/SearchInput/SearchInput.tsx
+++ b/packages/components/src/Filter/FilterMultiSelect/subcomponents/SearchInput/SearchInput.tsx
@@ -1,4 +1,5 @@
 import React, { useId } from "react"
+import { useIntl } from "@cultureamp/i18n-react-intl"
 import { InputSearch } from "~components/Input/InputSearch"
 import { useSelectionContext } from "../../context"
 import styles from "./SearchInput.module.scss"
@@ -14,6 +15,7 @@ export const SearchInput = ({
   id,
   isLoading,
 }: SearchInputProps): JSX.Element => {
+  const { formatMessage } = useIntl()
   const { setSearchQuery, searchQuery } = useSelectionContext()
 
   const handleChange: React.ChangeEventHandler<HTMLInputElement> = e => {
@@ -25,13 +27,24 @@ export const SearchInput = ({
   const reactId = useId()
   const inputId = id ?? reactId
 
+  const defaultAriaLabel = formatMessage({
+    id: "filterMultiSelectSearchInput.label",
+    defaultMessage: "Filter options by search query",
+    description: "Label for the search input",
+  })
+  const placeholder = formatMessage({
+    id: "filterMultiSelectSearchInput.placeholder",
+    defaultMessage: "Search…",
+    description: "Placeholder for the search input",
+  })
+
   return (
     <div className={styles.inputSearchContainer}>
       <InputSearch
         id={inputId}
-        aria-label={label ?? "Filter options by search query"}
+        aria-label={label ?? defaultAriaLabel}
         secondary
-        placeholder="Search…"
+        placeholder={placeholder}
         value={searchQuery}
         onChange={handleChange}
         onClear={handleClear}

--- a/packages/components/src/Input/InputSearch/InputSearch.tsx
+++ b/packages/components/src/Input/InputSearch/InputSearch.tsx
@@ -1,4 +1,5 @@
 import React, { InputHTMLAttributes, useRef } from "react"
+import { useIntl } from "@cultureamp/i18n-react-intl"
 import classnames from "classnames"
 import { ClearButton } from "~components/ClearButton"
 import { SearchIcon } from "~components/Icon/SearchIcon"
@@ -29,12 +30,20 @@ export const InputSearch = (props: InputSearchProps): JSX.Element => {
     secondary = false,
     ...restProps
   } = props
+  const { formatMessage } = useIntl()
   const inputRef = useRef<HTMLInputElement>(null)
 
   const handleOnClear = (): void => {
     inputRef.current?.focus()
     onClear && onClear()
   }
+
+  const clearButtonLabel = formatMessage({
+    id: "inputSearch.clear",
+    defaultMessage: "Clear search",
+    description: "Label for the clear search button",
+  })
+
   return (
     <div
       className={classnames(
@@ -78,7 +87,7 @@ export const InputSearch = (props: InputSearchProps): JSX.Element => {
           onClick={handleOnClear}
           disabled={disabled}
           classNameOverride={styles.endIconAdornment}
-          aria-label="clear search"
+          aria-label={clearButtonLabel}
         />
       )}
     </div>


### PR DESCRIPTION
## Why
<!-- Why have you created this PR? - Is it a new feature, or a bug fix? Or something else? -->
<!-- Reference any relevant Jira tickets so your reviewer can find more context if needed. -->
<!-- Fixing a GitHub issue? Add "Fixes [issue URL]". -->

[KZN-2449](https://cultureamp.atlassian.net/jira/software/c/projects/KZN/boards/634?selectedIssue=KZN-2449)

Support request. Customer noticed some strings in FilterMultiSelect were not translated.

## What
<!-- What do your changes do? How do they change/fix the current behavior? -->
<!-- Add screenshots, GIFs or videos to illustrate the changes.  -->

Translate embedded text in:
- `FilterMultiSelect.SearchInput`
- `InputSearch`

[KZN-2449]: https://cultureamp.atlassian.net/browse/KZN-2449?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ