### PR TITLE
 Update tiempos font face

### DIFF
--- a/.changeset/plenty-buses-fail.md
+++ b/.changeset/plenty-buses-fail.md
@@ -1,0 +1,5 @@
+---
+"@kaizen/components": patch
+---
+
+Add tiempos-headline-medium weight to font-face declaration

--- a/packages/components/styles/foundation/_fonts.css
+++ b/packages/components/styles/foundation/_fonts.css
@@ -8,6 +8,13 @@
   font-weight: 800;
 }
 
+@font-face {
+  font-family: "Tiempos Headline";
+  src: url("https://d1e7r7b0lb8p4d.cloudfront.net/fonts/tiempos/tiempos-headline-medium.woff2"),
+    url("https://d1e7r7b0lb8p4d.cloudfront.net/fonts/tiempos/tiempos-headline-medium.woff");
+  font-weight: 500;
+}
+
 /* GREYCLIFF */
 
 @font-face {


### PR DESCRIPTION
## Important: Request PR reviews on Slack
Please reach out to the design system team on Slack in `#prod_design_system` for PR reviews. GitHub notifications (e.g. from tagging a person) are not actively monitored.

## Why
We were missing a declaration for our the font-face to support Tiempos at a font weight of 500.

## Context
Kaizen font faces are stored in the `kaizen-design-system-assets` repo under fonts.
- @HeartSquared and I caught up with Jess and confirmed that we currently only want to support Tiempos 500 and 800 font weights.
  - If any more need to be added we will need to declare them in the `_fonts.css` in the `kaizen-design-system` repo 


## What
- add Tiempos `tiempos-headline-medium` to kaizen support font weights