### PR TITLE
fix(workflow future): CA logo a11y

### DIFF
--- a/.changeset/sixty-rockets-nail.md
+++ b/.changeset/sixty-rockets-nail.md
@@ -1,0 +1,5 @@
+---
+"@kaizen/components": patch
+---
+
+Fix workflow future logo a11y

--- a/packages/components/src/__future__/Workflow/subcomponents/Header/Header.tsx
+++ b/packages/components/src/__future__/Workflow/subcomponents/Header/Header.tsx
@@ -18,7 +18,7 @@ export const Header = ({
   ...restProps
 }: HeaderProps): JSX.Element => (
   <HeaderRoot {...restProps}>
-    <Branding alt="Cultureamp" />
+    <Branding alt="Culture Amp" />
     <Titles workflowName={workflowName} stepName={stepName} status={status} />
     <Actions headerActions={headerActions} />
   </HeaderRoot>


### PR DESCRIPTION
## Important: Request PR reviews on Slack
Please reach out to the design system team on Slack in `#prod_design_system` for PR reviews. GitHub notifications (e.g. from tagging a person) are not actively monitored.

## Why
As part of our accessibility review, we need to fix the Culture Amp logo https://cultureamp.atlassian.net/wiki/spaces/PA/pages/3684237362/Perform+create+cycle+v2+accessibility+review#%3Across_mark%3A-Images-have-alt-text-or-are-hidden-from-assistive-tech


## What
- renamed "Cultureamp" to "Culture Amp"
