### PR TITLE
Replace useFocuable with useButton in GenericButton

### DIFF
--- a/.changeset/neat-knives-end.md
+++ b/.changeset/neat-knives-end.md
@@ -1,0 +1,5 @@
+---
+"@kaizen/components": minor
+---
+
+Replace useFocuable with useButton in GenericButton


### PR DESCRIPTION
## Why
Required for Menu v3 (using RAC) to work with Kaizen Button

## What
Use react-aria's `useButton()` in GenericButton