### PR TITLE
feat: add all supported locales to date components

### DIFF
--- a/.changeset/perfect-cougars-sip.md
+++ b/.changeset/perfect-cougars-sip.md
@@ -1,0 +1,7 @@
+---
+"@kaizen/components": minor
+---
+
+Add all supported locales to `DatePicker`, `FilterDatePicker`, `FilterDateRangePicker`.
+
+Update `Calendar`s to infer starting weekday based on provided locale.

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "storybook:build:root": "storybook build -c storybook -o storybook/public",
     "storybook:build:test:root": "pnpm storybook:build:root --test",
     "storybook:build:prod:root": "pnpm storybook:build:root --docs",
-    "test:storybook": "test-storybook --config-dir storybook --url http://127.0.0.1:4479",
+    "test:storybook": "test-storybook --config-dir storybook --skipTags='skip-test' --url http://127.0.0.1:4479",
     "jest:debug": "node --inspect-brk node_modules/.bin/jest --runInBand --no-cache",
     "lint:ts": "tsc --noEmit && pnpm turbo lint:ts",
     "eslint-config": "pnpm eslint -c .eslintrc.js --max-warnings=0",

--- a/packages/components/src/Calendar/CalendarRange/CalendarRange.tsx
+++ b/packages/components/src/Calendar/CalendarRange/CalendarRange.tsx
@@ -4,7 +4,6 @@ import { DayPicker, DayPickerRangeProps } from "react-day-picker"
 import { ArrowBackwardIcon, ArrowForwardIcon } from "~components/Icon"
 import { OverrideClassName } from "~types/OverrideClassName"
 import { baseCalendarClassNames } from "../baseCalendarClassNames"
-import { DayOfWeek } from "../enums"
 import { isInvalidDate } from "../utils"
 import styles from "./CalendarRange.module.scss"
 
@@ -54,7 +53,6 @@ export const CalendarRange = ({
         mode="range"
         selected={selected}
         defaultMonth={selectedMonth}
-        weekStartsOn={DayOfWeek.Mon}
         classNames={classNames}
         components={{
           IconRight: () => <ArrowForwardIcon role="presentation" />,

--- a/packages/components/src/Calendar/CalendarSingle/CalendarSingle.tsx
+++ b/packages/components/src/Calendar/CalendarSingle/CalendarSingle.tsx
@@ -4,7 +4,6 @@ import { DayPicker, DayPickerSingleProps } from "react-day-picker"
 import { ArrowBackwardIcon, ArrowForwardIcon } from "~components/Icon"
 import { OverrideClassName } from "~types/OverrideClassName"
 import { baseCalendarClassNames } from "../baseCalendarClassNames"
-import { DayOfWeek } from "../enums"
 import { isInvalidDate, isValidWeekStartsOn } from "../utils"
 import styles from "./CalendarSingle.module.scss"
 
@@ -21,7 +20,7 @@ export const CalendarSingle = ({
   classNameOverride,
   selected,
   defaultMonth,
-  weekStartsOn = DayOfWeek.Mon,
+  weekStartsOn,
   locale = enAU,
   ...restProps
 }: CalendarSingleProps): JSX.Element => {

--- a/packages/components/src/DatePicker/DatePicker.tsx
+++ b/packages/components/src/DatePicker/DatePicker.tsx
@@ -46,8 +46,8 @@ export type DatePickerProps = {
   onButtonClick?: DateInputFieldProps["onButtonClick"]
   locale?: DatePickerSupportedLocales
   /**
-   * Accepts a DayOfWeek value to start the week on that day. By default,
-   * it's set to Monday.
+   * Accepts a DayOfWeek value to start the week on that day.
+   * By default it adapts to the provided locale.
    */
   weekStartsOn?: CalendarSingleProps["weekStartsOn"]
   /**

--- a/packages/components/src/DatePicker/_docs/DatePicker.mdx
+++ b/packages/components/src/DatePicker/_docs/DatePicker.mdx
@@ -42,8 +42,6 @@ Pass the values to `selectedDay` (can be passed a pre-loaded value) and `onDayCh
 Change the locale of the date-related elements within the DatePicker.
 This changes the input format and the contents in the calendar.
 
-Currently only supports `"en-AU"` and `"en-US"`.
-
 <Canvas of={DatePickerStories.Locale} />
 
 ### Description

--- a/packages/components/src/DatePicker/_docs/controls/datePickerLocaleControls.ts
+++ b/packages/components/src/DatePicker/_docs/controls/datePickerLocaleControls.ts
@@ -1,10 +1,16 @@
+import { LOCALE_REGIONS } from "@cultureamp/i18n-react-intl"
 import { ArgTypes } from "@storybook/react"
 
-const DATE_PICKER_SUPPORTED_LOCALES = ["en-US", "en-AU", "fr-CA"]
+const DATE_PICKER_SUPPORTED_LOCALES = [
+  ...Object.keys(LOCALE_REGIONS),
+  // The following are for murmur
+  "kr",
+  "no",
+]
 
 export const datePickerLocaleControls: Partial<ArgTypes> = {
   locale: {
     options: DATE_PICKER_SUPPORTED_LOCALES,
-    control: { type: "radio" },
+    control: { type: "select" },
   },
 }

--- a/packages/components/src/DatePicker/_docs/getLocale.stickersheet.stories.tsx
+++ b/packages/components/src/DatePicker/_docs/getLocale.stickersheet.stories.tsx
@@ -17,6 +17,7 @@ export default {
 } satisfies Meta
 
 export const UtilGetLocale: StickerSheetStory = {
+  tags: ["skip-test"],
   name: "Util - getLocale",
   render: () => {
     const locales = [

--- a/packages/components/src/DatePicker/_docs/getLocale.stickersheet.stories.tsx
+++ b/packages/components/src/DatePicker/_docs/getLocale.stickersheet.stories.tsx
@@ -1,0 +1,47 @@
+import React from "react"
+import { LOCALE_REGIONS } from "@cultureamp/i18n-react-intl"
+import { Meta } from "@storybook/react"
+import { CalendarSingle } from "~components/Calendar"
+import {
+  StickerSheet,
+  StickerSheetStory,
+} from "~storybook/components/StickerSheet"
+import { getLocale } from "../utils/getLocale"
+
+export default {
+  title: "Components/Date controls/DatePicker/Tests",
+  parameters: {
+    chromatic: { disable: false },
+    controls: { disable: true },
+  },
+} satisfies Meta
+
+export const UtilGetLocale: StickerSheetStory = {
+  name: "Util - getLocale",
+  render: () => {
+    const locales = [
+      ...Object.keys(LOCALE_REGIONS),
+      // The following are for murmur
+      "kr",
+      "no",
+      // Old API values
+      "en-AU",
+      "en-US",
+    ]
+
+    return (
+      <StickerSheet heading="Util - getLocale">
+        <StickerSheet.Body>
+          {locales.map(locale => (
+            <StickerSheet.Row key={locale} rowTitle={locale}>
+              <CalendarSingle
+                defaultMonth={new Date("2021-09-05")}
+                locale={getLocale(locale)}
+              />
+            </StickerSheet.Row>
+          ))}
+        </StickerSheet.Body>
+      </StickerSheet>
+    )
+  },
+}

--- a/packages/components/src/DatePicker/_docs/getLocale.stickersheet.stories.tsx
+++ b/packages/components/src/DatePicker/_docs/getLocale.stickersheet.stories.tsx
@@ -17,6 +17,7 @@ export default {
 } satisfies Meta
 
 export const UtilGetLocale: StickerSheetStory = {
+  // Skip running this with test-storybook (still runs in Chromatic) as it times out
   tags: ["skip-test"],
   name: "Util - getLocale",
   render: () => {

--- a/packages/components/src/DatePicker/utils/getLocale.spec.ts
+++ b/packages/components/src/DatePicker/utils/getLocale.spec.ts
@@ -1,8 +1,8 @@
-import { enAU } from "date-fns/locale"
+import { enGB } from "date-fns/locale"
 import { getLocale } from "./getLocale"
 
 describe("getLocale", () => {
   it("retrieves fallback value when passed an unsupported locale", () => {
-    expect(getLocale("invalid")).toEqual(enAU)
+    expect(getLocale("invalid")).toEqual(enGB)
   })
 })

--- a/packages/components/src/DatePicker/utils/getLocale.ts
+++ b/packages/components/src/DatePicker/utils/getLocale.ts
@@ -57,7 +57,6 @@ export const getLocale = (locale: DatePickerSupportedLocales): Locale => {
       return da
     case "nl":
       return nl
-    case "en":
     case "en-US":
       return enUS
     case "fr":
@@ -88,6 +87,7 @@ export const getLocale = (locale: DatePickerSupportedLocales): Locale => {
       return ptBR
     case "uk":
       return uk
+    case "en":
     case "en-GB":
     case "en-AU":
       return enGB

--- a/packages/components/src/DatePicker/utils/getLocale.ts
+++ b/packages/components/src/DatePicker/utils/getLocale.ts
@@ -1,21 +1,152 @@
 import type { Locale } from "date-fns"
-import { enAU, enUS, frCA } from "date-fns/locale"
-import { StringSuggestions } from "~types/StringSuggestions"
+import {
+  arSA,
+  bg,
+  cs,
+  cy,
+  da,
+  de,
+  el,
+  enGB,
+  enUS,
+  es,
+  et,
+  fi,
+  fr,
+  frCA,
+  he,
+  hi,
+  ht,
+  hu,
+  id,
+  it,
+  ja,
+  km,
+  ko,
+  lt,
+  lv,
+  ms,
+  nb,
+  nl,
+  pl,
+  pt,
+  ptBR,
+  ro,
+  ru,
+  sk,
+  sr,
+  sv,
+  th,
+  tr,
+  uk,
+  vi,
+  zhCN,
+  zhTW,
+} from "date-fns/locale"
 
 // Ensure you update the storybook DATE_PICKER_SUPPORTED_LOCALES arg options when updating DatePickerSupportedLocales.
-export type DatePickerSupportedLocales = StringSuggestions<
-  "en-US" | "en-AU" | "fr-CA"
->
+export type DatePickerSupportedLocales = string
 
 export const getLocale = (locale: DatePickerSupportedLocales): Locale => {
   switch (locale) {
-    case "en-AU":
-      return enAU
+    case "zh":
+      return zhCN
+    case "zh-TW":
+      return zhTW
+    case "da":
+      return da
+    case "nl":
+      return nl
+    case "en":
     case "en-US":
       return enUS
+    case "fr":
+      return fr
+    case "de":
+      return de
+    case "he":
+      return he
+    case "it":
+      return it
+    case "ja":
+      return ja
+    case "ko":
+    case "kr":
+      return ko
+    case "es-419":
+      return es
+    case "sv":
+      return sv
+    case "ru":
+      return ru
+    // @todo: Add when locale is available https://github.com/date-fns/date-fns/issues/2627
+    // case "mi":
+    // return miNZ
+    case "pl":
+      return pl
+    case "pt-BR":
+      return ptBR
+    case "uk":
+      return uk
+    case "en-GB":
+    case "en-AU":
+      return enGB
+    case "ar":
+      return arSA
+    case "bg":
+      return bg
+    case "cs":
+      return cs
+    case "et":
+      return et
+    case "fi":
+      return fi
     case "fr-CA":
       return frCA
+    case "ht":
+      return ht
+    case "el":
+      return el
+    case "hi":
+      return hi
+    case "hu":
+      return hu
+    case "id":
+      return id
+    case "km-KH":
+      return km
+    case "lv":
+      return lv
+    case "lt":
+      return lt
+    case "ms":
+      return ms
+    case "nb":
+    case "no":
+      return nb
+    case "pt":
+      return pt
+    case "ro":
+      return ro
+    case "sr":
+      return sr
+    // case "si-LK":
+    //   return siLK
+    case "sk":
+      return sk
+    case "es":
+      return es
+    // case "tl":
+    //   return tlPH
+    case "th":
+      return th
+    case "tr":
+      return tr
+    case "vi":
+      return vi
+    case "cy":
+      return cy
     default:
-      return enAU
+      return enGB
   }
 }

--- a/packages/components/src/DateRangePicker/DateRangePicker.tsx
+++ b/packages/components/src/DateRangePicker/DateRangePicker.tsx
@@ -37,8 +37,8 @@ export type DateRangePickerProps = {
    */
   value?: string
   /**
-   * Accepts a DayOfWeek value to start the week on that day. By default,
-   * it's set to Monday.
+   * Accepts a DayOfWeek value to start the week on that day.
+   * By default it adapts to the provided locale.
    */
   weekStartsOn?: LegacyCalendarRangeProps["weekStartsOn"]
   /**

--- a/packages/components/src/Filter/FilterDatePicker/_docs/FilterDatePicker.stickersheet.stories.tsx
+++ b/packages/components/src/Filter/FilterDatePicker/_docs/FilterDatePicker.stickersheet.stories.tsx
@@ -178,4 +178,10 @@ export const StickerSheetLocales: StickerSheetStory = {
       </div>
     ),
   ],
+  parameters: {
+    a11y: {
+      // Wait for translations to load
+      timeout: 1500,
+    },
+  },
 }


### PR DESCRIPTION
## Why
<!-- Why have you created this PR? - Is it a new feature, or a bug fix? Or something else? -->
<!-- Reference any relevant Jira tickets so your reviewer can find more context if needed. -->
<!-- Fixing a GitHub issue? Add "Fixes [issue URL]". -->
[KZN-2486](https://cultureamp.atlassian.net/jira/software/c/projects/KZN/boards/634?selectedIssue=KZN-2486)

Extension of support request which added `fr-CA`

## What
<!-- What do your changes do? How do they change/fix the current behavior? -->
<!-- Add screenshots, GIFs or videos to illustrate the changes.  -->

- Add all supported locales to `DatePicker`, `FilterDatePicker`, `FilterDateRangePicker`
- Update default locale object from `en-AU` to `en-GB`
	- They are visually the same, but `en-AU` is not in [our list of locales](https://github.com/cultureamp/unified-home/blob/master/packages/i18n-react-intl/src/constants.ts#L62)
- Update `Calendar`s to infer starting weekday based on provided locale


[KZN-2486]: https://cultureamp.atlassian.net/browse/KZN-2486?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ