### PR TITLE
fix(Menu): Ensure focus returns to correct menu button on close

### DIFF
--- a/.changeset/selfish-ears-lick.md
+++ b/.changeset/selfish-ears-lick.md
@@ -1,0 +1,5 @@
+---
+"@kaizen/components": patch
+---
+
+Fix bug where menu focus goes to a different menu button on close

--- a/packages/components/src/Menu/subcomponents/MenuDropdown/MenuDropdown.tsx
+++ b/packages/components/src/Menu/subcomponents/MenuDropdown/MenuDropdown.tsx
@@ -113,6 +113,10 @@ export const MenuDropdown = ({
       noIsolation
       shards={referenceElement ? [referenceElement] : undefined}
       onEscapeKey={hideMenuDropdown}
+      returnFocus={() => {
+        referenceElement?.focus()
+        return false
+      }}
     >
       {/* eslint-disable-next-line
       jsx-a11y/click-events-have-key-events,


### PR DESCRIPTION
## Why
Fixes an issue where there's multiple menus on a page, when closing a menu, the focus goes to a different menu button

React focus lock is getting confused about which trigger button to return focus to. It happens when focus is on one menu button when another one is opened, as shown in the video below.

https://github.com/user-attachments/assets/d48a68b7-9b39-4327-a08e-808d7043e89e


## What
Override React focus lock's default focus return, hard coding to always return to the menu's trigger button.
