### PR TITLE
fix(Menu): Pass onClick through even when rendered as a link

### DIFF
--- a/.changeset/lazy-crabs-pay.md
+++ b/.changeset/lazy-crabs-pay.md
@@ -1,0 +1,5 @@
+---
+"@kaizen/components": patch
+---
+
+Pass onClick through to MenuItem even when it is rendered as a link

--- a/packages/components/src/Menu/_docs/MenuContentExample.tsx
+++ b/packages/components/src/Menu/_docs/MenuContentExample.tsx
@@ -26,7 +26,10 @@ export const MenuContentExample = ({
         <MenuList heading={<MenuHeading>Buttons</MenuHeading>}>
           <MenuItem
             onClick={(
-              e: React.MouseEvent<HTMLButtonElement, MouseEvent>
+              e: React.MouseEvent<
+                HTMLButtonElement | HTMLAnchorElement,
+                MouseEvent
+              >
             ): void => {
               alert("Hello")
               e.preventDefault()
@@ -36,7 +39,10 @@ export const MenuContentExample = ({
           />
           <MenuItem
             onClick={(
-              e: React.MouseEvent<HTMLButtonElement, MouseEvent>
+              e: React.MouseEvent<
+                HTMLButtonElement | HTMLAnchorElement,
+                MouseEvent
+              >
             ): void => {
               e.preventDefault()
             }}
@@ -45,7 +51,10 @@ export const MenuContentExample = ({
           />
           <MenuItem
             onClick={(
-              e: React.MouseEvent<HTMLButtonElement, MouseEvent>
+              e: React.MouseEvent<
+                HTMLButtonElement | HTMLAnchorElement,
+                MouseEvent
+              >
             ): void => {
               e.preventDefault()
             }}
@@ -55,7 +64,10 @@ export const MenuContentExample = ({
           />
           <MenuItem
             onClick={(
-              e: React.MouseEvent<HTMLButtonElement, MouseEvent>
+              e: React.MouseEvent<
+                HTMLButtonElement | HTMLAnchorElement,
+                MouseEvent
+              >
             ): void => {
               e.preventDefault()
             }}
@@ -65,7 +77,10 @@ export const MenuContentExample = ({
           />
           <MenuItem
             onClick={(
-              e: React.MouseEvent<HTMLButtonElement, MouseEvent>
+              e: React.MouseEvent<
+                HTMLButtonElement | HTMLAnchorElement,
+                MouseEvent
+              >
             ): void => {
               e.preventDefault()
             }}
@@ -78,7 +93,10 @@ export const MenuContentExample = ({
         <MenuList heading={<MenuHeading>Buttons (no icons)</MenuHeading>}>
           <MenuItem
             onClick={(
-              e: React.MouseEvent<HTMLButtonElement, MouseEvent>
+              e: React.MouseEvent<
+                HTMLButtonElement | HTMLAnchorElement,
+                MouseEvent
+              >
             ): void => {
               e.preventDefault()
             }}
@@ -86,7 +104,10 @@ export const MenuContentExample = ({
           />
           <MenuItem
             onClick={(
-              e: React.MouseEvent<HTMLButtonElement, MouseEvent>
+              e: React.MouseEvent<
+                HTMLButtonElement | HTMLAnchorElement,
+                MouseEvent
+              >
             ): void => {
               e.preventDefault()
             }}

--- a/packages/components/src/Menu/subcomponents/MenuItem/MenuItem.tsx
+++ b/packages/components/src/Menu/subcomponents/MenuItem/MenuItem.tsx
@@ -7,7 +7,7 @@ export type MenuItemProps = {
   href?: string
   // Only applicable if href is supplied above
   target?: string
-  onClick?: (e: React.MouseEvent<HTMLButtonElement>) => void
+  onClick?: (e: React.MouseEvent<HTMLButtonElement | HTMLAnchorElement>) => void
   icon?: JSX.Element
   destructive?: boolean
   disabled?: boolean
@@ -70,6 +70,7 @@ export const MenuItem = ({
         <a
           id={id}
           href={href}
+          onClick={onClick}
           className={className}
           target={target}
           // this tells screenreaders that this link represents the current page


### PR DESCRIPTION
## Why
No reason to block this, it's needed in some cases where you want to do something before navigating, like tracking. Best to still keep the element as a link in the DOM in this case.

## What
Currently, `onClick` is not being passed through in the case that MenuItem has an `href` and renders a link
