### PR TITLE
fix(Menu): Hide outline and use border for focus ring

### DIFF
--- a/.changeset/red-walls-add.md
+++ b/.changeset/red-walls-add.md
@@ -1,0 +1,5 @@
+---
+"@kaizen/components": patch
+---
+
+Fix focus ring styling on MenuItems (v3)

--- a/packages/components/src/__actions__/Menu/v3/MenuItem.module.scss
+++ b/packages/components/src/__actions__/Menu/v3/MenuItem.module.scss
@@ -25,7 +25,8 @@
 .item[data-focused] {
   background-color: var(--color-blue-100);
   color: var(--color-blue-500);
-  border-color: var(--border-borderless-border-color);
+  outline: none;
+  border-color: var(--color-blue-500);
 }
 
 .item[data-disabled] {

--- a/packages/components/src/__actions__/Menu/v3/_docs/Menu.docs.stories.tsx
+++ b/packages/components/src/__actions__/Menu/v3/_docs/Menu.docs.stories.tsx
@@ -33,8 +33,8 @@ const DefaultMenuItems = (): ReactNode => (
   <>
     <MenuItem icon={<BookmarkOffIcon role="presentation" />}>Save</MenuItem>
     <MenuItem icon={<EditIcon role="presentation" />}>Edit</MenuItem>
-    <MenuItem icon={<ArrowUpIcon role="presentation" />}>Move Up</MenuItem>
-    <MenuItem icon={<ArrowDownIcon role="presentation" />}>Move Down</MenuItem>
+    <MenuItem icon={<ArrowUpIcon role="presentation" />}>Move up</MenuItem>
+    <MenuItem icon={<ArrowDownIcon role="presentation" />}>Move down</MenuItem>
     <MenuItem icon={<TrashIcon role="presentation" />}>Delete</MenuItem>
   </>
 )

--- a/packages/components/src/__actions__/Menu/v3/_docs/Menu.stories.tsx
+++ b/packages/components/src/__actions__/Menu/v3/_docs/Menu.stories.tsx
@@ -42,10 +42,10 @@ export const Playground: Story = {
           </MenuItem>
           <MenuItem icon={<EditIcon role="presentation" />}>Edit</MenuItem>
           <MenuItem icon={<ArrowUpIcon role="presentation" />}>
-            Move Up
+            Move up
           </MenuItem>
           <MenuItem icon={<ArrowDownIcon role="presentation" />}>
-            Move Down
+            Move down
           </MenuItem>
           <MenuItem icon={<TrashIcon role="presentation" />}>Delete</MenuItem>
         </Menu>


### PR DESCRIPTION
## Why
https://cultureamp.atlassian.net/browse/KZN-2531

## What
Remove `outline` and add border colour for menu item focus.

Bonus: Use sentence case in story examples to follow our guidelines
