### PR TITLE
fix(Modal): Remove focus ring on title when focus-visible

### DIFF
--- a/.changeset/bright-frogs-smile.md
+++ b/.changeset/bright-frogs-smile.md
@@ -1,0 +1,5 @@
+---
+"@kaizen/components": patch
+---
+
+Modal: Focus ring now wraps the dialog instead of the title

--- a/packages/components/src/Modal/GenericModal/GenericModal.module.scss
+++ b/packages/components/src/Modal/GenericModal/GenericModal.module.scss
@@ -54,6 +54,20 @@
   @include ca-media-tablet-and-up {
     width: 100%;
   }
+
+  // wrap the modal container with a focus ring when the title has focus
+  // don't copy this over on the rebuild
+  // rather than putting the focus on the title, put it on the role=dialog element itself
+  &:has(:global([class*="modalLabel"]):focus-visible)::after {
+    content: "";
+    position: absolute;
+    background: transparent;
+    border-radius: $border-focus-ring-border-radius;
+    border-width: $border-focus-ring-border-width;
+    border-style: $border-focus-ring-border-style;
+    border-color: $color-blue-300;
+    inset: -4px;
+  }
 }
 
 // WAITING FOR TEXTFIELD

--- a/packages/components/src/Modal/GenericModal/subcomponents/ModalAccessibleLabel/ModalAccessibleLabel.module.scss
+++ b/packages/components/src/Modal/GenericModal/subcomponents/ModalAccessibleLabel/ModalAccessibleLabel.module.scss
@@ -12,8 +12,6 @@ $ca-breakpoint-small-mobile: 375px;
 }
 
 .modalLabel {
-  position: relative;
-
   // TODO - Remove below styles for Heading once responsive styling has been added to the Heading Component
   h2 {
     @media (max-width: $layout-breakpoints-medium) {
@@ -34,18 +32,5 @@ $ca-breakpoint-small-mobile: 375px;
 
   &:focus {
     outline: none;
-  }
-
-  &:focus-visible::after {
-    $focus-ring-offset: calc((#{$border-focus-ring-border-width} * 2) + 1px);
-
-    content: "";
-    position: absolute;
-    background: transparent;
-    border-radius: $border-focus-ring-border-radius;
-    border-width: $border-focus-ring-border-width;
-    border-style: $border-focus-ring-border-style;
-    border-color: $color-blue-500;
-    inset: calc(-1 * #{$focus-ring-offset});
   }
 }


### PR DESCRIPTION
## What
Adjusting the focus styling when first opening a modal with a keyboard, to wrap the modal container instead of the title

Before:
<img width="887" alt="image" src="https://github.com/user-attachments/assets/0860304e-b7a7-4030-a829-bbb3070961a2">

After:
<img width="887" alt="image" src="https://github.com/user-attachments/assets/5c6fd471-7c8e-4102-a6b9-18e30b4443b1">


## Why
Looks nicer
