### PR TITLE
remove flipOnRtl prop on SVG pirimitive

### DIFF
--- a/.changeset/heavy-teachers-occur.md
+++ b/.changeset/heavy-teachers-occur.md
@@ -1,0 +1,5 @@
+---
+"@kaizen/components": patch
+---
+
+Remove shouldFlipOnRtl prop that doesn't get used in SVG primitive component

--- a/packages/components/src/Icon/subcomponents/SVG/SVG.tsx
+++ b/packages/components/src/Icon/subcomponents/SVG/SVG.tsx
@@ -15,7 +15,6 @@ type DecorativeIcon = {
 
 export type BaseSVGProps = {
   inheritSize?: boolean
-  shouldFlipOnRtl?: boolean
 } & OverrideClassName<SVGAttributes<SVGElement>> &
   (MeaningfulIcon | DecorativeIcon)
 
@@ -32,14 +31,12 @@ export const SVG = ({
   viewBox = "0 0 20 20",
   classNameOverride,
   children,
-  shouldFlipOnRtl,
   ...restProps
 }: SVGProps): JSX.Element => {
   const classes = classnames(
     styles.icon,
     classNameOverride,
-    inheritSize && styles.inheritSize,
-    shouldFlipOnRtl && styles.flipOnRtl
+    inheritSize && styles.inheritSize
   )
 
   if (role === "presentation") {


### PR DESCRIPTION
## Why
I accidentally merge this in with the Button v3 when I was exploring how to handle icons and RTL. I appear to have removed half of the logic so this is a redundant boolean prop that does nothing

## What
- removes redundant prop
