### PR TITLE
fix(Future Select): Remove role=dialog from listbox container

### DIFF
--- a/.changeset/red-trees-bow.md
+++ b/.changeset/red-trees-bow.md
@@ -1,0 +1,5 @@
+---
+"@kaizen/components": patch
+---
+
+Remove role=dialog from Select listbox container

--- a/packages/components/src/MultiSelect/MultiSelect.tsx
+++ b/packages/components/src/MultiSelect/MultiSelect.tsx
@@ -114,6 +114,9 @@ export const MultiSelect = ({
         <Popover
           refs={refs}
           id={`${id}--popover`}
+          role="dialog"
+          aria-modal="true"
+          tabIndex={-1}
           focusOnProps={{
             enabled: true,
             onClickOutside,

--- a/packages/components/src/MultiSelect/subcomponents/Popover/Popover.tsx
+++ b/packages/components/src/MultiSelect/subcomponents/Popover/Popover.tsx
@@ -65,9 +65,6 @@ export const Popover = <RT extends ReferenceType>({
         ref={refs.setFloating}
         style={floatingStyles}
         className={classnames(styles.popover, classNameOverride)}
-        role="dialog"
-        aria-modal="true"
-        tabIndex={-1}
         {...restProps}
       >
         {children}

--- a/packages/components/src/__future__/Select/Select.spec.tsx
+++ b/packages/components/src/__future__/Select/Select.spec.tsx
@@ -370,7 +370,7 @@ describe("<Select />", () => {
     it("will portal to the document body by default", async () => {
       render(<SelectWrapper selectedKey="batch-brew" isOpen />)
 
-      const popover = screen.getByRole("dialog")
+      const popover = screen.getByTestId("kz-select-popover")
       // expected div that FocusOn adds to the popover
       const popoverFocusWrapper = popover.parentNode
 
@@ -401,7 +401,7 @@ describe("<Select />", () => {
 
       await waitFor(() => {
         const newPortalRegion = screen.getByTestId("id--portal-container-test")
-        const popover = within(newPortalRegion).getByRole("dialog")
+        const popover = within(newPortalRegion).getByRole("listbox")
 
         expect(popover).toBeInTheDocument()
       })
@@ -424,7 +424,7 @@ describe("<Select />", () => {
       render(<SelectWithPortal />)
 
       await waitFor(() => {
-        const popover = within(document.body).getByRole("dialog")
+        const popover = within(document.body).getByTestId("kz-select-popover")
 
         expect(popover).toBeInTheDocument()
       })

--- a/packages/components/src/__future__/Select/Select.spec.tsx
+++ b/packages/components/src/__future__/Select/Select.spec.tsx
@@ -423,10 +423,13 @@ describe("<Select />", () => {
       }
       render(<SelectWithPortal />)
 
-      await waitFor(() => {
-        const popover = within(document.body).getByTestId("kz-select-popover")
+      const popover = screen.getByTestId("kz-select-popover")
+      // expected div that FocusOn adds to the popover
+      const popoverFocusWrapper = popover.parentNode
 
-        expect(popover).toBeInTheDocument()
+      await waitFor(() => {
+        const expectedBodyTag = popoverFocusWrapper?.parentNode
+        expect(expectedBodyTag?.nodeName).toEqual("BODY")
       })
     })
   })

--- a/packages/components/src/__future__/Select/Select.spec.tsx
+++ b/packages/components/src/__future__/Select/Select.spec.tsx
@@ -367,19 +367,6 @@ describe("<Select />", () => {
       })
     })
 
-    it("will portal to the document body by default", async () => {
-      render(<SelectWrapper selectedKey="batch-brew" isOpen />)
-
-      const popover = screen.getByTestId("kz-select-popover")
-      // expected div that FocusOn adds to the popover
-      const popoverFocusWrapper = popover.parentNode
-
-      await waitFor(() => {
-        const expectedBodyTag = popoverFocusWrapper?.parentNode
-        expect(expectedBodyTag?.nodeName).toEqual("BODY")
-      })
-    })
-
     it("will render as a descendant of the element matching the id", async () => {
       const SelectWithPortal = (): JSX.Element => {
         const portalContainerId = "id--portal-container"
@@ -401,13 +388,13 @@ describe("<Select />", () => {
 
       await waitFor(() => {
         const newPortalRegion = screen.getByTestId("id--portal-container-test")
-        const popover = within(newPortalRegion).getByRole("listbox")
+        const listbox = within(newPortalRegion).getByRole("listbox")
 
-        expect(popover).toBeInTheDocument()
+        expect(listbox).toBeInTheDocument()
       })
     })
 
-    it("will portal to the document body if the id does not match", async () => {
+    it("will still render the listbox when the portal id given is invalid", async () => {
       const SelectWithPortal = (): JSX.Element => {
         const expectedContainerId = "id--portal-container"
         return (
@@ -423,13 +410,9 @@ describe("<Select />", () => {
       }
       render(<SelectWithPortal />)
 
-      const popover = screen.getByTestId("kz-select-popover")
-      // expected div that FocusOn adds to the popover
-      const popoverFocusWrapper = popover.parentNode
-
       await waitFor(() => {
-        const expectedBodyTag = popoverFocusWrapper?.parentNode
-        expect(expectedBodyTag?.nodeName).toEqual("BODY")
+        const listbox = within(document.body).getByRole("listbox")
+        expect(listbox).toBeInTheDocument()
       })
     })
   })

--- a/packages/components/src/__future__/Select/Select.tsx
+++ b/packages/components/src/__future__/Select/Select.tsx
@@ -195,7 +195,6 @@ export const Select = <Option extends SelectOption = SelectOption>({
             id={popoverId}
             portalContainer={portalContainer}
             refs={refs}
-            data-testid="kz-select-popover"
             focusOnProps={{
               onEscapeKey: state.close,
               onClickOutside: state.close,

--- a/packages/components/src/__future__/Select/Select.tsx
+++ b/packages/components/src/__future__/Select/Select.tsx
@@ -195,6 +195,7 @@ export const Select = <Option extends SelectOption = SelectOption>({
             id={popoverId}
             portalContainer={portalContainer}
             refs={refs}
+            data-testid="kz-select-popover"
             focusOnProps={{
               onEscapeKey: state.close,
               onClickOutside: state.close,


### PR DESCRIPTION
Future Select uses the MultiSelect's Popover component, which has role=dialog built in.

Select shouldn't have this, so I've moved the role=dialog stuff to the MultiSelect implementation of Popover only.

Had to adjust tests a bit because a few of them were written to expect the dialog element and in a specific place. Deleted one because it wouldn't be possible to test without a test id and wasn't super valuable.