### PR TITLE
fix(Select/MultiSelect): Add z-index 100000 to popover

### DIFF
--- a/.changeset/chilly-weeks-judge.md
+++ b/.changeset/chilly-weeks-judge.md
@@ -1,0 +1,5 @@
+---
+"@kaizen/components": patch
+---
+
+Add z-index 100000 to Select/MultiSelect popover

--- a/packages/components/src/MultiSelect/subcomponents/Popover/Popover.module.scss
+++ b/packages/components/src/MultiSelect/subcomponents/Popover/Popover.module.scss
@@ -10,6 +10,7 @@
   border-radius: $border-solid-border-radius;
   background: $color-white;
   overflow: auto;
+  z-index: 100000;
 
   &:focus {
     outline: none;


### PR DESCRIPTION
## Why
We've had two instances of people needing to add z-index to the select portal, because it's not always possible to put the portal in a place that will place it over the top of everything while also not having the page shift in position on open.

100000 matches the z-index that react-aria uses for its Popover, if/when we move to using that.

## What
Add `z-index: 100000` to the Select/MultiSelect Popover
