### PR TITLE
fix(Future Select): remove redundant focus management

### DIFF
--- a/.changeset/twelve-pugs-whisper.md
+++ b/.changeset/twelve-pugs-whisper.md
@@ -1,0 +1,6 @@
+---
+"@kaizen/components": patch
+---
+
+Future Select: remove redundant focus management
+

--- a/packages/components/src/Filter/FilterSelect/FilterSelect.spec.tsx
+++ b/packages/components/src/Filter/FilterSelect/FilterSelect.spec.tsx
@@ -107,9 +107,7 @@ describe("<FilterSelect>", () => {
         render(<FilterSelectWrapper isOpen />)
         expect(screen.queryByRole("listbox")).toBeVisible()
         await waitFor(() => {
-          expect(
-            screen.queryByRole("option", { name: "Regular" })
-          ).toHaveFocus()
+          expect(screen.queryByRole("listbox")).toHaveFocus()
         })
       })
 

--- a/packages/components/src/__future__/Select/Select.spec.tsx
+++ b/packages/components/src/__future__/Select/Select.spec.tsx
@@ -194,11 +194,11 @@ describe("<Select />", () => {
       })
 
       describe("Given the menu is opened", () => {
-        it("moves the focus to the first focusable element inside the menu initially", async () => {
+        it("focuses the listbox initially", async () => {
           const { getByRole } = render(<SelectWrapper defaultOpen />)
           expect(getByRole("listbox")).toBeVisible()
           await waitFor(() => {
-            expect(getByRole("option", { name: "Short black" })).toHaveFocus()
+            expect(getByRole("listbox")).toHaveFocus()
           })
         })
         it("is closed when hits the escape key", async () => {
@@ -305,12 +305,12 @@ describe("<Select />", () => {
         })
       })
 
-      it("keeps the focus ring at the first element when hits arrow up key on it", async () => {
+      it("focuses the last item in the list on up arrow press", async () => {
         const { getByRole } = render(<SelectWrapper />)
         await user.tab()
         await user.keyboard("{ArrowUp}")
         await waitFor(() => {
-          expect(getByRole("option", { name: "Short black" })).toHaveFocus()
+          expect(getByRole("option", { name: "Magic" })).toHaveFocus()
         })
       })
 

--- a/packages/components/src/__future__/Select/Select.tsx
+++ b/packages/components/src/__future__/Select/Select.tsx
@@ -191,16 +191,7 @@ export const Select = <Option extends SelectOption = SelectOption>({
           trigger(selectToggleProps, selectToggleProps.ref)
         )}
         {state.isOpen && (
-          <Popover
-            id={popoverId}
-            portalContainer={portalContainer}
-            refs={refs}
-            focusOnProps={{
-              onEscapeKey: state.close,
-              onClickOutside: state.close,
-              noIsolation: true,
-            }}
-          >
+          <Popover id={popoverId} portalContainer={portalContainer} refs={refs}>
             <SelectProvider<Option> state={state}>
               <SelectPopoverContents menuProps={menuProps}>
                 {children}

--- a/packages/components/src/__future__/Select/subcomponents/ListBox/ListBox.module.scss
+++ b/packages/components/src/__future__/Select/subcomponents/ListBox/ListBox.module.scss
@@ -5,8 +5,8 @@
   padding: 0;
   display: grid;
   max-height: 22rem;
+}
 
-  &.focus {
-    outline: none;
-  }
+.listBox:focus-visible {
+  outline: none;
 }

--- a/packages/components/src/__future__/Select/subcomponents/ListBox/ListBox.tsx
+++ b/packages/components/src/__future__/Select/subcomponents/ListBox/ListBox.tsx
@@ -23,7 +23,7 @@ export const ListBox = <Option extends SelectOption>({
   const { state } = useSelectContext<Option>()
   const ref = React.useRef<HTMLUListElement>(null)
   const { listBoxProps } = useListBox(
-    { ...menuProps, disallowEmptySelection: true, autoFocus: "first" },
+    { ...menuProps, disallowEmptySelection: true },
     state,
     ref
   )


### PR DESCRIPTION
## Why
I was attempting to remove the page jump when the select is opened and found these focus management things that aren't needed and in some cases cause incorrect behaviour (e.g. pressing up arrow on the trigger was focusing the first item, should be the final item).

This has shown to cause no page jump in our storybook

Before:
https://github.com/user-attachments/assets/4cd87900-6ce9-4670-bdd1-385c772a7bf5

After:
https://github.com/user-attachments/assets/4796c5ac-f011-41e2-bd3d-28cdadb95e51

But when testing in one of our UIs via pnpm link, it was still jumping so I'm not confident that this has fixed that.

Either way, definitely still worth pushing this through.

## What
- The main change: remove the autoFocus in the `useListBox` hook causing it to always focus the first item in the list
  - This is already handled via some other react-aria stuff. It will focus the first item on enter or down arrow press, the final item on up arrow press, and it focuses the listbox itself when opened via click 
  - Adjust tests to the new behaviour
- Remove some redunant focus lock code on the Popover implementation
  - This actually wasn't doing anything because FocusLock `enabled` is set to false by default in the Popover
- Fix a styling selector in ListBox.module.scss
  - The class `.focus` doesn't exist so this wasn't doing anything. I needed to fix this to avoid a focus ring showing when opened via click 

