### PR TITLE
chore(deps): move color-string back from devDeps to deps

### DIFF
--- a/.changeset/long-impalas-repeat.md
+++ b/.changeset/long-impalas-repeat.md
@@ -1,0 +1,5 @@
+---
+"@kaizen/design-tokens": patch
+---
+
+Move `color-string` to dependencies.

--- a/packages/design-tokens/package.json
+++ b/packages/design-tokens/package.json
@@ -35,6 +35,7 @@
     "clean:dist": "rimraf 'dist'"
   },
   "dependencies": {
+    "color-string": "^1.9.1",
     "lodash.kebabcase": "^4.1.1"
   },
   "devDependencies": {
@@ -43,7 +44,6 @@
     "@types/lodash.flatmap": "^4.5.9",
     "@types/lodash.kebabcase": "^4.1.9",
     "@types/react-highlight": "^0.12.8",
-    "color-string": "^1.9.1",
     "json-to-flat-sass": "^1.0.0",
     "lodash.flatmap": "^4.5.0",
     "object-to-css-variables": "^0.2.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -513,6 +513,9 @@ importers:
 
   packages/design-tokens:
     dependencies:
+      color-string:
+        specifier: ^1.9.1
+        version: 1.9.1
       lodash.kebabcase:
         specifier: ^4.1.1
         version: 4.1.1
@@ -532,9 +535,6 @@ importers:
       '@types/react-highlight':
         specifier: ^0.12.8
         version: 0.12.8
-      color-string:
-        specifier: ^1.9.1
-        version: 1.9.1
       json-to-flat-sass:
         specifier: ^1.0.0
         version: 1.0.0


### PR DESCRIPTION
## Why
<!-- Why have you created this PR? - Is it a new feature, or a bug fix? Or something else? -->
<!-- Reference any relevant Jira tickets so your reviewer can find more context if needed. -->
<!-- Fixing a GitHub issue? Add "Fixes [issue URL]". -->

[KZN-2699](https://cultureamp.atlassian.net/jira/software/c/projects/KZN/boards/634?selectedIssue=KZN-2699)
![image](https://github.com/user-attachments/assets/c059bef3-de45-4ccb-9775-366b1de9f125)

## What
<!-- What do your changes do? How do they change/fix the current behavior? -->
<!-- Add screenshots, GIFs or videos to illustrate the changes.  -->

Move `color-string` back to dependencies.

[KZN-2699]: https://cultureamp.atlassian.net/browse/KZN-2699?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ