### PR TITLE
ProgressStepper spacing margin fix 

### DIFF
--- a/.changeset/popular-cherries-sparkle.md
+++ b/.changeset/popular-cherries-sparkle.md
@@ -1,0 +1,5 @@
+---
+"@kaizen/components": patch
+---
+
+Decouple ProgressStepper from Text component and fix spacing for Workflow stepper

--- a/packages/components/src/__layout__/Workflow/v2/subcomponents/Footer/components/ProgressStepper/ProgressStepper.module.scss
+++ b/packages/components/src/__layout__/Workflow/v2/subcomponents/Footer/components/ProgressStepper/ProgressStepper.module.scss
@@ -87,9 +87,15 @@ $indicator-size: 1.25rem;
 .stepperDescription {
   display: flex;
   justify-content: center;
+  color: var(--color-white);
+  font-family: var(--typography-paragraph-small-font-family);
+  font-weight: var(--typography-paragraph-small-font-weight);
+  font-size: var(--typography-paragraph-small-font-size);
+  line-height: var(--typography-paragraph-small-line-height);
+  letter-spacing: var(--typography-paragraph-small-letter-spacing);
 
-  @media (min-width: 768px) {
-    // sr hidden styles
+  @media (width >= 768px) {
+    /* sr hidden styles */
     position: absolute;
     width: 0;
     height: 0;

--- a/packages/components/src/__layout__/Workflow/v2/subcomponents/Footer/components/ProgressStepper/ProgressStepper.tsx
+++ b/packages/components/src/__layout__/Workflow/v2/subcomponents/Footer/components/ProgressStepper/ProgressStepper.tsx
@@ -133,14 +133,9 @@ export const ProgressStepper = ({
           )
         })}
       </ol>
-      <Text
-        classNameOverride={styles.stepperDescription}
-        variant="small"
-        color="white"
-        id="stepper-description"
-      >
+      <span className={styles.stepperDescription} id="stepper-description">
         Step {currentStepIndex + 1} of {steps.length}
-      </Text>
+      </span>
     </div>
   )
 }

--- a/packages/components/src/__layout__/Workflow/v3/subcomponents/Footer/components/ProgressStepper/ProgressStepper.module.css
+++ b/packages/components/src/__layout__/Workflow/v3/subcomponents/Footer/components/ProgressStepper/ProgressStepper.module.css
@@ -92,6 +92,11 @@
 .stepperDescription {
   display: flex;
   justify-content: center;
+  font-family: var(--typography-paragraph-small-font-family);
+  font-weight: var(--typography-paragraph-small-font-weight);
+  font-size: var(--typography-paragraph-small-font-size);
+  line-height: var(--typography-paragraph-small-line-height);
+  letter-spacing: var(--typography-paragraph-small-letter-spacing);
 
   @media (width >= 768px) {
     /* sr hidden styles */

--- a/packages/components/src/__layout__/Workflow/v3/subcomponents/Footer/components/ProgressStepper/ProgressStepper.tsx
+++ b/packages/components/src/__layout__/Workflow/v3/subcomponents/Footer/components/ProgressStepper/ProgressStepper.tsx
@@ -140,13 +140,9 @@ export const ProgressStepper = ({
           )
         })}
       </ol>
-      <Text
-        classNameOverride={styles.stepperDescription}
-        variant="small"
-        id="stepper-description"
-      >
+      <span className={styles.stepperDescription} id="stepper-description">
         Step {currentStepIndex + 1} of {steps.length}
-      </Text>
+      </span>
     </div>
   )
 }


### PR DESCRIPTION
## Why
I've remove the Text component from the Progress stepper as a fix to the CSS layer issue that Baptise was experiencing with the Workflow v3. I think this is a relatively safe move since the stepper is more a visual artifact than text and just needed the a few tokens.

## What
- replace Text usage with tokens
