### PR TITLE
Allow aria props on GuidanceBlock

### DIFF
--- a/.changeset/late-icons-know.md
+++ b/.changeset/late-icons-know.md
@@ -1,0 +1,5 @@
+---
+"@kaizen/components": patch
+---
+
+Allow aria props on GuidanceBlock actions

--- a/packages/components/src/GuidanceBlock/GuidanceBlock.tsx
+++ b/packages/components/src/GuidanceBlock/GuidanceBlock.tsx
@@ -12,6 +12,9 @@ import styles from "./GuidanceBlock.module.scss"
 
 export type ActionProps = ButtonProps & {
   tooltip?: TooltipProps
+  "aria-label"?: string
+  "aria-labelledby"?: string
+  "aria-describedby"?: string
 }
 
 type LayoutType = "default" | "inline" | "stacked"


### PR DESCRIPTION
## Why
To facilitate accessibility patches where a team already has this component implemented

## What
Allow aria props on GuidanceBlock actions
