### PR TITLE
fix(useMediaQueries): Add event listeners to small and large instead of medium

### DIFF
--- a/.changeset/popular-moons-sip.md
+++ b/.changeset/popular-moons-sip.md
@@ -1,0 +1,5 @@
+---
+"@kaizen/components": patch
+---
+
+fix(useMediaQueries): values will now update when jumping from small to large, or vice versa

--- a/packages/components/src/utils/useMediaQueries.tsx
+++ b/packages/components/src/utils/useMediaQueries.tsx
@@ -97,7 +97,7 @@ export const useMediaQueries = (
   })
 
   // ---------------------------------------
-  // Create an event listener based on the medium breakpoint and update state whenever it changes
+  // Create an event listener based on the small and large breakpoints and update state whenever one of those changes
   // ---------------------------------------
   useEffect(() => {
     if (isLegacyEdge || isUnsupportedSafari) {
@@ -118,10 +118,12 @@ export const useMediaQueries = (
       })
     }
 
-    mediumMatchMedia.addEventListener("change", updateMatches, true)
+    smallMatchMedia.addEventListener("change", updateMatches, true)
+    largeMatchMedia.addEventListener("change", updateMatches, true)
 
     return () => {
-      mediumMatchMedia.removeEventListener("change", updateMatches)
+      smallMatchMedia.removeEventListener("change", updateMatches)
+      largeMatchMedia.removeEventListener("change", updateMatches)
     }
   }, [])
 


### PR DESCRIPTION
## Why
Fixes a bug where the events wouldn't run if you jump straight from small viewport to large, or vice versa

## What
Rather than just adding an event listener for the medium viewport, add one for small and large.

Putting this just on medium was an attempt to keep this as performant as possible, but unfortunately meant that the updates never trigger when bypassing the medium size.
