### PR TITLE
fix: Remove ToggleSwitch default onToggle prop type

### DIFF
--- a/.changeset/gorgeous-cameras-repeat.md
+++ b/.changeset/gorgeous-cameras-repeat.md
@@ -1,0 +1,5 @@
+---
+"@kaizen/components": patch
+---
+
+Remove default `onToggle` event from ToggleSwitch type. We already override it with a `ChangeEvent` instead.

--- a/packages/components/src/ToggleSwitch/ToggleSwitch/ToggleSwitch.tsx
+++ b/packages/components/src/ToggleSwitch/ToggleSwitch/ToggleSwitch.tsx
@@ -13,7 +13,9 @@ export type ToggleSwitchProps = {
    */
   onToggle?: React.ChangeEventHandler<HTMLInputElement>
   reversed?: boolean
-} & OverrideClassName<Omit<InputHTMLAttributes<HTMLInputElement>, "onChange">>
+} & OverrideClassName<
+  Omit<InputHTMLAttributes<HTMLInputElement>, "onChange" | "onToggle">
+>
 
 export const ToggleSwitch = ({
   toggledStatus,


### PR DESCRIPTION
## Important: Request PR reviews on Slack
Please reach out to the design system team on Slack in `#prod_design_system` for PR reviews. GitHub notifications (e.g. from tagging a person) are not actively monitored.

## Why
We override the ToggleSwitch `onToggle` prop with a `ChangeEvent`, but since we are not removing the default event from the HTMLInputElement as we extend it, typescript thinks the event expects either a `ChangeEvent` type or a `ToggleEvent` type.

![Screenshot 2024-09-25 at 3 16 38 PM](https://github.com/user-attachments/assets/5b529a3f-2a82-4be7-a833-15db94e63b9a)



## What
Omit the `onToggle` event from the `ToggleSwitchProps`.
