### PR TITLE
fix(Brand): move styling props to img instead of picture

### DIFF
--- a/.changeset/giant-ghosts-sniff.md
+++ b/.changeset/giant-ghosts-sniff.md
@@ -1,0 +1,5 @@
+---
+"@kaizen/components": patch
+---
+
+Fix Brand `classNameOverride` to be on the `<img>` instead of `<picture>`

--- a/.changeset/giant-ghosts-sniff.md
+++ b/.changeset/giant-ghosts-sniff.md
@@ -2,4 +2,4 @@
 "@kaizen/components": patch
 ---
 
-Fix Brand `classNameOverride` to be on the `<img>` instead of `<picture>`
+Fix Brand styling props to be on the `<img>` instead of `<picture>`

--- a/packages/components/src/Brand/Brand.tsx
+++ b/packages/components/src/Brand/Brand.tsx
@@ -1,4 +1,5 @@
 import React, { HTMLAttributes, SVGAttributes } from "react"
+import classnames from "classnames"
 import { OverrideClassName } from "~components/types/OverrideClassName"
 import { assetUrl } from "~components/utils/hostedAssets"
 import { BrandCollectiveIntelligence } from "./BrandCollectiveIntelligence"
@@ -62,7 +63,7 @@ export const Brand = ({
   const brandTheme = reversed ? "-reversed" : "-default"
 
   return (
-    <picture className={classNameOverride} {...otherProps}>
+    <picture {...otherProps}>
       <source
         srcSet={assetUrl(`brand/${variant}-reversed.svg`)}
         media="(forced-colors: active) and (prefers-color-scheme: dark)"
@@ -74,7 +75,7 @@ export const Brand = ({
       <img
         src={assetUrl(`brand/${variant}${brandTheme}.svg`)}
         alt={alt}
-        className={styles.img}
+        className={classnames(styles.img, classNameOverride)}
       />
     </picture>
   )

--- a/packages/components/src/Brand/Brand.tsx
+++ b/packages/components/src/Brand/Brand.tsx
@@ -59,7 +59,7 @@ export const Brand = ({
     )
   }
 
-  const { alt, classNameOverride, ...otherProps } = restProps
+  const { alt, classNameOverride, style, ...otherProps } = restProps
   const brandTheme = reversed ? "-reversed" : "-default"
 
   return (
@@ -76,6 +76,7 @@ export const Brand = ({
         src={assetUrl(`brand/${variant}${brandTheme}.svg`)}
         alt={alt}
         className={classnames(styles.img, classNameOverride)}
+        style={style}
       />
     </picture>
   )

--- a/packages/components/src/Workflow/subcomponents/Header/components/Branding/Branding.module.css
+++ b/packages/components/src/Workflow/subcomponents/Header/components/Branding/Branding.module.css
@@ -1,15 +1,14 @@
 .branding {
-  justify-content: center;
   grid-area: branding;
   display: flex;
-  flex-grow: 1;
+  justify-content: center;
   padding-top: var(--spacing-4);
 
-  @media (width >= 768px) {
+  @media (width >=768px) {
     justify-content: unset;
   }
 }
 
 .logo {
-  flex-basis: 7.5rem;
+  width: 7.5rem;
 }


### PR DESCRIPTION
## Why
<!-- Why have you created this PR? - Is it a new feature, or a bug fix? Or something else? -->
<!-- Reference any relevant Jira tickets so your reviewer can find more context if needed. -->
<!-- Fixing a GitHub issue? Add "Fixes [issue URL]". -->

[KZN-2755](https://cultureamp.atlassian.net/jira/software/c/projects/KZN/boards/634?selectedIssue=KZN-2755)

Styles do not apply properly to Brand as the classes get added to the `picture` element (where they disappear) instead of `img`.

Need this to work to be able to proceed with Icon codemod (where `CaMonogramIcon` changes to use `Brand`).

## What
<!-- What do your changes do? How do they change/fix the current behavior? -->
<!-- Add screenshots, GIFs or videos to illustrate the changes.  -->

Move `classNameOverride` and `style` to `img` element.

[KZN-2755]: https://cultureamp.atlassian.net/browse/KZN-2755?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ