### PR TITLE
fix(future/Select): stop propagation on touch devices

### DIFF
--- a/.changeset/nasty-toys-raise.md
+++ b/.changeset/nasty-toys-raise.md
@@ -1,0 +1,5 @@
+---
+"@kaizen/components": patch
+---
+
+Future Select - stop propagation when selecting an option using a touch device.

--- a/packages/components/src/__future__/Select/_docs/Select.stories.tsx
+++ b/packages/components/src/__future__/Select/_docs/Select.stories.tsx
@@ -196,8 +196,8 @@ export const PortalContainer: Story = {
   parameters: { docs: { source: { type: "code" } } },
 }
 
-export const Propagation: Story = {
-  name: "Stop Propagation (Manual Test)",
+export const TouchDeviceTest: Story = {
+  name: "Touch Device Pointer Event (Manual Test)",
   render: args => {
     const [selected, setSelected] = React.useState("radio-1")
     return (

--- a/packages/components/src/__future__/Select/_docs/Select.stories.tsx
+++ b/packages/components/src/__future__/Select/_docs/Select.stories.tsx
@@ -1,5 +1,6 @@
 import React from "react"
 import { Meta, StoryObj } from "@storybook/react"
+import { RadioField, RadioGroup } from "~components/Radio"
 import { Select } from "../Select"
 import { SelectOption } from "../types"
 import {
@@ -26,6 +27,10 @@ const meta = {
   args: {
     label: "Label",
     items: singleMockItems,
+    onFocus: undefined,
+    onFocusChange: undefined,
+    onOpenChange: undefined,
+    onSelectionChange: undefined,
   },
   parameters: {
     actions: {
@@ -189,4 +194,46 @@ export const PortalContainer: Story = {
     )
   },
   parameters: { docs: { source: { type: "code" } } },
+}
+
+export const Propagation: Story = {
+  name: "Stop Propagation (Manual Test)",
+  render: args => {
+    const [selected, setSelected] = React.useState("radio-1")
+    return (
+      <div>
+        <p>
+          On touch devices, the radios below were changing when selecting an
+          option sitting above it.
+          <br />
+          At this time, we could not automate this test, so this story exists
+          for manual testing.
+        </p>
+        <Select {...args} />
+        <RadioGroup labelText="Radio group">
+          <RadioField
+            labelText="Label 1"
+            name="radio-group"
+            value="radio-value-1"
+            onChange={() => setSelected("radio-1")}
+            selectedStatus={selected === "radio-1"}
+          />
+          <RadioField
+            labelText="Label 2"
+            name="radio-group"
+            value="radio-value-2"
+            onChange={() => setSelected("radio-2")}
+            selectedStatus={selected === "radio-2"}
+          />
+          <RadioField
+            labelText="Label 3"
+            name="radio-group"
+            value="radio-value-3"
+            onChange={() => setSelected("radio-3")}
+            selectedStatus={selected === "radio-3"}
+          />
+        </RadioGroup>
+      </div>
+    )
+  },
 }

--- a/packages/components/src/__future__/Select/subcomponents/Option/Option.tsx
+++ b/packages/components/src/__future__/Select/subcomponents/Option/Option.tsx
@@ -1,8 +1,6 @@
 import React, { HTMLAttributes } from "react"
-import { useFocusRing } from "@react-aria/focus"
-import { useOption } from "@react-aria/listbox"
-import { mergeProps } from "@react-aria/utils"
 import classnames from "classnames"
+import { mergeProps, useFocusRing, useOption } from "react-aria"
 import { CheckIcon } from "~components/Icon"
 import { OverrideClassName } from "~components/types/OverrideClassName"
 import { useSelectContext } from "../../context"
@@ -26,11 +24,24 @@ export const Option = <Option extends SelectOption = SelectOption>({
     ref
   )
 
+  const {
+    // Remove these props as they cause propagation issues on touch devices
+    onClick: _onClick,
+    onPointerUp: _onPointerUp,
+    ...restOptionProps
+  } = optionProps
+
   const { isFocusVisible, focusProps } = useFocusRing()
 
   return (
     <li
-      {...mergeProps(optionProps, focusProps, props)}
+      {...mergeProps(restOptionProps, focusProps, props, {
+        // Manually control onClick to stop propagation on touch devices
+        onClick: () => {
+          state.setSelectedKey(item.key)
+          state.close()
+        },
+      })}
       ref={ref}
       className={classnames(
         styles.option,

--- a/packages/components/src/__future__/Select/subcomponents/Option/Option.tsx
+++ b/packages/components/src/__future__/Select/subcomponents/Option/Option.tsx
@@ -1,4 +1,5 @@
 import React, { HTMLAttributes } from "react"
+import { FocusableElement } from "@react-types/shared"
 import classnames from "classnames"
 import { mergeProps, useFocusRing, useOption } from "react-aria"
 import { CheckIcon } from "~components/Icon"
@@ -24,22 +25,21 @@ export const Option = <Option extends SelectOption = SelectOption>({
     ref
   )
 
-  const {
-    // Remove these props as they cause propagation issues on touch devices
-    onClick: _onClick,
-    onPointerUp: _onPointerUp,
-    ...restOptionProps
-  } = optionProps
+  const { onPointerUp, ...restOptionProps } = optionProps
 
   const { isFocusVisible, focusProps } = useFocusRing()
 
   return (
     <li
       {...mergeProps(restOptionProps, focusProps, props, {
-        // Manually control onClick to stop propagation on touch devices
-        onClick: () => {
-          state.setSelectedKey(item.key)
-          state.close()
+        onPointerUp: (e: React.PointerEvent<FocusableElement>) => {
+          if (e.pointerType === "touch") {
+            // On touch devices, the listbox closes too quickly so below elements will trigger their pointer events.
+            // Slow it down a bit to prevent the appearance of propagation.
+            setTimeout(() => state.setSelectedKey(item.key), 250)
+          } else {
+            onPointerUp?.(e)
+          }
         },
       })}
       ref={ref}


### PR DESCRIPTION
## Why
<!-- Why have you created this PR? - Is it a new feature, or a bug fix? Or something else? -->
<!-- Reference any relevant Jira tickets so your reviewer can find more context if needed. -->
<!-- Fixing a GitHub issue? Add "Fixes [issue URL]". -->

[KZN-2764](https://cultureamp.atlassian.net/jira/software/c/projects/KZN/boards/634?selectedIssue=KZN-2764)
~~Selecting an option that sits above other elements (eg. radios) propagates the events.
React Aria does not allow us access to `stopPropagation`.~~

On touch devices, there is an appearance of event propagation.
Testing with @mcwinter07 shows that it is closer to a visual race condition, where the closing of the select happens so fast that the device thinks it is also clicking on the area after it is closed.

## What
<!-- What do your changes do? How do they change/fix the current behavior? -->
<!-- Add screenshots, GIFs or videos to illustrate the changes.  -->

~~Disable the RAC events that allow propagation, and re-simulate the selection manually.~~
Set a timeout for touch events to slow down the processing of events.

[KZN-2764]: https://cultureamp.atlassian.net/browse/KZN-2764?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ