### PR TITLE
chore(kaio): remove type module in package.json

### DIFF
--- a/.changeset/strange-scissors-peel.md
+++ b/.changeset/strange-scissors-peel.md
@@ -1,0 +1,5 @@
+---
+"@kaizen/components": patch
+---
+
+Revert `@kaizen/components` from being explicitly an ESM build"

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -33,7 +33,6 @@
   "bin": {
     "kaizen-codemod": "./bin/codemod.sh"
   },
-  "type": "module",
   "scripts": {
     "lint:ts": "tsc --noEmit",
     "build": "pnpm package-bundler build-shared-ui && pnpm build:styles",


### PR DESCRIPTION
## Why
<!-- Why have you created this PR? - Is it a new feature, or a bug fix? Or something else? -->
<!-- Reference any relevant Jira tickets so your reviewer can find more context if needed. -->
<!-- Fixing a GitHub issue? Add "Fixes [issue URL]". -->

[KZN-2766](https://cultureamp.atlassian.net/jira/software/c/projects/KZN/boards/634?selectedIssue=KZN-2766)

Teams with a CJS set up have been seeing TypeScript errors as our explicit `"type": "module"` tells their TypeScript we are ESM, despite us actually building with both CJS/ESM compatibility.

## What
<!-- What do your changes do? How do they change/fix the current behavior? -->
<!-- Add screenshots, GIFs or videos to illustrate the changes.  -->

Remove `"type": "module"`

[KZN-2766]: https://cultureamp.atlassian.net/browse/KZN-2766?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ