### PR TITLE
Filter select aria label fix

### DIFF
--- a/.changeset/twelve-goats-greet.md
+++ b/.changeset/twelve-goats-greet.md
@@ -1,0 +1,5 @@
+---
+"@kaizen/components": patch
+---
+
+Add accessible label fix for selects

--- a/packages/components/src/Filter/FilterSelect/FilterSelect.tsx
+++ b/packages/components/src/Filter/FilterSelect/FilterSelect.tsx
@@ -80,7 +80,7 @@ export const FilterSelect = <Option extends SelectOption = SelectOption>({
   const { buttonProps } = useButton(triggerProps, triggerRef)
   const renderTriggerButtonProps = {
     ...buttonProps,
-    "aria-labelledBy": undefined,
+    "aria-labelledby": undefined,
     "aria-controls": menuProps.id,
   }
   return (

--- a/packages/components/src/Filter/FilterSelect/FilterSelect.tsx
+++ b/packages/components/src/Filter/FilterSelect/FilterSelect.tsx
@@ -78,7 +78,11 @@ export const FilterSelect = <Option extends SelectOption = SelectOption>({
   )
 
   const { buttonProps } = useButton(triggerProps, triggerRef)
-
+  const renderTriggerButtonProps = {
+    ...buttonProps,
+    "aria-labelledBy": undefined,
+    "aria-controls": menuProps.id,
+  }
   return (
     <>
       <HiddenSelect label={label} state={state} triggerRef={triggerRef} />
@@ -90,19 +94,24 @@ export const FilterSelect = <Option extends SelectOption = SelectOption>({
             selectedValue: state.selectedItem?.textValue || undefined,
             label,
             isOpen,
-            ...buttonProps,
+            ...renderTriggerButtonProps,
           })
         }
         onMount={setTriggerRef}
         classNameOverride={classNameOverride}
       >
-        <FilterContents classNameOverride={styles.filterContents}>
-          <SelectProvider<Option> state={state}>
-            <SelectPopoverContents menuProps={menuProps}>
-              {children}
-            </SelectPopoverContents>
-          </SelectProvider>
-        </FilterContents>
+        <>
+          {/* <VisuallyHidden id={menuProps.id}>{label}</VisuallyHidden> */}
+          <FilterContents classNameOverride={styles.filterContents}>
+            <SelectProvider<Option> state={state}>
+              <SelectPopoverContents
+                menuProps={{ ...menuProps, "aria-labelledby": buttonProps.id }}
+              >
+                {children}
+              </SelectPopoverContents>
+            </SelectProvider>
+          </FilterContents>
+        </>
       </Filter>
     </>
   )

--- a/packages/components/src/Filter/FilterSelect/FilterSelect.tsx
+++ b/packages/components/src/Filter/FilterSelect/FilterSelect.tsx
@@ -100,18 +100,15 @@ export const FilterSelect = <Option extends SelectOption = SelectOption>({
         onMount={setTriggerRef}
         classNameOverride={classNameOverride}
       >
-        <>
-          {/* <VisuallyHidden id={menuProps.id}>{label}</VisuallyHidden> */}
-          <FilterContents classNameOverride={styles.filterContents}>
-            <SelectProvider<Option> state={state}>
-              <SelectPopoverContents
-                menuProps={{ ...menuProps, "aria-labelledby": buttonProps.id }}
-              >
-                {children}
-              </SelectPopoverContents>
-            </SelectProvider>
-          </FilterContents>
-        </>
+        <FilterContents classNameOverride={styles.filterContents}>
+          <SelectProvider<Option> state={state}>
+            <SelectPopoverContents
+              menuProps={{ ...menuProps, "aria-labelledby": buttonProps.id }}
+            >
+              {children}
+            </SelectPopoverContents>
+          </SelectProvider>
+        </FilterContents>
       </Filter>
     </>
   )


### PR DESCRIPTION

## Why
This PR addresses the a11y issues that Kayd raised with the Filter Select - this was split from the PR that had to be reverted.


## What
- remaps the id to draw the accessible label from the trigger