### PR TITLE
FilterBar: manage focus on add/remove filters

### DIFF
--- a/.changeset/many-plums-jam.md
+++ b/.changeset/many-plums-jam.md
@@ -1,0 +1,5 @@
+---
+"@kaizen/components": patch
+---
+
+FilterBar: manage focus on add/remove filters

--- a/packages/components/src/Filter/FilterBar/context/FilterBarContext.tsx
+++ b/packages/components/src/Filter/FilterBar/context/FilterBarContext.tsx
@@ -44,7 +44,7 @@ export type FilterBarContextValue<
   getInactiveFilters: () => Array<FilterAttributes<ValuesMap>>
   clearAllFilters: () => void
   setFocus: <Id extends keyof ValuesMap>(id: Id | undefined) => void
-  focusId: keyof ValuesMap | undefined
+  focusId?: keyof ValuesMap
 }
 
 const FilterBarContext = React.createContext<FilterBarContextValue<any> | null>(

--- a/packages/components/src/Filter/FilterBar/context/FilterBarContext.tsx
+++ b/packages/components/src/Filter/FilterBar/context/FilterBarContext.tsx
@@ -43,6 +43,8 @@ export type FilterBarContextValue<
   hideFilter: <Id extends keyof ValuesMap>(id: Id) => void
   getInactiveFilters: () => Array<FilterAttributes<ValuesMap>>
   clearAllFilters: () => void
+  setFocus: <Id extends keyof ValuesMap>(id: Id | undefined) => void
+  focusId: keyof ValuesMap | undefined
 }
 
 const FilterBarContext = React.createContext<FilterBarContextValue<any> | null>(
@@ -119,10 +121,13 @@ export const FilterBarProvider = <ValuesMap extends FiltersValues>({
         values: { ...values, [id]: getValidValue(newValue) },
       })
     },
-    showFilter: <Id extends keyof ValuesMap>(id: Id): void =>
-      dispatch({ type: "activate_filter", id }),
+    showFilter: <Id extends keyof ValuesMap>(id: Id): void => {
+      dispatch({ type: "activate_filter", id })
+      dispatch({ type: "set_focus", id })
+    },
     hideFilter: <Id extends keyof ValuesMap>(id: Id): void => {
       dispatch({ type: "deactivate_filter", id })
+      dispatch({ type: "set_focus", id: "add_filter" })
     },
     getInactiveFilters: () => getInactiveFilters<ValuesMap>(state),
     clearAllFilters: () => {
@@ -132,6 +137,10 @@ export const FilterBarProvider = <ValuesMap extends FiltersValues>({
       })
       dispatch({ type: "update_values", values: {} })
     },
+    setFocus: <Id extends keyof ValuesMap>(id: Id | undefined) => {
+      dispatch({ type: "set_focus", id })
+    },
+    focusId: state.focusId,
   } satisfies FilterBarContextValue<any, ValuesMap>
 
   useEffect(() => {

--- a/packages/components/src/Filter/FilterBar/context/reducer/filterBarStateReducer.ts
+++ b/packages/components/src/Filter/FilterBar/context/reducer/filterBarStateReducer.ts
@@ -15,12 +15,19 @@ type Actions<ValuesMap extends FiltersValues> =
   | { type: "activate_filter"; id: keyof ValuesMap }
   | { type: "deactivate_filter"; id: keyof ValuesMap }
   | { type: "update_filter_labels"; data: Filters<ValuesMap> }
+  | { type: "set_focus"; id: keyof ValuesMap | undefined }
 
 export const filterBarStateReducer = <ValuesMap extends FiltersValues>(
   state: FilterBarState<ValuesMap>,
   action: Actions<ValuesMap>
 ): FilterBarState<ValuesMap> => {
   switch (action.type) {
+    case "set_focus":
+      return {
+        ...state,
+        focusId: action.id,
+      }
+
     case "update_values":
       return { ...updateValues(state, action.values) }
 

--- a/packages/components/src/Filter/FilterBar/context/reducer/setupFilterBarState.ts
+++ b/packages/components/src/Filter/FilterBar/context/reducer/setupFilterBarState.ts
@@ -35,6 +35,7 @@ export const setupFilterBarState = <ValuesMap extends FiltersValues>(
       values,
       dependentFilterIds: new Set(),
       hasUpdatedValues: false,
+      focusId: undefined,
     } as FilterBarState<ValuesMap>
   )
 

--- a/packages/components/src/Filter/FilterBar/context/types.ts
+++ b/packages/components/src/Filter/FilterBar/context/types.ts
@@ -32,6 +32,7 @@ export type FilterBarState<ValuesMap extends FiltersValues> = {
   activeFilterIds: Set<keyof ValuesMap>
   values: Partial<ValuesMap>
   dependentFilterIds: Set<keyof ValuesMap>
+  focusId?: keyof ValuesMap | undefined
 }
 
 export type ActiveFiltersArray<ValuesMap extends FiltersValues> = Array<

--- a/packages/components/src/Filter/FilterBar/context/types.ts
+++ b/packages/components/src/Filter/FilterBar/context/types.ts
@@ -32,7 +32,7 @@ export type FilterBarState<ValuesMap extends FiltersValues> = {
   activeFilterIds: Set<keyof ValuesMap>
   values: Partial<ValuesMap>
   dependentFilterIds: Set<keyof ValuesMap>
-  focusId?: keyof ValuesMap | undefined
+  focusId?: keyof ValuesMap
 }
 
 export type ActiveFiltersArray<ValuesMap extends FiltersValues> = Array<

--- a/packages/components/src/Filter/FilterBar/subcomponents/AddFiltersMenu/AddFiltersMenu.tsx
+++ b/packages/components/src/Filter/FilterBar/subcomponents/AddFiltersMenu/AddFiltersMenu.tsx
@@ -1,4 +1,4 @@
-import React from "react"
+import React, { useEffect, useRef } from "react"
 import { useIntl } from "@cultureamp/i18n-react-intl"
 import { Menu, MenuList, MenuItem, Button } from "~components/__actions__/v2"
 import { Icon } from "~components/__future__/Icon"
@@ -6,6 +6,7 @@ import { useFilterBarContext } from "../../context/FilterBarContext"
 
 export const AddFiltersMenu = (): JSX.Element => {
   const { formatMessage } = useIntl()
+  const buttonRef = useRef<HTMLButtonElement>(null)
 
   const menuButtonLabel = formatMessage({
     id: "filterBar.addFiltersMenu.buttonLabel",
@@ -14,13 +15,22 @@ export const AddFiltersMenu = (): JSX.Element => {
       "Menu button label to show additional available filter options",
   })
 
-  const { getInactiveFilters, showFilter } = useFilterBarContext()
+  const { getInactiveFilters, showFilter, focusId, setFocus } =
+    useFilterBarContext()
   const inactiveFilters = getInactiveFilters()
+
+  useEffect(() => {
+    if (focusId === "add_filter") {
+      buttonRef.current?.focus()
+      setFocus(undefined)
+    }
+  }, [focusId])
 
   return (
     <Menu
       button={
         <Button
+          ref={buttonRef}
           label={menuButtonLabel}
           secondary
           disabled={inactiveFilters.length === 0}

--- a/packages/components/src/Filter/FilterBar/subcomponents/FilterBarButton/FilterBarButton.tsx
+++ b/packages/components/src/Filter/FilterBar/subcomponents/FilterBarButton/FilterBarButton.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef } from "react"
+import React, { forwardRef, useEffect } from "react"
 import { FilterTriggerRef } from "~components/Filter/Filter"
 import { useFilterBarContext } from "~components/Filter/FilterBar/context/FilterBarContext"
 import {
@@ -6,6 +6,7 @@ import {
   FilterButtonProps,
   FilterButtonRemovable,
 } from "~components/Filter/FilterButton"
+import { isRefObject } from "~components/utils/isRefObject"
 
 export type FilterBarButtonProps = FilterButtonProps & {
   filterId: string
@@ -16,7 +17,14 @@ export const FilterBarButton = forwardRef<
   FilterTriggerRef,
   FilterBarButtonProps
 >(({ filterId, isRemovable = false, ...props }, ref): JSX.Element => {
-  const { hideFilter } = useFilterBarContext()
+  const { hideFilter, focusId, setFocus } = useFilterBarContext()
+
+  useEffect(() => {
+    if (focusId === filterId && isRefObject(ref)) {
+      ref?.current?.triggerRef?.current?.focus()
+      setFocus(undefined)
+    }
+  }, [focusId])
 
   return isRemovable ? (
     <FilterButtonRemovable

--- a/packages/components/src/Filter/FilterBar/subcomponents/FilterBarMultiSelect/FilterBarMultiSelect.tsx
+++ b/packages/components/src/Filter/FilterBar/subcomponents/FilterBarMultiSelect/FilterBarMultiSelect.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react"
+import React, { useEffect, useRef, useState } from "react"
 import { Selection, Key } from "@react-types/shared"
 import {
   FilterMultiSelect,
@@ -43,9 +43,16 @@ export const FilterBarMultiSelect = ({
   onSelectionChange,
   ...props
 }: FilterBarMultiSelectProps): JSX.Element | null => {
-  const { getFilterState, setFilterOpenState, updateValue, hideFilter } =
-    useFilterBarContext<ConsumableSelection>()
+  const {
+    getFilterState,
+    setFilterOpenState,
+    updateValue,
+    hideFilter,
+    focusId,
+    setFocus,
+  } = useFilterBarContext<ConsumableSelection>()
   const [items, setItems] = useState<ItemType[]>(propsItems)
+  const buttonRef = useRef<HTMLButtonElement>(null)
 
   if (!id) throw Error("Missing `id` prop in FilterBarMultiSelect")
 
@@ -69,6 +76,13 @@ export const FilterBarMultiSelect = ({
       }
     }
   }, [items])
+
+  useEffect(() => {
+    if (focusId === id) {
+      buttonRef.current?.focus()
+      setFocus(undefined)
+    }
+  }, [focusId])
 
   return (
     <FilterMultiSelect
@@ -103,6 +117,7 @@ export const FilterBarMultiSelect = ({
           <FilterMultiSelect.TriggerButton {...triggerProps} />
         )
       }}
+      triggerRef={buttonRef}
       {...props}
     >
       {children}

--- a/packages/components/src/Filter/FilterMultiSelect/FilterMultiSelect.tsx
+++ b/packages/components/src/Filter/FilterMultiSelect/FilterMultiSelect.tsx
@@ -41,6 +41,7 @@ type SelectionProps = {
 export type FilterMultiSelectProps = {
   trigger: (value?: MenuTriggerProviderContextType) => React.ReactNode
   children: (value?: SelectionProviderContextType) => React.ReactNode // the content of the menu
+  triggerRef?: React.RefObject<HTMLButtonElement>
 } & Omit<MenuPopupProps, "children"> &
   Omit<MenuTriggerProviderProps, "children"> &
   SelectionProps
@@ -60,8 +61,9 @@ export const FilterMultiSelect = ({
   onSelectionChange,
   selectionMode = "multiple",
   onSearchInputChange,
+  triggerRef,
 }: FilterMultiSelectProps): JSX.Element => {
-  const menuTriggerProps = { isOpen, defaultOpen, onOpenChange }
+  const menuTriggerProps = { isOpen, defaultOpen, onOpenChange, triggerRef }
   const menuPopupProps = { isLoading, loadingSkeleton }
   const disabledKeys: Selection = new Set(
     items

--- a/packages/components/src/Filter/FilterMultiSelect/context/MenuTriggerProvider/MenuTriggerProvider.tsx
+++ b/packages/components/src/Filter/FilterMultiSelect/context/MenuTriggerProvider/MenuTriggerProvider.tsx
@@ -14,6 +14,7 @@ export type MenuTriggerProviderProps = {
   defaultOpen?: boolean
   onOpenChange?: (isOpen: boolean) => void
   children: React.ReactNode
+  triggerRef?: React.RefObject<HTMLButtonElement>
 }
 
 export type MenuTriggerProviderContextType = {
@@ -32,12 +33,14 @@ export function MenuTriggerProvider({
   defaultOpen,
   onOpenChange,
   children,
+  triggerRef,
 }: MenuTriggerProviderProps): JSX.Element {
   // Create state based on the incoming props to manage the open/close
   const state = useMenuTriggerState({ isOpen, defaultOpen, onOpenChange })
 
   // Get A11y attributes and events for the menu trigger and menu elements
-  const ref = useRef<HTMLButtonElement>(null)
+  const fallbackRef = useRef<HTMLButtonElement>(null)
+  const ref = triggerRef || fallbackRef
   const { menuTriggerProps, menuProps } = useMenuTrigger<ItemType>(
     {},
     state,


### PR DESCRIPTION
## Why
Avoid losing focus for a11y purposes

## What
* Move focus to the filter button when adding a filter
* Move focus to 'Add filter' button when removing a filter