### PR TITLE
chore(peerDeps): update version compatibilty for typescript

### DIFF
--- a/.changeset/chilly-starfishes-marry.md
+++ b/.changeset/chilly-starfishes-marry.md
@@ -1,0 +1,6 @@
+---
+"@kaizen/package-bundler": patch
+---
+
+Peer dependency `typescript` version restricted as alias resolution breaks.
+See https://github.com/LeDDGroup/typescript-transform-paths/issues/266

--- a/.changeset/three-students-peel.md
+++ b/.changeset/three-students-peel.md
@@ -1,0 +1,5 @@
+---
+"@kaizen/components": patch
+---
+
+Peer dependency version for `typescript` updated to `5.x`.

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "stylelint-config-standard": "^36.0.1",
     "stylelint-config-standard-scss": "^13.1.0",
     "turbo": "^2.2.3",
-    "typescript": "^5.5.4",
+    "typescript": "5.5.4",
     "vite": "^5.4.10",
     "vitest": "^2.1.3",
     "vitest-axe": "^0.1.0"
@@ -95,6 +95,7 @@
     "@storybook/*": "Required for Storybook stories across all packages",
     "chromatic": "Required for Storybook stories across all packages",
     "playwright": "Required for github actions setup",
+    "typescript": "Version locked for package-bundler",
     "vite-plugin-node-polyfills": "Adds the node `assert` polyfill to Vite for prosemirror to run in storybook"
   },
   "pnpm": {

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -133,19 +133,20 @@
     "tslib": "^2.8.0",
     "tsx": "^4.19.2"
   },
+  "devDependenciesComments": {
+    "typescript": "Installed in root"
+  },
   "peerDependencies": {
     "@cultureamp/i18n-react-intl": "^2.5.9",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-intl": "^6.6.8",
-    "typescript": "^5.5.4"
-  },
-  "peerDependenciesComments": {
-    "typescript": "Used for codemods"
+    "typescript": "5.x"
   },
   "peerDependenciesMeta": {
     "typescript": {
-      "optional": true
+      "optional": true,
+      "comments": "Used for codemods"
     }
   }
 }

--- a/packages/package-bundler/package.json
+++ b/packages/package-bundler/package.json
@@ -52,6 +52,12 @@
     "postcss": "^8.4.41",
     "postcss-preset-env": "^9.5.14 || ^10.0.0",
     "rollup": "^4.18.0",
-    "tslib": ">=2.6.2"
+    "tslib": ">=2.6.2",
+    "typescript": ">= 5.4.5 <= 5.5.4"
+  },
+  "peerDependenciesMeta": {
+    "typescript": {
+      "comments": "https://github.com/LeDDGroup/typescript-transform-paths/issues/266"
+    }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -151,7 +151,7 @@ importers:
         specifier: ^2.2.3
         version: 2.2.3
       typescript:
-        specifier: ^5.5.4
+        specifier: 5.5.4
         version: 5.5.4
       vite:
         specifier: ^5.4.10
@@ -374,7 +374,7 @@ importers:
         specifier: ^1.5.1
         version: 1.5.1
       typescript:
-        specifier: ^5.5.4
+        specifier: 5.x
         version: 5.5.4
       use-debounce:
         specifier: ^10.0.4
@@ -608,6 +608,9 @@ importers:
       tslib:
         specifier: '>=2.6.2'
         version: 2.6.3
+      typescript:
+        specifier: '>= 5.4.5 <= 5.5.4'
+        version: 5.5.4
       typescript-transform-paths:
         specifier: ^3.5.1
         version: 3.5.1(typescript@5.5.4)

--- a/turbo.json
+++ b/turbo.json
@@ -60,11 +60,15 @@
       "outputs": ["dist/**"]
     },
     "@kaizen/tailwind#build": {
-      "dependsOn": ["@kaizen/design-tokens#build"],
+      "dependsOn": [
+        "@kaizen/design-tokens#build",
+        "@kaizen/package-bundler#build"
+      ],
       "inputs": ["src/**"],
       "outputs": ["dist/**"]
     },
     "@kaizen/design-tokens#build": {
+      "dependsOn": ["@kaizen/package-bundler#build"],
       "inputs": ["css/**", "less/**", "sass/**", "src/**"],
       "outputs": ["dist/**"]
     },


### PR DESCRIPTION
## Why
<!-- Why have you created this PR? - Is it a new feature, or a bug fix? Or something else? -->
<!-- Reference any relevant Jira tickets so your reviewer can find more context if needed. -->
<!-- Fixing a GitHub issue? Add "Fixes [issue URL]". -->

Package bundler will fail to build as TypeScript paths cannot be resolved when updating to 5.6.
See https://github.com/LeDDGroup/typescript-transform-paths/issues/266

## What
<!-- What do your changes do? How do they change/fix the current behavior? -->
<!-- Add screenshots, GIFs or videos to illustrate the changes.  -->

Lock `typescript` version and update peerDeps versions to reflect compatibility.