### PR TITLE
Fix visual stacking issues from container query on FilterBar

### DIFF
--- a/.changeset/tame-coats-reflect.md
+++ b/.changeset/tame-coats-reflect.md
@@ -1,0 +1,8 @@
+---
+"@kaizen/components": patch
+---
+
+Fix visual stacking issues from container query on FilterBar
+
+- Menu v1, Tooltip v1, and all Filter* components now portal to document.body by default
+- FilterMultiSelect now positions itself explicitly instead of relying on position in DOM

--- a/packages/components/src/Filter/Filter/Filter.tsx
+++ b/packages/components/src/Filter/Filter/Filter.tsx
@@ -6,7 +6,6 @@ import React, {
   useState,
 } from "react"
 import classnames from "classnames"
-import { FocusOn } from "react-focus-on"
 import { OverrideClassName } from "~components/types/OverrideClassName"
 import { FilterPopover } from "./subcomponents/FilterPopover"
 import { FilterTriggerRef } from "./types"
@@ -64,20 +63,19 @@ export const Filter = ({
         ref: filterButtonRef,
       })}
       {isRefLoaded && isOpen && (
-        <FocusOn
-          scrollLock={false}
-          onClickOutside={(): void => setIsOpen(false)}
-          onEscapeKey={(): void => setIsOpen(false)}
+        <FilterPopover
+          referenceElement={
+            filterButtonRef.current?.triggerRef?.current || null
+          }
+          aria-labelledby={trigger.props.id}
+          focusOnProps={{
+            scrollLock: false,
+            onClickOutside: (): void => setIsOpen(false),
+            onEscapeKey: (): void => setIsOpen(false),
+          }}
         >
-          <FilterPopover
-            referenceElement={
-              filterButtonRef.current?.triggerRef?.current || null
-            }
-            aria-labelledby={trigger.props.id}
-          >
-            {children}
-          </FilterPopover>
-        </FocusOn>
+          {children}
+        </FilterPopover>
       )}
     </div>
   )

--- a/packages/components/src/Filter/Filter/subcomponents/FilterPopover/FilterPopover.tsx
+++ b/packages/components/src/Filter/Filter/subcomponents/FilterPopover/FilterPopover.tsx
@@ -1,6 +1,9 @@
 import React, { HTMLAttributes, useState } from "react"
+import { createPortal } from "react-dom"
 import { Options } from "@popperjs/core"
 import classnames from "classnames"
+import { FocusOn } from "react-focus-on"
+import { ReactFocusOnProps } from "react-focus-on/dist/es5/types"
 import { usePopper } from "react-popper"
 import { OverrideClassName } from "~components/types/OverrideClassName"
 import styles from "./FilterPopover.module.scss"
@@ -9,6 +12,7 @@ export type FilterPopoverProps = {
   children: React.ReactNode
   referenceElement: HTMLElement | null
   popperOptions?: Partial<Options>
+  focusOnProps?: Omit<ReactFocusOnProps, "children">
 } & OverrideClassName<HTMLAttributes<HTMLDivElement>>
 
 export const FilterPopover = ({
@@ -16,6 +20,7 @@ export const FilterPopover = ({
   referenceElement,
   popperOptions,
   classNameOverride,
+  focusOnProps,
   ...restProps
 }: FilterPopoverProps): JSX.Element => {
   const [popperElement, setPopperElement] = useState<HTMLDivElement | null>(
@@ -39,18 +44,21 @@ export const FilterPopover = ({
     }
   )
 
-  return (
-    <div
-      ref={setPopperElement}
-      style={popperStyles?.popper}
-      {...popperAttributes?.popper}
-      className={classnames(styles.filterPopover, classNameOverride)}
-      role="dialog"
-      aria-modal="true"
-      {...restProps}
-    >
-      {children}
-    </div>
+  return createPortal(
+    <FocusOn {...focusOnProps}>
+      <div
+        ref={setPopperElement}
+        style={popperStyles?.popper}
+        {...popperAttributes?.popper}
+        className={classnames(styles.filterPopover, classNameOverride)}
+        role="dialog"
+        aria-modal="true"
+        {...restProps}
+      >
+        {children}
+      </div>
+    </FocusOn>,
+    document.body
   )
 }
 

--- a/packages/components/src/Filter/FilterBar/_docs/FilterBar.stories.tsx
+++ b/packages/components/src/Filter/FilterBar/_docs/FilterBar.stories.tsx
@@ -195,12 +195,18 @@ export const BasicImplementation: Story = {
     })
 
     return (
-      <FilterBar<Values>
-        {...args}
-        filters={filters}
-        values={activeValues}
-        onValuesChange={onActiveValuesChange}
-      />
+      <div>
+        <FilterBar<Values>
+          {...args}
+          filters={filters}
+          values={activeValues}
+          onValuesChange={onActiveValuesChange}
+        />
+        <p style={{ position: "relative", zIndex: 2 }}>
+          Some content that sits below with z-index
+        </p>
+        <p style={{ opacity: 0.9 }}>Text with opacity</p>
+      </div>
     )
   },
   parameters: {

--- a/packages/components/src/Filter/FilterBar/subcomponents/FilterBarMultiSelect/FilterBarMultiSelect.spec.tsx
+++ b/packages/components/src/Filter/FilterBar/subcomponents/FilterBarMultiSelect/FilterBarMultiSelect.spec.tsx
@@ -195,9 +195,9 @@ describe("<FilterBarMultiSelect />", () => {
 
     await user.click(getByRole("option", { name: "Fruit Jelly" }))
     await waitFor(() => {
-      expect(
-        getByRole("button", { name: "Toppings : Pearls, Fruit Jelly" })
-      ).toBeInTheDocument()
+      expect(triggerButton).toHaveAccessibleName(
+        "Toppings : Pearls, Fruit Jelly"
+      )
     })
   })
 

--- a/packages/components/src/Filter/FilterMultiSelect/context/MenuTriggerProvider/MenuTriggerProvider.spec.tsx
+++ b/packages/components/src/Filter/FilterMultiSelect/context/MenuTriggerProvider/MenuTriggerProvider.spec.tsx
@@ -59,14 +59,11 @@ describe("<MenuTriggerProvider /> - Visual content", () => {
       expect(screen.queryByText("menu-content-mock")).not.toBeInTheDocument()
     })
 
-    it("fires the onOpenChange callback when the trigger is interacted", async () => {
+    it("fires the onOpenChange callback on outside click", async () => {
       const onOpenChange = vi.fn()
       render(<MenuTriggerProviderWrapper isOpen onOpenChange={onOpenChange} />)
 
-      const trigger = screen.getByRole("button", {
-        name: "trigger-display-label-mock",
-      })
-      await user.click(trigger)
+      await user.click(document.body)
 
       await waitFor(() => {
         expect(onOpenChange).toBeCalledTimes(1)
@@ -91,17 +88,6 @@ describe("<MenuTriggerProvider /> - Mouse interaction", () => {
   })
 
   describe("Given the menu is opened", () => {
-    it("is closed when user clicks on the trigger", async () => {
-      render(<MenuTriggerProviderWrapper defaultOpen />)
-      const trigger = screen.getByRole("button", {
-        name: "trigger-display-label-mock",
-      })
-      await user.click(trigger)
-      await waitFor(() => {
-        expect(screen.queryByText("menu-content-mock")).not.toBeInTheDocument()
-      })
-    })
-
     it("is closed when user clicks outside of the menu", async () => {
       render(<MenuTriggerProviderWrapper defaultOpen />)
       await user.click(document.body)

--- a/packages/components/src/Filter/FilterMultiSelect/subcomponents/MenuPopup/MenuPopup.module.scss
+++ b/packages/components/src/Filter/FilterMultiSelect/subcomponents/MenuPopup/MenuPopup.module.scss
@@ -8,8 +8,8 @@ $menu-container-width: 294px;
 $menu-container-max-height: 312px;
 
 .menuPopup {
-  position: absolute;
-  z-index: 1000; // from $ca-z-index-dropdown
+  display: flex;
+  flex-direction: column;
   box-sizing: border-box;
   background: $color-white;
   color: $color-purple-800;

--- a/packages/components/src/Filter/FilterMultiSelect/subcomponents/MenuPopup/MenuPopup.tsx
+++ b/packages/components/src/Filter/FilterMultiSelect/subcomponents/MenuPopup/MenuPopup.tsx
@@ -1,6 +1,6 @@
 import React from "react"
 import { FocusScope } from "@react-aria/focus"
-import { useOverlay, DismissButton } from "@react-aria/overlays"
+import { Overlay, usePopover, DismissButton } from "react-aria"
 import { useMenuTriggerContext } from "../../context"
 import styles from "./MenuPopup.module.scss"
 
@@ -15,20 +15,18 @@ export const MenuPopup = ({
   loadingSkeleton,
   children,
 }: MenuPopupProps): JSX.Element => {
-  const { menuTriggerState } = useMenuTriggerContext()
+  const { menuTriggerState, buttonRef } = useMenuTriggerContext()
 
   const onClose = (): void => menuTriggerState.close()
 
-  // Handle events that should cause the menu to close,
-  // e.g. blur, clicking outside, or pressing the escape key.
-  const overlayRef = React.createRef<HTMLDivElement>()
-  const { overlayProps } = useOverlay(
+  const popoverRef = React.useRef(null)
+  const { popoverProps } = usePopover(
     {
-      onClose,
-      isOpen: menuTriggerState.isOpen,
-      isDismissable: true,
+      triggerRef: buttonRef,
+      popoverRef,
+      placement: "bottom start",
     },
-    overlayRef
+    menuTriggerState
   )
 
   // Wrap in <FocusScope> so that focus is restored back to the trigger when the menu is closed
@@ -36,23 +34,25 @@ export const MenuPopup = ({
   // In addition, add hidden <DismissButton> components at the start and end of the list
   // to allow screen reader users to dismiss the popup easily.
   return menuTriggerState.isOpen ? (
-    <div {...overlayProps} ref={overlayRef} className={styles.menuPopup}>
-      {isLoading && loadingSkeleton ? (
-        <>
-          <DismissButton onDismiss={onClose} />
-          {loadingSkeleton}
-          <DismissButton onDismiss={onClose} />
-        </>
-      ) : (
-        // eslint-disable-next-line jsx-a11y/no-autofocus
-        <FocusScope contain autoFocus restoreFocus>
-          <DismissButton onDismiss={onClose} />
+    <Overlay>
+      <div ref={popoverRef} className={styles.menuPopup} {...popoverProps}>
+        {isLoading && loadingSkeleton ? (
+          <>
+            <DismissButton onDismiss={onClose} />
+            {loadingSkeleton}
+            <DismissButton onDismiss={onClose} />
+          </>
+        ) : (
+          // eslint-disable-next-line jsx-a11y/no-autofocus
+          <FocusScope contain autoFocus restoreFocus>
+            <DismissButton onDismiss={onClose} />
 
-          {children}
-          <DismissButton onDismiss={onClose} />
-        </FocusScope>
-      )}
-    </div>
+            {children}
+            <DismissButton onDismiss={onClose} />
+          </FocusScope>
+        )}
+      </div>
+    </Overlay>
   ) : (
     <></>
   )

--- a/packages/components/src/__actions__/Menu/v1/subcomponents/StatelessMenu/StatelessMenu.tsx
+++ b/packages/components/src/__actions__/Menu/v1/subcomponents/StatelessMenu/StatelessMenu.tsx
@@ -85,7 +85,7 @@ export const StatelessMenu = ({
   useEffect(() => {
     portalSelectorElementRef.current = portalSelector
       ? document.querySelector(portalSelector)
-      : null
+      : document.body
   }, [portalSelector])
 
   useEffect(() => {
@@ -116,9 +116,8 @@ export const StatelessMenu = ({
       <div className={styles.buttonWrapper} ref={setReferenceElement}>
         {menuButton}
       </div>
-      {portalSelector && portalSelectorElementRef.current
-        ? ReactDOM.createPortal(menu, portalSelectorElementRef.current)
-        : menu}
+      {portalSelectorElementRef.current &&
+        ReactDOM.createPortal(menu, portalSelectorElementRef.current)}
     </div>
   )
 }

--- a/packages/components/src/__overlays__/Tooltip/v1/Tooltip.tsx
+++ b/packages/components/src/__overlays__/Tooltip/v1/Tooltip.tsx
@@ -201,7 +201,7 @@ export const Tooltip = ({
   useEffect(() => {
     portalSelectorElementRef.current = portalSelector
       ? document.querySelector(portalSelector)
-      : null
+      : document.body
   }, [portalSelector])
 
   useEffect(() => {
@@ -247,9 +247,8 @@ export const Tooltip = ({
           {renderChildren(children, tooltipId, hasActiveTooltip)}
         </div>
 
-        {portalSelector && portalSelectorElementRef.current
-          ? ReactDOM.createPortal(tooltip, portalSelectorElementRef.current)
-          : tooltip}
+        {portalSelectorElementRef.current &&
+          ReactDOM.createPortal(tooltip, portalSelectorElementRef.current)}
       </>
     </AnimationProvider>
   )


### PR DESCRIPTION
To do:
* Restore container queries that were switched to media queries in https://github.com/cultureamp/kaizen-design-system/pull/5238
* Fix annoying jump issue when selecting an option from FilterMultiSelect (and browser doesn't have much height)
* Fix remaining broken tests
* Add visual regression tests for these components to check they overlay text with opacity:
  * FilterSelect
  * FilterMultiSelect
  * FilterDatePicker
  * FilterDateRangePicker
  * Menu
  * Tooltip  
