### PR TITLE
fix(future/Icon): copy CDN styles to internal styles

### DIFF
--- a/.changeset/afraid-schools-cover.md
+++ b/.changeset/afraid-schools-cover.md
@@ -1,0 +1,5 @@
+---
+"@kaizen/components": patch
+---
+
+Update future Icon to only use internal styles as opposed to global styles from the CDN.

--- a/.stylelintrc-css.mjs
+++ b/.stylelintrc-css.mjs
@@ -5,5 +5,11 @@ export default {
   rules: {
     "selector-class-pattern": null,
     "color-function-notation": ["modern", { ignore: ["with-var-inside"] }],
+    "font-family-no-missing-generic-family-keyword": [
+      true,
+      {
+        ignoreFontFamilies: ["Material Symbols Outlined"],
+      },
+    ],
   },
 }

--- a/packages/components/src/__future__/Icon/Icon.module.css
+++ b/packages/components/src/__future__/Icon/Icon.module.css
@@ -1,3 +1,21 @@
+/*
+ * This is taken from the Material Symbols CDN
+ * font-weight & font-size removed as overridden in .icon
+ */
+.material-symbols-outlined {
+  font-family: "Material Symbols Outlined";
+  font-style: normal;
+  line-height: 1;
+  letter-spacing: normal;
+  text-transform: none;
+  display: inline-block;
+  white-space: nowrap;
+  word-wrap: normal;
+  direction: ltr;
+  font-feature-settings: "liga";
+  -webkit-font-smoothing: antialiased;
+}
+
 .icon {
   font-size: calc(1px * var(--icon-size, 20));
   font-weight: var(--icon-font-weight, 400);

--- a/packages/components/src/__future__/Icon/Icon.tsx
+++ b/packages/components/src/__future__/Icon/Icon.tsx
@@ -34,7 +34,7 @@ const MaterialIcon = ({
 }: MaterialIconProps): JSX.Element => (
   <span
     className={classNames(
-      "material-symbols-outlined",
+      styles["material-symbols-outlined"],
       styles.icon,
       isFilled && styles.filled,
       className


### PR DESCRIPTION
## Why
<!-- Why have you created this PR? - Is it a new feature, or a bug fix? Or something else? -->
<!-- Reference any relevant Jira tickets so your reviewer can find more context if needed. -->
<!-- Fixing a GitHub issue? Add "Fixes [issue URL]". -->

Reported by Viet, in dev farms the CDN styles somehow override KAIO as opposed to KAIO taking precedence (does not happen in Storybook nor local dev).

## What
<!-- What do your changes do? How do they change/fix the current behavior? -->
<!-- Add screenshots, GIFs or videos to illustrate the changes.  -->

Remove the usage of the CDN global style, and copy the default styles across into a custom class instead.

Note: We accept the risk that if Google changes the font name, all our icons will cease to work. We assume this is extremely unlikely to happen.