### PR TITLE
Pagination responsive adjustments

### DIFF
--- a/.changeset/fifty-snails-hunt.md
+++ b/.changeset/fifty-snails-hunt.md
@@ -1,0 +1,9 @@
+---
+"@kaizen/components": patch
+---
+
+Pagination responsive adjustments
+
+- Margins partially restored to have 8px between buttons
+- Boundary pages will now only show on large viewports and up
+- Sibling pages will continue to show on medium viewports and up

--- a/packages/components/src/Pagination/Pagination.tsx
+++ b/packages/components/src/Pagination/Pagination.tsx
@@ -154,7 +154,7 @@ export const Pagination = ({
       />
 
       <div className={styles.pagesIndicatorWrapper}>
-        {pagination(1, queries.isSmall ? 0 : 1)}
+        {pagination(queries.isMediumOrSmaller ? 0 : 1, queries.isSmall ? 0 : 1)}
       </div>
 
       <DirectionalLink

--- a/packages/components/src/Pagination/subcomponents/PaginationLink/PaginationLink.module.scss
+++ b/packages/components/src/Pagination/subcomponents/PaginationLink/PaginationLink.module.scss
@@ -9,7 +9,7 @@
   width: 40px;
   height: 40px;
   min-height: auto;
-  margin: 0 var(--spacing-2);
+  margin: 0 var(--spacing-4);
   border-radius: 50%;
 
   &:not(:disabled) {

--- a/packages/components/src/Pagination/subcomponents/TruncateIndicator/TruncateIndicator.module.css
+++ b/packages/components/src/Pagination/subcomponents/TruncateIndicator/TruncateIndicator.module.css
@@ -5,5 +5,5 @@
   width: 36px;
   background-color: transparent;
   color: rgba(var(color-purple-800-rgb), 0.7);
-  margin: 0 var(--spacing-2);
+  margin: 0 var(--spacing-4);
 }


### PR DESCRIPTION
## Why
Got some things wrong in https://github.com/cultureamp/kaizen-design-system/pull/5269

## What
- Increase spacing between pagination buttons
- Only show boundary pages on large viewports and up
