### PR TITLE
Remove container CSS from FilterBar wrapper

### DIFF
--- a/.changeset/nervous-gorillas-teach.md
+++ b/.changeset/nervous-gorillas-teach.md
@@ -1,0 +1,5 @@
+---
+"@kaizen/components": patch
+---
+
+fix(FilterBar): Remove container property from FilterBar wrapper

--- a/packages/components/src/Filter/FilterBar/FilterBar.module.css
+++ b/packages/components/src/Filter/FilterBar/FilterBar.module.css
@@ -1,7 +1,3 @@
-.wrapper {
-  container: filter-bar-wrapper / inline-size;
-}
-
 .filterBar {
   display: flex;
   padding: var(--spacing-8);

--- a/packages/components/src/Filter/FilterBar/FilterBar.tsx
+++ b/packages/components/src/Filter/FilterBar/FilterBar.tsx
@@ -27,21 +27,19 @@ export const FilterBar = <ValuesMap extends FiltersValues>({
 }: FilterBarProps<ValuesMap>): JSX.Element => (
   <FilterBarProvider<ValuesMap> filters={filters} {...providerProps}>
     {(activeFilters): JSX.Element => (
-      <div className={styles.wrapper}>
-        <div className={classnames(styles.filterBar, classNameOverride)}>
-          <div className={styles.filtersContainer}>
-            {Object.values(activeFilters).map(({ id, Component }) => (
-              // `id` will always be `string`, but keyof ValuesMap transformed it
-              <React.Fragment key={id as string}>
-                {React.cloneElement(Component, { id })}
-              </React.Fragment>
-            ))}
-            <AddFiltersMenu />
-          </div>
+      <div className={classnames(styles.filterBar, classNameOverride)}>
+        <div className={styles.filtersContainer}>
+          {Object.values(activeFilters).map(({ id, Component }) => (
+            // `id` will always be `string`, but keyof ValuesMap transformed it
+            <React.Fragment key={id as string}>
+              {React.cloneElement(Component, { id })}
+            </React.Fragment>
+          ))}
+          <AddFiltersMenu />
+        </div>
 
-          <div>
-            <ClearAllButton />
-          </div>
+        <div>
+          <ClearAllButton />
         </div>
       </div>
     )}


### PR DESCRIPTION
## Why
Missed this in https://github.com/cultureamp/kaizen-design-system/pull/5238

## What
Remove this container property that's not being used (still causing the issue mentioned in ☝️)
