### PR TITLE
Kzn 2730/update info button label

### DIFF
--- a/.changeset/two-bugs-march.md
+++ b/.changeset/two-bugs-march.md
@@ -1,0 +1,5 @@
+---
+"@kaizen/components": patch
+---
+
+Add infoButtonLabel prop to GenericTile and internationalise default label.

--- a/packages/components/locales/en.json
+++ b/packages/components/locales/en.json
@@ -165,6 +165,14 @@
     "description": "Home button label",
     "message": "Go to Home"
   },
+  "kzGenericTile.infoButtonLabel": {
+    "description": "Prompts user to interact with button to reveal more information",
+    "message": "View more information:"
+  },
+  "kzGenericTile.infoButtonReturnLabel": {
+    "description": "Prompts user to interact with button to hide information",
+    "message": "Hide information:"
+  },
   "splitButton.dropdownButton.label": {
     "description": "Label for a dropdown menu holding additional actions",
     "message": "Additional actions"

--- a/packages/components/src/Tile/InformationTile/_docs/InformationTile.mdx
+++ b/packages/components/src/Tile/InformationTile/_docs/InformationTile.mdx
@@ -30,3 +30,7 @@ A visually interesting item in a list consisting of a card, visual, title, metad
 
 ### Information
 <Canvas of={InformationTileStories.Information} />
+
+
+### Information Button Label
+<Canvas of={InformationTileStories.TileWithCustomInfoLabel} />

--- a/packages/components/src/Tile/InformationTile/_docs/InformationTile.stories.tsx
+++ b/packages/components/src/Tile/InformationTile/_docs/InformationTile.stories.tsx
@@ -9,7 +9,6 @@ const meta = {
     title: "Title",
     metadata: "Side A",
     footer: <>Example Footer</>,
-    information: "Side B",
   },
   argTypes: {
     mood: { control: false },
@@ -27,12 +26,6 @@ export const Playground: Story = {
         sourceState: "shown",
       },
     },
-  },
-}
-
-export const InfoLabelTest: Story = {
-  args: {
-    infoButtonLabel: "Test",
   },
 }
 
@@ -58,6 +51,13 @@ export const Variants: Story = {
 
 export const Information: Story = {
   args: {
+    information: "Side B",
+  },
+}
+
+export const TileWithCustomInfoLabel: Story = {
+  args: {
+    infoButtonLabel: "Test",
     information: "Side B",
   },
 }

--- a/packages/components/src/Tile/InformationTile/_docs/InformationTile.stories.tsx
+++ b/packages/components/src/Tile/InformationTile/_docs/InformationTile.stories.tsx
@@ -32,8 +32,8 @@ export const Playground: Story = {
 
 export const InfoLabelTest: Story = {
   args: {
-    infoButtonLabel: "Test"
-  }
+    infoButtonLabel: "Test",
+  },
 }
 
 export const Variants: Story = {

--- a/packages/components/src/Tile/InformationTile/_docs/InformationTile.stories.tsx
+++ b/packages/components/src/Tile/InformationTile/_docs/InformationTile.stories.tsx
@@ -9,6 +9,7 @@ const meta = {
     title: "Title",
     metadata: "Side A",
     footer: <>Example Footer</>,
+    information: "Side B",
   },
   argTypes: {
     mood: { control: false },
@@ -27,6 +28,20 @@ export const Playground: Story = {
       },
     },
   },
+}
+
+export const InfoLabelTest: Story = {
+  render: args => (
+    <>
+      <InformationTile
+        {...args}
+        variant="default"
+        title="default"
+        footer="default"
+        infoButtonLabel="Testy test"
+      />
+    </>
+  ),
 }
 
 export const Variants: Story = {

--- a/packages/components/src/Tile/InformationTile/_docs/InformationTile.stories.tsx
+++ b/packages/components/src/Tile/InformationTile/_docs/InformationTile.stories.tsx
@@ -32,7 +32,7 @@ export const Playground: Story = {
 
 export const InfoLabelTest: Story = {
   args: {
-    infoButtonLabel: "Super Testy test"
+    infoButtonLabel: "Test"
   }
 }
 

--- a/packages/components/src/Tile/InformationTile/_docs/InformationTile.stories.tsx
+++ b/packages/components/src/Tile/InformationTile/_docs/InformationTile.stories.tsx
@@ -31,17 +31,9 @@ export const Playground: Story = {
 }
 
 export const InfoLabelTest: Story = {
-  render: args => (
-    <>
-      <InformationTile
-        {...args}
-        variant="default"
-        title="default"
-        footer="default"
-        infoButtonLabel="Testy test"
-      />
-    </>
-  ),
+  args: {
+    infoButtonLabel: "Super Testy test"
+  }
 }
 
 export const Variants: Story = {

--- a/packages/components/src/Tile/subcomponents/GenericTile/GenericTile.spec.stories.tsx
+++ b/packages/components/src/Tile/subcomponents/GenericTile/GenericTile.spec.stories.tsx
@@ -1,6 +1,6 @@
 import React from "react"
 import type { Meta, StoryObj } from "@storybook/react"
-import { expect, within, userEvent, waitFor } from "@storybook/test"
+import { expect, within, waitFor } from "@storybook/test"
 import { GenericTile } from "./GenericTile"
 
 const meta: Meta<typeof GenericTile> = {

--- a/packages/components/src/Tile/subcomponents/GenericTile/GenericTile.spec.stories.tsx
+++ b/packages/components/src/Tile/subcomponents/GenericTile/GenericTile.spec.stories.tsx
@@ -38,12 +38,6 @@ export const Flip: Story = {
 }
 
 export const InfoButtonLabelDefault: Story = {
-  args: {
-    title: "Title",
-    metadata: "Side A",
-    information: "Side B",
-    footer: <>Example Footer</>,
-  },
   play: async ({ canvasElement, step }) => {
     const canvas = within(canvasElement)
 
@@ -70,10 +64,6 @@ export const InfoButtonLabelDefault: Story = {
 export const InfoButtonLabel: Story = {
   args: {
     infoButtonLabel: "Test Label",
-    title: "Title",
-    metadata: "Side A",
-    information: "Side B",
-    footer: <>Example Footer</>,
   },
   play: async ({ canvasElement, step }) => {
     const canvas = within(canvasElement)

--- a/packages/components/src/Tile/subcomponents/GenericTile/GenericTile.spec.stories.tsx
+++ b/packages/components/src/Tile/subcomponents/GenericTile/GenericTile.spec.stories.tsx
@@ -27,3 +27,18 @@ export const Flip: Story = {
     await expect(canvas.getByText("Side B")).toBeInTheDocument()
   },
 }
+
+export const InfoButtonLabel: Story = {
+  args: {infoButtonLabel: "Test Label",
+    title: "Title",
+    metadata: "Side A",
+    information: "Side B",
+    footer: <>Example Footer</>,},
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+
+    const buttonWithInfoLabel = canvas.getByRole("button", {name: "Test Label"})
+    buttonWithInfoLabel.focus()
+    await expect(buttonWithInfoLabel).toHaveFocus();
+  },
+}

--- a/packages/components/src/Tile/subcomponents/GenericTile/GenericTile.spec.stories.tsx
+++ b/packages/components/src/Tile/subcomponents/GenericTile/GenericTile.spec.stories.tsx
@@ -40,7 +40,7 @@ export const InfoButtonLabel: Story = {
     const canvas = within(canvasElement)
 
     const buttonWithInfoLabel = canvas.getByRole("button", {
-      name: "Test Label",
+      name: "Test Label Title",
     })
     buttonWithInfoLabel.focus()
     await expect(buttonWithInfoLabel).toHaveFocus()

--- a/packages/components/src/Tile/subcomponents/GenericTile/GenericTile.spec.stories.tsx
+++ b/packages/components/src/Tile/subcomponents/GenericTile/GenericTile.spec.stories.tsx
@@ -1,7 +1,6 @@
 import React from "react"
 import type { Meta, StoryObj } from "@storybook/react"
-import { expect, within, userEvent } from "@storybook/test"
-
+import { expect, within, userEvent, waitFor } from "@storybook/test"
 import { GenericTile } from "./GenericTile"
 
 const meta: Meta<typeof GenericTile> = {
@@ -19,14 +18,22 @@ export default meta
 type Story = StoryObj<typeof GenericTile>
 
 export const Flip: Story = {
-  play: async ({ canvasElement }) => {
+  play: async ({ canvasElement, step }) => {
     const canvas = within(canvasElement)
 
-    await userEvent.click(
-      canvas.getByRole("button", { name: "View more information: Title" })
-    )
+    await step("initial render complete", async () => {
+      await waitFor(() => {
+        canvas.getByRole("button", {
+          name: "View more information: Title",
+        })
+      })
+    })
 
-    await expect(canvas.getByText("Side B")).toBeInTheDocument()
+    await step("Can focus to tile", async () => {
+      await waitFor(() => {
+        expect(canvas.getByText("Side B")).toBeInTheDocument()
+      })
+    })
   },
 }
 
@@ -37,14 +44,26 @@ export const InfoButtonLabelDefault: Story = {
     information: "Side B",
     footer: <>Example Footer</>,
   },
-  play: async ({ canvasElement }) => {
+  play: async ({ canvasElement, step }) => {
     const canvas = within(canvasElement)
 
-    const buttonWithInfoLabel = canvas.getByRole("button", {
-      name: "View more information: Title",
+    await step("initial render complete", async () => {
+      await waitFor(() => {
+        canvas.getByRole("button", {
+          name: "View more information: Title",
+        })
+      })
     })
-    buttonWithInfoLabel.focus()
-    await expect(buttonWithInfoLabel).toHaveFocus()
+
+    await step("Can focus to button", async () => {
+      await waitFor(() => {
+        const buttonWithInfoLabel = canvas.getByRole("button", {
+          name: "View more information: Title",
+        })
+        buttonWithInfoLabel.focus()
+        expect(buttonWithInfoLabel).toHaveFocus()
+      })
+    })
   },
 }
 
@@ -56,13 +75,25 @@ export const InfoButtonLabel: Story = {
     information: "Side B",
     footer: <>Example Footer</>,
   },
-  play: async ({ canvasElement }) => {
+  play: async ({ canvasElement, step }) => {
     const canvas = within(canvasElement)
 
-    const buttonWithInfoLabel = canvas.getByRole("button", {
-      name: "Test Label",
+    await step("initial render complete", async () => {
+      await waitFor(() => {
+        canvas.getByRole("button", {
+          name: "Test Label",
+        })
+      })
     })
-    buttonWithInfoLabel.focus()
-    await expect(buttonWithInfoLabel).toHaveFocus()
+
+    await step("Can focus to button", async () => {
+      await waitFor(() => {
+        const buttonWithInfoLabel = canvas.getByRole("button", {
+          name: "Test Label",
+        })
+        buttonWithInfoLabel.focus()
+        expect(buttonWithInfoLabel).toHaveFocus()
+      })
+    })
   },
 }

--- a/packages/components/src/Tile/subcomponents/GenericTile/GenericTile.spec.stories.tsx
+++ b/packages/components/src/Tile/subcomponents/GenericTile/GenericTile.spec.stories.tsx
@@ -22,7 +22,9 @@ export const Flip: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement)
 
-    await userEvent.click(canvas.getByRole("button", { name: "Information" }))
+    await userEvent.click(
+      canvas.getByRole("button", { name: "View more information: Title" })
+    )
 
     await expect(canvas.getByText("Side B")).toBeInTheDocument()
   },

--- a/packages/components/src/Tile/subcomponents/GenericTile/GenericTile.spec.stories.tsx
+++ b/packages/components/src/Tile/subcomponents/GenericTile/GenericTile.spec.stories.tsx
@@ -29,16 +29,20 @@ export const Flip: Story = {
 }
 
 export const InfoButtonLabel: Story = {
-  args: {infoButtonLabel: "Test Label",
+  args: {
+    infoButtonLabel: "Test Label",
     title: "Title",
     metadata: "Side A",
     information: "Side B",
-    footer: <>Example Footer</>,},
+    footer: <>Example Footer</>,
+  },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement)
 
-    const buttonWithInfoLabel = canvas.getByRole("button", {name: "Test Label"})
+    const buttonWithInfoLabel = canvas.getByRole("button", {
+      name: "Test Label",
+    })
     buttonWithInfoLabel.focus()
-    await expect(buttonWithInfoLabel).toHaveFocus();
+    await expect(buttonWithInfoLabel).toHaveFocus()
   },
 }

--- a/packages/components/src/Tile/subcomponents/GenericTile/GenericTile.spec.stories.tsx
+++ b/packages/components/src/Tile/subcomponents/GenericTile/GenericTile.spec.stories.tsx
@@ -30,6 +30,24 @@ export const Flip: Story = {
   },
 }
 
+export const InfoButtonLabelDefault: Story = {
+  args: {
+    title: "Title",
+    metadata: "Side A",
+    information: "Side B",
+    footer: <>Example Footer</>,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+
+    const buttonWithInfoLabel = canvas.getByRole("button", {
+      name: "View more information: Title",
+    })
+    buttonWithInfoLabel.focus()
+    await expect(buttonWithInfoLabel).toHaveFocus()
+  },
+}
+
 export const InfoButtonLabel: Story = {
   args: {
     infoButtonLabel: "Test Label",
@@ -42,7 +60,7 @@ export const InfoButtonLabel: Story = {
     const canvas = within(canvasElement)
 
     const buttonWithInfoLabel = canvas.getByRole("button", {
-      name: "Test Label Title",
+      name: "Test Label",
     })
     buttonWithInfoLabel.focus()
     await expect(buttonWithInfoLabel).toHaveFocus()

--- a/packages/components/src/Tile/subcomponents/GenericTile/GenericTile.tsx
+++ b/packages/components/src/Tile/subcomponents/GenericTile/GenericTile.tsx
@@ -23,7 +23,7 @@ export type GenericTileProps = {
   titleTag?: AllowedHeadingTags
   metadata?: string
   information?: TileInformation | React.ReactNode
-  /** @default Information */
+  /** Provides accessible label for the title's info button @default "View more information: [title]" */
   infoButtonLabel?: string
   /** @deprecated Use `variant` instead */
   mood?:
@@ -59,13 +59,14 @@ export const GenericTile = ({
   const [isFlipped, setIsFlipped] = useState<boolean>(false)
   const { formatMessage } = useIntl()
 
-  infoButtonLabel = infoButtonLabel
-    ? formatMessage({
+  const translatedInfoLabel = infoButtonLabel
+    ? infoButtonLabel
+    : formatMessage({
         id: "kzGenericTile.infoButtonLabel",
-        defaultMessage: infoButtonLabel,
-        description: "Info Button Label",
+        defaultMessage: "View more information: ",
+        description:
+          "Prompts user to interact with button to reveal more information",
       })
-    : "See more about {$title}"
 
   const renderTitle = (): JSX.Element => (
     <div className={styles.title}>
@@ -93,7 +94,7 @@ export const GenericTile = ({
       {information && (
         <div className={styles.informationBtn}>
           <IconButton
-            label={infoButtonLabel}
+            label={`${translatedInfoLabel} ${title}`}
             icon={<Icon name="info" isPresentational isFilled />}
             onClick={(): void => setIsFlipped(true)}
             disabled={isFlipped}
@@ -148,11 +149,17 @@ export const GenericTile = ({
   const renderBack = (): JSX.Element | void => {
     if (!information) return
 
+    const returnButtonLabel = formatMessage({
+      id: "kzGenericTile.infoButtonReturnLabel",
+      defaultMessage: "Hide information: ",
+      description: "Prompts user to interact with button to hide information",
+    })
+
     return (
       <div className={classnames(styles.face, styles.faceBack)}>
         <div className={styles.informationBtn}>
           <IconButton
-            label={`Return to ${title}`}
+            label={`${returnButtonLabel} ${title}`}
             icon={<Icon name="arrow_back" isPresentational />}
             onClick={(): void => setIsFlipped(false)}
             disabled={!isFlipped}

--- a/packages/components/src/Tile/subcomponents/GenericTile/GenericTile.tsx
+++ b/packages/components/src/Tile/subcomponents/GenericTile/GenericTile.tsx
@@ -1,4 +1,5 @@
 import React, { HTMLAttributes, useState } from "react"
+import { FormattedMessage, useIntl } from "@cultureamp/i18n-react-intl"
 import classnames from "classnames"
 import { AllowedHeadingTags, Heading } from "~components/Heading"
 import { Text } from "~components/Text"
@@ -41,13 +42,15 @@ export type GenericTileProps = {
   footer: React.ReactNode
 } & OverrideClassName<Omit<HTMLAttributes<HTMLDivElement>, "title">>
 
+const { formatMessage } = useIntl()
+
 export const GenericTile = ({
   children,
   title,
   titleTag = "h3",
   metadata,
   information,
-  infoButtonLabel = "Information",
+  infoButtonLabel = formatMessage({id: "kzGenericTile.infoButtonLabel", defaultMessage: "Information", description: "Info Buttn Label"}),
   mood,
   variant = "default",
   footer,

--- a/packages/components/src/Tile/subcomponents/GenericTile/GenericTile.tsx
+++ b/packages/components/src/Tile/subcomponents/GenericTile/GenericTile.tsx
@@ -66,7 +66,7 @@ export const GenericTile = ({
         defaultMessage: "View more information: ",
         description:
           "Prompts user to interact with button to reveal more information",
-      })
+      }) + title
 
   const renderTitle = (): JSX.Element => (
     <div className={styles.title}>
@@ -94,7 +94,7 @@ export const GenericTile = ({
       {information && (
         <div className={styles.informationBtn}>
           <IconButton
-            label={`${translatedInfoLabel} ${title}`}
+            label={translatedInfoLabel}
             icon={<Icon name="info" isPresentational isFilled />}
             onClick={(): void => setIsFlipped(true)}
             disabled={isFlipped}

--- a/packages/components/src/Tile/subcomponents/GenericTile/GenericTile.tsx
+++ b/packages/components/src/Tile/subcomponents/GenericTile/GenericTile.tsx
@@ -60,11 +60,11 @@ export const GenericTile = ({
   const { formatMessage } = useIntl()
 
   const translatedInfoLabel = formatMessage({
-        id: "kzGenericTile.infoButtonLabel",
-        defaultMessage: "View more information:",
-        description:
-          "Prompts user to interact with button to reveal more information",
-      })
+    id: "kzGenericTile.infoButtonLabel",
+    defaultMessage: "View more information:",
+    description:
+      "Prompts user to interact with button to reveal more information",
+  })
 
   const renderTitle = (): JSX.Element => (
     <div className={styles.title}>

--- a/packages/components/src/Tile/subcomponents/GenericTile/GenericTile.tsx
+++ b/packages/components/src/Tile/subcomponents/GenericTile/GenericTile.tsx
@@ -60,7 +60,7 @@ export const GenericTile = ({
   const [isFlipped, setIsFlipped] = useState<boolean>(false)
   const { formatMessage } = useIntl()
 
-  infoButtonLabel = infoButtonLabel ? formatMessage({id: "kzGenericTile.infoButtonLabel", defaultMessage: "Information", description: "Info Buttn Label"}) : "Information"
+  infoButtonLabel = infoButtonLabel ? formatMessage({id: "kzGenericTile.infoButtonLabel", defaultMessage: infoButtonLabel, description: "Info Button Label"}) : "Information"
 
   const renderTitle = (): JSX.Element => (
     <div className={styles.title}>
@@ -147,7 +147,7 @@ export const GenericTile = ({
       <div className={classnames(styles.face, styles.faceBack)}>
         <div className={styles.informationBtn}>
           <IconButton
-            label="Information"
+            label={`Return to ${title}`}
             icon={<Icon name="arrow_back" isPresentational />}
             onClick={(): void => setIsFlipped(false)}
             disabled={!isFlipped}

--- a/packages/components/src/Tile/subcomponents/GenericTile/GenericTile.tsx
+++ b/packages/components/src/Tile/subcomponents/GenericTile/GenericTile.tsx
@@ -59,14 +59,12 @@ export const GenericTile = ({
   const [isFlipped, setIsFlipped] = useState<boolean>(false)
   const { formatMessage } = useIntl()
 
-  const translatedInfoLabel = infoButtonLabel
-    ? infoButtonLabel
-    : formatMessage({
+  const translatedInfoLabel = formatMessage({
         id: "kzGenericTile.infoButtonLabel",
         defaultMessage: "View more information: ",
         description:
           "Prompts user to interact with button to reveal more information",
-      }) + title
+      })
 
   const renderTitle = (): JSX.Element => (
     <div className={styles.title}>
@@ -94,7 +92,7 @@ export const GenericTile = ({
       {information && (
         <div className={styles.informationBtn}>
           <IconButton
-            label={translatedInfoLabel}
+            label={infoButtonLabel || translatedInfoLabel + title}
             icon={<Icon name="info" isPresentational isFilled />}
             onClick={(): void => setIsFlipped(true)}
             disabled={isFlipped}

--- a/packages/components/src/Tile/subcomponents/GenericTile/GenericTile.tsx
+++ b/packages/components/src/Tile/subcomponents/GenericTile/GenericTile.tsx
@@ -1,5 +1,5 @@
 import React, { HTMLAttributes, useState } from "react"
-import { FormattedMessage, useIntl } from "@cultureamp/i18n-react-intl"
+import { useIntl } from "@cultureamp/i18n-react-intl"
 import classnames from "classnames"
 import { AllowedHeadingTags, Heading } from "~components/Heading"
 import { Text } from "~components/Text"
@@ -23,6 +23,7 @@ export type GenericTileProps = {
   titleTag?: AllowedHeadingTags
   metadata?: string
   information?: TileInformation | React.ReactNode
+  /** @default Information */
   infoButtonLabel?: string
   /** @deprecated Use `variant` instead */
   mood?:

--- a/packages/components/src/Tile/subcomponents/GenericTile/GenericTile.tsx
+++ b/packages/components/src/Tile/subcomponents/GenericTile/GenericTile.tsx
@@ -43,7 +43,6 @@ export type GenericTileProps = {
   footer: React.ReactNode
 } & OverrideClassName<Omit<HTMLAttributes<HTMLDivElement>, "title">>
 
-
 export const GenericTile = ({
   children,
   title,
@@ -60,7 +59,13 @@ export const GenericTile = ({
   const [isFlipped, setIsFlipped] = useState<boolean>(false)
   const { formatMessage } = useIntl()
 
-  infoButtonLabel = infoButtonLabel ? formatMessage({id: "kzGenericTile.infoButtonLabel", defaultMessage: infoButtonLabel, description: "Info Button Label"}) : "Information"
+  infoButtonLabel = infoButtonLabel
+    ? formatMessage({
+        id: "kzGenericTile.infoButtonLabel",
+        defaultMessage: infoButtonLabel,
+        description: "Info Button Label",
+      })
+    : "Information"
 
   const renderTitle = (): JSX.Element => (
     <div className={styles.title}>

--- a/packages/components/src/Tile/subcomponents/GenericTile/GenericTile.tsx
+++ b/packages/components/src/Tile/subcomponents/GenericTile/GenericTile.tsx
@@ -43,7 +43,6 @@ export type GenericTileProps = {
   footer: React.ReactNode
 } & OverrideClassName<Omit<HTMLAttributes<HTMLDivElement>, "title">>
 
-const { formatMessage } = useIntl()
 
 export const GenericTile = ({
   children,
@@ -51,7 +50,7 @@ export const GenericTile = ({
   titleTag = "h3",
   metadata,
   information,
-  infoButtonLabel = formatMessage({id: "kzGenericTile.infoButtonLabel", defaultMessage: "Information", description: "Info Buttn Label"}),
+  infoButtonLabel,
   mood,
   variant = "default",
   footer,
@@ -59,6 +58,9 @@ export const GenericTile = ({
   ...restProps
 }: GenericTileProps): JSX.Element => {
   const [isFlipped, setIsFlipped] = useState<boolean>(false)
+  const { formatMessage } = useIntl()
+
+  information =  information ? information : formatMessage({id: "kzGenericTile.infoButtonLabel", defaultMessage: "Information", description: "Info Buttn Label"})
 
   const renderTitle = (): JSX.Element => (
     <div className={styles.title}>

--- a/packages/components/src/Tile/subcomponents/GenericTile/GenericTile.tsx
+++ b/packages/components/src/Tile/subcomponents/GenericTile/GenericTile.tsx
@@ -22,6 +22,7 @@ export type GenericTileProps = {
   titleTag?: AllowedHeadingTags
   metadata?: string
   information?: TileInformation | React.ReactNode
+  infoButtonLabel?: string
   /** @deprecated Use `variant` instead */
   mood?:
     | "positive"
@@ -46,6 +47,7 @@ export const GenericTile = ({
   titleTag = "h3",
   metadata,
   information,
+  infoButtonLabel = "Information",
   mood,
   variant = "default",
   footer,
@@ -80,7 +82,7 @@ export const GenericTile = ({
       {information && (
         <div className={styles.informationBtn}>
           <IconButton
-            label="Information"
+            label={infoButtonLabel}
             icon={<Icon name="info" isPresentational isFilled />}
             onClick={(): void => setIsFlipped(true)}
             disabled={isFlipped}

--- a/packages/components/src/Tile/subcomponents/GenericTile/GenericTile.tsx
+++ b/packages/components/src/Tile/subcomponents/GenericTile/GenericTile.tsx
@@ -65,7 +65,7 @@ export const GenericTile = ({
         defaultMessage: infoButtonLabel,
         description: "Info Button Label",
       })
-    : "Information"
+    : "See more about {$title}"
 
   const renderTitle = (): JSX.Element => (
     <div className={styles.title}>

--- a/packages/components/src/Tile/subcomponents/GenericTile/GenericTile.tsx
+++ b/packages/components/src/Tile/subcomponents/GenericTile/GenericTile.tsx
@@ -60,7 +60,7 @@ export const GenericTile = ({
   const [isFlipped, setIsFlipped] = useState<boolean>(false)
   const { formatMessage } = useIntl()
 
-  information =  information ? information : formatMessage({id: "kzGenericTile.infoButtonLabel", defaultMessage: "Information", description: "Info Buttn Label"})
+  infoButtonLabel = infoButtonLabel ? formatMessage({id: "kzGenericTile.infoButtonLabel", defaultMessage: "Information", description: "Info Buttn Label"}) : "Information"
 
   const renderTitle = (): JSX.Element => (
     <div className={styles.title}>

--- a/packages/components/src/Tile/subcomponents/GenericTile/GenericTile.tsx
+++ b/packages/components/src/Tile/subcomponents/GenericTile/GenericTile.tsx
@@ -61,7 +61,7 @@ export const GenericTile = ({
 
   const translatedInfoLabel = formatMessage({
         id: "kzGenericTile.infoButtonLabel",
-        defaultMessage: "View more information: ",
+        defaultMessage: "View more information:",
         description:
           "Prompts user to interact with button to reveal more information",
       })
@@ -92,7 +92,7 @@ export const GenericTile = ({
       {information && (
         <div className={styles.informationBtn}>
           <IconButton
-            label={infoButtonLabel || translatedInfoLabel + title}
+            label={infoButtonLabel || `${translatedInfoLabel} ${title}`}
             icon={<Icon name="info" isPresentational isFilled />}
             onClick={(): void => setIsFlipped(true)}
             disabled={isFlipped}
@@ -149,7 +149,7 @@ export const GenericTile = ({
 
     const returnButtonLabel = formatMessage({
       id: "kzGenericTile.infoButtonReturnLabel",
-      defaultMessage: "Hide information: ",
+      defaultMessage: "Hide information:",
       description: "Prompts user to interact with button to hide information",
     })
 


### PR DESCRIPTION
## Why
Provide users with a way to have contextual accessible labels for the Information Button.

https://cultureamp.atlassian.net/jira/software/c/projects/KZN/boards/634?selectedIssue=KZN-2730


## What
Adds a prop to the GenericTile component to allow control of the Information button's label.
