### PR TITLE
Tabs (future): add carousel functionality when tabs overflow container

### DIFF
--- a/.changeset/thin-actors-knock.md
+++ b/.changeset/thin-actors-knock.md
@@ -1,0 +1,5 @@
+---
+'@kaizen/components': patch
+---
+
+Tabs (future): add carousel functionality when tabs overflow container width

--- a/packages/components/src/__future__/Tabs/_docs/Tabs.spec.stories.tsx
+++ b/packages/components/src/__future__/Tabs/_docs/Tabs.spec.stories.tsx
@@ -1,13 +1,12 @@
 import React from 'react'
 import { Meta, StoryObj } from '@storybook/react'
-import { within, userEvent } from '@storybook/test'
+import { within, userEvent, expect } from '@storybook/test'
 import { Text } from '~components/Text'
 import { Tab, TabList, TabPanel, Tabs } from '../index'
 
 const meta = {
-  title: 'Components/Tabs/Tabs (Future)/ Tabs (Future) (Tests)',
+  title: 'Components/Tabs/Tabs (Future)/Tests',
   parameters: {
-    chromatic: { disable: false },
     controls: { disable: true },
   },
 } satisfies Meta
@@ -16,7 +15,7 @@ export default meta
 
 type Story = StoryObj<typeof meta>
 
-export const OverflowCarousel: Story = {
+export const ArrowsShowingAndHiding: Story = {
   render: () => {
     return (
       <div style={{ maxWidth: '500px' }}>
@@ -58,16 +57,22 @@ export const OverflowCarousel: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement.parentElement!)
 
+    expect(canvas.queryByTestId('kz-tablist-left-arrow')).not.toBeInTheDocument()
+
     const rightArrow = await canvas.findByTestId('kz-tablist-right-arrow')
 
     await userEvent.click(rightArrow)
-    await new Promise((r) => setTimeout(r, 200))
-
-    await userEvent.click(rightArrow)
-    await new Promise((r) => setTimeout(r, 200))
+    await new Promise((r) => setTimeout(r, 500))
 
     const leftArrow = await canvas.findByTestId('kz-tablist-left-arrow')
-    await userEvent.click(leftArrow)
-    await new Promise((r) => setTimeout(r, 200))
+
+    expect(leftArrow).toBeInTheDocument()
+    expect(rightArrow).toBeInTheDocument()
+
+    await userEvent.click(rightArrow)
+    await new Promise((r) => setTimeout(r, 500))
+
+    expect(leftArrow).toBeInTheDocument()
+    expect(rightArrow).not.toBeInTheDocument()
   },
 }

--- a/packages/components/src/__future__/Tabs/_docs/Tabs.spec.stories.tsx
+++ b/packages/components/src/__future__/Tabs/_docs/Tabs.spec.stories.tsx
@@ -20,7 +20,7 @@ export const ArrowsShowingAndHiding: Story = {
     return (
       <div style={{ maxWidth: '500px' }}>
         <Tabs>
-          <TabList aria-label="Tabs">
+          <TabList aria-label="Tabs" data-testid="sb-arrows">
             <Tab id="one">Tab 1</Tab>
             <Tab id="two">Tab 2</Tab>
             <Tab id="three" badge="3">
@@ -59,12 +59,12 @@ export const ArrowsShowingAndHiding: Story = {
 
     expect(canvas.queryByTestId('kz-tablist-left-arrow')).not.toBeInTheDocument()
 
-    const rightArrow = await canvas.findByTestId('kz-tablist-right-arrow')
+    const rightArrow = await canvas.findByTestId('sb-arrows-kz-tablist-right-arrow')
 
     await userEvent.click(rightArrow)
     await new Promise((r) => setTimeout(r, 500))
 
-    const leftArrow = await canvas.findByTestId('kz-tablist-left-arrow')
+    const leftArrow = await canvas.findByTestId('sb-arrows-kz-tablist-left-arrow')
 
     expect(leftArrow).toBeInTheDocument()
     expect(rightArrow).toBeInTheDocument()

--- a/packages/components/src/__future__/Tabs/_docs/Tabs.spec.stories.tsx
+++ b/packages/components/src/__future__/Tabs/_docs/Tabs.spec.stories.tsx
@@ -1,0 +1,73 @@
+import React from 'react'
+import { Meta, StoryObj } from '@storybook/react'
+import { within, userEvent } from '@storybook/test'
+import { Text } from '~components/Text'
+import { Tab, TabList, TabPanel, Tabs } from '../index'
+
+const meta = {
+  title: 'Components/Tabs/Tabs (Future)/ Tabs (Future) (Tests)',
+  parameters: {
+    chromatic: { disable: false },
+    controls: { disable: true },
+  },
+} satisfies Meta
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const OverflowCarousel: Story = {
+  render: () => {
+    return (
+      <div style={{ maxWidth: '500px' }}>
+        <Tabs>
+          <TabList aria-label="Tabs">
+            <Tab id="one">Tab 1</Tab>
+            <Tab id="two">Tab 2</Tab>
+            <Tab id="three" badge="3">
+              Tab 3
+            </Tab>
+            <Tab id="disabled" isDisabled>
+              Disabled Tab
+            </Tab>
+            <Tab id="four">Tab 4</Tab>
+            <Tab id="five">Tab 5</Tab>
+          </TabList>
+          <TabPanel id="one" className="p-24">
+            <Text variant="body">Content 1</Text>
+          </TabPanel>
+          <TabPanel id="two" className="p-24">
+            <Text variant="body">Content 2</Text>
+          </TabPanel>
+          <TabPanel id="three" className="p-24">
+            <Text variant="body">Content 3</Text>
+          </TabPanel>
+          <TabPanel id="disabled" className="p-24">
+            <Text variant="body">Disabled content</Text>
+          </TabPanel>
+          <TabPanel id="four" className="p-24">
+            <Text variant="body">Content 4</Text>
+          </TabPanel>
+          <TabPanel id="five" className="p-24">
+            <Text variant="body">Content 5</Text>
+          </TabPanel>
+        </Tabs>
+      </div>
+    )
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement.parentElement!)
+
+    const rightArrow = await canvas.findByTestId('kz-tablist-right-arrow')
+
+    await userEvent.click(rightArrow)
+    await new Promise((r) => setTimeout(r, 200))
+
+    await userEvent.click(rightArrow)
+    await new Promise((r) => setTimeout(r, 200))
+
+    const leftArrow = await canvas.findByTestId('kz-tablist-left-arrow')
+    await userEvent.click(leftArrow)
+    await new Promise((r) => setTimeout(r, 200))
+  },
+}

--- a/packages/components/src/__future__/Tabs/_docs/Tabs.spec.stories.tsx
+++ b/packages/components/src/__future__/Tabs/_docs/Tabs.spec.stories.tsx
@@ -9,7 +9,7 @@ const meta = {
   parameters: {
     controls: { disable: true },
   },
-} satisfies Meta
+} satisfies Meta<typeof Tabs>
 
 export default meta
 

--- a/packages/components/src/__future__/Tabs/_docs/Tabs.spec.stories.tsx
+++ b/packages/components/src/__future__/Tabs/_docs/Tabs.spec.stories.tsx
@@ -9,6 +9,42 @@ const meta = {
   parameters: {
     controls: { disable: true },
   },
+  args: {
+    children: (
+      <>
+        <TabList aria-label="Tabs" data-testid="sb-arrows">
+          <Tab id="one">Tab 1</Tab>
+          <Tab id="two">Tab 2</Tab>
+          <Tab id="three" badge="3">
+            Tab 3
+          </Tab>
+          <Tab id="disabled" isDisabled>
+            Disabled Tab
+          </Tab>
+          <Tab id="four">Tab 4</Tab>
+          <Tab id="five">Tab 5</Tab>
+        </TabList>
+        <TabPanel id="one" className="p-24">
+          <Text variant="body">Content 1</Text>
+        </TabPanel>
+        <TabPanel id="two" className="p-24">
+          <Text variant="body">Content 2</Text>
+        </TabPanel>
+        <TabPanel id="three" className="p-24">
+          <Text variant="body">Content 3</Text>
+        </TabPanel>
+        <TabPanel id="disabled" className="p-24">
+          <Text variant="body">Disabled content</Text>
+        </TabPanel>
+        <TabPanel id="four" className="p-24">
+          <Text variant="body">Content 4</Text>
+        </TabPanel>
+        <TabPanel id="five" className="p-24">
+          <Text variant="body">Content 5</Text>
+        </TabPanel>
+      </>
+    ),
+  },
 } satisfies Meta<typeof Tabs>
 
 export default meta
@@ -16,41 +52,10 @@ export default meta
 type Story = StoryObj<typeof meta>
 
 export const ArrowsShowingAndHiding: Story = {
-  render: () => {
+  render: (args) => {
     return (
       <div style={{ maxWidth: '500px' }}>
-        <Tabs>
-          <TabList aria-label="Tabs" data-testid="sb-arrows">
-            <Tab id="one">Tab 1</Tab>
-            <Tab id="two">Tab 2</Tab>
-            <Tab id="three" badge="3">
-              Tab 3
-            </Tab>
-            <Tab id="disabled" isDisabled>
-              Disabled Tab
-            </Tab>
-            <Tab id="four">Tab 4</Tab>
-            <Tab id="five">Tab 5</Tab>
-          </TabList>
-          <TabPanel id="one" className="p-24">
-            <Text variant="body">Content 1</Text>
-          </TabPanel>
-          <TabPanel id="two" className="p-24">
-            <Text variant="body">Content 2</Text>
-          </TabPanel>
-          <TabPanel id="three" className="p-24">
-            <Text variant="body">Content 3</Text>
-          </TabPanel>
-          <TabPanel id="disabled" className="p-24">
-            <Text variant="body">Disabled content</Text>
-          </TabPanel>
-          <TabPanel id="four" className="p-24">
-            <Text variant="body">Content 4</Text>
-          </TabPanel>
-          <TabPanel id="five" className="p-24">
-            <Text variant="body">Content 5</Text>
-          </TabPanel>
-        </Tabs>
+        <Tabs {...args} />
       </div>
     )
   },
@@ -74,5 +79,40 @@ export const ArrowsShowingAndHiding: Story = {
 
     expect(leftArrow).toBeInTheDocument()
     expect(rightArrow).not.toBeInTheDocument()
+  },
+}
+
+export const ArrowsShowingAndHidingRTL: Story = {
+  name: 'Arrows Showing and Hiding (RTL)',
+  parameters: {
+    textDirection: 'rtl',
+  },
+  render: (args) => {
+    return (
+      <div style={{ maxWidth: '500px' }}>
+        <Tabs {...args} />
+      </div>
+    )
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement.parentElement!)
+
+    expect(canvas.queryByTestId('kz-tablist-right-arrow')).not.toBeInTheDocument()
+
+    const leftArrow = await canvas.findByTestId('sb-arrows-kz-tablist-left-arrow')
+
+    await userEvent.click(leftArrow)
+    await new Promise((r) => setTimeout(r, 500))
+
+    const rightArrow = await canvas.findByTestId('sb-arrows-kz-tablist-right-arrow')
+
+    expect(leftArrow).toBeInTheDocument()
+    expect(rightArrow).toBeInTheDocument()
+
+    await userEvent.click(leftArrow)
+    await new Promise((r) => setTimeout(r, 500))
+
+    expect(rightArrow).toBeInTheDocument()
+    expect(leftArrow).not.toBeInTheDocument()
   },
 }

--- a/packages/components/src/__future__/Tabs/_docs/Tabs.stickersheet.stories.tsx
+++ b/packages/components/src/__future__/Tabs/_docs/Tabs.stickersheet.stories.tsx
@@ -1,0 +1,84 @@
+import React from 'react'
+import { Meta } from '@storybook/react'
+import { Text } from '~components/Text'
+import { StickerSheet, StickerSheetStory } from '~storybook/components/StickerSheet'
+import { Tab, TabList, TabPanel, Tabs } from '../index'
+
+export default {
+  title: 'Components/Tabs/Tabs (Future)',
+  parameters: {
+    chromatic: { disable: false },
+    controls: { disable: true },
+  },
+} satisfies Meta
+
+const ExampleTabs = (): JSX.Element => (
+  <Tabs>
+    <TabList aria-label="Tabs">
+      <Tab id="one">Tab 1</Tab>
+      <Tab id="two">Tab 2</Tab>
+      <Tab id="three" badge="3">
+        Tab 3
+      </Tab>
+      <Tab id="disabled" isDisabled>
+        Disabled Tab
+      </Tab>
+      <Tab id="four">Tab 4</Tab>
+      <Tab id="five">Tab 5</Tab>
+    </TabList>
+    <TabPanel id="one" className="p-24">
+      <Text variant="body">Content 1</Text>
+    </TabPanel>
+    <TabPanel id="two" className="p-24">
+      <Text variant="body">Content 2</Text>
+    </TabPanel>
+    <TabPanel id="three" className="p-24">
+      <Text variant="body">Content 3</Text>
+    </TabPanel>
+    <TabPanel id="disabled" className="p-24">
+      <Text variant="body">Content 4</Text>
+    </TabPanel>
+    <TabPanel id="four" className="p-24">
+      <Text variant="body">Content 4</Text>
+    </TabPanel>
+    <TabPanel id="five" className="p-24">
+      <Text variant="body">Content 5</Text>
+    </TabPanel>
+  </Tabs>
+)
+
+const StickerSheetTemplate: StickerSheetStory = {
+  render: () => {
+    return (
+      <>
+        <StickerSheet title="Tabs" layout="stretch">
+          <StickerSheet.Row>
+            <ExampleTabs />
+          </StickerSheet.Row>
+        </StickerSheet>
+
+        <StickerSheet title="Overflow (container 500px)" layout="stretch">
+          <StickerSheet.Row>
+            <div style={{ maxWidth: '500px' }}>
+              <ExampleTabs />
+            </div>
+          </StickerSheet.Row>
+        </StickerSheet>
+      </>
+    )
+  },
+}
+
+export const StickerSheetDefault: StickerSheetStory = {
+  ...StickerSheetTemplate,
+  name: 'Sticker Sheet (Default)',
+}
+
+export const StickerSheetRTL: StickerSheetStory = {
+  ...StickerSheetTemplate,
+  name: 'Sticker Sheet (RTL)',
+  parameters: {
+    ...StickerSheetTemplate.parameters,
+    textDirection: 'rtl',
+  },
+}

--- a/packages/components/src/__future__/Tabs/_docs/Tabs.stickersheet.stories.tsx
+++ b/packages/components/src/__future__/Tabs/_docs/Tabs.stickersheet.stories.tsx
@@ -12,36 +12,36 @@ export default {
   },
 } satisfies Meta
 
-const ExampleTabs = (): JSX.Element => (
+const ExampleTabs = ({ id }: { id: string }): JSX.Element => (
   <Tabs>
     <TabList aria-label="Tabs">
-      <Tab id="one">Tab 1</Tab>
-      <Tab id="two">Tab 2</Tab>
-      <Tab id="three" badge="3">
+      <Tab id={`${id}-1`}>Tab 1</Tab>
+      <Tab id={`${id}-2`}>Tab 2</Tab>
+      <Tab id={`${id}-3`} badge="3">
         Tab 3
       </Tab>
-      <Tab id="disabled" isDisabled>
+      <Tab id={`${id}-disabled`} isDisabled>
         Disabled Tab
       </Tab>
-      <Tab id="four">Tab 4</Tab>
-      <Tab id="five">Tab 5</Tab>
+      <Tab id={`${id}-4`}>Tab 4</Tab>
+      <Tab id={`${id}-5`}>Tab 5</Tab>
     </TabList>
-    <TabPanel id="one" className="p-24">
+    <TabPanel id={`${id}-1`} className="p-24">
       <Text variant="body">Content 1</Text>
     </TabPanel>
-    <TabPanel id="two" className="p-24">
+    <TabPanel id={`${id}-2`} className="p-24">
       <Text variant="body">Content 2</Text>
     </TabPanel>
-    <TabPanel id="three" className="p-24">
+    <TabPanel id={`${id}-3`} className="p-24">
       <Text variant="body">Content 3</Text>
     </TabPanel>
-    <TabPanel id="disabled" className="p-24">
+    <TabPanel id={`${id}-disabled`} className="p-24">
+      <Text variant="body">Disabled content</Text>
+    </TabPanel>
+    <TabPanel id={`${id}-4`} className="p-24">
       <Text variant="body">Content 4</Text>
     </TabPanel>
-    <TabPanel id="four" className="p-24">
-      <Text variant="body">Content 4</Text>
-    </TabPanel>
-    <TabPanel id="five" className="p-24">
+    <TabPanel id={`${id}-5`} className="p-24">
       <Text variant="body">Content 5</Text>
     </TabPanel>
   </Tabs>
@@ -53,14 +53,14 @@ const StickerSheetTemplate: StickerSheetStory = {
       <>
         <StickerSheet title="Tabs" layout="stretch">
           <StickerSheet.Row>
-            <ExampleTabs />
+            <ExampleTabs id="fullwidth" />
           </StickerSheet.Row>
         </StickerSheet>
 
         <StickerSheet title="Overflow (container 500px)" layout="stretch">
           <StickerSheet.Row>
             <div style={{ maxWidth: '500px' }}>
-              <ExampleTabs />
+              <ExampleTabs id="overflow" />
             </div>
           </StickerSheet.Row>
         </StickerSheet>

--- a/packages/components/src/__future__/Tabs/_docs/Tabs.stories.tsx
+++ b/packages/components/src/__future__/Tabs/_docs/Tabs.stories.tsx
@@ -16,9 +16,11 @@ const meta = {
           <Tab id="three" badge="3">
             Tab 3
           </Tab>
-          <Tab id="four" isDisabled>
+          <Tab id="disabled" isDisabled>
             Disabled Tab
           </Tab>
+          <Tab id="four">Tab 4</Tab>
+          <Tab id="five">Tab 5</Tab>
         </TabList>
         <TabPanel id="one" className="p-24">
           <Text variant="body">Content 1</Text>
@@ -28,6 +30,15 @@ const meta = {
         </TabPanel>
         <TabPanel id="three" className="p-24">
           <Text variant="body">Content 3</Text>
+        </TabPanel>
+        <TabPanel id="disabled" className="p-24">
+          <Text variant="body">Content 4</Text>
+        </TabPanel>
+        <TabPanel id="four" className="p-24">
+          <Text variant="body">Content 4</Text>
+        </TabPanel>
+        <TabPanel id="five" className="p-24">
+          <Text variant="body">Content 5</Text>
         </TabPanel>
       </>
     ),

--- a/packages/components/src/__future__/Tabs/constants.ts
+++ b/packages/components/src/__future__/Tabs/constants.ts
@@ -1,0 +1,1 @@
+export const SCROLL_AMOUNT = 120

--- a/packages/components/src/__future__/Tabs/subcomponents/Tab/Tab.tsx
+++ b/packages/components/src/__future__/Tabs/subcomponents/Tab/Tab.tsx
@@ -28,7 +28,7 @@ export const Tab = (props: TabProps): JSX.Element => {
   }
 
   return (
-    <RACTab {...tabProps}>
+    <RACTab data-kz-tab {...tabProps}>
       {({ isSelected, isFocusVisible, isHovered }) => (
         <>
           {children}

--- a/packages/components/src/__future__/Tabs/subcomponents/TabList/TabList.module.css
+++ b/packages/components/src/__future__/Tabs/subcomponents/TabList/TabList.module.css
@@ -32,22 +32,25 @@
   cursor: default;
 }
 
+/*
+ * Note: we're purposefully using directional properties instead of start/end for positioning and styling related to the carousel arrows
+*/
 .leftArrow {
-  inset-inline-start: 0;
+  left: 0;
 }
 
 .leftArrow,
 .leftArrow:hover {
-  border-inline-end: 1px solid rgba(var(--color-gray-600-rgb), 0.1);
+  border-right: 1px solid rgba(var(--color-gray-600-rgb), 0.1);
 }
 
 .rightArrow {
-  inset-inline-end: 0;
+  right: 0;
 }
 
 .rightArrow,
 .rightArrow:hover {
-  border-inline-start: 1px solid rgba(var(--color-gray-600-rgb), 0.1);
+  border-left: 1px solid rgba(var(--color-gray-600-rgb), 0.1);
 }
 
 .leftArrow:hover,

--- a/packages/components/src/__future__/Tabs/subcomponents/TabList/TabList.module.css
+++ b/packages/components/src/__future__/Tabs/subcomponents/TabList/TabList.module.css
@@ -30,10 +30,6 @@
   inset-block: 0 1px;
   width: 48px;
   cursor: default;
-
-  &:hover {
-    background: var(--color-blue-100);
-  }
 }
 
 .leftArrow {
@@ -52,4 +48,9 @@
 .rightArrow,
 .rightArrow:hover {
   border-inline-start: 1px solid rgba(var(--color-gray-600-rgb), 0.1);
+}
+
+.leftArrow:hover,
+.rightArrow:hover {
+  background: var(--color-blue-100);
 }

--- a/packages/components/src/__future__/Tabs/subcomponents/TabList/TabList.module.css
+++ b/packages/components/src/__future__/Tabs/subcomponents/TabList/TabList.module.css
@@ -30,6 +30,7 @@
   inset-block: 0 1px;
   width: 48px;
   cursor: default;
+  user-select: none;
 }
 
 /*
@@ -55,5 +56,5 @@
 
 .leftArrow:hover,
 .rightArrow:hover {
-  background: var(--color-blue-100);
+  background: var(--color-gray-200);
 }

--- a/packages/components/src/__future__/Tabs/subcomponents/TabList/TabList.module.css
+++ b/packages/components/src/__future__/Tabs/subcomponents/TabList/TabList.module.css
@@ -1,8 +1,47 @@
+.container {
+  position: relative;
+}
+
 .tabList {
   border-bottom: 1px solid rgba(var(--color-gray-600-rgb), 0.1);
-  padding: var(--spacing-xs) var(--spacing-md) 0;
+  padding: var(--spacing-xs) 0 0;
+  width: 100%;
+  height: 100%;
+  overflow-x: scroll;
+  white-space: nowrap;
+  scrollbar-width: none;
+  scroll-behavior: smooth;
 }
 
 .noPadding {
   padding: 0;
+}
+
+.leftArrow,
+.rightArrow {
+  --button-bg-color: var(--color-white);
+
+  position: absolute;
+  z-index: 10000;
+  inset-block: 0 1px;
+  border-radius: 0;
+  width: 48px;
+}
+
+.leftArrow {
+  inset-inline-start: 0;
+}
+
+.leftArrow,
+.leftArrow:hover {
+  border-inline-end: 1px solid rgba(var(--color-gray-600-rgb), 0.1);
+}
+
+.rightArrow {
+  inset-inline-end: 0;
+}
+
+.rightArrow,
+.rightArrow:hover {
+  border-inline-start: 1px solid rgba(var(--color-gray-600-rgb), 0.1);
 }

--- a/packages/components/src/__future__/Tabs/subcomponents/TabList/TabList.module.css
+++ b/packages/components/src/__future__/Tabs/subcomponents/TabList/TabList.module.css
@@ -19,13 +19,21 @@
 
 .leftArrow,
 .rightArrow {
-  --button-bg-color: var(--color-white);
+  --icon-size: 24;
 
+  display: flex;
+  align-items: center;
+  justify-content: center;
   position: absolute;
   z-index: 10000;
+  background: var(--color-white);
   inset-block: 0 1px;
-  border-radius: 0;
   width: 48px;
+  cursor: default;
+
+  &:hover {
+    background: var(--color-blue-100);
+  }
 }
 
 .leftArrow {

--- a/packages/components/src/__future__/Tabs/subcomponents/TabList/TabList.module.css
+++ b/packages/components/src/__future__/Tabs/subcomponents/TabList/TabList.module.css
@@ -4,7 +4,7 @@
 
 .tabList {
   border-bottom: 1px solid rgba(var(--color-gray-600-rgb), 0.1);
-  padding: var(--spacing-xs) 0 0;
+  padding: var(--spacing-6) 0 0;
   width: 100%;
   height: 100%;
   overflow-x: scroll;

--- a/packages/components/src/__future__/Tabs/subcomponents/TabList/TabList.tsx
+++ b/packages/components/src/__future__/Tabs/subcomponents/TabList/TabList.tsx
@@ -1,6 +1,8 @@
-import React, { ReactNode } from 'react'
+import React, { ReactNode, useEffect, useRef, useState } from 'react'
 import classnames from 'classnames'
 import { TabList as RACTabList, TabListProps as RACTabListProps } from 'react-aria-components'
+import { Button } from '~components/__actions__/v3'
+import { Icon } from '~components/__future__/Icon'
 import styles from './TabList.module.css'
 
 export type TabListProps = {
@@ -20,13 +22,93 @@ export type TabListProps = {
  */
 export const TabList = (props: TabListProps): JSX.Element => {
   const { 'aria-label': ariaLabel, noPadding = false, children, className, ...restProps } = props
+  const [isDocumentReady, setIsDocumentReady] = useState<boolean>(false)
+  const [leftArrowEnabled, setLeftArrowEnabled] = useState<boolean>(false)
+  const [rightArrowEnabled, setRightArrowEnabled] = useState<boolean>(false)
+
+  useEffect(() => {
+    if (!isDocumentReady) {
+      setIsDocumentReady(true)
+      return
+    }
+
+    const tabs = document.querySelectorAll('[data-kz-tab]')
+
+    const firstTabObserver = new IntersectionObserver(
+      (entries) => {
+        if (!entries[0].isIntersecting) {
+          setLeftArrowEnabled(true)
+          return
+        }
+        setLeftArrowEnabled(false)
+      },
+      {
+        threshold: 0.75,
+      },
+    )
+    firstTabObserver.observe(tabs[0])
+
+    const lastTabObserver = new IntersectionObserver(
+      (entries) => {
+        if (!entries[0].isIntersecting) {
+          setRightArrowEnabled(true)
+          return
+        }
+        setRightArrowEnabled(false)
+      },
+      {
+        threshold: 0.75,
+      },
+    )
+    lastTabObserver.observe(tabs[tabs.length - 1])
+  }, [isDocumentReady])
+
+  const tabListRef = useRef<HTMLDivElement | null>(null)
+
+  const handleArrowPress = (direction: 'left' | 'right'): void => {
+    if (tabListRef.current) {
+      const scrollAmount = 120
+      const tabListScrollPos = tabListRef.current.scrollLeft
+      const newSpot =
+        direction === 'left' ? tabListScrollPos - scrollAmount : tabListScrollPos + scrollAmount
+      tabListRef.current.scrollLeft = newSpot
+    }
+  }
+
   return (
-    <RACTabList
-      aria-label={ariaLabel}
-      className={classnames(styles.tabList, className, noPadding && styles.noPadding)}
-      {...restProps}
-    >
-      {children}
-    </RACTabList>
+    <div className={styles.container}>
+      {leftArrowEnabled && (
+        <Button
+          hasHiddenLabel
+          icon={<Icon name="chevron_left" isPresentational />}
+          onPress={() => handleArrowPress('left')}
+          variant="tertiary"
+          className={styles.leftArrow}
+          excludeFromTabOrder
+        >
+          Slide tab list left
+        </Button>
+      )}
+      <RACTabList
+        aria-label={ariaLabel}
+        ref={tabListRef}
+        className={classnames(styles.tabList, className, noPadding && styles.noPadding)}
+        {...restProps}
+      >
+        {children}
+      </RACTabList>
+      {rightArrowEnabled && (
+        <Button
+          hasHiddenLabel
+          icon={<Icon name="chevron_right" isPresentational />}
+          onPress={() => handleArrowPress('right')}
+          variant="tertiary"
+          className={styles.rightArrow}
+          excludeFromTabOrder
+        >
+          Slide tab list right
+        </Button>
+      )}
+    </div>
   )
 }

--- a/packages/components/src/__future__/Tabs/subcomponents/TabList/TabList.tsx
+++ b/packages/components/src/__future__/Tabs/subcomponents/TabList/TabList.tsx
@@ -60,6 +60,7 @@ export const TabList = (props: TabListProps): JSX.Element => {
       },
       {
         threshold: 0.75,
+        root: containerElement,
       },
     )
     firstTabObserver.observe(isRTL ? tabs[tabs.length - 1] : tabs[0])
@@ -74,6 +75,7 @@ export const TabList = (props: TabListProps): JSX.Element => {
       },
       {
         threshold: 0.75,
+        root: containerElement,
       },
     )
     lastTabObserver.observe(isRTL ? tabs[0] : tabs[tabs.length - 1])

--- a/packages/components/src/__future__/Tabs/subcomponents/TabList/TabList.tsx
+++ b/packages/components/src/__future__/Tabs/subcomponents/TabList/TabList.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, useEffect, useRef, useState } from 'react'
+import React, { ReactNode, useEffect, useId, useRef, useState } from 'react'
 import classnames from 'classnames'
 import { TabList as RACTabList, TabListProps as RACTabListProps } from 'react-aria-components'
 import { Icon } from '~components/__future__/Icon'
@@ -25,6 +25,7 @@ export const TabList = (props: TabListProps): JSX.Element => {
   const [leftArrowEnabled, setLeftArrowEnabled] = useState<boolean>(false)
   const [rightArrowEnabled, setRightArrowEnabled] = useState<boolean>(false)
   const tabListRef = useRef<HTMLDivElement | null>(null)
+  const tabListId = useId()
 
   useEffect(() => {
     if (!isDocumentReady) {
@@ -32,7 +33,12 @@ export const TabList = (props: TabListProps): JSX.Element => {
       return
     }
 
-    const tabs = document.querySelectorAll('[data-kz-tab]')
+    const container = document.getElementById(tabListId)
+    const tabs = container?.querySelectorAll('[data-kz-tab]')
+
+    if (!tabs) {
+      return
+    }
 
     const firstTabObserver = new IntersectionObserver(
       (entries) => {
@@ -61,7 +67,7 @@ export const TabList = (props: TabListProps): JSX.Element => {
       },
     )
     lastTabObserver.observe(tabs[tabs.length - 1])
-  }, [isDocumentReady])
+  }, [isDocumentReady, tabListId])
 
   const handleArrowPress = (direction: 'left' | 'right'): void => {
     if (tabListRef.current) {
@@ -74,7 +80,7 @@ export const TabList = (props: TabListProps): JSX.Element => {
   }
 
   return (
-    <div className={styles.container}>
+    <div className={styles.container} id={tabListId}>
       {leftArrowEnabled && (
         // making a conscious decision to use <div onClick> over <button> here, because:
         // - <button> would add pointless noise for a screen reader user

--- a/packages/components/src/__future__/Tabs/subcomponents/TabList/TabList.tsx
+++ b/packages/components/src/__future__/Tabs/subcomponents/TabList/TabList.tsx
@@ -1,6 +1,10 @@
-import React, { ReactNode, useEffect, useId, useRef, useState } from 'react'
+import React, { ReactNode, useContext, useEffect, useId, useRef, useState } from 'react'
 import classnames from 'classnames'
-import { TabList as RACTabList, TabListProps as RACTabListProps } from 'react-aria-components'
+import {
+  TabList as RACTabList,
+  TabListProps as RACTabListProps,
+  TabListStateContext,
+} from 'react-aria-components'
 import { Icon } from '~components/__future__/Icon'
 import styles from './TabList.module.css'
 
@@ -28,6 +32,8 @@ export const TabList = (props: TabListProps): JSX.Element => {
   const tabListId = useId()
   const [isRTL, setIsRTL] = useState<boolean>(false)
   const [containerElement, setContainerElement] = useState<HTMLElement | null>()
+  const tabListContext = useContext(TabListStateContext)
+  const selectedKey = tabListContext?.selectedKey
 
   useEffect(() => {
     if (!isDocumentReady) {
@@ -85,6 +91,17 @@ export const TabList = (props: TabListProps): JSX.Element => {
       lastTabObserver.disconnect()
     }
   }, [isDocumentReady, containerElement, isRTL])
+
+  useEffect(() => {
+    if (!isDocumentReady) {
+      return
+    }
+
+    // Scroll selected tab into view
+    containerElement
+      ?.querySelector('[role="tab"][data-selected=true]')
+      ?.scrollIntoView({ block: 'nearest', inline: 'center' })
+  }, [selectedKey, containerElement, isDocumentReady])
 
   const handleArrowPress = (direction: 'left' | 'right'): void => {
     if (tabListRef.current) {

--- a/packages/components/src/__future__/Tabs/subcomponents/TabList/TabList.tsx
+++ b/packages/components/src/__future__/Tabs/subcomponents/TabList/TabList.tsx
@@ -6,6 +6,7 @@ import {
   TabListStateContext,
 } from 'react-aria-components'
 import { Icon } from '~components/__future__/Icon'
+import { SCROLL_AMOUNT } from '../../constants'
 import styles from './TabList.module.css'
 
 export type TabListProps = {
@@ -113,10 +114,9 @@ export const TabList = (props: TabListProps): JSX.Element => {
 
   const handleArrowPress = (direction: 'left' | 'right'): void => {
     if (tabListRef.current) {
-      const scrollAmount = 120
       const tabListScrollPos = tabListRef.current.scrollLeft
       const newSpot =
-        direction === 'left' ? tabListScrollPos - scrollAmount : tabListScrollPos + scrollAmount
+        direction === 'left' ? tabListScrollPos - SCROLL_AMOUNT : tabListScrollPos + SCROLL_AMOUNT
       tabListRef.current.scrollLeft = newSpot
     }
   }

--- a/packages/components/src/__future__/Tabs/subcomponents/TabList/TabList.tsx
+++ b/packages/components/src/__future__/Tabs/subcomponents/TabList/TabList.tsx
@@ -18,13 +18,21 @@ export type TabListProps = {
    */
   'noPadding'?: boolean
   'children': ReactNode
+  'data-testid'?: string
 } & RACTabListProps<HTMLElement>
 
 /**
  * Wrapper for the tabs themselves
  */
 export const TabList = (props: TabListProps): JSX.Element => {
-  const { 'aria-label': ariaLabel, noPadding = false, children, className, ...restProps } = props
+  const {
+    'aria-label': ariaLabel,
+    noPadding = false,
+    children,
+    className,
+    'data-testid': testId,
+    ...restProps
+  } = props
   const [isDocumentReady, setIsDocumentReady] = useState<boolean>(false)
   const [leftArrowEnabled, setLeftArrowEnabled] = useState<boolean>(false)
   const [rightArrowEnabled, setRightArrowEnabled] = useState<boolean>(false)
@@ -123,7 +131,7 @@ export const TabList = (props: TabListProps): JSX.Element => {
         <div
           onClick={() => handleArrowPress('left')}
           className={styles.leftArrow}
-          data-testid="kz-tablist-left-arrow"
+          data-testid={testId ? `${testId}-kz-tablist-left-arrow` : undefined}
         >
           <Icon name="chevron_left" isPresentational />
         </div>
@@ -141,7 +149,7 @@ export const TabList = (props: TabListProps): JSX.Element => {
         <div
           onClick={() => handleArrowPress('right')}
           className={styles.rightArrow}
-          data-testid="kz-tablist-right-arrow"
+          data-testid={testId ? `${testId}-kz-tablist-right-arrow` : undefined}
         >
           <Icon name="chevron_right" isPresentational />
         </div>

--- a/packages/components/src/__future__/Tabs/subcomponents/TabList/TabList.tsx
+++ b/packages/components/src/__future__/Tabs/subcomponents/TabList/TabList.tsx
@@ -6,6 +6,7 @@ import {
   TabListStateContext,
 } from 'react-aria-components'
 import { Icon } from '~components/__future__/Icon'
+import { isRTL as isRTLCheck } from '~components/__utilities__/isRTL'
 import { SCROLL_AMOUNT } from '../../constants'
 import styles from './TabList.module.css'
 
@@ -52,7 +53,7 @@ export const TabList = (props: TabListProps): JSX.Element => {
 
     const container = document.getElementById(tabListId)
     setContainerElement(container)
-    setIsRTL(!!container?.closest('[dir]')?.matches('[dir="rtl"]'))
+    setIsRTL(container ? isRTLCheck(container) : false)
   }, [isDocumentReady, tabListId])
 
   useEffect(() => {

--- a/packages/components/src/__future__/Tabs/subcomponents/TabList/TabList.tsx
+++ b/packages/components/src/__future__/Tabs/subcomponents/TabList/TabList.tsx
@@ -96,7 +96,11 @@ export const TabList = (props: TabListProps): JSX.Element => {
         // - <button> would add pointless noise for a screen reader user
         // - keyboard only user can toggle through tabs with left/right arrow keys already
         // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
-        <div onClick={() => handleArrowPress('left')} className={styles.leftArrow}>
+        <div
+          onClick={() => handleArrowPress('left')}
+          className={styles.leftArrow}
+          data-testid="kz-tablist-left-arrow"
+        >
           <Icon name="chevron_left" isPresentational />
         </div>
       )}
@@ -110,7 +114,11 @@ export const TabList = (props: TabListProps): JSX.Element => {
       </RACTabList>
       {rightArrowEnabled && (
         // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
-        <div onClick={() => handleArrowPress('right')} className={styles.rightArrow}>
+        <div
+          onClick={() => handleArrowPress('right')}
+          className={styles.rightArrow}
+          data-testid="kz-tablist-right-arrow"
+        >
           <Icon name="chevron_right" isPresentational />
         </div>
       )}

--- a/packages/components/src/__future__/Tabs/subcomponents/TabList/TabList.tsx
+++ b/packages/components/src/__future__/Tabs/subcomponents/TabList/TabList.tsx
@@ -26,6 +26,8 @@ export const TabList = (props: TabListProps): JSX.Element => {
   const [rightArrowEnabled, setRightArrowEnabled] = useState<boolean>(false)
   const tabListRef = useRef<HTMLDivElement | null>(null)
   const tabListId = useId()
+  const [isRTL, setIsRTL] = useState<boolean>(false)
+  const [containerElement, setContainerElement] = useState<HTMLElement | null>()
 
   useEffect(() => {
     if (!isDocumentReady) {
@@ -34,8 +36,16 @@ export const TabList = (props: TabListProps): JSX.Element => {
     }
 
     const container = document.getElementById(tabListId)
-    const tabs = container?.querySelectorAll('[data-kz-tab]')
+    setContainerElement(container)
+    setIsRTL(!!container?.closest('[dir]')?.matches('[dir="rtl"]'))
+  }, [isDocumentReady, tabListId])
 
+  useEffect(() => {
+    if (!isDocumentReady) {
+      return
+    }
+
+    const tabs = containerElement?.querySelectorAll('[data-kz-tab]')
     if (!tabs) {
       return
     }
@@ -52,7 +62,7 @@ export const TabList = (props: TabListProps): JSX.Element => {
         threshold: 0.75,
       },
     )
-    firstTabObserver.observe(tabs[0])
+    firstTabObserver.observe(isRTL ? tabs[tabs.length - 1] : tabs[0])
 
     const lastTabObserver = new IntersectionObserver(
       (entries) => {
@@ -66,8 +76,8 @@ export const TabList = (props: TabListProps): JSX.Element => {
         threshold: 0.75,
       },
     )
-    lastTabObserver.observe(tabs[tabs.length - 1])
-  }, [isDocumentReady, tabListId])
+    lastTabObserver.observe(isRTL ? tabs[0] : tabs[tabs.length - 1])
+  }, [isDocumentReady, containerElement, isRTL])
 
   const handleArrowPress = (direction: 'left' | 'right'): void => {
     if (tabListRef.current) {

--- a/packages/components/src/__future__/Tabs/subcomponents/TabList/TabList.tsx
+++ b/packages/components/src/__future__/Tabs/subcomponents/TabList/TabList.tsx
@@ -1,7 +1,6 @@
 import React, { ReactNode, useEffect, useRef, useState } from 'react'
 import classnames from 'classnames'
 import { TabList as RACTabList, TabListProps as RACTabListProps } from 'react-aria-components'
-import { Button } from '~components/__actions__/v3'
 import { Icon } from '~components/__future__/Icon'
 import styles from './TabList.module.css'
 
@@ -25,6 +24,7 @@ export const TabList = (props: TabListProps): JSX.Element => {
   const [isDocumentReady, setIsDocumentReady] = useState<boolean>(false)
   const [leftArrowEnabled, setLeftArrowEnabled] = useState<boolean>(false)
   const [rightArrowEnabled, setRightArrowEnabled] = useState<boolean>(false)
+  const tabListRef = useRef<HTMLDivElement | null>(null)
 
   useEffect(() => {
     if (!isDocumentReady) {
@@ -63,8 +63,6 @@ export const TabList = (props: TabListProps): JSX.Element => {
     lastTabObserver.observe(tabs[tabs.length - 1])
   }, [isDocumentReady])
 
-  const tabListRef = useRef<HTMLDivElement | null>(null)
-
   const handleArrowPress = (direction: 'left' | 'right'): void => {
     if (tabListRef.current) {
       const scrollAmount = 120
@@ -78,16 +76,13 @@ export const TabList = (props: TabListProps): JSX.Element => {
   return (
     <div className={styles.container}>
       {leftArrowEnabled && (
-        <Button
-          hasHiddenLabel
-          icon={<Icon name="chevron_left" isPresentational />}
-          onPress={() => handleArrowPress('left')}
-          variant="tertiary"
-          className={styles.leftArrow}
-          excludeFromTabOrder
-        >
-          Slide tab list left
-        </Button>
+        // making a conscious decision to use <div onClick> over <button> here, because:
+        // - <button> would add pointless noise for a screen reader user
+        // - keyboard only user can toggle through tabs with left/right arrow keys already
+        // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
+        <div onClick={() => handleArrowPress('left')} className={styles.leftArrow}>
+          <Icon name="chevron_left" isPresentational />
+        </div>
       )}
       <RACTabList
         aria-label={ariaLabel}
@@ -98,16 +93,10 @@ export const TabList = (props: TabListProps): JSX.Element => {
         {children}
       </RACTabList>
       {rightArrowEnabled && (
-        <Button
-          hasHiddenLabel
-          icon={<Icon name="chevron_right" isPresentational />}
-          onPress={() => handleArrowPress('right')}
-          variant="tertiary"
-          className={styles.rightArrow}
-          excludeFromTabOrder
-        >
-          Slide tab list right
-        </Button>
+        // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
+        <div onClick={() => handleArrowPress('right')} className={styles.rightArrow}>
+          <Icon name="chevron_right" isPresentational />
+        </div>
       )}
     </div>
   )

--- a/packages/components/src/__future__/Tabs/subcomponents/TabList/TabList.tsx
+++ b/packages/components/src/__future__/Tabs/subcomponents/TabList/TabList.tsx
@@ -77,6 +77,11 @@ export const TabList = (props: TabListProps): JSX.Element => {
       },
     )
     lastTabObserver.observe(isRTL ? tabs[0] : tabs[tabs.length - 1])
+
+    return () => {
+      firstTabObserver.disconnect()
+      lastTabObserver.disconnect()
+    }
   }, [isDocumentReady, containerElement, isRTL])
 
   const handleArrowPress = (direction: 'left' | 'right'): void => {

--- a/packages/components/src/__utilities__/isRTL/index.ts
+++ b/packages/components/src/__utilities__/isRTL/index.ts
@@ -1,0 +1,1 @@
+export * from './isRTL'

--- a/packages/components/src/__utilities__/isRTL/isRTL.spec.tsx
+++ b/packages/components/src/__utilities__/isRTL/isRTL.spec.tsx
@@ -1,0 +1,38 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import { isRTL } from './isRTL'
+
+describe('isRTL', () => {
+  it('returns false when no element with dir found', () => {
+    const Example = (): JSX.Element => <button type="button">Test</button>
+    render(<Example />)
+    const button = screen.getByRole('button')
+    expect(isRTL(button)).toBe(false)
+  })
+
+  it('returns false when greater parent is dir=rtl, but closer parent is dir=ltr', () => {
+    const Example = (): JSX.Element => (
+      <div dir="rtl">
+        <div dir="ltr">
+          <button type="button">Test</button>
+        </div>
+      </div>
+    )
+    render(<Example />)
+    const button = screen.getByRole('button')
+    expect(isRTL(button)).toBe(false)
+  })
+
+  it('returns true when greater parent is dir=ltr, but closer parent is dir=rtl', () => {
+    const Example = (): JSX.Element => (
+      <div dir="ltr">
+        <div dir="rtl">
+          <button type="button">Test</button>
+        </div>
+      </div>
+    )
+    render(<Example />)
+    const button = screen.getByRole('button')
+    expect(isRTL(button)).toBe(true)
+  })
+})

--- a/packages/components/src/__utilities__/isRTL/isRTL.ts
+++ b/packages/components/src/__utilities__/isRTL/isRTL.ts
@@ -1,0 +1,6 @@
+/**
+ * Finds the first ancestor with a `dir` property on it
+ * Returning true is that is `dir=rtl` and returning false in all other cases
+ */
+export const isRTL = (element: Element): boolean =>
+  !!element.closest('[dir]')?.matches('[dir="rtl"]')


### PR DESCRIPTION
## What
Add carousel to Future Tabs when tabs start overflowing the width of the viewport

https://github.com/user-attachments/assets/a98a1d97-b6ef-428d-ac53-9e87ad3ebffc

## Why
Nicer than having heaps of tabs wrap to a new line
