### PR TITLE
fix(TextArea): Only use internal value for autogrow data property

### DIFF
--- a/.changeset/giant-maps-enjoy.md
+++ b/.changeset/giant-maps-enjoy.md
@@ -1,0 +1,5 @@
+---
+'@kaizen/components': patch
+---
+
+TextArea: no longer forced into controlled mode under the hood, allowing value manipulation via JS if needed

--- a/packages/components/src/TextArea/TextArea.tsx
+++ b/packages/components/src/TextArea/TextArea.tsx
@@ -33,11 +33,9 @@ export const TextArea = ({
 }: TextAreaProps): JSX.Element => {
   const [internalValue, setInternalValue] = useState<
     string | number | readonly string[] | undefined
-  >(autogrow && !value ? defaultValue : undefined)
-  // ^ holds an internal state of the value so that autogrow can still work with uncontrolled textareas
-  // essentially forces the textarea into an (interally) controlled mode if autogrow is true and mode is uncontrolled
+  >(value ?? defaultValue ?? '')
+  // ^holds an internal state of the value, used for the autogrow feature if uncontrolled (no `value` provided)
 
-  const controlledValue = value ?? internalValue
   const fallbackRef = useRef(null)
   const textAreaRef = propsTextAreaRef ?? fallbackRef
 
@@ -51,7 +49,7 @@ export const TextArea = ({
       className={classnames(styles.wrapper, {
         [styles.wrapperAutogrow]: autogrow,
       })}
-      data-value={autogrow ? controlledValue : undefined}
+      data-value={value ?? internalValue}
     >
       <textarea
         className={classnames(
@@ -65,8 +63,8 @@ export const TextArea = ({
         )}
         rows={rows}
         onChange={onChange}
-        value={controlledValue}
-        defaultValue={controlledValue ? undefined : defaultValue}
+        value={value}
+        defaultValue={value ? undefined : defaultValue}
         // ^ React throws a warning if you specify both a value and a defaultValue
         ref={textAreaRef}
         disabled={disabled}

--- a/packages/components/src/TextArea/TextArea.tsx
+++ b/packages/components/src/TextArea/TextArea.tsx
@@ -33,7 +33,7 @@ export const TextArea = ({
 }: TextAreaProps): JSX.Element => {
   const [internalValue, setInternalValue] = useState<
     string | number | readonly string[] | undefined
-  >(value ?? defaultValue ?? '')
+  >(defaultValue)
   // ^holds an internal state of the value, used for the autogrow feature if uncontrolled (no `value` provided)
 
   const fallbackRef = useRef(null)
@@ -41,7 +41,10 @@ export const TextArea = ({
 
   const onChange = (event: React.ChangeEvent<HTMLTextAreaElement>): void => {
     propsOnChange?.(event)
-    setInternalValue(event.target.value)
+
+    if (!value) {
+      setInternalValue(event.target.value)
+    }
   }
 
   return (
@@ -49,7 +52,7 @@ export const TextArea = ({
       className={classnames(styles.wrapper, {
         [styles.wrapperAutogrow]: autogrow,
       })}
-      data-value={value ?? internalValue}
+      data-value={autogrow ? (value ?? internalValue) : undefined}
     >
       <textarea
         className={classnames(

--- a/packages/components/src/TextArea/TextArea.tsx
+++ b/packages/components/src/TextArea/TextArea.tsx
@@ -42,7 +42,7 @@ export const TextArea = ({
   const onChange = (event: React.ChangeEvent<HTMLTextAreaElement>): void => {
     propsOnChange?.(event)
 
-    if (!value) {
+    if (!value && autogrow) {
       setInternalValue(event.target.value)
     }
   }

--- a/packages/components/src/TextArea/_docs/TextArea.stickersheet.stories.tsx
+++ b/packages/components/src/TextArea/_docs/TextArea.stickersheet.stories.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { Meta } from '@storybook/react'
+import { Heading } from '~components/Heading'
 import { StickerSheet, StickerSheetStory } from '~storybook/components/StickerSheet'
 import { TextArea } from '../index'
 
@@ -24,20 +25,30 @@ export default {
 
 const StickerSheetTemplate: StickerSheetStory = {
   render: ({ isReversed }) => (
-    <StickerSheet isReversed={isReversed} headers={['Default', 'Hover', 'Active', 'Focus']}>
-      <StickerSheet.Row header="Enabled">
-        <TextArea reversed={isReversed} />
-        <TextArea reversed={isReversed} data-sb-pseudo-styles="hover" />
-        <TextArea reversed={isReversed} data-sb-pseudo-styles="active" />
-        <TextArea reversed={isReversed} data-sb-pseudo-styles="focus" />
-      </StickerSheet.Row>
-      <StickerSheet.Row header="Disabled">
-        <TextArea reversed={isReversed} disabled />
-        <TextArea reversed={isReversed} disabled data-sb-pseudo-styles="hover" />
-        <TextArea reversed={isReversed} disabled data-sb-pseudo-styles="active" />
-        <TextArea reversed={isReversed} disabled data-sb-pseudo-styles="focus" />
-      </StickerSheet.Row>
-    </StickerSheet>
+    <>
+      <StickerSheet isReversed={isReversed} headers={['Default', 'Hover', 'Active', 'Focus']}>
+        <StickerSheet.Row header="Enabled">
+          <TextArea reversed={isReversed} />
+          <TextArea reversed={isReversed} data-sb-pseudo-styles="hover" />
+          <TextArea reversed={isReversed} data-sb-pseudo-styles="active" />
+          <TextArea reversed={isReversed} data-sb-pseudo-styles="focus" />
+        </StickerSheet.Row>
+        <StickerSheet.Row header="Disabled">
+          <TextArea reversed={isReversed} disabled />
+          <TextArea reversed={isReversed} disabled data-sb-pseudo-styles="hover" />
+          <TextArea reversed={isReversed} disabled data-sb-pseudo-styles="active" />
+          <TextArea reversed={isReversed} disabled data-sb-pseudo-styles="focus" />
+        </StickerSheet.Row>
+      </StickerSheet>
+      <Heading variant="heading-5" classNameOverride="mt-32 mb-12">
+        Autogrow
+      </Heading>
+      <TextArea
+        rows={1}
+        value="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque mattis nisi sit amet consectetur ultricies. Vestibulum porta arcu vitae erat egestas pulvinar. Proin tincidunt mi ultricies risus ultrices semper. Donec consequat, mi at tincidunt mattis, felis metus semper metus, a imperdiet justo odio ac elit. Nulla et lacinia enim. Donec placerat, arcu a hendrerit iaculis, massa ante venenatis urna, vitae vestibulum massa orci et erat. Sed in cursus arcu. Fusce fringilla urna tincidunt risus sodales mollis. Ut sit amet mi vitae justo aliquam congue eget eu nisl. Mauris sit amet dolor fermentum, rutrum orci eget, feugiat mi. Etiam feugiat auctor augue, non volutpat nisi aliquet non. Praesent dignissim, lacus id iaculis porttitor, purus libero fermentum urna, in faucibus massa enim sed dui. Maecenas et nisi in nulla condimentum dictum. Maecenas tincidunt turpis non consequat pharetra. Suspendisse in auctor erat, vel ullamcorper elit. Nullam rutrum pharetra turpis, id luctus nisi sollicitudin ac. Maecenas sodales malesuada orci. Integer ultrices, nisi non blandit commodo, turpis enim iaculis ante, vel blandit diam sapien eget justo. Mauris scelerisque euismod quam, nec accumsan lorem venenatis vel. Sed rhoncus purus turpis, vel efficitur metus placerat et."
+        autogrow
+      />
+    </>
   ),
   parameters: {
     pseudo: {

--- a/packages/components/src/TextArea/_docs/TextArea.stickersheet.stories.tsx
+++ b/packages/components/src/TextArea/_docs/TextArea.stickersheet.stories.tsx
@@ -1,6 +1,5 @@
 import React from 'react'
 import { Meta } from '@storybook/react'
-import { Heading } from '~components/Heading'
 import { StickerSheet, StickerSheetStory } from '~storybook/components/StickerSheet'
 import { TextArea } from '../index'
 
@@ -40,14 +39,13 @@ const StickerSheetTemplate: StickerSheetStory = {
           <TextArea reversed={isReversed} disabled data-sb-pseudo-styles="focus" />
         </StickerSheet.Row>
       </StickerSheet>
-      <Heading variant="heading-5" classNameOverride="mt-32 mb-12">
-        Autogrow
-      </Heading>
-      <TextArea
-        rows={1}
-        value="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque mattis nisi sit amet consectetur ultricies. Vestibulum porta arcu vitae erat egestas pulvinar. Proin tincidunt mi ultricies risus ultrices semper. Donec consequat, mi at tincidunt mattis, felis metus semper metus, a imperdiet justo odio ac elit. Nulla et lacinia enim. Donec placerat, arcu a hendrerit iaculis, massa ante venenatis urna, vitae vestibulum massa orci et erat. Sed in cursus arcu. Fusce fringilla urna tincidunt risus sodales mollis. Ut sit amet mi vitae justo aliquam congue eget eu nisl. Mauris sit amet dolor fermentum, rutrum orci eget, feugiat mi. Etiam feugiat auctor augue, non volutpat nisi aliquet non. Praesent dignissim, lacus id iaculis porttitor, purus libero fermentum urna, in faucibus massa enim sed dui. Maecenas et nisi in nulla condimentum dictum. Maecenas tincidunt turpis non consequat pharetra. Suspendisse in auctor erat, vel ullamcorper elit. Nullam rutrum pharetra turpis, id luctus nisi sollicitudin ac. Maecenas sodales malesuada orci. Integer ultrices, nisi non blandit commodo, turpis enim iaculis ante, vel blandit diam sapien eget justo. Mauris scelerisque euismod quam, nec accumsan lorem venenatis vel. Sed rhoncus purus turpis, vel efficitur metus placerat et."
-        autogrow
-      />
+      <StickerSheet title="Autogrow">
+        <TextArea
+          rows={1}
+          value="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque mattis nisi sit amet consectetur ultricies. Vestibulum porta arcu vitae erat egestas pulvinar. Proin tincidunt mi ultricies risus ultrices semper. Donec consequat, mi at tincidunt mattis, felis metus semper metus, a imperdiet justo odio ac elit. Nulla et lacinia enim. Donec placerat, arcu a hendrerit iaculis, massa ante venenatis urna, vitae vestibulum massa orci et erat. Sed in cursus arcu. Fusce fringilla urna tincidunt risus sodales mollis. Ut sit amet mi vitae justo aliquam congue eget eu nisl. Mauris sit amet dolor fermentum, rutrum orci eget, feugiat mi. Etiam feugiat auctor augue, non volutpat nisi aliquet non. Praesent dignissim, lacus id iaculis porttitor, purus libero fermentum urna, in faucibus massa enim sed dui. Maecenas et nisi in nulla condimentum dictum. Maecenas tincidunt turpis non consequat pharetra. Suspendisse in auctor erat, vel ullamcorper elit. Nullam rutrum pharetra turpis, id luctus nisi sollicitudin ac. Maecenas sodales malesuada orci. Integer ultrices, nisi non blandit commodo, turpis enim iaculis ante, vel blandit diam sapien eget justo. Mauris scelerisque euismod quam, nec accumsan lorem venenatis vel. Sed rhoncus purus turpis, vel efficitur metus placerat et."
+          autogrow
+        />
+      </StickerSheet>
     </>
   ),
   parameters: {


### PR DESCRIPTION
## Why
https://cultureamp.slack.com/archives/C0189KBPM4Y/p1733288289604299

## What
There's an internal version of the TextArea value held to support the autogrow feature. It was being used to feed into the TextArea in the case that value isn't provided, but that's not actually needed.
