### PR TITLE
Mark up Tiles in TileGrid as List

### DIFF
--- a/.changeset/afraid-dolls-visit.md
+++ b/.changeset/afraid-dolls-visit.md
@@ -1,0 +1,5 @@
+---
+'@kaizen/components': patch
+---
+
+TileGrid renders Tiles in a <ul>, wrapping each Tile in an <li>

--- a/packages/components/src/Tile/TileGrid/TileGrid.module.scss
+++ b/packages/components/src/Tile/TileGrid/TileGrid.module.scss
@@ -3,6 +3,7 @@
 @import '../subcomponents/GenericTile/variables';
 
 .grid {
+  list-style-type: none;
   display: grid;
   // the more we shave off the width here,
   // the less the tiles will grow when they lose one from the row

--- a/packages/components/src/Tile/TileGrid/TileGrid.tsx
+++ b/packages/components/src/Tile/TileGrid/TileGrid.tsx
@@ -1,4 +1,4 @@
-import React, { Children, HTMLAttributes, ReactElement, useId } from 'react'
+import React, { Children, HTMLAttributes, ReactElement, ReactNode, useId } from 'react'
 import classnames from 'classnames'
 import { OverrideClassName } from '~components/types/OverrideClassName'
 import { InformationTileProps } from '../InformationTile'
@@ -23,30 +23,20 @@ export const TileGrid = ({
   ...restProps
 }: TileGridProps): JSX.Element => {
   const tileGridBaseId = useId()
-
-  const tiles = getTiles(children, tileGridBaseId)
+  const child = Children.only(children)
 
   return (
     <ul className={classnames(styles.grid, classNameOverride)} data-tile-grid {...restProps}>
-      {tiles}
+      {Array.isArray(child.props.children) ? (
+        child.props.children.map((tile: TileElement, index) => (
+          <li className={classnames(styles.li)} key={`${tileGridBaseId}-${index}`}>
+            {tile}
+          </li>
+        ))
+      ) : (
+        <li className={classnames(styles.li)}>{child}</li>
+      )}
     </ul>
   )
 }
 TileGrid.displayName = 'TileGrid'
-
-const getTiles = (
-  children: TileElement | TileElement[],
-  tileGridBaseId: string,
-): JSX.Element | JSX.Element[] => {
-  const child = Children.only(children)
-
-  if (Array.isArray(child.props.children)) {
-    return child.props.children!.map((tile: TileElement, index) => (
-      <li className={classnames(styles.li)} key={`${tileGridBaseId}-${index}`}>
-        {tile}
-      </li>
-    ))
-  }
-
-  return <li className={classnames(styles.li)}>{child}</li>
-}

--- a/packages/components/src/Tile/TileGrid/TileGrid.tsx
+++ b/packages/components/src/Tile/TileGrid/TileGrid.tsx
@@ -1,4 +1,4 @@
-import React, { Children, HTMLAttributes, ReactElement } from 'react'
+import React, { HTMLAttributes, ReactElement } from 'react'
 import classnames from 'classnames'
 import { OverrideClassName } from '~components/types/OverrideClassName'
 import { InformationTileProps } from '../InformationTile'
@@ -22,20 +22,42 @@ export const TileGrid = ({
   classNameOverride,
   ...restProps
 }: TileGridProps): JSX.Element => {
-  const child = Children.only(children)
-
-  return (
-    <ul className={classnames(styles.grid, classNameOverride)} data-tile-grid {...restProps}>
-      {Array.isArray(child.props.children) ? (
-        child.props.children.map((tile: TileElement, index) => (
+  if (Array.isArray(children)) {
+    return (
+      <ul className={classnames(styles.grid, classNameOverride)} data-tile-grid {...restProps}>
+        {children.map((tile: TileElement, index) => (
           <li className={classnames(styles.li)} key={`${tile.props.title}-${index}`}>
             {tile}
           </li>
-        ))
+        ))}
+      </ul>
+    )
+  }
+
+  return (
+    <ul className={classnames(styles.grid, classNameOverride)} data-tile-grid {...restProps}>
+      {children.type === React.Fragment ? (
+        children?.props?.children ? (
+          Array.isArray(children.props.children) ? (
+            children.props.children.map((tile: TileElement, index) => (
+              <li className={classnames(styles.li)} key={`${tile.props.title}-${index}`}>
+                {tile}
+              </li>
+            ))
+          ) : (
+            <li className={classnames(styles.li)}>{children}</li>
+          )
+        ) : null
       ) : (
-        <li className={classnames(styles.li)}>{child}</li>
+        <li className={classnames(styles.li)}>{children}</li>
       )}
     </ul>
   )
 }
 TileGrid.displayName = 'TileGrid'
+
+/*
+const TileListItem = () => {
+
+}
+*/

--- a/packages/components/src/Tile/TileGrid/TileGrid.tsx
+++ b/packages/components/src/Tile/TileGrid/TileGrid.tsx
@@ -1,4 +1,4 @@
-import React, { Children, HTMLAttributes, ReactElement, ReactNode, useId } from 'react'
+import React, { Children, HTMLAttributes, ReactElement } from 'react'
 import classnames from 'classnames'
 import { OverrideClassName } from '~components/types/OverrideClassName'
 import { InformationTileProps } from '../InformationTile'
@@ -22,14 +22,13 @@ export const TileGrid = ({
   classNameOverride,
   ...restProps
 }: TileGridProps): JSX.Element => {
-  const tileGridBaseId = useId()
   const child = Children.only(children)
 
   return (
     <ul className={classnames(styles.grid, classNameOverride)} data-tile-grid {...restProps}>
       {Array.isArray(child.props.children) ? (
         child.props.children.map((tile: TileElement, index) => (
-          <li className={classnames(styles.li)} key={`${tileGridBaseId}-${index}`}>
+          <li className={classnames(styles.li)} key={`${tile.props.title}-${index}`}>
             {tile}
           </li>
         ))

--- a/packages/components/src/Tile/TileGrid/TileGrid.tsx
+++ b/packages/components/src/Tile/TileGrid/TileGrid.tsx
@@ -1,4 +1,4 @@
-import React, { HTMLAttributes, ReactElement } from 'react'
+import React, { Children, HTMLAttributes, ReactElement, useId } from 'react'
 import classnames from 'classnames'
 import { OverrideClassName } from '~components/types/OverrideClassName'
 import { InformationTileProps } from '../InformationTile'
@@ -9,7 +9,7 @@ type TileProps = InformationTileProps | MultiActionTileProps
 
 export type TileElement = ReactElement<TileProps>
 
-export interface TileGridProps extends OverrideClassName<HTMLAttributes<HTMLDivElement>> {
+export interface TileGridProps extends OverrideClassName<HTMLAttributes<HTMLUListElement>> {
   children: TileElement[] | TileElement
 }
 
@@ -21,10 +21,32 @@ export const TileGrid = ({
   children,
   classNameOverride,
   ...restProps
-}: TileGridProps): JSX.Element => (
-  <div className={classnames(styles.grid, classNameOverride)} data-tile-grid {...restProps}>
-    {children}
-  </div>
-)
+}: TileGridProps): JSX.Element => {
+  const tileGridBaseId = useId()
 
+  const tiles = getTiles(children, tileGridBaseId)
+
+  return (
+    <ul className={classnames(styles.grid, classNameOverride)} data-tile-grid {...restProps}>
+      {tiles}
+    </ul>
+  )
+}
 TileGrid.displayName = 'TileGrid'
+
+const getTiles = (
+  children: TileElement | TileElement[],
+  tileGridBaseId: string,
+): JSX.Element | JSX.Element[] => {
+  const child = Children.only(children)
+
+  if (Array.isArray(child.props.children)) {
+    return child.props.children!.map((tile: TileElement, index) => (
+      <li className={classnames(styles.li)} key={`${tileGridBaseId}-${index}`}>
+        {tile}
+      </li>
+    ))
+  }
+
+  return <li className={classnames(styles.li)}>{child}</li>
+}

--- a/packages/components/src/Tile/TileGrid/TileGrid.tsx
+++ b/packages/components/src/Tile/TileGrid/TileGrid.tsx
@@ -1,4 +1,4 @@
-import React, { HTMLAttributes, ReactElement } from 'react'
+import React, { HTMLAttributes, ReactElement, ReactNode } from 'react'
 import classnames from 'classnames'
 import { OverrideClassName } from '~components/types/OverrideClassName'
 import { InformationTileProps } from '../InformationTile'
@@ -22,42 +22,34 @@ export const TileGrid = ({
   classNameOverride,
   ...restProps
 }: TileGridProps): JSX.Element => {
-  if (Array.isArray(children)) {
-    return (
-      <ul className={classnames(styles.grid, classNameOverride)} data-tile-grid {...restProps}>
-        {children.map((tile: TileElement, index) => (
-          <li className={classnames(styles.li)} key={`${tile.props.title}-${index}`}>
-            {tile}
-          </li>
-        ))}
-      </ul>
-    )
-  }
+  const isFragment = !Array.isArray(children) && children.type === React.Fragment
 
   return (
     <ul className={classnames(styles.grid, classNameOverride)} data-tile-grid {...restProps}>
-      {children.type === React.Fragment ? (
+      {isFragment ? (
         children?.props?.children ? (
-          Array.isArray(children.props.children) ? (
-            children.props.children.map((tile: TileElement, index) => (
-              <li className={classnames(styles.li)} key={`${tile.props.title}-${index}`}>
-                {tile}
-              </li>
-            ))
-          ) : (
-            <li className={classnames(styles.li)}>{children}</li>
-          )
+          <TileListItem tiles={children.props.children} />
         ) : null
       ) : (
-        <li className={classnames(styles.li)}>{children}</li>
+        <TileListItem tiles={children} />
       )}
     </ul>
   )
 }
 TileGrid.displayName = 'TileGrid'
 
-/*
-const TileListItem = () => {
+type TileListItemProps = { tiles: ReactNode }
 
+const TileListItem = ({ tiles }: TileListItemProps): JSX.Element => {
+  if (Array.isArray(tiles)) {
+    return (
+      <>
+        {tiles.map((tile: TileElement, index) => (
+          <li key={`${tile.props.title}-${index}`}>{tile}</li>
+        ))}
+      </>
+    )
+  }
+
+  return <li>{tiles}</li>
 }
-*/

--- a/packages/components/src/Tile/TileGrid/_docs/TileGrid.stickersheet.stories.tsx
+++ b/packages/components/src/Tile/TileGrid/_docs/TileGrid.stickersheet.stories.tsx
@@ -105,6 +105,46 @@ const StickerSheetTemplate: StickerSheetStory = {
           />
         </TileGrid>
       </StickerSheet.Row>
+      <StickerSheet.Row header="Single Tile">
+        <TileGrid>
+          <InformationTile
+            title="Title"
+            metadata="Side A"
+            information="Side B"
+            footer={<>Footer</>}
+          />
+        </TileGrid>
+      </StickerSheet.Row>
+      <StickerSheet.Row header="Fragment">
+        <TileGrid>
+          <>
+            <InformationTile
+              title="Title"
+              metadata="Side A"
+              information="Side B"
+              footer={<>Footer</>}
+            />
+            <InformationTile
+              title="Title"
+              metadata="Side A"
+              information="Side B"
+              footer={<>Footer</>}
+            />
+            <InformationTile
+              title="Title"
+              metadata="Side A"
+              information="Side B"
+              footer={<>Footer</>}
+            />
+            <InformationTile
+              title="Title"
+              metadata="Side A"
+              information="Side B"
+              footer={<>Footer</>}
+            />
+          </>
+        </TileGrid>
+      </StickerSheet.Row>
     </StickerSheet>
   ),
 }

--- a/packages/components/src/Tile/TileGrid/_docs/TileGrid.stories.tsx
+++ b/packages/components/src/Tile/TileGrid/_docs/TileGrid.stories.tsx
@@ -78,3 +78,43 @@ export const FlipOneNotOthers: Story = {
     })
   },
 }
+
+// Does it work with one tile
+export const OneTile: Story = {
+  args: {
+    children: (
+      <InformationTile
+        title="Title A"
+        metadata="Side A"
+        information="Side A - Back"
+        footer={<>Footer</>}
+      />
+    ),
+  },
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement)
+
+    await step('initial render complete', async () => {
+      await waitFor(() => {
+        expect(canvas.getByRole('listitem')).toBeInTheDocument()
+      })
+    })
+  },
+}
+
+// Multiple tiles
+export const MultipleTiles: Story = {
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement)
+
+    await step('initial render complete', async () => {
+      await waitFor(() => {
+        const listOfTiles = canvas.getByRole('list')
+        const { getAllByRole } = within(listOfTiles)
+        const tiles = getAllByRole('listitem')
+
+        expect(tiles.length).toBe(3)
+      })
+    })
+  },
+}

--- a/packages/components/src/Tile/TileGrid/_docs/TileGrid.stories.tsx
+++ b/packages/components/src/Tile/TileGrid/_docs/TileGrid.stories.tsx
@@ -94,7 +94,7 @@ export const OneTile: Story = {
   play: async ({ canvasElement, step }) => {
     const canvas = within(canvasElement)
 
-    await step('initial render complete', async () => {
+    await step('Tile renders as <li>', async () => {
       await waitFor(() => {
         expect(canvas.getByRole('listitem')).toBeInTheDocument()
       })
@@ -107,7 +107,7 @@ export const MultipleTiles: Story = {
   play: async ({ canvasElement, step }) => {
     const canvas = within(canvasElement)
 
-    await step('initial render complete', async () => {
+    await step('All Tiles marked up as individual <li> elements', async () => {
       await waitFor(() => {
         const listOfTiles = canvas.getByRole('list')
         const { getAllByRole } = within(listOfTiles)

--- a/packages/components/src/Tile/TileGrid/_docs/TileGrid.stories.tsx
+++ b/packages/components/src/Tile/TileGrid/_docs/TileGrid.stories.tsx
@@ -47,7 +47,6 @@ export const Playground: Story = {
   },
 }
 
-// Test for multiple tiles, flipping one doesn't flip others
 export const FlipOneNotOthers: Story = {
   play: async ({ canvasElement, step }) => {
     const canvas = within(canvasElement)
@@ -79,9 +78,6 @@ export const FlipOneNotOthers: Story = {
   },
 }
 
-// @Zystix: Add Chromatic flag to tests or add to stickersheet.
-
-// Does it work with one tile
 export const OneTile: Story = {
   args: {
     children: (
@@ -104,7 +100,6 @@ export const OneTile: Story = {
   },
 }
 
-// Multiple tiles
 export const MultipleTiles: Story = {
   render: () => {
     return (

--- a/packages/components/src/Tile/TileGrid/_docs/TileGrid.stories.tsx
+++ b/packages/components/src/Tile/TileGrid/_docs/TileGrid.stories.tsx
@@ -104,6 +104,46 @@ export const OneTile: Story = {
 
 // Multiple tiles
 export const MultipleTiles: Story = {
+  render: () => {
+    return (
+      <TileGrid>
+        <InformationTile
+          title="Title A"
+          metadata="Side A"
+          information="Side A - Back"
+          footer={<>Footer</>}
+        />
+        <InformationTile
+          title="Title B"
+          metadata="Side B"
+          information="Side B - Back"
+          footer={<>Footer</>}
+        />
+        <InformationTile
+          title="Title C"
+          metadata="Side C"
+          information="Side C - Back"
+          footer={<>Footer</>}
+        />
+      </TileGrid>
+    )
+  },
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement)
+
+    await step('All Tiles marked up as individual <li> elements', async () => {
+      await waitFor(() => {
+        const listOfTiles = canvas.getByRole('list')
+        const { getAllByRole } = within(listOfTiles)
+        const tiles = getAllByRole('listitem')
+
+        expect(tiles.length).toBe(3)
+      })
+    })
+  },
+}
+
+export const Fragment: Story = {
   play: async ({ canvasElement, step }) => {
     const canvas = within(canvasElement)
 

--- a/packages/components/src/Tile/TileGrid/_docs/TileGrid.stories.tsx
+++ b/packages/components/src/Tile/TileGrid/_docs/TileGrid.stories.tsx
@@ -79,6 +79,8 @@ export const FlipOneNotOthers: Story = {
   },
 }
 
+// @Zystix: Add Chromatic flag to tests or add to stickersheet.
+
 // Does it work with one tile
 export const OneTile: Story = {
   args: {


### PR DESCRIPTION
## Why

Marking up TileGrid items in a list so that screen readers can report on how many tiles are in a list, so that context about the TileGrid is more accessible.

https://cultureamp.atlassian.net/browse/KZN-2865

## What

Converted TileGrid to contain its children in an unordered list and wrapped each tile in a list item when passed as props to the TileGrid.