### PR TITLE
1:1 Future Tags hover state incorrect

### DIFF
--- a/.changeset/lemon-kings-push.md
+++ b/.changeset/lemon-kings-push.md
@@ -1,0 +1,5 @@
+---
+'@kaizen/components': patch
+---
+
+Made Future Tab hover cursor consistent with current Tab.

--- a/packages/components/src/__future__/Tabs/subcomponents/Tab/Tab.module.css
+++ b/packages/components/src/__future__/Tabs/subcomponents/Tab/Tab.module.css
@@ -31,6 +31,10 @@
     opacity: 0.3;
   }
 
+  &[data-disabled]:hover {
+    cursor: default;
+  }
+
   &:not(:first-child) {
     margin-inline-start: var(--spacing-xs);
   }
@@ -38,6 +42,7 @@
   &:not([data-disabled]):hover {
     background: var(--color-blue-100);
     color: var(--color-blue-500);
+    cursor: default;
   }
 }
 
@@ -91,8 +96,4 @@
     bottom: 0;
     border-bottom: 2px solid transparent;
   }
-}
-
-.tab:hover {
-  cursor: pointer;
 }

--- a/packages/components/src/__future__/Tabs/subcomponents/Tab/Tab.module.css
+++ b/packages/components/src/__future__/Tabs/subcomponents/Tab/Tab.module.css
@@ -92,3 +92,7 @@
     border-bottom: 2px solid transparent;
   }
 }
+
+.tab:hover {
+  cursor: pointer;
+}

--- a/packages/components/src/__future__/Tabs/subcomponents/Tab/Tab.module.css
+++ b/packages/components/src/__future__/Tabs/subcomponents/Tab/Tab.module.css
@@ -16,6 +16,7 @@
   line-height: var(--typography-heading-4-line-height);
   letter-spacing: var(--typography-heading-4-letter-spacing);
   color: var(--color-purple-800);
+  cursor: default;
 
   &:focus {
     outline: none;
@@ -31,10 +32,6 @@
     opacity: 0.3;
   }
 
-  &[data-disabled]:hover {
-    cursor: default;
-  }
-
   &:not(:first-child) {
     margin-inline-start: var(--spacing-xs);
   }
@@ -42,7 +39,6 @@
   &:not([data-disabled]):hover {
     background: var(--color-blue-100);
     color: var(--color-blue-500);
-    cursor: default;
   }
 }
 


### PR DESCRIPTION
## Why

Hovering over the Future Tabs turns your cursor into the text input variant instead of the default. This has been changed to be consistent with the current Tab component. 

https://cultureamp.atlassian.net/browse/KZN-2916

## What

Set the cursor to default on hover when tab is disabled and not disabled.
