### PR TITLE
Build RAC Popover into Menu to simplify API

### DIFF
--- a/.changeset/flat-taxis-cross.md
+++ b/.changeset/flat-taxis-cross.md
@@ -1,0 +1,5 @@
+---
+'@kaizen/components': patch
+---
+
+Build RAC Popover into Menu to simplify API

--- a/packages/components/src/__actions__/Menu/v3/Menu.tsx
+++ b/packages/components/src/__actions__/Menu/v3/Menu.tsx
@@ -1,5 +1,5 @@
 import React, { forwardRef } from 'react'
-import { Menu as RACMenu, MenuProps as RACMenuProps } from 'react-aria-components'
+import { Popover, Menu as RACMenu, MenuProps as RACMenuProps } from 'react-aria-components'
 import { mergeClassNames } from '~components/utils/mergeClassNames'
 import styles from './Menu.module.css'
 
@@ -13,7 +13,9 @@ export type MenuProps = Omit<
  */
 export const Menu = forwardRef<HTMLDivElement, MenuProps>(
   ({ className, ...props }, ref): JSX.Element => (
-    <RACMenu className={mergeClassNames(styles.menu, className)} ref={ref} {...props} />
+    <Popover>
+      <RACMenu className={mergeClassNames(styles.menu, className)} ref={ref} {...props} />
+    </Popover>
   ),
 )
 

--- a/packages/components/src/__actions__/Menu/v3/MenuTrigger.tsx
+++ b/packages/components/src/__actions__/Menu/v3/MenuTrigger.tsx
@@ -7,6 +7,6 @@ import {
 export type MenuTriggerProps = Omit<RACMenuTriggerProps, 'trigger'>
 
 /**
- * A MenuTrigger adds open/close functionality when wrapping a Button and a Popover (with a Menu inside of the Popover)
+ * A MenuTrigger adds open/close functionality when wrapping a <Button> and a <Menu>
  */
 export const MenuTrigger = (props: MenuTriggerProps): JSX.Element => <RACMenuTrigger {...props} />

--- a/packages/components/src/__actions__/Menu/v3/_docs/ApiSpecification.mdx
+++ b/packages/components/src/__actions__/Menu/v3/_docs/ApiSpecification.mdx
@@ -37,7 +37,7 @@ Updated July 4, 2024
 {' '}
 
 <Source
-  code={'import { Popover, Section, Header } from "@kaizen/components/v3/react-aria-components"'}
+  code={'import { Section, Header } from "@kaizen/components/v3/react-aria-components"'}
   language="tsx"
 />
 
@@ -54,12 +54,10 @@ A menu displays a list of actions in a popover, toggled opened with a button.
     code: `
 <MenuTrigger>
   <Button><Icon name="more_horiz" alt="Actions" /></Button>
-  <Popover>
-    <Menu>
-      <MenuItem href="#">Menu Item</MenuItem>
-      <MenuItem onAction={handleAction}>Menu Item</MenuItem>
-    </Menu>
-  </Popover>
+  <Menu>
+    <MenuItem href="#">Menu Item</MenuItem>
+    <MenuItem onAction={handleAction}>Menu Item</MenuItem>
+  </Menu>
 </MenuTrigger>
   `,
   }}

--- a/packages/components/src/__actions__/Menu/v3/_docs/Menu.docs.stories.tsx
+++ b/packages/components/src/__actions__/Menu/v3/_docs/Menu.docs.stories.tsx
@@ -1,7 +1,6 @@
 import React, { FunctionComponent, ReactNode } from 'react'
 import { Meta, StoryObj } from '@storybook/react'
 import isChromatic from 'chromatic'
-import { Popover } from 'react-aria-components'
 import { Button } from '~components/__actions__/v3'
 import { Icon } from '~components/__future__/Icon'
 import { Menu, MenuItem, MenuTrigger } from '../index'
@@ -41,12 +40,10 @@ export const Actions: Story = {
       >
         Additional actions
       </Button>
-      <Popover>
-        <Menu>
-          <MenuItem href="https://cultureamp.com">Action that navigates</MenuItem>
-          <MenuItem onAction={() => null}>Non-navigation action</MenuItem>
-        </Menu>
-      </Popover>
+      <Menu>
+        <MenuItem href="https://cultureamp.com">Action that navigates</MenuItem>
+        <MenuItem onAction={() => null}>Non-navigation action</MenuItem>
+      </Menu>
     </MenuTrigger>
   ),
 }
@@ -62,11 +59,9 @@ export const ItemsDo: Story = {
       >
         Additional actions
       </Button>
-      <Popover>
-        <Menu>
-          <DefaultMenuItems />
-        </Menu>
-      </Popover>
+      <Menu>
+        <DefaultMenuItems />
+      </Menu>
     </MenuTrigger>
   ),
 }
@@ -82,11 +77,9 @@ export const ItemsDont: Story = {
       >
         Additional actions
       </Button>
-      <Popover>
-        <Menu>
-          <MenuItem icon={<Icon name="delete" isPresentational isFilled />}>Delete</MenuItem>
-        </Menu>
-      </Popover>
+      <Menu>
+        <MenuItem icon={<Icon name="delete" isPresentational isFilled />}>Delete</MenuItem>
+      </Menu>
     </MenuTrigger>
   ),
 }
@@ -98,12 +91,10 @@ export const SelectionDont: Story = {
         Sort by
         <Icon name="keyboard_arrow_down" isPresentational />
       </Button>
-      <Popover>
-        <Menu>
-          <MenuItem icon={<Icon name="check" isPresentational />}>Recommended</MenuItem>
-          <MenuItem>Most recent</MenuItem>
-        </Menu>
-      </Popover>
+      <Menu>
+        <MenuItem icon={<Icon name="check" isPresentational />}>Recommended</MenuItem>
+        <MenuItem>Most recent</MenuItem>
+      </Menu>
     </MenuTrigger>
   ),
 }
@@ -115,11 +106,9 @@ export const LabelChevronDo: Story = {
         Edit item
         <Icon name="keyboard_arrow_down" isPresentational />
       </Button>
-      <Popover>
-        <Menu>
-          <DefaultMenuItems />
-        </Menu>
-      </Popover>
+      <Menu>
+        <DefaultMenuItems />
+      </Menu>
     </MenuTrigger>
   ),
 }
@@ -128,11 +117,9 @@ export const LabelChevronDont: Story = {
   render: ({ defaultOpen, ...args }) => (
     <MenuTrigger defaultOpen={defaultOpen} {...args}>
       <Button variant="secondary">Edit item</Button>
-      <Popover>
-        <Menu>
-          <DefaultMenuItems />
-        </Menu>
-      </Popover>
+      <Menu>
+        <DefaultMenuItems />
+      </Menu>
     </MenuTrigger>
   ),
 }
@@ -144,11 +131,9 @@ export const LabelDo: Story = {
         Actions [visually hidden], conversation with Harper[/visually hidden]
         <Icon name="keyboard_arrow_down" isPresentational />
       </Button>
-      <Popover>
-        <Menu {...args}>
-          <DefaultMenuItems />
-        </Menu>
-      </Popover>
+      <Menu {...args}>
+        <DefaultMenuItems />
+      </Menu>
     </MenuTrigger>
   ),
 }
@@ -160,11 +145,9 @@ export const LabelDont: Story = {
         Open menu
         <Icon name="keyboard_arrow_down" isPresentational />
       </Button>
-      <Popover>
-        <Menu {...args}>
-          <DefaultMenuItems />
-        </Menu>
-      </Popover>
+      <Menu {...args}>
+        <DefaultMenuItems />
+      </Menu>
     </MenuTrigger>
   ),
 }
@@ -180,18 +163,16 @@ export const IconsDont: Story = {
       >
         Additional actions
       </Button>
-      <Popover>
-        <Menu {...args}>
-          <MenuItem icon={<Icon name="edit" isPresentational isFilled />}>
-            Edit &lsquo;Strengths&rsquo;
-          </MenuItem>
-          <MenuItem icon={<Icon name="edit" isPresentational isFilled />}>
-            Edit &lsquo;Weaknesses&rsquo;
-          </MenuItem>
-          <MenuItem>Export PDF</MenuItem>
-          <MenuItem>Export Powerpoint</MenuItem>
-        </Menu>
-      </Popover>
+      <Menu {...args}>
+        <MenuItem icon={<Icon name="edit" isPresentational isFilled />}>
+          Edit &lsquo;Strengths&rsquo;
+        </MenuItem>
+        <MenuItem icon={<Icon name="edit" isPresentational isFilled />}>
+          Edit &lsquo;Weaknesses&rsquo;
+        </MenuItem>
+        <MenuItem>Export PDF</MenuItem>
+        <MenuItem>Export Powerpoint</MenuItem>
+      </Menu>
     </MenuTrigger>
   ),
 }
@@ -207,13 +188,11 @@ export const MenuItemLabelsDont: Story = {
       >
         Additional actions
       </Button>
-      <Popover>
-        <Menu {...args}>
-          <MenuItem>Save comment</MenuItem>
-          <MenuItem>Edit comment</MenuItem>
-          <MenuItem>Delete comment</MenuItem>
-        </Menu>
-      </Popover>
+      <Menu {...args}>
+        <MenuItem>Save comment</MenuItem>
+        <MenuItem>Edit comment</MenuItem>
+        <MenuItem>Delete comment</MenuItem>
+      </Menu>
     </MenuTrigger>
   ),
 }
@@ -229,13 +208,11 @@ export const SentenceCaseDo: Story = {
       >
         Additional actions
       </Button>
-      <Popover>
-        <Menu {...args}>
-          <MenuItem>Quick export</MenuItem>
-          <MenuItem>Open a copy</MenuItem>
-          <MenuItem>Share a link</MenuItem>
-        </Menu>
-      </Popover>
+      <Menu {...args}>
+        <MenuItem>Quick export</MenuItem>
+        <MenuItem>Open a copy</MenuItem>
+        <MenuItem>Share a link</MenuItem>
+      </Menu>
     </MenuTrigger>
   ),
 }
@@ -251,13 +228,11 @@ export const SentenceCaseDont: Story = {
       >
         Additional actions
       </Button>
-      <Popover>
-        <Menu {...args}>
-          <MenuItem>Quick Export</MenuItem>
-          <MenuItem>Open A Copy</MenuItem>
-          <MenuItem>Share A Link</MenuItem>
-        </Menu>
-      </Popover>
+      <Menu {...args}>
+        <MenuItem>Quick Export</MenuItem>
+        <MenuItem>Open A Copy</MenuItem>
+        <MenuItem>Share A Link</MenuItem>
+      </Menu>
     </MenuTrigger>
   ),
 }
@@ -273,13 +248,11 @@ export const ElipsesDo: Story = {
       >
         Additional actions
       </Button>
-      <Popover>
-        <Menu {...args}>
-          <MenuItem>Quick export</MenuItem>
-          <MenuItem>Open a copy</MenuItem>
-          <MenuItem>Share a link</MenuItem>
-        </Menu>
-      </Popover>
+      <Menu {...args}>
+        <MenuItem>Quick export</MenuItem>
+        <MenuItem>Open a copy</MenuItem>
+        <MenuItem>Share a link</MenuItem>
+      </Menu>
     </MenuTrigger>
   ),
 }
@@ -295,13 +268,11 @@ export const ElipsesDont: Story = {
       >
         Additional actions
       </Button>
-      <Popover>
-        <Menu {...args}>
-          <MenuItem>Quick export…</MenuItem>
-          <MenuItem>Open a copy…</MenuItem>
-          <MenuItem>Share a link…</MenuItem>
-        </Menu>
-      </Popover>
+      <Menu {...args}>
+        <MenuItem>Quick export…</MenuItem>
+        <MenuItem>Open a copy…</MenuItem>
+        <MenuItem>Share a link…</MenuItem>
+      </Menu>
     </MenuTrigger>
   ),
 }

--- a/packages/components/src/__actions__/Menu/v3/_docs/Menu.mdx
+++ b/packages/components/src/__actions__/Menu/v3/_docs/Menu.mdx
@@ -41,18 +41,16 @@ A menu displays a list of actions in a popover, toggled opened with a button.
   of={MenuStories.Playground}
   source={{
     code: `
-<TooltipTrigger>
+<MenuTrigger>
   <Button>
     <Icon name="more_horiz" alt="Additional actions" />
   </Button>
-  <Popover>
-    <Menu>
-      <MenuItem>Save</MenuItem>
-      <MenuItem>Edit</MenuItem>
-      <MenuItem>Delete</MenuItem>
-    </Menu>
-  </Popover>
-</TooltipTrigger>
+  <Menu>
+    <MenuItem>Save</MenuItem>
+    <MenuItem>Edit</MenuItem>
+    <MenuItem>Delete</MenuItem>
+  </Menu>
+</MenuTrigger>
   `,
   }}
 />

--- a/packages/components/src/__actions__/Menu/v3/_docs/Menu.spec.stories.tsx
+++ b/packages/components/src/__actions__/Menu/v3/_docs/Menu.spec.stories.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react'
 import { Meta, StoryObj } from '@storybook/react'
 import { expect, userEvent, waitFor, within, fn } from '@storybook/test'
 import isChromatic from 'chromatic'
-import { Popover, Header, Section } from 'react-aria-components'
+import { Header, Section } from 'react-aria-components'
 import { Button } from '~components/__actions__/v3'
 import { Icon } from '~components/__future__/Icon'
 import { Menu, MenuItem, MenuTrigger } from '../index'
@@ -44,35 +44,30 @@ export const KitchenSink: Story = {
       >
         Additional actions
       </Button>
-      <Popover>
-        <Menu>
-          <Section>
-            <Header>Section One</Header>
-            <MenuItem
-              icon={<Icon name="bookmark" isPresentational />}
-              href="https://cultureamp.com"
-            >
-              Save
-            </MenuItem>
-            <MenuItem icon={<Icon name="edit" isPresentational isFilled />}>Edit</MenuItem>
-          </Section>
-          <Section>
-            <MenuItem icon={<Icon name="arrow_upward" isPresentational />}>Move Up</MenuItem>
-            <MenuItem icon={<Icon name="arrow_downward" isPresentational />}>
-              Menu item with a longer label
-            </MenuItem>
-          </Section>
-          <Section>
-            <MenuItem icon={<Icon name="delete" isPresentational isFilled />}>Delete</MenuItem>
-            <MenuItem icon={<Icon name="delete" isPresentational isFilled />} isDisabled>
-              Delete but disabled
-            </MenuItem>
-            <MenuItem>Other action</MenuItem>
-            <MenuItem>Other action</MenuItem>
-            <MenuItem>Other action</MenuItem>
-          </Section>
-        </Menu>
-      </Popover>
+      <Menu>
+        <Section>
+          <Header>Section One</Header>
+          <MenuItem icon={<Icon name="bookmark" isPresentational />} href="https://cultureamp.com">
+            Save
+          </MenuItem>
+          <MenuItem icon={<Icon name="edit" isPresentational isFilled />}>Edit</MenuItem>
+        </Section>
+        <Section>
+          <MenuItem icon={<Icon name="arrow_upward" isPresentational />}>Move Up</MenuItem>
+          <MenuItem icon={<Icon name="arrow_downward" isPresentational />}>
+            Menu item with a longer label
+          </MenuItem>
+        </Section>
+        <Section>
+          <MenuItem icon={<Icon name="delete" isPresentational isFilled />}>Delete</MenuItem>
+          <MenuItem icon={<Icon name="delete" isPresentational isFilled />} isDisabled>
+            Delete but disabled
+          </MenuItem>
+          <MenuItem>Other action</MenuItem>
+          <MenuItem>Other action</MenuItem>
+          <MenuItem>Other action</MenuItem>
+        </Section>
+      </Menu>
     </MenuTrigger>
   ),
 }
@@ -88,27 +83,24 @@ export const Basic: Story = {
       >
         Additional actions
       </Button>
-
-      <Popover>
-        <Menu>
-          <MenuItem
-            icon={<Icon name="warning" isPresentational isFilled />}
-            onAction={() => alert('Menu item pressed')}
-          >
-            Trigger an alert
-          </MenuItem>
-          <MenuItem
-            icon={<Icon name="open_in_new" isPresentational />}
-            href="https://cultureamp.com"
-            target="_blank"
-          >
-            Go to cultureamp.com
-          </MenuItem>
-          <MenuItem>Item 3</MenuItem>
-          <MenuItem>Item 4</MenuItem>
-          <MenuItem>Item 5</MenuItem>
-        </Menu>
-      </Popover>
+      <Menu>
+        <MenuItem
+          icon={<Icon name="warning" isPresentational isFilled />}
+          onAction={() => alert('Menu item pressed')}
+        >
+          Trigger an alert
+        </MenuItem>
+        <MenuItem
+          icon={<Icon name="open_in_new" isPresentational />}
+          href="https://cultureamp.com"
+          target="_blank"
+        >
+          Go to cultureamp.com
+        </MenuItem>
+        <MenuItem>Item 3</MenuItem>
+        <MenuItem>Item 4</MenuItem>
+        <MenuItem>Item 5</MenuItem>
+      </Menu>
     </MenuTrigger>
   ),
   play: async ({ canvasElement, step }) => {
@@ -165,17 +157,15 @@ export const DisabledItems: Story = {
       >
         Additional actions
       </Button>
-      <Popover>
-        <Menu>
-          <MenuItem isDisabled onAction={mockOnClick}>
-            Item 1
-          </MenuItem>
-          <MenuItem>Item 2</MenuItem>
-          <MenuItem isDisabled>Item 3</MenuItem>
-          <MenuItem>Item 4</MenuItem>
-          <MenuItem>Item 5</MenuItem>
-        </Menu>
-      </Popover>
+      <Menu>
+        <MenuItem isDisabled onAction={mockOnClick}>
+          Item 1
+        </MenuItem>
+        <MenuItem>Item 2</MenuItem>
+        <MenuItem isDisabled>Item 3</MenuItem>
+        <MenuItem>Item 4</MenuItem>
+        <MenuItem>Item 5</MenuItem>
+      </Menu>
     </MenuTrigger>
   ),
   play: async ({ canvasElement, step }) => {
@@ -210,22 +200,20 @@ export const WithSections: Story = {
       >
         Additional actions
       </Button>
-      <Popover>
-        <Menu>
-          <Section>
-            <Header>Section One</Header>
-            <MenuItem>Item 1</MenuItem>
-            <MenuItem>Item 2</MenuItem>
-          </Section>
+      <Menu>
+        <Section>
+          <Header>Section One</Header>
+          <MenuItem>Item 1</MenuItem>
+          <MenuItem>Item 2</MenuItem>
+        </Section>
 
-          <Section>
-            <Header>Section Two</Header>
-            <MenuItem>Item 3</MenuItem>
-            <MenuItem>Item 4</MenuItem>
-            <MenuItem>Item 5</MenuItem>
-          </Section>
-        </Menu>
-      </Popover>
+        <Section>
+          <Header>Section Two</Header>
+          <MenuItem>Item 3</MenuItem>
+          <MenuItem>Item 4</MenuItem>
+          <MenuItem>Item 5</MenuItem>
+        </Section>
+      </Menu>
     </MenuTrigger>
   ),
 }
@@ -246,15 +234,13 @@ export const Controlled: Story = {
           >
             Additional actions
           </Button>
-          <Popover>
-            <Menu>
-              <MenuItem>Item 1</MenuItem>
-              <MenuItem onAction={() => setOpen(true)}>Item 2</MenuItem>
-              <MenuItem>Item 3</MenuItem>
-              <MenuItem>Item 4</MenuItem>
-              <MenuItem>Item 5</MenuItem>
-            </Menu>
-          </Popover>
+          <Menu>
+            <MenuItem>Item 1</MenuItem>
+            <MenuItem onAction={() => setOpen(true)}>Item 2</MenuItem>
+            <MenuItem>Item 3</MenuItem>
+            <MenuItem>Item 4</MenuItem>
+            <MenuItem>Item 5</MenuItem>
+          </Menu>
         </MenuTrigger>
       </>
     )

--- a/packages/components/src/__actions__/Menu/v3/_docs/Menu.stories.tsx
+++ b/packages/components/src/__actions__/Menu/v3/_docs/Menu.stories.tsx
@@ -1,7 +1,6 @@
 import React, { FunctionComponent } from 'react'
 import { Meta, StoryObj } from '@storybook/react'
 import isChromatic from 'chromatic'
-import { Popover } from 'react-aria-components'
 import { Text } from '~components/Text'
 import { Button } from '~components/__actions__/v3'
 import { Icon } from '~components/__future__/Icon'
@@ -33,15 +32,13 @@ export const Playground: Story = {
       >
         Additional actions
       </Button>
-      <Popover>
-        <Menu>
-          <MenuItem icon={<Icon name="bookmark" isPresentational />}>Save</MenuItem>
-          <MenuItem icon={<Icon name="edit" isPresentational isFilled />}>Edit</MenuItem>
-          <MenuItem icon={<Icon name="arrow_upward" isPresentational />}>Move up</MenuItem>
-          <MenuItem icon={<Icon name="arrow_downward" isPresentational />}>Move down</MenuItem>
-          <MenuItem icon={<Icon name="delete" isPresentational isFilled />}>Delete</MenuItem>
-        </Menu>
-      </Popover>
+      <Menu>
+        <MenuItem icon={<Icon name="bookmark" isPresentational />}>Save</MenuItem>
+        <MenuItem icon={<Icon name="edit" isPresentational isFilled />}>Edit</MenuItem>
+        <MenuItem icon={<Icon name="arrow_upward" isPresentational />}>Move up</MenuItem>
+        <MenuItem icon={<Icon name="arrow_downward" isPresentational />}>Move down</MenuItem>
+        <MenuItem icon={<Icon name="delete" isPresentational isFilled />}>Delete</MenuItem>
+      </Menu>
     </MenuTrigger>
   ),
 }
@@ -71,28 +68,26 @@ export const RichContent: Story = {
       >
         Additional actions
       </Button>
-      <Popover>
-        <Menu>
-          <MenuItem textValue="Save">
-            <div>Save</div>
-            <Text tag="div" variant="extra-small">
-              Saves all data
-            </Text>
-          </MenuItem>
-          <MenuItem textValue="Edit">
-            <div>Edit</div>
-            <Text tag="div" variant="extra-small">
-              Adjust the name and description
-            </Text>
-          </MenuItem>
-          <MenuItem textValue="Delete">
-            Delete
-            <Text tag="div" variant="extra-small">
-              Completely remove, cannot be undone
-            </Text>
-          </MenuItem>
-        </Menu>
-      </Popover>
+      <Menu>
+        <MenuItem textValue="Save">
+          <div>Save</div>
+          <Text tag="div" variant="extra-small">
+            Saves all data
+          </Text>
+        </MenuItem>
+        <MenuItem textValue="Edit">
+          <div>Edit</div>
+          <Text tag="div" variant="extra-small">
+            Adjust the name and description
+          </Text>
+        </MenuItem>
+        <MenuItem textValue="Delete">
+          Delete
+          <Text tag="div" variant="extra-small">
+            Completely remove, cannot be undone
+          </Text>
+        </MenuItem>
+      </Menu>
     </MenuTrigger>
   ),
 }


### PR DESCRIPTION
## Why
Currently v3 Menu requires consumers to pull `Popover` from `react-aria-components` every time.

The only downside is that it would no longer allow someone to add a Menu _not_ inside a Popover. e.g.
<img width="626" alt="image" src="https://github.com/user-attachments/assets/77146d52-b5b3-457b-8f9d-d4d13a26f5bf" />

If we really wanted to support that, we could create a subcomponent and expose that, but I can't imagine any use case for this.


## What
Bake RAC `Popover` into `Menu` so to simplify the API down

### Before

```
<MenuTrigger>
  <Button />
  <Popover>
    <Menu />
  </Popover>
</MenuTrigger>
```

### After
```
<MenuTrigger>
  <Button />
  <Menu />
</MenuTrigger>
```
