### PR TITLE
fix MenuItem and Tab RAC children type issue

### DIFF
--- a/.changeset/gorgeous-numbers-beg.md
+++ b/.changeset/gorgeous-numbers-beg.md
@@ -1,0 +1,5 @@
+---
+'@kaizen/components': patch
+---
+
+Update RC MenuItem and Tab child render to fix types and allow for RAC render props

--- a/packages/components/src/__rc__/Menu/MenuItem.tsx
+++ b/packages/components/src/__rc__/Menu/MenuItem.tsx
@@ -26,16 +26,14 @@ export const MenuItem = forwardRef<HTMLDivElement, MenuItemProps>(
         textValue={determinedTextValue}
         {...props}
       >
-        <>
-          {typeof children === 'string' && icon ? (
-            <div className={styles.flexWrapper}>
-              <span className={styles.iconWrapper}>{icon}</span>
-              {children}
-            </div>
-          ) : (
-            <>{children}</>
-          )}
-        </>
+        {typeof children === 'string' && icon ? (
+          <div className={styles.flexWrapper}>
+            <span className={styles.iconWrapper}>{icon}</span>
+            {children}
+          </div>
+        ) : (
+          children
+        )}
       </RACMenuItem>
     )
   },

--- a/packages/components/src/__rc__/Tabs/subcomponents/Tab/Tab.tsx
+++ b/packages/components/src/__rc__/Tabs/subcomponents/Tab/Tab.tsx
@@ -29,12 +29,20 @@ export const Tab = (props: TabProps): JSX.Element => {
 
   return (
     <RACTab data-kz-tab {...tabProps}>
-      {({ isSelected, isFocusVisible, isHovered }) => (
+      {(TabRenderProps) => (
         <>
-          {children}
+          {typeof children === 'function' ? children(TabRenderProps) : children}
           {badge && (
             <span className={styles.badge}>
-              <Badge variant={isSelected || isFocusVisible || isHovered ? 'active' : 'default'}>
+              <Badge
+                variant={
+                  TabRenderProps.isSelected ||
+                  TabRenderProps.isFocusVisible ||
+                  TabRenderProps.isHovered
+                    ? 'active'
+                    : 'default'
+                }
+              >
                 {badge}
               </Badge>
             </span>


### PR DESCRIPTION
## Important: Request PR reviews on Slack

Please reach out to the design system team on Slack in `#prod_design_system` for PR reviews. GitHub notifications (e.g. from tagging a person) are not actively monitored.

## Why
Some I noticed when working through dep update was some type issue with Children in these components. As RAC can accept children either as a function with render props or a React node there's were throwing a type error. I've made this small change to fix this, which should account for both scenarios. If we don't want this as a feature from RAC then we should update the children type :) You've probably got more context on this @dougmacknz so if you get a squiz, otherwise keen for any other feedback

![Screenshot 2025-01-14 at 1 38 23 PM](https://github.com/user-attachments/assets/93944218-c3e7-4703-a6e2-666970660906)


## What
Update child rendering in MenuItem and Tab rc
