### PR TITLE
update build storybook script

### DIFF
--- a/.buildkite/scripts/build-storybook.sh
+++ b/.buildkite/scripts/build-storybook.sh
@@ -4,7 +4,18 @@ set -e
 # shellcheck source=setup-registry.sh
 . ".buildkite/scripts/helpers/setup-registry.sh"
 
+echo "--- Build Storybook"
 corepack enable
+echo "--- installing deps"
 pnpm install --frozen-lockfile
-pnpm turbo build:docs --filter=@docs/storybook
-tar -czf ./storybook.tar.gz ./docs/storybook-static
+echo "--- building storybook"
+if pnpm turbo build:docs --filter=@docs/storybook; then
+  echo "--- unpack Storybook" to ./docs/storybook-static
+  if tar -czf ./storybook.tar.gz ./docs/storybook-static; then
+    echo "Build and unpack of Storybook successful"
+    exit 0
+  fi
+fi
+
+echo "Build or unpack of Storybook failed"
+exit 1

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -40,4 +40,12 @@ export default {
     globals: true,
     setupFiles: path.resolve(__dirname, './vitest.setup.ts'),
   },
+  css: {
+    preprocessorOptions: {
+      scss: {
+        // This surpresses the warning on dart-sass. As we are sunsetting our use of scss in Kaizen, this will not be a required dep update and just creates noise
+        silenceDeprecations: ['legacy-js-api'],
+      },
+    },
+  },
 }


### PR DESCRIPTION
## Why
Storybook is currently hanging on our Build Storybook step in Buildkite. This causes our build to time out after 15m depsite looking like it should be finished (all other build logs seem to indicate that its fine). This PR is to test out if adding a success (0) or fail exit code (1) will impact this.

## What
- Add some additional echos in the script for easier logging
- Add an exit code
