### PR TITLE
Revert margin to padding change on Content

### DIFF
--- a/.changeset/brave-keys-check.md
+++ b/.changeset/brave-keys-check.md
@@ -1,0 +1,5 @@
+---
+'@kaizen/components': patch
+---
+
+[Revert] Content: use padding instead of margin for inline spacing

--- a/packages/components/src/Content/Content.module.scss
+++ b/packages/components/src/Content/Content.module.scss
@@ -3,10 +3,10 @@
 
 .content {
   max-width: $layout-content-max-width;
-  padding: 0 $layout-content-side-margin;
+  margin: 0 $layout-content-side-margin;
   width: 100%;
 
   @media (max-width: calc(#{$layout-breakpoints-large} - 1px)) {
-    padding: 0 $content-margin-width-on-medium-and-small;
+    margin: 0 $content-margin-width-on-medium-and-small;
   }
 }


### PR DESCRIPTION
Reverts https://github.com/cultureamp/kaizen-design-system/pull/5444 due to unforeseen side effects where the content width got smaller.