### PR TITLE
Content: Adjust width on small viewports

### DIFF
--- a/.changeset/moody-terms-drum.md
+++ b/.changeset/moody-terms-drum.md
@@ -1,0 +1,5 @@
+---
+'@kaizen/components': patch
+---
+
+Content: Adjust width on small viewports

--- a/packages/components/src/Content/Content.module.scss
+++ b/packages/components/src/Content/Content.module.scss
@@ -8,5 +8,6 @@
 
   @media (max-width: calc(#{$layout-breakpoints-large} - 1px)) {
     margin: 0 $content-margin-width-on-medium-and-small;
+    width: calc(100% - 2 * #{$content-margin-width-on-medium-and-small});
   }
 }


### PR DESCRIPTION
## Why

Adjust width on small viewports to take horizontal margin into account as this could cause the margin to flow outside the viewport when components with `nowrap` applied cause the 100% width to be greater than it's parent.

## What

Added `calc()` to content when in small viewports to minus off the horizontal margin applied.

Initially I converted this to CSS module, but reverted that due [vars and calcs not working in media queries](https://bholmes.dev/blog/alternative-to-css-variable-media-queries/). I decided to keep this change small and will follow up with CSS module conversion after.

### Before:
<img width="366" alt="Screenshot 2025-01-28 at 11 54 28 am" src="https://github.com/user-attachments/assets/f8ad68be-4fbe-4eb5-aa3b-38f0d855ec4a" />

### After:
<img width="365" alt="Screenshot 2025-01-28 at 11 52 47 am" src="https://github.com/user-attachments/assets/e9e10d24-8dad-422b-9e79-dd6794abf143" />