### PR TITLE
Ryan/hanging storybook builds

### DIFF
--- a/.changeset/stale-toys-brake.md
+++ b/.changeset/stale-toys-brake.md
@@ -2,4 +2,4 @@
 '@docs/storybook': patch
 ---
 
-Move from react-docgen-typescript to react-docgen
+Overriding transient dependency @storybook/react-vite package to fix issue

--- a/.changeset/stale-toys-brake.md
+++ b/.changeset/stale-toys-brake.md
@@ -1,0 +1,5 @@
+---
+'@docs/storybook': patch
+---
+
+Move from react-docgen-typescript to react-docgen

--- a/docs/.storybook/main.ts
+++ b/docs/.storybook/main.ts
@@ -35,7 +35,7 @@ const config: StorybookConfig = {
     },
   ],
   typescript: {
-    reactDocgen: 'react-docgen-typescript',
+    reactDocgen: 'react-docgen',
     reactDocgenTypescriptOptions: {
       include: ['../packages/**/*.tsx'],
       skipChildrenPropWithoutDoc: false,

--- a/docs/.storybook/main.ts
+++ b/docs/.storybook/main.ts
@@ -35,7 +35,7 @@ const config: StorybookConfig = {
     },
   ],
   typescript: {
-    reactDocgen: 'react-docgen',
+    reactDocgen: 'react-docgen-typescript',
     reactDocgenTypescriptOptions: {
       include: ['../packages/**/*.tsx'],
       skipChildrenPropWithoutDoc: false,

--- a/package.json
+++ b/package.json
@@ -104,6 +104,9 @@
         "react-dom": "18",
         "eslint": "9"
       }
+    },
+    "overrides": {
+      "@joshwooding/vite-plugin-react-docgen-typescript": "0.5.0"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  '@joshwooding/vite-plugin-react-docgen-typescript': 0.5.0
+
 importers:
 
   .:
@@ -2190,8 +2193,8 @@ packages:
     resolution: {integrity: sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
-  '@joshwooding/vite-plugin-react-docgen-typescript@0.4.2':
-    resolution: {integrity: sha512-feQ+ntr+8hbVudnsTUapiMN9q8T90XA1d5jn9QzY09sNoj4iD9wi0PY1vsBFTda4ZjEaxRK9S81oarR2nj7TFQ==}
+  '@joshwooding/vite-plugin-react-docgen-typescript@0.5.0':
+    resolution: {integrity: sha512-qYDdL7fPwLRI+bJNurVcis+tNgJmvWjH4YTBGXTA8xMuxFrnAz6E5o35iyzyKbq5J5Lr8mJGfrR5GXl+WGwhgQ==}
     peerDependencies:
       typescript: '>= 4.3.x'
       vite: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0
@@ -12124,8 +12127,9 @@ snapshots:
       '@types/yargs': 17.0.33
       chalk: 4.1.2
 
-  '@joshwooding/vite-plugin-react-docgen-typescript@0.4.2(typescript@5.7.2)(vite@5.4.10(@types/node@20.17.9)(less@4.2.0)(sass@1.79.6)(stylus@0.62.0)(terser@5.31.5))':
+  '@joshwooding/vite-plugin-react-docgen-typescript@0.5.0(typescript@5.7.2)(vite@5.4.10(@types/node@20.17.9)(less@4.2.0)(sass@1.79.6)(stylus@0.62.0)(terser@5.31.5))':
     dependencies:
+      glob: 10.4.5
       magic-string: 0.27.0
       react-docgen-typescript: 2.2.2(typescript@5.7.2)
       vite: 5.4.10(@types/node@20.17.9)(less@4.2.0)(sass@1.79.6)(stylus@0.62.0)(terser@5.31.5)
@@ -13776,7 +13780,7 @@ snapshots:
 
   '@storybook/react-vite@8.4.7(@storybook/test@8.4.7(storybook@8.4.7(prettier@3.4.2)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.30.1)(storybook@8.4.7(prettier@3.4.2))(typescript@5.7.2)(vite@5.4.10(@types/node@20.17.9)(less@4.2.0)(sass@1.79.6)(stylus@0.62.0)(terser@5.31.5))':
     dependencies:
-      '@joshwooding/vite-plugin-react-docgen-typescript': 0.4.2(typescript@5.7.2)(vite@5.4.10(@types/node@20.17.9)(less@4.2.0)(sass@1.79.6)(stylus@0.62.0)(terser@5.31.5))
+      '@joshwooding/vite-plugin-react-docgen-typescript': 0.5.0(typescript@5.7.2)(vite@5.4.10(@types/node@20.17.9)(less@4.2.0)(sass@1.79.6)(stylus@0.62.0)(terser@5.31.5))
       '@rollup/pluginutils': 5.1.0(rollup@4.30.1)
       '@storybook/builder-vite': 8.4.7(storybook@8.4.7(prettier@3.4.2))(vite@5.4.10(@types/node@20.17.9)(less@4.2.0)(sass@1.79.6)(stylus@0.62.0)(terser@5.31.5))
       '@storybook/react': 8.4.7(@storybook/test@8.4.7(storybook@8.4.7(prettier@3.4.2)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.4.7(prettier@3.4.2))(typescript@5.7.2)


### PR DESCRIPTION
## Why

Our buildkite builds would sometimes just hang and timeout due to storybook never exiting the `build:docs` task.

## What

The culprit was `react-docgen-typescript` as mentioned in this [issue](https://github.com/storybookjs/storybook/issues/30424) commenting out the entire `typescript` block in `docs/.storybook/main.ts` no longer made `build:docs` hang and it would exit correctly.

Digging into the storbook src it mentions that in v8 they've moved from `react-docgen-typescript` to `react-docgen` and that is the recommendation going forward.

https://github.com/storybookjs/storybook/blob/ba47d3e3aea378a2da911219b78e36e76bfff930/code/lib/cli-storybook/src/automigrate/fixes/react-docgen.ts#L49-L54

So I just edited the `reactDocgen` key to use that and the build no longer hung!
