### PR TITLE
feat: export dist styles from kaio

### DIFF
--- a/.changeset/unlucky-shrimps-relate.md
+++ b/.changeset/unlucky-shrimps-relate.md
@@ -1,0 +1,5 @@
+---
+'@kaizen/components': patch
+---
+
+Export dist styles from exports field

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -80,6 +80,10 @@
       "import": "./dist/esm/reactAriaComponentsV3.mjs",
       "require": "./dist/cjs/reactAriaComponentsV3.cjs",
       "types": "./dist/types/__react-aria-components__/index.d.ts"
+    },
+    "./dist/styles.css": {
+      "import": "./dist/styles.css",
+      "require": "./dist/styles.css"
     }
   },
   "bin": {


### PR DESCRIPTION
This is a follow-up from my earlier work here: https://github.com/cultureamp/kaizen-design-system/pull/5492

I had missed that consumers are also importing the built out CSS. I think ideally we don't want to expose the `./dist` directory, but in order to avoid a breaking change, I figured it would be best to keep the same path for now.

I've tested this via a Canary and the problem looks to be resolved.