### PR TITLE
feat: set style condition in exports so styles can be imported from a CSS file.

### DIFF
--- a/.changeset/giant-monkeys-turn.md
+++ b/.changeset/giant-monkeys-turn.md
@@ -1,0 +1,5 @@
+---
+'@kaizen/components': patch
+---
+
+Set styles to be in style condition for export

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -83,7 +83,8 @@
     },
     "./dist/styles.css": {
       "import": "./dist/styles.css",
-      "require": "./dist/styles.css"
+      "require": "./dist/styles.css",
+      "style": "./dist/styles.css"
     }
   },
   "bin": {


### PR DESCRIPTION
A follow-up to https://github.com/cultureamp/kaizen-design-system/pull/5499. We'll get there eventually!

While it's not encouraged, some of our packages & apps are importing the `dist/styles.css` file from a `.css` file. In these cases, we need to set the `style` condition for that to resolve properly.

I've tested a canary and it looks sweet. 🚀 