### PR TITLE
removes disabled hover state for ToggleSwitchField

### DIFF
--- a/.changeset/slow-students-hear.md
+++ b/.changeset/slow-students-hear.md
@@ -1,0 +1,5 @@
+---
+'@kaizen/components': patch
+---
+
+ToggleSwitchField: removes hover style from disabled state

--- a/packages/components/src/ToggleSwitch/ToggleSwitch/ToggleSwitch.module.scss
+++ b/packages/components/src/ToggleSwitch/ToggleSwitch/ToggleSwitch.module.scss
@@ -125,6 +125,11 @@ $focus-ring-offset: 1px;
   }
 }
 
+// When the ToggleSwitch is used as part of the ToggleSwitchField, the disabled state opacity is set on the Label component
+label .disabled.track {
+  opacity: 100%;
+}
+
 .disabled.track {
   opacity: 30%;
 }

--- a/packages/components/src/ToggleSwitch/ToggleSwitch/ToggleSwitch.module.scss
+++ b/packages/components/src/ToggleSwitch/ToggleSwitch/ToggleSwitch.module.scss
@@ -36,7 +36,7 @@ $focus-ring-offset: 1px;
   }
 
   .checkbox:not(.disabled) + &:hover,
-  label:hover .checkbox + & {
+  label:hover .checkbox:not(.disabled) + & {
     background-color: $color-purple-500;
     background-color: $color-gray-600;
   }
@@ -55,6 +55,7 @@ $focus-ring-offset: 1px;
   transition:
     left $animation-timing,
     right $animation-timing;
+  cursor: default;
 }
 
 .checkIcon {
@@ -72,7 +73,7 @@ $focus-ring-offset: 1px;
 
   .checkbox:focus + .track {
     border-color: transparent;
-    background-color: $color-green-500;
+    background-color: $color-green-600;
   }
 
   .thumb {
@@ -88,7 +89,7 @@ $focus-ring-offset: 1px;
   }
 
   .checkbox:not(.disabled) + .track:hover,
-  label:hover & .checkbox + .track {
+  label:hover & .checkbox:not(.disabled) + .track {
     background-color: $color-green-600;
   }
 }
@@ -118,10 +119,18 @@ $focus-ring-offset: 1px;
     }
 
     .checkbox:not(.disabled) + .track:hover,
-    label:hover & .checkbox + .track {
+    label:hover & .checkbox:not(.disabled) + .track {
       background-color: rgba($color-white-rgb, 0.65);
     }
   }
+}
+
+label .disabled.track {
+  opacity: 100%;
+}
+
+.disabled.track {
+  opacity: 30%;
 }
 
 /* stylelint-enable no-descending-specificity */

--- a/packages/components/src/ToggleSwitch/ToggleSwitch/ToggleSwitch.module.scss
+++ b/packages/components/src/ToggleSwitch/ToggleSwitch/ToggleSwitch.module.scss
@@ -125,10 +125,6 @@ $focus-ring-offset: 1px;
   }
 }
 
-label .disabled.track {
-  opacity: 100%;
-}
-
 .disabled.track {
   opacity: 30%;
 }

--- a/packages/components/src/ToggleSwitch/ToggleSwitchField/ToggleSwitchField.tsx
+++ b/packages/components/src/ToggleSwitch/ToggleSwitchField/ToggleSwitchField.tsx
@@ -59,6 +59,7 @@ export const ToggleSwitchField = ({
         >
           <ToggleSwitch
             id={`${id}-field-toggle`}
+            disabled={disabled}
             reversed={reversed}
             toggledStatus={toggledStatus}
             {...restProps}

--- a/packages/components/src/ToggleSwitch/ToggleSwitchField/ToggleSwitchField.tsx
+++ b/packages/components/src/ToggleSwitch/ToggleSwitchField/ToggleSwitchField.tsx
@@ -59,7 +59,6 @@ export const ToggleSwitchField = ({
         >
           <ToggleSwitch
             id={`${id}-field-toggle`}
-            disabled={disabled}
             reversed={reversed}
             toggledStatus={toggledStatus}
             {...restProps}


### PR DESCRIPTION
## Why

Bug fix for `ToggleSwitchField` component
https://cultureamp.atlassian.net/browse/KZN-2988

## What

- removes colour change on disabled hover state for `ToggleSwitchField`
- updates the cursor to be consistently `default` and not a mix of `default` and `text` over the `ToggleSwitch`
- applies disabled state opacity to `ToggleSwitch` 

Video of hover state before:
https://www.loom.com/share/79edbb648b6f4d1dbb8353f374830784?sid=01bd2fb2-1834-479f-b8c8-556a04b02511

Video of hover state after: 
https://www.loom.com/share/4d0ee52c50b94589895f57fd56c46250?sid=72a576b4-7dfa-441e-bb3e-01dcfead71bc


Before:
<img width="478" alt="old" src="https://github.com/user-attachments/assets/bbdc9e1f-b42f-4cfa-8dc6-1fe0e65a8402" />

After:
<img width="441" alt="new" src="https://github.com/user-attachments/assets/73430127-1e7a-43a2-bed3-6a679e855439" />

