### PR TITLE
fix: drill down isDisabled prop for Select

### DIFF
--- a/.changeset/thin-planets-cheat.md
+++ b/.changeset/thin-planets-cheat.md
@@ -1,0 +1,5 @@
+---
+'@kaizen/components': patch
+---
+
+Fix drilling down isDisabled prop for Select

--- a/packages/components/src/Select/Select.tsx
+++ b/packages/components/src/Select/Select.tsx
@@ -57,7 +57,6 @@ export const Select = React.forwardRef<any, SelectProps>(
       description,
       fullWidth: propsFullWidth,
       className: propsClassName,
-      isDisabled,
       placeholder,
       ...props
     },
@@ -76,7 +75,7 @@ export const Select = React.forwardRef<any, SelectProps>(
       variant === 'secondary' && styles.secondary,
       variant === 'secondary-small' && styles.secondarySmall,
       !fullWidth && styles.notFullWidth,
-      isDisabled && styles.disabled,
+      props.isDisabled && styles.disabled,
       status === 'error' && styles.error,
     )
 


### PR DESCRIPTION
## Important: Request PR reviews on Slack

Please reach out to the design system team on Slack in `#prod_design_system` for PR reviews. GitHub notifications (e.g. from tagging a person) are not actively monitored.

## Why

<!-- Why have you created this PR? - Is it a new feature, or a bug fix? Or something else? -->
<!-- Reference any relevant Jira tickets so your reviewer can find more context if needed. -->
<!-- Fixing a GitHub issue? Add "Fixes [issue URL]". -->

Drill down `isDisabled` prop to react-select

## What

<!-- What do your changes do? How do they change/fix the current behavior? -->
<!-- Add screenshots, GIFs or videos to illustrate the changes.  -->
Verified in local storybook, compared to [live one where isDisabled isn't working](https://cultureamp.design/?path=/docs/components-select--docs)
<img width="1319" alt="Screenshot 2025-02-11 at 9 22 58 am" src="https://github.com/user-attachments/assets/d897344f-17de-4a54-923a-11975a46b687" />
