### PR TITLE
feat: add exports for v3 utilities

### DIFF
--- a/.changeset/silent-chefs-return.md
+++ b/.changeset/silent-chefs-return.md
@@ -1,0 +1,5 @@
+---
+'@kaizen/components': patch
+---
+
+Add missing v3 utilites export field

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -81,6 +81,11 @@
       "require": "./dist/cjs/reactAriaComponentsV3.cjs",
       "types": "./dist/types/__react-aria-components__/index.d.ts"
     },
+    "./v3/utilities": {
+      "import": "./dist/esm/utilitiesV3.mjs",
+      "require": "./dist/cjs/utilitiesV3.cjs",
+      "types": "./dist/types/__utilities__/v3.d.ts"
+    },
     "./dist/styles.css": {
       "import": "./dist/styles.css",
       "require": "./dist/styles.css",


### PR DESCRIPTION
## Why

v3 utilities need to be exported in packge.json like the rest of the modules

## What

If we don't set the exports then esm envs don't know where to find the correct module.
