### PR TITLE
update Filter exports to include the FilterButtonBase primitive

### DIFF
--- a/.changeset/friendly-mangos-deny.md
+++ b/.changeset/friendly-mangos-deny.md
@@ -1,0 +1,5 @@
+---
+'@kaizen/components': patch
+---
+
+Expose the FilterButtonBase primitive for tier 3 usages

--- a/packages/components/src/Filter/FilterButton/index.ts
+++ b/packages/components/src/Filter/FilterButton/index.ts
@@ -1,2 +1,3 @@
+export * from './subcomponents/FilterButtonBase'
 export * from './FilterButton'
 export * from './FilterButtonRemovable'


### PR DESCRIPTION
## Why
To more easily enable teams to more to construct a tier 3 implementation of the FilterButton to meet new designs ([See thread](https://cultureamp.slack.com/archives/C0189KBPM4Y/p1738730513616289) for additional context on the support request).

While we have recommended they attempt to use the new Button API in its place with tailwind to align to the original styles of the FitlerButton, this does not seem like it will work with their current API.

We have caveat-ed this update stating that any changes to Filters and its primitives like FilterButtonBase (ie: with the Pickers rebuild initiative), will likely lead to a larger migration effort for the team.

## What
- adds `FilterButtonBase` primitive to exports from the component
