### PR TITLE
Export react-aria Selection type

### DIFF
--- a/.changeset/nasty-steaks-wonder.md
+++ b/.changeset/nasty-steaks-wonder.md
@@ -1,0 +1,5 @@
+---
+'@kaizen/components': patch
+---
+
+Export react-aria Selection type

--- a/packages/components/src/Filter/FilterMultiSelect/types.ts
+++ b/packages/components/src/Filter/FilterMultiSelect/types.ts
@@ -1,4 +1,4 @@
-import { type Key, type Node } from '@react-types/shared'
+import { type Key, type Node, type Selection as ReactAriaSelection } from '@react-types/shared'
 
 export type ItemType = {
   label: string
@@ -8,3 +8,5 @@ export type ItemType = {
 }
 
 export type MultiSelectItem = Node<ItemType>
+
+export type Selection = ReactAriaSelection


### PR DESCRIPTION
## Why
This was exported from `@kaizen/select` but not migrated over to KAIO. It has usages.

## What
Export the `Selection` type from `@react-types/shared`