### PR TITLE
Revert: Export RTE mockRangeForBoundingRect

### DIFF
--- a/.changeset/poor-suns-fly.md
+++ b/.changeset/poor-suns-fly.md
@@ -1,0 +1,5 @@
+---
+'@kaizen/components': patch
+---
+
+Revert: Export RTE mockRangeForBoundingRect helper function

--- a/packages/components/src/RichTextEditor/utils/commands/index.ts
+++ b/packages/components/src/RichTextEditor/utils/commands/index.ts
@@ -1,4 +1,3 @@
-export * from './fixtures/mockRangeForBoundingRect'
 export * from './addMark'
 export * from './getMarkAttrs'
 export * from './getMarkRange'


### PR DESCRIPTION
Appears to be causing build failures for teams
