### PR TITLE
Fixes popovers being underneath title

### DIFF
--- a/.changeset/wet-planets-sniff.md
+++ b/.changeset/wet-planets-sniff.md
@@ -1,0 +1,5 @@
+---
+'@kaizen/components': patch
+---
+
+Remove stacking context from TBZ to avoid sitting over popovers

--- a/packages/components/src/TitleBlockZen/TitleBlockZen.module.scss
+++ b/packages/components/src/TitleBlockZen/TitleBlockZen.module.scss
@@ -114,7 +114,6 @@ $tab-container-height-medium-and-small-collapsed: 0;
   display: flex;
   align-items: center;
   min-width: 0; // this is an important trick to prevent flexbox items from overflowing
-  z-index: $ca-z-index-dropdown; // this ensures the page switcher dropdown sits over nav tabs
   transform: translateY(-0.0833em);
 
   .hasSubtitle & {
@@ -434,7 +433,7 @@ $tab-container-height-medium-and-small-collapsed: 0;
     width: $tab-container-height-small;
     height: $tab-container-height-small;
     background: linear-gradient(0deg, $color-purple-600, rgba($color-purple-600-rgb, 0));
-    z-index: $ca-z-index-sticky;
+    z-index: 1;
   }
 
   .adminVariant & {
@@ -503,7 +502,6 @@ $tab-container-height-medium-and-small-collapsed: 0;
   cursor: pointer;
   display: flex;
   position: absolute;
-  z-index: $ca-z-index-sticky;
   align-items: center;
   top: 50%;
   transform: translateY(-50%);
@@ -573,8 +571,6 @@ $tab-container-height-medium-and-small-collapsed: 0;
   // We are using visually hidden here instead of display:none so that a screen reader
   // navigating via 'read mode' (which doesn't trigger hover/focus) will still hear this link name
   @include visually-hidden;
-
-  z-index: $ca-z-index-sticky - 1;
 
   @include ca-position($start: -2 * $ca-grid);
 

--- a/packages/components/src/TitleBlockZen/TitleBlockZen.module.scss
+++ b/packages/components/src/TitleBlockZen/TitleBlockZen.module.scss
@@ -571,7 +571,6 @@ $tab-container-height-medium-and-small-collapsed: 0;
   // We are using visually hidden here instead of display:none so that a screen reader
   // navigating via 'read mode' (which doesn't trigger hover/focus) will still hear this link name
   @include visually-hidden;
-
   @include ca-position($start: -2 * $ca-grid);
 
   position: absolute;


### PR DESCRIPTION
## Why

To fix a stacking context issue the title sitting over the top of any popover that may intersect with it.

https://cultureamp.atlassian.net/browse/KZN-2956

## What

There was a few places that a z-index was applied that is no longer needed, one being a comment on the page switcher which is no longer located in the title area when active.

### Before
<img width="779" alt="Screenshot 2025-02-17 at 12 18 00 pm" src="https://github.com/user-attachments/assets/9687e961-b82b-4aed-8570-8bc277bea886" />

### After
<img width="787" alt="Screenshot 2025-02-17 at 12 18 16 pm" src="https://github.com/user-attachments/assets/fa574b20-53d2-4876-b606-059e385e546c" />

I reduced the z-index in the `%navigationTabEdgeShadow` extend block as it's still needed to ensure the shadow apears over the navigation it just doesn't need to be any higher than `1` for it too work correctly.

### If the shadow edges were left with the 1000+ z-index value.
<img width="831" alt="Screenshot 2025-02-17 at 12 13 12 pm" src="https://github.com/user-attachments/assets/2b6cc188-16a7-460e-8269-91e88d1748a7" />

