### PR TITLE
Adjust Modal className implementations to insert at the top level

### DIFF
--- a/.changeset/clever-crews-relax.md
+++ b/.changeset/clever-crews-relax.md
@@ -1,0 +1,5 @@
+---
+'@kaizen/components': patch
+---
+
+Adjust Modal className implementations to insert at the top level

--- a/packages/components/src/Modal/ConfirmationModal/ConfirmationModal.tsx
+++ b/packages/components/src/Modal/ConfirmationModal/ConfirmationModal.tsx
@@ -124,6 +124,7 @@ export const ConfirmationModal = ({
   confirmWorking,
   onDismiss: propsOnDismiss,
   children,
+  className,
   ...props
 }: ConfirmationModalProps): JSX.Element => {
   const variantName = variant ?? mood
@@ -158,6 +159,7 @@ export const ConfirmationModal = ({
       onOutsideModalClick={onDismiss}
       onAfterLeave={onAfterLeave}
       onAfterEnter={onAfterEnter}
+      className={className}
     >
       <div className={styles.modal} data-modal {...props}>
         <ModalHeader onDismiss={onDismiss}>

--- a/packages/components/src/Modal/ContextModal/ContextModal.tsx
+++ b/packages/components/src/Modal/ContextModal/ContextModal.tsx
@@ -71,6 +71,7 @@ export const ContextModal = ({
   image,
   secondaryLabel,
   onSecondaryAction,
+  className,
   ...props
 }: ContextModalProps): JSX.Element => {
   const onDismiss = confirmWorking ? undefined : propsOnDismiss
@@ -105,6 +106,7 @@ export const ContextModal = ({
       onOutsideModalClick={onDismiss}
       onAfterLeave={onAfterLeave}
       onAfterEnter={onAfterEnter}
+      className={className}
     >
       <div className={styles.modal} data-modal {...props}>
         {renderBackground?.()}

--- a/packages/components/src/Modal/GenericModal/GenericModal.tsx
+++ b/packages/components/src/Modal/GenericModal/GenericModal.tsx
@@ -17,6 +17,7 @@ export type GenericModalProps = {
   onAfterEnter?: () => void
   /** A callback that is triggered after the modal is closed. */
   onAfterLeave?: () => void
+  className?: string
 }
 
 export const GenericModal = ({
@@ -28,6 +29,7 @@ export const GenericModal = ({
   onOutsideModalClick,
   onAfterEnter,
   onAfterLeave: propsOnAfterLeave,
+  className,
 }: GenericModalProps): JSX.Element => {
   const reactId = useId()
   const id = propsId ?? reactId
@@ -137,6 +139,7 @@ export const GenericModal = ({
       afterLeave={onAfterLeaveHandler}
       data-generic-modal-transition-wrapper
       onClick={(e: React.MouseEvent): void => e.stopPropagation()}
+      className={className}
     >
       <FocusLock
         disabled={focusLockDisabled}

--- a/packages/components/src/Modal/InputEditModal/InputEditModal.tsx
+++ b/packages/components/src/Modal/InputEditModal/InputEditModal.tsx
@@ -58,6 +58,7 @@ export const InputEditModal = ({
   unpadded = false,
   onDismiss: propsOnDismiss,
   onAfterEnter,
+  className,
   ...props
 }: InputEditModalProps): JSX.Element => {
   const onDismiss = submitWorking ? undefined : propsOnDismiss
@@ -87,6 +88,7 @@ export const InputEditModal = ({
       onEscapeKeyup={onDismiss}
       onAfterLeave={onAfterLeave}
       onAfterEnter={onAfterEnter}
+      className={className}
     >
       <div className={styles.modal} dir={localeDirection} data-modal {...props}>
         <ModalHeader onDismiss={onDismiss}>


### PR DESCRIPTION
`className` for our modal components was overriding our built in styles (our pattern on this is to extend rather than override)

It was also being passed in at a lower level than the top, meaning you can't access everything in the tree.

This is technically a breaking change, I'll be reaching out to the one team currently using this prop.