### PR TITLE
Modal: Update directional CSS to logical properties/values for RTL support

### DIFF
--- a/.changeset/stupid-jars-sip.md
+++ b/.changeset/stupid-jars-sip.md
@@ -1,0 +1,5 @@
+---
+'@kaizen/components': patch
+---
+
+Modal: Update directional CSS to logical properties/values for RTL support

--- a/packages/components/src/Modal/ConfirmationModal/ConfirmationModal.module.scss
+++ b/packages/components/src/Modal/ConfirmationModal/ConfirmationModal.module.scss
@@ -21,7 +21,7 @@
   grid-template-columns: 0.2fr 2fr;
   align-items: center;
   color: $color-white;
-  text-align: left;
+  text-align: start;
   border-radius: $border-solid-border-radius $border-solid-border-radius 0 0;
 
   &.padded {
@@ -53,9 +53,9 @@
     height: 30px;
 
     @media (max-width: $layout-breakpoints-medium) {
-      margin-right: 0.9375rem;
+      margin-inline-end: 0.9375rem;
       position: relative;
-      top: 0.125rem;
+      inset-block-start: 0.125rem;
     }
   }
 }
@@ -75,12 +75,12 @@
 
   .iconContainer {
     position: absolute;
-    top: 8%;
+    inset-block-start: 8%;
 
     @media (max-width: $layout-breakpoints-medium) {
       position: relative;
-      top: 0;
-      margin-bottom: $spacing-sm;
+      inset-block-start: 0;
+      margin-block-end: $spacing-sm;
     }
   }
 

--- a/packages/components/src/Modal/ContextModal/ContextModal.module.scss
+++ b/packages/components/src/Modal/ContextModal/ContextModal.module.scss
@@ -58,7 +58,7 @@
 .footerWithSecondaryAction {
   @extend %footer;
 
-  margin-left: calc(-1 * #{$spacing-sm});
+  margin-inline-start: calc(-1 * #{$spacing-sm});
 }
 
 .emptyFooter {
@@ -97,7 +97,7 @@
   }
 
   .content {
-    padding-left: 0;
+    padding-inline-start: 0;
 
     @media (min-width: $layout-breakpoints-medium) {
       max-width: 100%;

--- a/packages/components/src/Modal/GenericModal/GenericModal.module.scss
+++ b/packages/components/src/Modal/GenericModal/GenericModal.module.scss
@@ -115,7 +115,7 @@
 
 .pseudoScrollbar {
   /* Tech debt - this !important existed before Stylelint rules */
-  padding-right: 15px !important; /* stylelint-disable-line declaration-no-important */
+  padding-inline-end: 15px !important; /* stylelint-disable-line declaration-no-important */
 }
 
 .hide {

--- a/packages/components/src/Modal/GenericModal/subcomponents/ModalAccessibleLabel/ModalAccessibleLabel.module.scss
+++ b/packages/components/src/Modal/GenericModal/subcomponents/ModalAccessibleLabel/ModalAccessibleLabel.module.scss
@@ -27,7 +27,7 @@ $ca-breakpoint-small-mobile: 375px;
 
   &.prominent {
     grid-column-start: 2;
-    text-align: left;
+    text-align: start;
   }
 
   &:focus {

--- a/packages/components/src/Modal/GenericModal/subcomponents/ModalFooter/ModalFooter.module.scss
+++ b/packages/components/src/Modal/GenericModal/subcomponents/ModalFooter/ModalFooter.module.scss
@@ -32,10 +32,10 @@
 }
 
 .actionButton + .actionButton {
-  margin-right: $spacing-sm;
+  margin-inline-end: $spacing-sm;
 
   @media (max-width: (calc(#{$layout-breakpoints-medium} - 1px))) {
-    margin-top: $spacing-sm;
+    margin-block-start: $spacing-sm;
   }
 }
 
@@ -51,7 +51,7 @@
 }
 
 .border {
-  border-top: 1px solid $border-solid-border-color;
+  border-block-start: 1px solid $border-solid-border-color;
 }
 
 .start {
@@ -66,8 +66,8 @@
 
 .fixed {
   position: absolute;
-  bottom: 0;
-  left: 0;
+  inset-block-end: 0;
+  inset-inline-start: 0;
 }
 
 .filler {

--- a/packages/components/src/Modal/GenericModal/subcomponents/ModalHeader/ModalHeader.module.scss
+++ b/packages/components/src/Modal/GenericModal/subcomponents/ModalHeader/ModalHeader.module.scss
@@ -15,8 +15,8 @@
 
 .fixed {
   position: absolute;
-  top: 0;
-  left: 0;
+  inset-block-start: 0;
+  inset-inline-start: 0;
 }
 
 .filler {

--- a/packages/components/src/Modal/InputEditModal/InputEditModal.module.scss
+++ b/packages/components/src/Modal/InputEditModal/InputEditModal.module.scss
@@ -28,11 +28,7 @@
 
 .header {
   color: $color-purple-800;
-  text-align: left;
-
-  &.textAlignRTL {
-    text-align: right;
-  }
+  text-align: start;
 
   &.padded {
     padding: $spacing-md $spacing-lg;

--- a/packages/components/src/Modal/InputEditModal/InputEditModal.tsx
+++ b/packages/components/src/Modal/InputEditModal/InputEditModal.tsx
@@ -26,7 +26,6 @@ export type InputEditModalProps = {
   onAfterEnter?: () => void
   /** A callback that is triggered after the modal is closed. */
   onAfterLeave?: () => void
-  localeDirection?: 'rtl' | 'ltr'
   submitLabel?: string
   dismissLabel?: string
   secondaryLabel?: string
@@ -49,7 +48,6 @@ export const InputEditModal = ({
   onSubmit,
   onSecondaryAction,
   onAfterLeave,
-  localeDirection = 'ltr',
   submitLabel = 'Submit',
   dismissLabel = 'Cancel',
   secondaryLabel,
@@ -90,15 +88,9 @@ export const InputEditModal = ({
       onAfterEnter={onAfterEnter}
       className={className}
     >
-      <div className={styles.modal} dir={localeDirection} data-modal {...props}>
+      <div className={styles.modal} data-modal {...props}>
         <ModalHeader onDismiss={onDismiss}>
-          <div
-            className={classnames(
-              styles.header,
-              localeDirection === 'rtl' && styles.textAlignRTL,
-              !unpadded && styles.padded,
-            )}
-          >
+          <div className={classnames(styles.header, !unpadded && styles.padded)}>
             <ModalAccessibleLabel>
               <Heading tag="h2" variant="heading-2">
                 {title}
@@ -107,12 +99,7 @@ export const InputEditModal = ({
           </div>
         </ModalHeader>
         <ModalBody>
-          <div
-            className={classnames(styles.body, !unpadded && styles.padded)}
-            dir={localeDirection}
-          >
-            {children}
-          </div>
+          <div className={classnames(styles.body, !unpadded && styles.padded)}>{children}</div>
         </ModalBody>
         <ModalFooter
           actions={footerActions}


### PR DESCRIPTION
Updates all hardcoded directional properties and values to logical properties and values for RTL support.

Also removes `localeDirection` prop from `InputEditModal` which only has legacy usages in murmur, so should've been gotten rid of in the move to KAIO.