### PR TITLE
One1/add length check for tabs

### DIFF
--- a/.changeset/gorgeous-impalas-hunt.md
+++ b/.changeset/gorgeous-impalas-hunt.md
@@ -1,0 +1,5 @@
+---
+'@kaizen/components': patch
+---
+
+add length check for tabs

--- a/packages/components/src/__next__/Tabs/subcomponents/TabList/TabList.tsx
+++ b/packages/components/src/__next__/Tabs/subcomponents/TabList/TabList.tsx
@@ -62,7 +62,7 @@ export const TabList = (props: TabListProps): JSX.Element => {
     }
 
     const tabs = containerElement?.querySelectorAll('[data-kz-tab]')
-    if (!tabs) {
+    if (!tabs || tabs.length === 0) {
       return
     }
 


### PR DESCRIPTION
## Important: Request PR reviews on Slack

Please reach out to the design system team on Slack in `#prod_design_system` for PR reviews. GitHub notifications (e.g. from tagging a person) are not actively monitored.

## Why

<!-- Why have you created this PR? - Is it a new feature, or a bug fix? Or something else? -->
After upgrading react-aria-components to 1.7.0, we in team 1-on-1s had an issue on storybook stories consists tabs
https://github.com/cultureamp/conversations-ui/actions/runs/13805171752/job/38614475530?pr=1708

@vietanhtran16  investigation:
![image](https://github.com/user-attachments/assets/9b8aa601-eb30-4a00-a5b3-0764b6624159) 
![image](https://github.com/user-attachments/assets/904eff74-a586-43f5-9e31-fc5e840dbb39)

`firstTabObserver.observe(isRTL ? tabs[tabs.length - 1] : tabs[0])`  is throwing the error as tabs[0]  is undefined
the early return at the top needs to handle when tabs is empty too. We assume 

<!-- Reference any relevant Jira tickets so your reviewer can find more context if needed. -->
<!-- Fixing a GitHub issue? Add "Fixes [issue URL]". -->

## What

<!-- What do your changes do? How do they change/fix the current behavior? -->
<!-- Add screenshots, GIFs or videos to illustrate the changes.  -->
