### PR TITLE
Avoid changesets-exists and chromatic jobs when PR isn't going into main

### DIFF
--- a/.github/workflows/check-files.yml
+++ b/.github/workflows/check-files.yml
@@ -19,7 +19,7 @@ on:
 
 jobs:
   changesets-exists:
-    if: github.head_ref != 'changeset-release/main'
+    if: github.head_ref != 'changeset-release/main' && github.base_ref == 'main'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:

--- a/.github/workflows/chromatic-pr.yaml
+++ b/.github/workflows/chromatic-pr.yaml
@@ -25,7 +25,7 @@ on:
 jobs:
   run-check:
     name: Check if we should run Chromatic tests
-    if: github.head_ref != 'changeset-release/main' && github.event.pull_request.draft == false
+    if: github.head_ref != 'changeset-release/main' && github.event.pull_request.draft == false && github.base_ref == 'main'
     runs-on: ubuntu-latest
     timeout-minutes: 3
     steps:


### PR DESCRIPTION
Avoids running the changeset check and chromatic when the PR isn't going into main.

This is mainly for the renovate PRs, so that they can go straight through to the rollup branch without requiring our intervention.