### PR TITLE
Renovate: don't create as draft

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -1,7 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "updatePinnedDependencies": false,
-  "draftPR": true,
   "ignoreDeps": [
     // We can't always stick to latest due to infra and compatibility with other plugins
     "node"


### PR DESCRIPTION
Following https://github.com/cultureamp/kaizen-design-system/pull/5570, remove this setting so that Renovate PRs are no longer created as drafts and hopefully go through to the rollup branch without intervention