### PR TITLE
Remove check for changeset

### DIFF
--- a/.github/workflows/check-files.yml
+++ b/.github/workflows/check-files.yml
@@ -18,17 +18,6 @@ on:
       - '**/CHANGELOG.md' # only changesets releases touch changelogs
 
 jobs:
-  changesets-exists:
-    if: github.head_ref != 'changeset-release/main' && github.base_ref == 'main'
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - uses: ./.github/actions/setup
-      - run: pnpm changeset status --since=origin/main
-
   verify-build:
     if: github.head_ref != 'changeset-release/main'
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Why
No need for such a hard block here. We have the changeset bot on PRs to remind us in case we've forgotten.
