### PR TITLE
TimeField: fix spacing after dep update

### DIFF
--- a/.changeset/vast-gifts-know.md
+++ b/.changeset/vast-gifts-know.md
@@ -1,0 +1,5 @@
+---
+'@kaizen/components': patch
+---
+
+TimeField: fix spacing after dep update

--- a/packages/components/src/TimeField/TimeField.tsx
+++ b/packages/components/src/TimeField/TimeField.tsx
@@ -108,9 +108,17 @@ const TimeFieldComponent = ({
             state.validationState === 'invalid' && styles.error,
           )}
         >
-          {state.segments.map((segment, i) => (
-            <TimeSegment key={i} segment={segment} state={state} />
-          ))}
+          {state.segments.map((segment, i) => {
+            return (
+              <TimeSegment
+                key={i}
+                segment={segment}
+                state={state}
+                hasPadding={![8294, 8297].includes(segment.text.charCodeAt(0))}
+                // ^react-aria includes these characters to ensure correct RTL behaviour, but we want to avoid these adding random spacing
+              />
+            )
+          })}
           <div className={styles.focusRing} />
         </div>
       </div>

--- a/packages/components/src/TimeField/subcomponents/TimeSegment/TimeSegment.module.scss
+++ b/packages/components/src/TimeField/subcomponents/TimeSegment/TimeSegment.module.scss
@@ -10,7 +10,6 @@
 
 .timeSegment {
   display: block;
-  padding: 0 4px;
   text-align: end;
   background-color: $color-gray-300;
   border-radius: 3px;
@@ -25,6 +24,10 @@
     background: $color-blue-500;
     outline: none;
   }
+}
+
+.hasPadding {
+  padding: 0 4px;
 }
 
 .placeholder {

--- a/packages/components/src/TimeField/subcomponents/TimeSegment/TimeSegment.tsx
+++ b/packages/components/src/TimeField/subcomponents/TimeSegment/TimeSegment.tsx
@@ -8,9 +8,14 @@ import styles from './TimeSegment.module.scss'
 export type TimeSegmentProps = {
   segment: DateSegment
   state: DateFieldState
+  hasPadding?: boolean
 }
 
-export const TimeSegment = ({ segment, state }: TimeSegmentProps): JSX.Element => {
+export const TimeSegment = ({
+  segment,
+  state,
+  hasPadding = true,
+}: TimeSegmentProps): JSX.Element => {
   const ref = React.useRef<HTMLDivElement>(null)
   const { segmentProps } = useDateSegment(segment, state, ref)
 
@@ -29,6 +34,7 @@ export const TimeSegment = ({ segment, state }: TimeSegmentProps): JSX.Element =
           segment.type === 'literal' && styles.literal,
           segment.isPlaceholder && styles.placeholder,
           segment.type === 'dayPeriod' && styles.dayPeriod,
+          hasPadding && styles.hasPadding,
         )}
       >
         {generateSegmentDisplayText(segment)}


### PR DESCRIPTION
## Why
A recent dep update of the `@react-stately/datepicker` package caused some extra padding in the component

Before:
<img width="314" alt="image" src="https://github.com/user-attachments/assets/86b9caa1-3b37-4fcf-879e-c7ef36948d7d" />

After:
<img width="314" alt="image" src="https://github.com/user-attachments/assets/c6459370-279e-4ae4-913d-0a193182af1b" />

On further investigation, there were some new invisible 'segment' characters added to ensure correct RTL behaviour:
<img width="1603" alt="image" src="https://github.com/user-attachments/assets/3949132f-a23a-4ef8-9202-a364ca194394" />

Currently, every segment has padding added by us.

## What
Avoid adding padding to these new invisible character segments.
