### PR TITLE
fix: add argTypes to Tag (next) for the icon prop

### DIFF
--- a/packages/components/src/__next__/Tag/Tag/_docs/Tag.stories.tsx
+++ b/packages/components/src/__next__/Tag/Tag/_docs/Tag.stories.tsx
@@ -10,6 +10,16 @@ const meta = {
   args: {
     children: 'My tag',
   },
+  argTypes: {
+    icon: {
+      options: ['delete', 'arrow', 'add'],
+      mapping: {
+        delete: <Icon isPresentational name="delete" />,
+        arrow: <Icon isPresentational name="arrow_forward" />,
+        add: <Icon isPresentational name="add" />,
+      },
+    },
+  },
 } satisfies Meta<typeof Tag>
 
 export default meta


### PR DESCRIPTION
## Important: Request PR reviews on Slack

Please reach out to the design system team on Slack in `#prod_design_system` for PR reviews. GitHub notifications (e.g. from tagging a person) are not actively monitored.

## Why

<!-- Why have you created this PR? - Is it a new feature, or a bug fix? Or something else? -->
<!-- Reference any relevant Jira tickets so your reviewer can find more context if needed. -->
<!-- Fixing a GitHub issue? Add "Fixes [issue URL]". -->

https://cultureamp.slack.com/archives/C05D8V4GALX/p1743656786238939

The `icon` prop for Tag (next) has a type of `React.ReactElement`. By default, Storybook will make the control value an object, but clicking "Set object" in the preview panel will break the component.

## What

<!-- What do your changes do? How do they change/fix the current behavior? -->
<!-- Add screenshots, GIFs or videos to illustrate the changes.  -->

This PR adds `argTypes` to the Tag stories to provide some example options that the user can choose to preview icons in the Tag preview. It does it in the same way that it's done in Button (next)
