### PR TITLE
add changeset to release color-string pkg rollback

### DIFF
--- a/.changeset/light-waves-fall.md
+++ b/.changeset/light-waves-fall.md
@@ -1,0 +1,5 @@
+---
+'@kaizen/design-tokens': patch
+---
+
+version lock color-string to 1.9.1 to ensure compatibility with older repos

--- a/packages/design-tokens/package.json
+++ b/packages/design-tokens/package.json
@@ -35,8 +35,11 @@
     "clean:dist": "rimraf 'dist'"
   },
   "dependencies": {
-    "color-string": "^1.9.1",
+    "color-string": "1.9.1",
     "lodash.kebabcase": "^4.1.1"
+  },
+  "dependenciesComments": {
+    "color-string": "Version locked as 2.x as this will break implementation of older repos that are using the ThemeProvider (https://cultureamp.slack.com/archives/C0189KBPM4Y/p1742787520546679) - we will remove this in KAIO 2.0 so we can upgrade to 2.x then if still needed"
   },
   "devDependencies": {
     "@kaizen/package-bundler": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -516,7 +516,7 @@ importers:
   packages/design-tokens:
     dependencies:
       color-string:
-        specifier: ^1.9.1
+        specifier: 1.9.1
         version: 1.9.1
       lodash.kebabcase:
         specifier: ^4.1.1


### PR DESCRIPTION
## Why
We missed adding a changeset for the design-tokens package on the color-string roll back.

## What
- adds changset for color-string rollback
- add dep comments so we don't accidentally bump the version
