### PR TITLE
fix(components): reorder package.json export fields to prioritize types

### DIFF
--- a/.changeset/forty-women-wink.md
+++ b/.changeset/forty-women-wink.md
@@ -1,0 +1,5 @@
+---
+'@kaizen/components': patch
+---
+
+Reorder types and style to come first in exports package.json object

--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ Install and start processes (this start an interactive UI in your terminal) `dev
 The interactive terminal UI that pops up is called process-compose, see our [Confluence page](1) for tips on how to use it.
 
 Please see the [LDE Confluence page](2) for more information
-[1]:https://cultureamp.atlassian.net/wiki/x/ZYGJyw
-[2]:https://cultureamp.atlassian.net/wiki/spaces/DE/pages/3342434338
+[1]:<https://cultureamp.atlassian.net/wiki/x/ZYGJyw>
+[2]:<https://cultureamp.atlassian.net/wiki/spaces/DE/pages/3342434338>
 
 (Having trouble running Storybook? Try running `pnpm reset`, which includes `pnpm clean` and `pnpm install --force`!)
 
@@ -76,4 +76,4 @@ Please open a new [GitHub Issue](https://github.com/cultureamp/kaizen-design-sys
 
 ## Learn more
 
-Culture Amp employees can reach out to the Design Systems crew on Slack.
+Culture Amp employees can reach out to the Unified Systems crew on Slack.

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -93,9 +93,9 @@
       "require": "./dist/cjs/utilitiesV3.cjs"
     },
     "./dist/styles.css": {
+      "style": "./dist/styles.css",
       "import": "./dist/styles.css",
-      "require": "./dist/styles.css",
-      "style": "./dist/styles.css"
+      "require": "./dist/styles.css"
     }
   },
   "bin": {

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -33,64 +33,64 @@
   ],
   "exports": {
     ".": {
+      "types": "./dist/types/index.d.ts",
       "import": "./dist/esm/index.mjs",
-      "require": "./dist/cjs/index.cjs",
-      "types": "./dist/types/index.d.ts"
+      "require": "./dist/cjs/index.cjs"
     },
     "./future": {
+      "types": "./dist/types/__next__/index.d.ts",
       "import": "./dist/esm/future.mjs",
-      "require": "./dist/cjs/future.cjs",
-      "types": "./dist/types/__next__/index.d.ts"
+      "require": "./dist/cjs/future.cjs"
     },
     "./next": {
+      "types": "./dist/types/__next__/index.d.ts",
       "import": "./dist/esm/next.mjs",
-      "require": "./dist/cjs/next.cjs",
-      "types": "./dist/types/__next__/index.d.ts"
+      "require": "./dist/cjs/next.cjs"
     },
     "./v1/actions": {
+      "types": "./dist/types/v1-actions.d.ts",
       "import": "./dist/esm/actionsV1.mjs",
-      "require": "./dist/cjs/actionsV1.cjs",
-      "types": "./dist/types/v1-actions.d.ts"
+      "require": "./dist/cjs/actionsV1.cjs"
     },
     "./v1/overlays": {
+      "types": "./dist/types/v1-overlays.d.ts",
       "import": "./dist/esm/overlaysV1.mjs",
-      "main": "./dist/cjs/overlaysV1.cjs",
-      "types": "./dist/types/v1-overlays.d.ts"
+      "main": "./dist/cjs/overlaysV1.cjs"
     },
     "./v2/actions": {
+      "types": "./dist/types/v2-actions.d.ts",
       "import": "./dist/esm/actionsV2.mjs",
-      "require": "./dist/cjs/actionsV2.cjs",
-      "types": "./dist/types/v2-actions.d.ts"
+      "require": "./dist/cjs/actionsV2.cjs"
     },
     "./v2/overlays": {
+      "types": "./dist/types/v2-overlays.d.ts",
       "import": "./dist/esm/overlaysV2.mjs",
-      "require": "./dist/cjs/overlaysV2.cjs",
-      "types": "./dist/types/v2-overlays.d.ts"
+      "require": "./dist/cjs/overlaysV2.cjs"
     },
     "./v3/actions": {
+      "types": "./dist/types/v3-actions.d.ts",
       "import": "./dist/esm/actionsV3.mjs",
-      "require": "./dist/cjs/actionsV3.cjs",
-      "types": "./dist/types/v3-actions.d.ts"
+      "require": "./dist/cjs/actionsV3.cjs"
     },
     "./v3/overlays": {
+      "types": "./dist/types/v3-overlays.d.ts",
       "import": "./dist/esm/overlaysV3.mjs",
-      "require": "./dist/cjs/overlaysV3.cjs",
-      "types": "./dist/types/v3-overlays.d.ts"
+      "require": "./dist/cjs/overlaysV3.cjs"
     },
     "./v3/react-aria": {
+      "types": "./dist/types/__react-aria__/index.d.ts",
       "import": "./dist/esm/reactAriaV3.mjs",
-      "require": "./dist/cjs/reactAriaV3.cjs",
-      "types": "./dist/types/__react-aria__/index.d.ts"
+      "require": "./dist/cjs/reactAriaV3.cjs"
     },
     "./v3/react-aria-components": {
+      "types": "./dist/types/__react-aria-components__/index.d.ts",
       "import": "./dist/esm/reactAriaComponentsV3.mjs",
-      "require": "./dist/cjs/reactAriaComponentsV3.cjs",
-      "types": "./dist/types/__react-aria-components__/index.d.ts"
+      "require": "./dist/cjs/reactAriaComponentsV3.cjs"
     },
     "./v3/utilities": {
+      "types": "./dist/types/__utilities__/index.d.ts",
       "import": "./dist/esm/utilitiesV3.mjs",
-      "require": "./dist/cjs/utilitiesV3.cjs",
-      "types": "./dist/types/__utilities__/index.d.ts"
+      "require": "./dist/cjs/utilitiesV3.cjs"
     },
     "./dist/styles.css": {
       "import": "./dist/styles.css",


### PR DESCRIPTION
## Why

In our vitest CI jobs we were getting a [bunch of warnings](https://github.com/cultureamp/kaizen-design-system/actions/runs/14325027474/job/40148863590?pr=5625#step:4:62) about types needing to come first in our exports object.

## What

Reordered exports to have types come first.
