### PR TITLE
docs(client-side-routing): update documentation with next-services routing info

### DIFF
--- a/.changeset/lemon-rooms-laugh.md
+++ b/.changeset/lemon-rooms-laugh.md
@@ -1,0 +1,5 @@
+---
+'@docs/storybook': patch
+---
+
+Update client side routing docs to point to >= next-services@4.6.0 as the easy path to adopt

--- a/docs/pages/client-side-routing.mdx
+++ b/docs/pages/client-side-routing.mdx
@@ -4,9 +4,15 @@ import { Meta } from '@storybook/blocks'
 
 # Client Side Routing
 
-Updated Jan 29, 2025
+Updated Apr 11, 2025
 
 ## Client side routing
+
+### Using next-services
+
+If you use >= `@cultureamp/next-serivces@4.6.0` you'll get client side routing for free as this release includes`<RacRouterProvider>`in the`<FrontendServices>`provider tree and is part of the`defaultPresets`.
+
+### Not using next-services
 
 To enable client side routing, you will need to wrap your application in a [RouterProvider](https://react-spectrum.adobe.com/react-aria/routing.html#routerprovider) from the `react-aria-components` library. This allows you to set the `navigation` method that performs the client side routing in the `LinkButton` and `Link` component. Refer to the framework specific guidance below for [Next.js](#nextjs-config-example) or [React Router](#react-router-config-example).
 

--- a/docs/pages/client-side-routing.mdx
+++ b/docs/pages/client-side-routing.mdx
@@ -10,7 +10,7 @@ Updated Apr 11, 2025
 
 ### Using next-services
 
-If you use >= `@cultureamp/next-serivces@4.6.0` you'll get client side routing for free as this release includes`<RacRouterProvider>`in the`<FrontendServices>`provider tree and is part of the`defaultPresets`.
+If you use >= `@cultureamp/next-serivces@4.6.0` you'll get client side routing for free as this release includes `<RacRouterProvider>` in the `<FrontendServices>` provider tree and is part of the `defaultPresets`.
 
 ### Not using next-services
 
@@ -24,10 +24,10 @@ The following example demonstrates how you might use the React Aria's `RouterPro
 // ...imports
 import type { AppProps } from 'next/app'
 import { type NextRouter } from 'next/router'
-import { RouterProvider as RacRouterProvider } from 'react-aria-components'
+import { RouterProvider as RacRouterProvider } from '@kaizen/components/v3/react-aria-components'
 
 // This provides the correct types for `routerOptions` based on the routing solution. As the component agnostic to routing technology this must defined here
-declare module 'react-aria-components' {
+declare module '@kaizen/components/v3/react-aria-components' {
   interface RouterConfig {
     // index 2 is the types for the pages routerOptions
     routerOptions: NonNullable<Parameters<NextRouter['push']>[2]>
@@ -53,7 +53,7 @@ The implementation for `LinkButton` in your application would then look somethin
 
 ```tsx
 import { useRouter } from 'next/router'
-import { LinkButton } from '@kaizen/components/v3/actions'
+import { LinkButton } from '@kaizen/components'
 
 const Component = () => {
   const router = useRouter()
@@ -77,10 +77,10 @@ Additional config options for Next.js can be found in the React Aria's documenta
 The following example demonstrates how to use the `RouterProvider` with `React Router`'s. This will allow the `LinkButton` to navigate using the `useNavigate` hook.
 
 ```tsx
-import { RouterProvider } from 'react-aria-components'
+import { RouterProvider } from '@kaizen/components/v3/react-aria-components'
 import { BrowserRouter, NavigateOptions, useHref, useNavigate } from 'react-router-dom'
 
-declare module 'react-aria-components' {
+declare module '@kaizen/components/v3/react-aria-components' {
   interface RouterConfig {
     routerOptions: NavigateOptions
   }

--- a/docs/pages/client-side-routing.mdx
+++ b/docs/pages/client-side-routing.mdx
@@ -10,11 +10,11 @@ Updated Apr 11, 2025
 
 ### Using next-services
 
-If you use >= `@cultureamp/next-serivces@4.6.0` you'll get client side routing for free as this release includes `<RacRouterProvider>` in the `<FrontendServices>` provider tree and is part of the `defaultPresets`.
+If you use >= [`@cultureamp/next-serivces@4.6.0`](https://github.com/cultureamp/frontend-foundations/tree/master/packages/next-services) you'll get client side routing for free as this release includes `<RacRouterProvider>` in the `<FrontendServices>` provider tree and is part of the `defaultPresets`.
 
 ### Not using next-services
 
-To enable client side routing, you will need to wrap your application in a [RouterProvider](https://react-spectrum.adobe.com/react-aria/routing.html#routerprovider) from the `react-aria-components` library. This allows you to set the `navigation` method that performs the client side routing in the `LinkButton` and `Link` component. Refer to the framework specific guidance below for [Next.js](#nextjs-config-example) or [React Router](#react-router-config-example).
+To enable client side routing, you will need to wrap your application in a [RouterProvider](https://react-spectrum.adobe.com/react-aria/routing.html#routerprovider) from `@kaizen/components/v3/react-aria-components`. This allows you to set the `navigation` method that performs the client side routing in the `LinkButton` and `Link` component. Refer to the framework specific guidance below for [Next.js](#nextjs-config-example) or [React Router](#react-router-config-example).
 
 ### Next.js config example
 


### PR DESCRIPTION
## Why

next-services@4.6.0 now includes react-aria-components `RouterProvider` as part of the defaultPresets so `Link` & `LinkButton` will just work™️

## What

Updated client-side routing docs, this also changes the docs to show that using the RAC re-export is the preferred method.

https://cultureamp.atlassian.net/browse/KZN-3239
