### PR TITLE
chore: Ignore peerDep warnings for older packages

### DIFF
--- a/.changeset/late-terms-hide.md
+++ b/.changeset/late-terms-hide.md
@@ -1,0 +1,5 @@
+---
+'@kaizen/components': patch
+---
+
+chore: add targetted allowed versions for unmaintained dependencies

--- a/package.json
+++ b/package.json
@@ -108,6 +108,8 @@
         "react-textfit>react-dom": "19",
         "react-popper>react": "19",
         "react-popper>react-dom": "19",
+        "@popper/core>react": "19",
+        "@popper/core>react-dom": "19",
         "eslint": "9"
       }
     },

--- a/package.json
+++ b/package.json
@@ -100,8 +100,12 @@
   "pnpm": {
     "peerDependencyRules": {
       "allowedVersions": {
-        "react": "18",
-        "react-dom": "18",
+        "@reach/tabs>react": "19",
+        "@reach/tabs>react-dom": "19",
+        "react-focus-on>react": "19",
+        "react-focus-on>react-dom": "19",
+        "react-textfit>react": "19",
+        "react-textfit>react-dom": "19",
         "eslint": "9"
       }
     },

--- a/package.json
+++ b/package.json
@@ -100,17 +100,17 @@
   "pnpm": {
     "peerDependencyRules": {
       "allowedVersions": {
-        "@reach/tabs>react": "19",
-        "@reach/tabs>react-dom": "19",
-        "react-focus-on>react": "19",
-        "react-focus-on>react-dom": "19",
-        "react-textfit>react": "19",
-        "react-textfit>react-dom": "19",
-        "react-popper>react": "19",
-        "react-popper>react-dom": "19",
         "@popper/core>react": "19",
         "@popper/core>react-dom": "19",
-        "eslint": "9"
+        "@reach/tabs>react": "19",
+        "@reach/tabs>react-dom": "19",
+        "eslint": "9",
+        "react-focus-on>react": "19",
+        "react-focus-on>react-dom": "19",
+        "react-popper>react": "19",
+        "react-popper>react-dom": "19",
+        "react-textfit>react": "19",
+        "react-textfit>react-dom": "19"
       }
     },
     "overrides": {

--- a/package.json
+++ b/package.json
@@ -106,6 +106,8 @@
         "react-focus-on>react-dom": "19",
         "react-textfit>react": "19",
         "react-textfit>react-dom": "19",
+        "react-popper>react": "19",
+        "react-popper>react-dom": "19",
         "eslint": "9"
       }
     },


### PR DESCRIPTION
## Why

In order to upgrade to react 19 we need to suppress some peerdep warnings for specific packages as they no longer maintained.

## What

The 5 packages so far that need to have peerDep versions changed/ignored are:

* @reach/tab - no longer maintained
* react-focus-on - has an [outstanding issue](https://github.com/theKashey/react-focus-on/issues/98) to allow 19 as a peerDep
* react-textfit - no longer maintained
* react-popper - archived, floating-ui is the path forward
* @popper/core - same as above

Will create some tech health cards if they don't exist already to address and track these issues.