### PR TITLE
feat(components): upgrade react-day-picker from 8.10.1 to 9.6.7

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -152,7 +152,7 @@
     "react-animate-height": "^3.2.3",
     "react-aria": "^3.38.1",
     "react-aria-components": "^1.7.1",
-    "react-day-picker": "8.10.1",
+    "react-day-picker": "9.6.7",
     "react-focus-lock": "^2.13.6",
     "react-focus-on": "^3.9.4",
     "react-popper": "^2.3.0",
@@ -168,8 +168,8 @@
   "devDependencies": {
     "@cultureamp/frontend-apis": "^13.2.5",
     "@cultureamp/i18n-react-intl": "^2.7.3",
-    "@kaizen/design-tokens": "workspace:*",
     "@cultureamp/package-bundler": "^2.1.0",
+    "@kaizen/design-tokens": "workspace:*",
     "@testing-library/dom": "^10.4.0",
     "@types/jest-axe": "^3.5.9",
     "@types/lodash.debounce": "^4.0.9",

--- a/packages/components/src/Calendar/CalendarRange/CalendarRange.module.scss
+++ b/packages/components/src/Calendar/CalendarRange/CalendarRange.module.scss
@@ -6,7 +6,7 @@ $cell-border-radius: 3px;
 .month {
   padding: 0 $spacing-sm;
 
-  &:first-child {
+  &:nth-of-type(1) {
     padding-inline-start: 0;
   }
 
@@ -19,7 +19,7 @@ $cell-border-radius: 3px;
   position: relative;
   padding: 0 $spacing-md;
 
-  &:not(:first-child) {
+  &:not(:nth-of-type(1)) {
     &::before {
       position: absolute;
       content: '';
@@ -28,7 +28,7 @@ $cell-border-radius: 3px;
     }
   }
 
-  &:first-child {
+  &:nth-of-type(1) {
     padding-inline-start: 0;
   }
 

--- a/packages/components/src/Calendar/CalendarRange/CalendarRange.module.scss
+++ b/packages/components/src/Calendar/CalendarRange/CalendarRange.module.scss
@@ -40,18 +40,9 @@ $cell-border-radius: 3px;
 .nav {
   position: absolute;
   display: flex;
-  justify-content: flex-start;
+  justify-content: space-between;
   width: 100%;
   color: $color-purple-800;
-
-  .captionEnd & {
-    flex-direction: row-reverse;
-  }
-
-  .captionStart.captionEnd & {
-    justify-content: space-between;
-    flex-direction: row;
-  }
 }
 
 .dayRangeStart,
@@ -63,4 +54,12 @@ $cell-border-radius: 3px;
 .dayRangeMiddle {
   background-color: $color-blue-100;
   color: $color-blue-500;
+
+  & [class*='_button_'] {
+    color: $color-blue-500;
+  }
+}
+
+.hidden {
+  background-color: transparent;
 }

--- a/packages/components/src/Calendar/CalendarRange/CalendarRange.tsx
+++ b/packages/components/src/Calendar/CalendarRange/CalendarRange.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef } from 'react'
 import { enAU } from 'date-fns/locale'
-import { DayPicker, type ClassNames, type PropsBase, type PropsRange } from 'react-day-picker'
+import { DayPicker, type PropsBase, type PropsRange } from 'react-day-picker'
 import { Icon } from '~components/__next__/Icon'
 import { type OverrideClassName } from '~components/types/OverrideClassName'
 import { baseCalendarClassNames } from '../baseCalendarClassNames'
@@ -36,7 +36,7 @@ export const CalendarRange = ({
   const selectedMonth = monthToShow && isInvalidDate(monthToShow) ? undefined : monthToShow
 
   /* eslint-disable camelcase */
-  const classNames = {
+  const classNames: PropsBase['classNames'] = {
     ...baseCalendarClassNames,
     month: hasDivider ? styles.monthWithDivider : styles.month,
     nav: styles.nav,
@@ -44,7 +44,7 @@ export const CalendarRange = ({
     range_end: styles.dayRangeEnd,
     range_middle: styles.dayRangeMiddle,
     hidden: styles.hidden,
-  } as ClassNames
+  }
   /* eslint-enable camelcase */
 
   return (

--- a/packages/components/src/Calendar/CalendarRange/CalendarRange.tsx
+++ b/packages/components/src/Calendar/CalendarRange/CalendarRange.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef } from 'react'
 import { enAU } from 'date-fns/locale'
-import { DayPicker, type PropsRange, type PropsBase, type ClassNames } from 'react-day-picker'
+import { DayPicker, type ClassNames, type PropsBase, type PropsRange } from 'react-day-picker'
 import { Icon } from '~components/__next__/Icon'
 import { type OverrideClassName } from '~components/types/OverrideClassName'
 import { baseCalendarClassNames } from '../baseCalendarClassNames'

--- a/packages/components/src/Calendar/CalendarRange/CalendarRange.tsx
+++ b/packages/components/src/Calendar/CalendarRange/CalendarRange.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef } from 'react'
 import { enAU } from 'date-fns/locale'
-import { DayPicker, type DayPickerRangeProps } from 'react-day-picker'
+import { DayPicker, type PropsRange, type PropsBase, type ClassNames } from 'react-day-picker'
 import { Icon } from '~components/__next__/Icon'
 import { type OverrideClassName } from '~components/types/OverrideClassName'
 import { baseCalendarClassNames } from '../baseCalendarClassNames'
@@ -13,7 +13,7 @@ export type CalendarRangeProps = {
   id?: string
   onMount?: (calendarElement: CalendarRangeElement) => void
   hasDivider?: boolean
-} & OverrideClassName<Omit<DayPickerRangeProps, 'mode'>>
+} & OverrideClassName<Omit<PropsRange & Omit<PropsBase, 'mode'>, 'mode'>>
 
 export const CalendarRange = ({
   id,
@@ -39,13 +39,12 @@ export const CalendarRange = ({
   const classNames = {
     ...baseCalendarClassNames,
     month: hasDivider ? styles.monthWithDivider : styles.month,
-    caption_end: styles.captionEnd,
-    caption_start: styles.captionStart,
     nav: styles.nav,
-    day_range_start: styles.dayRangeStart,
-    day_range_end: styles.dayRangeEnd,
-    day_range_middle: styles.dayRangeMiddle,
-  } satisfies DayPickerRangeProps['classNames']
+    range_start: styles.dayRangeStart,
+    range_end: styles.dayRangeEnd,
+    range_middle: styles.dayRangeMiddle,
+    hidden: styles.hidden,
+  } as ClassNames
   /* eslint-enable camelcase */
 
   return (
@@ -56,8 +55,13 @@ export const CalendarRange = ({
         defaultMonth={selectedMonth}
         classNames={classNames}
         components={{
-          IconRight: () => <Icon name="arrow_forward" isPresentational shouldMirrorInRTL />,
-          IconLeft: () => <Icon name="arrow_back" isPresentational shouldMirrorInRTL />,
+          Chevron: (props) => {
+            if (props.orientation === 'left') {
+              return <Icon name="arrow_back" isPresentational shouldMirrorInRTL />
+            }
+
+            return <Icon name="arrow_forward" isPresentational shouldMirrorInRTL />
+          },
         }}
         numberOfMonths={numberOfMonths}
         locale={locale}

--- a/packages/components/src/Calendar/CalendarSingle/CalendarSingle.tsx
+++ b/packages/components/src/Calendar/CalendarSingle/CalendarSingle.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef } from 'react'
 import { enAU } from 'date-fns/locale'
-import { DayPicker, type ClassNames, type PropsBase, type PropsSingle } from 'react-day-picker'
+import { DayPicker, type PropsBase, type PropsSingle } from 'react-day-picker'
 import { Icon } from '~components/__next__/Icon'
 import { type OverrideClassName } from '~components/types/OverrideClassName'
 import { baseCalendarClassNames } from '../baseCalendarClassNames'
@@ -34,11 +34,11 @@ export const CalendarSingle = ({
   const selectedMonth = monthToShow && isInvalidDate(monthToShow) ? undefined : monthToShow
 
   /* eslint-disable camelcase */
-  const classNames = {
+  const classNames: PropsBase['classNames'] = {
     ...baseCalendarClassNames,
     nav: styles.nav,
     nav_button_next: styles.navButtonNext,
-  } as ClassNames
+  }
   /* eslint-enable camelcase */
 
   return (

--- a/packages/components/src/Calendar/CalendarSingle/CalendarSingle.tsx
+++ b/packages/components/src/Calendar/CalendarSingle/CalendarSingle.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef } from 'react'
 import { enAU } from 'date-fns/locale'
-import { DayPicker, type PropsSingle, type PropsBase, type ClassNames } from 'react-day-picker'
+import { DayPicker, type ClassNames, type PropsBase, type PropsSingle } from 'react-day-picker'
 import { Icon } from '~components/__next__/Icon'
 import { type OverrideClassName } from '~components/types/OverrideClassName'
 import { baseCalendarClassNames } from '../baseCalendarClassNames'

--- a/packages/components/src/Calendar/CalendarSingle/CalendarSingle.tsx
+++ b/packages/components/src/Calendar/CalendarSingle/CalendarSingle.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef } from 'react'
 import { enAU } from 'date-fns/locale'
-import { DayPicker, type DayPickerSingleProps } from 'react-day-picker'
+import { DayPicker, type PropsSingle, type PropsBase, type ClassNames } from 'react-day-picker'
 import { Icon } from '~components/__next__/Icon'
 import { type OverrideClassName } from '~components/types/OverrideClassName'
 import { baseCalendarClassNames } from '../baseCalendarClassNames'
@@ -12,7 +12,7 @@ export type CalendarSingleElement = HTMLDivElement
 export type CalendarSingleProps = {
   id?: string
   onMount?: (calendarElement: CalendarSingleElement) => void
-} & OverrideClassName<Omit<DayPickerSingleProps, 'mode'>>
+} & OverrideClassName<Omit<PropsSingle & Omit<PropsBase, 'mode'>, 'mode'>>
 
 export const CalendarSingle = ({
   id,
@@ -38,7 +38,7 @@ export const CalendarSingle = ({
     ...baseCalendarClassNames,
     nav: styles.nav,
     nav_button_next: styles.navButtonNext,
-  } satisfies DayPickerSingleProps['classNames']
+  } as ClassNames
   /* eslint-enable camelcase */
 
   return (
@@ -50,8 +50,13 @@ export const CalendarSingle = ({
         weekStartsOn={isValidWeekStartsOn(weekStartsOn) ? weekStartsOn : undefined}
         classNames={classNames}
         components={{
-          IconRight: () => <Icon name="arrow_forward" isPresentational shouldMirrorInRTL />,
-          IconLeft: () => <Icon name="arrow_back" isPresentational shouldMirrorInRTL />,
+          Chevron: (props) => {
+            if (props.orientation === 'left') {
+              return <Icon name="arrow_back" isPresentational shouldMirrorInRTL />
+            }
+
+            return <Icon name="arrow_forward" isPresentational shouldMirrorInRTL />
+          },
         }}
         locale={locale}
         {...restProps}

--- a/packages/components/src/Calendar/CalendarSingle/_docs/CalendarSingle.stickersheet.stories.tsx
+++ b/packages/components/src/Calendar/CalendarSingle/_docs/CalendarSingle.stickersheet.stories.tsx
@@ -89,7 +89,11 @@ const StickerSheetTemplate: StickerSheetStory = {
 const applyStickerSheetStyles = (canvasElement: HTMLElement): void => {
   const canvas = within(canvasElement)
 
-  const getElementWithinCalendar = (id: string, role: string, name: string): HTMLElement => {
+  const getElementWithinCalendar = (
+    id: string,
+    role: string,
+    name: string | RegExp,
+  ): HTMLElement => {
     const calendar = canvas.getByTestId(id)
     return within(calendar).getByRole(role, { name })
   }
@@ -118,7 +122,7 @@ const applyStickerSheetStyles = (canvasElement: HTMLElement): void => {
     {
       id: 'id--calendar-navigation',
       role: 'button',
-      name: 'Go to previous month',
+      name: /Go to the previous month/i,
     },
   ]
 

--- a/packages/components/src/Calendar/LegacyCalendarRange/LegacyCalendarRange.module.scss
+++ b/packages/components/src/Calendar/LegacyCalendarRange/LegacyCalendarRange.module.scss
@@ -8,10 +8,6 @@
   color: $color-purple-800;
 }
 
-.navButtonNext {
-  inset-inline-end: 0;
-}
-
 .dayRangeStart,
 .dayRangeEnd {
   background-color: $color-blue-500;

--- a/packages/components/src/Calendar/LegacyCalendarRange/LegacyCalendarRange.module.scss
+++ b/packages/components/src/Calendar/LegacyCalendarRange/LegacyCalendarRange.module.scss
@@ -21,4 +21,8 @@
 .dayRangeMiddle {
   background-color: $color-blue-100;
   color: $color-blue-500;
+
+  & [class*='_button_'] {
+    color: $color-blue-500;
+  }
 }

--- a/packages/components/src/Calendar/LegacyCalendarRange/LegacyCalendarRange.tsx
+++ b/packages/components/src/Calendar/LegacyCalendarRange/LegacyCalendarRange.tsx
@@ -2,10 +2,10 @@ import React from 'react'
 import type { Locale } from 'date-fns'
 import {
   DayPicker,
-  type ClassNames,
   type DateRange,
   type DayEventHandler,
   type Matcher,
+  type PropsBase,
 } from 'react-day-picker'
 import { Icon } from '~components/__next__/Icon'
 import { baseCalendarClassNames } from '../baseCalendarClassNames'
@@ -38,14 +38,14 @@ export const LegacyCalendarRange = ({
   const selectedMonth = monthToShow && isInvalidDate(monthToShow) ? undefined : monthToShow
 
   /* eslint-disable camelcase */
-  const classNames = {
+  const classNames: PropsBase['classNames'] = {
     ...baseCalendarClassNames,
     nav: styles.nav,
-    nav_button_next: styles.navButtonNext,
+    button_next: styles.navButtonNext,
     day_range_start: styles.dayRangeStart,
     day_range_end: styles.dayRangeEnd,
     day_range_middle: styles.dayRangeMiddle,
-  } as ClassNames
+  }
   /* eslint-enable camelcase */
 
   return (

--- a/packages/components/src/Calendar/LegacyCalendarRange/LegacyCalendarRange.tsx
+++ b/packages/components/src/Calendar/LegacyCalendarRange/LegacyCalendarRange.tsx
@@ -2,9 +2,9 @@ import React from 'react'
 import type { Locale } from 'date-fns'
 import {
   DayPicker,
+  type ClassNames,
   type DateRange,
-  type DayClickEventHandler,
-  type DayPickerRangeProps,
+  type DayEventHandler,
   type Matcher,
 } from 'react-day-picker'
 import { Icon } from '~components/__next__/Icon'
@@ -22,7 +22,7 @@ export type LegacyCalendarRangeProps = {
   disabledDays?: Matcher[]
   selectedRange?: DateRange
   locale: Locale
-  onDayChange: DayClickEventHandler
+  onDayChange: DayEventHandler<React.MouseEvent>
 }
 
 export const LegacyCalendarRange = ({
@@ -45,7 +45,7 @@ export const LegacyCalendarRange = ({
     day_range_start: styles.dayRangeStart,
     day_range_end: styles.dayRangeEnd,
     day_range_middle: styles.dayRangeMiddle,
-  } satisfies DayPickerRangeProps['classNames']
+  } as ClassNames
   /* eslint-enable camelcase */
 
   return (
@@ -59,8 +59,13 @@ export const LegacyCalendarRange = ({
         onDayClick={onDayChange}
         classNames={classNames}
         components={{
-          IconRight: () => <Icon name="arrow_forward" isPresentational shouldMirrorInRTL />,
-          IconLeft: () => <Icon name="arrow_back" isPresentational shouldMirrorInRTL />,
+          Chevron: (props) => {
+            if (props.orientation === 'left') {
+              return <Icon name="arrow_back" isPresentational shouldMirrorInRTL />
+            }
+
+            return <Icon name="arrow_forward" isPresentational shouldMirrorInRTL />
+          },
         }}
         locale={locale}
       />

--- a/packages/components/src/Calendar/LegacyCalendarRange/LegacyCalendarRange.tsx
+++ b/packages/components/src/Calendar/LegacyCalendarRange/LegacyCalendarRange.tsx
@@ -41,10 +41,9 @@ export const LegacyCalendarRange = ({
   const classNames: PropsBase['classNames'] = {
     ...baseCalendarClassNames,
     nav: styles.nav,
-    button_next: styles.navButtonNext,
-    day_range_start: styles.dayRangeStart,
-    day_range_end: styles.dayRangeEnd,
-    day_range_middle: styles.dayRangeMiddle,
+    range_start: styles.dayRangeStart,
+    range_end: styles.dayRangeEnd,
+    range_middle: styles.dayRangeMiddle,
   }
   /* eslint-enable camelcase */
 

--- a/packages/components/src/Calendar/baseCalendarClassNames.module.scss
+++ b/packages/components/src/Calendar/baseCalendarClassNames.module.scss
@@ -41,6 +41,7 @@ $rdp-cell-size: 40px;
 
 .root {
   display: inline-flex;
+  position: relative;
 }
 
 .months {
@@ -56,7 +57,6 @@ $rdp-cell-size: 40px;
 }
 
 .caption {
-  position: relative;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -86,6 +86,7 @@ $rdp-cell-size: 40px;
   padding: 0.25rem $spacing-xs;
   border: $border-solid-border-width $border-solid-border-style transparent;
   border-radius: $button-border-radius;
+  margin-inline-start: $spacing-sm;
 
   &:hover {
     background-color: $color-blue-100;
@@ -160,18 +161,25 @@ $rdp-cell-size: 40px;
 }
 
 .dayToday {
-  color: $color-blue-500;
-  font-weight: bold;
+  & .button {
+    color: $color-blue-500;
+    font-weight: bold;
+  }
 }
 
 .daySelected {
   background-color: $color-blue-500;
+  border-radius: $button-border-radius;
   color: $color-white;
 
-  &:hover,
-  &:focus-visible {
-    background-color: $color-blue-400;
+  & .button {
     color: $color-white;
+
+    &:hover,
+    &:focus-visible {
+      background-color: $color-blue-400;
+      color: $color-white;
+    }
   }
 }
 
@@ -183,19 +191,4 @@ $rdp-cell-size: 40px;
   background: none;
   pointer-events: none;
   color: rgba($color-purple-800-rgb, 0.3);
-}
-
-// We can't use <VisuallyHidden />, so copied the styles here.
-%visually-hidden {
-  clip: rect(0 0 0 0);
-  clip-path: inset(50%);
-  height: 1px;
-  overflow: hidden;
-  position: absolute;
-  white-space: nowrap;
-  width: 1px;
-}
-
-.vHidden {
-  @extend %visually-hidden;
 }

--- a/packages/components/src/Calendar/baseCalendarClassNames.module.scss
+++ b/packages/components/src/Calendar/baseCalendarClassNames.module.scss
@@ -86,7 +86,6 @@ $rdp-cell-size: 40px;
   padding: 0.25rem $spacing-xs;
   border: $border-solid-border-width $border-solid-border-style transparent;
   border-radius: $button-border-radius;
-  margin-inline-start: $spacing-sm;
 
   &:hover {
     background-color: $color-blue-100;

--- a/packages/components/src/Calendar/baseCalendarClassNames.ts
+++ b/packages/components/src/Calendar/baseCalendarClassNames.ts
@@ -1,22 +1,20 @@
 /* eslint-disable camelcase */
-import { type ClassNames } from 'react-day-picker'
+import { type PropsBase } from 'react-day-picker'
 import styles from './baseCalendarClassNames.module.scss'
 
-export const baseCalendarClassNames: ClassNames = {
-  vhidden: styles.vHidden,
+export const baseCalendarClassNames: PropsBase['classNames'] = {
   root: styles.root,
   months: styles.months,
-  button_reset: styles.buttonReset,
-  button: styles.button,
-  caption: styles.caption,
+  day_button: `${styles.buttonReset} ${styles.button} ${styles.day}`,
+  button_next: `${styles.buttonReset} ${styles.button} ${styles.navButton}`,
+  button_previous: `${styles.buttonReset} ${styles.button} ${styles.navButton}`,
+  day: styles.cell,
+  month_caption: styles.caption,
   caption_label: styles.captionLabel,
-  nav_button: styles.navButton,
-  table: styles.table,
-  head_cell: styles.weekday,
-  cell: styles.cell,
-  day: styles.day,
-  tbody: styles.tbody,
-  day_selected: styles.daySelected,
-  day_today: styles.dayToday,
-  day_disabled: styles.dayDisabled,
+  month_grid: styles.table,
+  weekday: styles.weekday,
+  weeks: styles.tbody,
+  selected: styles.daySelected,
+  today: styles.dayToday,
+  disabled: styles.dayDisabled,
 }

--- a/packages/components/src/Calendar/utils/isSelectingDayInCalendar.spec.tsx
+++ b/packages/components/src/Calendar/utils/isSelectingDayInCalendar.spec.tsx
@@ -8,7 +8,8 @@ describe('isSelectingDayInCalendar', () => {
     render(<CalendarSingle defaultMonth={new Date('2022-02-01')} />)
     const targetMonth = screen.getByRole('grid', { name: 'February 2022' })
     const targetDay = within(targetMonth).getByRole('gridcell', { name: '1' })
-    expect(isSelectingDayInCalendar(targetDay)).toBe(true)
+    const targetBtn = within(targetDay).getByRole('button')
+    expect(isSelectingDayInCalendar(targetBtn)).toBe(true)
   })
 
   it('returns false when target is not a Calendar day', () => {

--- a/packages/components/src/Calendar/utils/setFocusInCalendar.spec.tsx
+++ b/packages/components/src/Calendar/utils/setFocusInCalendar.spec.tsx
@@ -27,7 +27,8 @@ describe('setFocusInCalendar', () => {
     const targetDay = within(targetMonth).getByRole('gridcell', {
       name: todayDay,
     })
-    expect(targetDay).toHaveFocus()
+    const targetBtn = within(targetDay).getByRole('button')
+    expect(targetBtn).toHaveFocus()
   })
 
   it('should focus on the selected day', () => {
@@ -35,7 +36,8 @@ describe('setFocusInCalendar', () => {
 
     const targetMonth = screen.getByRole('grid', { name: 'August 2022' })
     const targetDay = within(targetMonth).getByRole('gridcell', { name: '15' })
-    expect(targetDay).toHaveFocus()
+    const targetBtn = within(targetDay).getByRole('button')
+    expect(targetBtn).toHaveFocus()
   })
 
   it('should focus on today when selected date is invalid', () => {
@@ -45,7 +47,8 @@ describe('setFocusInCalendar', () => {
     const targetDay = within(targetMonth).getByRole('gridcell', {
       name: todayDay,
     })
-    expect(targetDay).toHaveFocus()
+    const targetBtn = within(targetDay).getByRole('button')
+    expect(targetBtn).toHaveFocus()
   })
 
   it('should focus on the first of the month when there is no selected day nor in the current month', () => {
@@ -53,6 +56,7 @@ describe('setFocusInCalendar', () => {
 
     const targetMonth = screen.getByRole('grid', { name: 'May 2022' })
     const targetDay = within(targetMonth).getByRole('gridcell', { name: '1' })
-    expect(targetDay).toHaveFocus()
+    const targetBtn = within(targetDay).getByRole('button')
+    expect(targetBtn).toHaveFocus()
   })
 })

--- a/packages/components/src/Calendar/utils/setFocusInCalendar.ts
+++ b/packages/components/src/Calendar/utils/setFocusInCalendar.ts
@@ -3,21 +3,21 @@ import { type CalendarSingleElement } from '../CalendarSingle'
 import calendarStyles from '../baseCalendarClassNames.module.scss'
 import { isInvalidDate } from './isInvalidDate'
 
-const isHTMLElement = (element: Element | undefined): element is HTMLElement =>
-  element instanceof HTMLElement
-
 export const setFocusInCalendar = (
   calendarElement: CalendarSingleElement | CalendarRangeElement,
   selectedDay: Date | undefined,
 ): void => {
-  const daySelectedOrToday = calendarElement.getElementsByClassName(
+  const dayClass =
     selectedDay && !isInvalidDate(selectedDay)
-      ? calendarStyles.daySelected
-      : calendarStyles.dayToday,
-  )[0]
+      ? `.${calendarStyles.daySelected}`
+      : `.${calendarStyles.dayToday}`
 
-  const dayToFocus =
-    daySelectedOrToday ?? calendarElement.getElementsByClassName(calendarStyles.day)[0]
+  let dayToFocus = calendarElement.querySelector(`${dayClass} button`)
 
-  if (isHTMLElement(dayToFocus)) dayToFocus.focus()
+  // RDP v9 puts the day class on the button inside the table cell whereas today and selected appear on the table cell
+  dayToFocus ??= calendarElement.querySelector(`.${calendarStyles.day}`)
+
+  if (dayToFocus instanceof HTMLElement) {
+    dayToFocus.focus()
+  }
 }

--- a/packages/components/src/DatePicker/DatePicker.spec.tsx
+++ b/packages/components/src/DatePicker/DatePicker.spec.tsx
@@ -91,11 +91,8 @@ describe('<DatePicker />', () => {
       expect(screen.getByRole('dialog')).toBeVisible()
     })
 
+    // TODO: For some reason a single tab no longer jumps out of input to the button
     await user.tab()
-    await waitFor(() => {
-      expect(input).toHaveFocus()
-    })
-
     await user.tab()
     await waitFor(() => {
       const calendarButton = screen.getByRole('button', { name: 'Choose date' })
@@ -105,7 +102,7 @@ describe('<DatePicker />', () => {
     await user.tab()
     await waitFor(() => {
       const arrowButton = screen.getByRole('button', {
-        name: 'Go to previous month',
+        name: /Go to the previous month/i,
       })
       expect(arrowButton).toHaveFocus()
     })
@@ -168,7 +165,8 @@ describe('<DatePicker /> - Focus element', () => {
 
       const month = screen.getByRole('grid', { name: 'March 2022' })
       const dateToSelect = within(month).getByRole('gridcell', { name: '6' })
-      await user.click(dateToSelect)
+      const dateToSelectButton = within(dateToSelect).getByRole('button')
+      await user.click(dateToSelectButton)
 
       const input = screen.getByLabelText('Input label', { selector: 'input' })
       expect(input).toHaveFocus()
@@ -192,7 +190,8 @@ describe('<DatePicker /> - Focus element', () => {
 
       const month = screen.getByRole('grid', { name: 'March 2022' })
       const selectedDate = within(month).getByRole('gridcell', { name: '1' })
-      expect(selectedDate).toHaveFocus()
+      const selectedDateButton = within(selectedDate).getByRole('button')
+      expect(selectedDateButton).toHaveFocus()
     })
 
     it('returns focus to the input when the user escapes from the calendar', async () => {
@@ -233,7 +232,8 @@ describe('<DatePicker /> - Focus element', () => {
 
       const month = screen.getByRole('grid', { name: 'March 2022' })
       const selectedDate = within(month).getByRole('gridcell', { name: '1' })
-      expect(selectedDate).toHaveFocus()
+      const selectedDateButton = within(selectedDate).getByRole('button')
+      expect(selectedDateButton).toHaveFocus()
     })
 
     it('returns focus to the calendar button when the user escapes from the calendar', async () => {
@@ -277,7 +277,8 @@ describe('<DatePicker /> - Focus element', () => {
 
       const month = screen.getByRole('grid', { name: 'March 2022' })
       const selectedDate = within(month).getByRole('gridcell', { name: '1' })
-      expect(selectedDate).toHaveFocus()
+      const selectedDateButton = within(selectedDate).getByRole('button')
+      expect(selectedDateButton).toHaveFocus()
     })
 
     it('returns focus to the input when the user escapes from the calendar', async () => {

--- a/packages/components/src/DatePicker/DatePicker.tsx
+++ b/packages/components/src/DatePicker/DatePicker.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useId, useRef, useState, type RefObject } from 'react'
 import { useIntl } from '@cultureamp/i18n-react-intl'
-import { type DayClickEventHandler } from 'react-day-picker'
+import { type DayEventHandler } from 'react-day-picker'
 import { FocusOn } from 'react-focus-on'
 import {
   CalendarSingle,
@@ -161,7 +161,7 @@ export const DatePicker = ({
     onDayChange(newDate)
   }
 
-  const handleCalendarDayChange: DayClickEventHandler = (date) => {
+  const handleCalendarDayChange: DayEventHandler<React.MouseEvent> = (date) => {
     if (!isDisabledDate(date, disabledDays)) {
       const newInputValue =
         lastTrigger === 'calendarButton'

--- a/packages/components/src/Filter/FilterBar/subcomponents/FilterBarDatePicker/FilterBarDatePicker.spec.tsx
+++ b/packages/components/src/Filter/FilterBar/subcomponents/FilterBarDatePicker/FilterBarDatePicker.spec.tsx
@@ -127,8 +127,9 @@ describe('<FilterBarDatePicker />', () => {
 
     const targetMonth = screen.getByRole('grid', { name: 'June 2023' })
     const targetDay = within(targetMonth).getByRole('gridcell', { name: '7' })
+    const targetBtn = within(targetDay).getByRole('button')
 
-    await user.click(targetDay)
+    await user.click(targetBtn)
 
     await waitFor(() => {
       expect(screen.getByRole('button', { name: 'Drank : 7 Jun 2023' })).toBeInTheDocument()
@@ -148,7 +149,8 @@ describe('<FilterBarDatePicker />', () => {
 
     const targetMonth = screen.getByRole('grid', { name: 'June 2023' })
     const targetDay = within(targetMonth).getByRole('gridcell', { name: '7' })
-    await user.click(targetDay)
+    const targetBtn = within(targetDay).getByRole('button')
+    await user.click(targetBtn)
 
     await waitFor(() => {
       expect(onChange.mock.calls).toEqual([[new Date('2023-06-07')]])

--- a/packages/components/src/Filter/FilterBar/subcomponents/FilterBarDateRangePicker/FilterBarDateRangePicker.spec.tsx
+++ b/packages/components/src/Filter/FilterBar/subcomponents/FilterBarDateRangePicker/FilterBarDateRangePicker.spec.tsx
@@ -138,7 +138,9 @@ describe('<FilterBarDateRangePicker />', () => {
 
     const targetMonth = screen.getByRole('grid', { name: 'June 2022' })
     const targetDay = within(targetMonth).getByRole('gridcell', { name: '23' })
-    await user.click(targetDay)
+    const targetBtn = within(targetDay).getByRole('button')
+
+    await user.click(targetBtn)
     await user.click(document.body) // Exit the focus lock
 
     await waitFor(() => {
@@ -170,7 +172,9 @@ describe('<FilterBarDateRangePicker />', () => {
 
     const targetMonth = screen.getByRole('grid', { name: 'June 2022' })
     const targetDay = within(targetMonth).getByRole('gridcell', { name: '23' })
-    await user.click(targetDay)
+    const targetBtn = within(targetDay).getByRole('button')
+
+    await user.click(targetBtn)
 
     await waitFor(() => {
       expect(onChange).toHaveBeenCalledWith({

--- a/packages/components/src/Filter/FilterDatePicker/FilterDatePicker.spec.tsx
+++ b/packages/components/src/Filter/FilterDatePicker/FilterDatePicker.spec.tsx
@@ -75,7 +75,8 @@ describe('<FilterDatePicker />', () => {
 
     const targetMonth = screen.getByRole('grid', { name: 'May 2022' })
     const targetDay = within(targetMonth).getByRole('gridcell', { name: '2' })
-    await user.click(targetDay)
+    const targetBtn = within(targetDay).getByRole('button')
+    await user.click(targetBtn)
 
     await waitFor(() => {
       expect(dialog).not.toBeInTheDocument()
@@ -196,7 +197,7 @@ describe('<FilterDatePicker />', () => {
     })
 
     const navigateMonthsButton = getByRole('button', {
-      name: 'Go to next month',
+      name: /Go to the next month/i,
     })
 
     await user.click(navigateMonthsButton)

--- a/packages/components/src/Filter/FilterDatePicker/subcomponents/FilterDatePickerField/FilterDatePickerField.spec.tsx
+++ b/packages/components/src/Filter/FilterDatePicker/subcomponents/FilterDatePickerField/FilterDatePickerField.spec.tsx
@@ -191,7 +191,8 @@ describe('<FilterDatePickerField />', () => {
       const targetDay = within(targetMonth).getByRole('gridcell', {
         name: '15',
       })
-      await user.click(targetDay)
+      const targetBtn = within(targetDay).getByRole('button')
+      await user.click(targetBtn)
 
       await waitFor(() => {
         expect(inputDateOnSubmit).toHaveBeenCalled()
@@ -210,7 +211,8 @@ describe('<FilterDatePickerField />', () => {
         name: '12',
       })
       expect(targetDay).not.toHaveAttribute('aria-selected')
-      await user.click(targetDay)
+      const targetBtn = within(targetDay).getByRole('button')
+      await user.click(targetBtn)
 
       await waitFor(() => {
         expect(targetDay).toHaveAttribute('aria-selected', 'true')
@@ -229,7 +231,8 @@ describe('<FilterDatePickerField />', () => {
       const firstSelectedDay = within(targetMonth).getByRole('gridcell', {
         name: '15',
       })
-      await user.click(firstSelectedDay)
+      const targetBtn = within(firstSelectedDay).getByRole('button')
+      await user.click(targetBtn)
 
       await waitFor(() => {
         expect(inputDate).toHaveValue('')
@@ -323,7 +326,8 @@ describe('<FilterDatePickerField />', () => {
       const targetDay = within(targetMonth).getByRole('gridcell', {
         name: '12',
       })
-      await user.click(targetDay)
+      const targetBtn = within(targetDay).getByRole('button')
+      await user.click(targetBtn)
 
       await waitFor(() => {
         expect(dateErrorContainer).not.toBeInTheDocument()

--- a/packages/components/src/Filter/FilterDateRangePicker/_docs/FilterDateRangePicker.stories.tsx
+++ b/packages/components/src/Filter/FilterDateRangePicker/_docs/FilterDateRangePicker.stories.tsx
@@ -454,8 +454,8 @@ export const OnSmallViewport: Story = {
 
     await step('Back and Forward arrow and both visible', async () => {
       await waitFor(() => {
-        const prevMonth = canvas.getByLabelText('Go to previous month')
-        const nextMonth = canvas.getByLabelText('Go to next month')
+        const prevMonth = canvas.getByLabelText(/Go to the previous month/i)
+        const nextMonth = canvas.getByLabelText(/Go to the next month/i)
 
         expect(prevMonth).toBeVisible()
         expect(nextMonth).toBeVisible()

--- a/packages/components/src/Filter/FilterDateRangePicker/subcomponents/FilterDateRangePickerField/FilterDateRangePickerField.spec.tsx
+++ b/packages/components/src/Filter/FilterDateRangePicker/subcomponents/FilterDateRangePickerField/FilterDateRangePickerField.spec.tsx
@@ -254,7 +254,9 @@ describe('<FilterDateRangePickerField />', () => {
         name: '12',
       })
       expect(targetDay).not.toHaveAttribute('aria-selected')
-      await user.click(targetDay)
+
+      const targetBtn = within(targetDay).getByRole('button')
+      await user.click(targetBtn)
 
       await waitFor(() => {
         expect(targetDay).toHaveAttribute('aria-selected', 'true')
@@ -281,7 +283,8 @@ describe('<FilterDateRangePickerField />', () => {
         name: '23',
       })
       expect(targetDay).not.toHaveAttribute('aria-selected')
-      await user.click(targetDay)
+      const targetBtn = within(targetDay).getByRole('button')
+      await user.click(targetBtn)
 
       await waitFor(() => {
         expect(targetDay).toHaveAttribute('aria-selected', 'true')
@@ -289,7 +292,7 @@ describe('<FilterDateRangePickerField />', () => {
       })
     })
 
-    it('clears the inputs when clearing the calendar value', async () => {
+    it('sets the range end date to match the start date when clicking on the start date with an active range', async () => {
       render(
         <FilterDateRangePickerFieldWrapper
           selectedRange={{
@@ -302,18 +305,20 @@ describe('<FilterDateRangePickerField />', () => {
 
       const inputStartDate = screen.getByLabelText('Date from')
       const inputEndDate = screen.getByLabelText('Date to')
-      expect(inputStartDate).toHaveValue('15 May 2022')
+      const startDate = '15 May 2022'
+      expect(inputStartDate).toHaveValue(startDate)
       expect(inputEndDate).toHaveValue('22 May 2022')
 
       const targetMonth = screen.getByRole('grid', { name: 'May 2022' })
       const firstSelectedDay = within(targetMonth).getByRole('gridcell', {
         name: '15',
       })
-      await user.click(firstSelectedDay)
+      const firstSelectedDayBtn = within(firstSelectedDay).getByRole('button')
+      await user.click(firstSelectedDayBtn)
 
       await waitFor(() => {
-        expect(inputStartDate).toHaveValue('')
-        expect(inputEndDate).toHaveValue('')
+        expect(inputStartDate).toHaveValue(startDate)
+        expect(inputEndDate).toHaveValue(startDate)
       })
     })
   })
@@ -634,7 +639,8 @@ describe('<FilterDateRangePickerField />', () => {
       const targetDay = within(targetMonth).getByRole('gridcell', {
         name: '12',
       })
-      await user.click(targetDay)
+      const targetBtn = within(targetDay).getByRole('button')
+      await user.click(targetBtn)
 
       await waitFor(() => {
         expect(dateEndErrorContainer).not.toBeInTheDocument()

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -368,8 +368,8 @@ importers:
         specifier: ^1.7.1
         version: 1.7.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react-day-picker:
-        specifier: 8.10.1
-        version: 8.10.1(date-fns@4.1.0)(react@19.1.0)
+        specifier: 9.6.7
+        version: 9.6.7(react@19.1.0)
       react-focus-lock:
         specifier: ^2.13.6
         version: 2.13.6(@types/react@18.3.20)(react@19.1.0)
@@ -581,7 +581,7 @@ importers:
     devDependencies:
       '@cultureamp/package-bundler':
         specifier: ^2.1.0
-        version: 2.1.0(@babel/core@7.26.0)(@types/babel__core@7.20.5)(postcss-preset-env@10.1.5(postcss@8.5.3))(postcss@8.5.3)(rollup@4.39.0)(ts-node@10.9.2(@swc/core@1.7.10(@swc/helpers@0.5.15))(@types/node@22.13.10)(typescript@5.8.3))(tslib@2.8.1)(typescript@5.8.3)
+        version: 2.1.0(@babel/core@7.26.0)(@types/babel__core@7.20.5)(postcss-preset-env@10.1.5(postcss@8.4.49))(postcss@8.4.49)(rollup@4.39.0)(ts-node@10.9.2(@swc/core@1.7.10(@swc/helpers@0.5.15))(@types/node@22.13.10)(typescript@5.8.3))(tslib@2.8.1)(typescript@5.8.3)
       classnames:
         specifier: ^2.5.1
         version: 2.5.1
@@ -1172,11 +1172,6 @@ packages:
       '@cultureamp/next-head-hook': '>=1 || ~0.0.0'
       next: '>=13.5.0'
       react: '>=16.14.0'
-    peerDependenciesMeta:
-      '@cultureamp/next-head-hook':
-        optional: true
-      next:
-        optional: true
 
   '@cultureamp/frontend-env@2.1.3':
     resolution: {integrity: sha512-W/r3T/IP3l7TZddtuxnwzsk6rhpk2dpFuqWQGfWaJMQAXWoiGWHw14rGffWbiTe3DNjiqmNwHgKx+TjUWOitJQ==, tarball: https://npm.pkg.github.com/download/@cultureamp/frontend-env/2.1.3/30af7b9a8adef27979846f23ee2de877f02f6e6e}
@@ -1188,9 +1183,6 @@ packages:
       '@cultureamp/frontend-apis': '>=9 || ~0.0.0'
       next: '>=13.5.0'
       react: ^18.3.1
-    peerDependenciesMeta:
-      next:
-        optional: true
 
   '@cultureamp/next-head-hook@1.1.11':
     resolution: {integrity: sha512-FyaCA3oKHnxZ+pPHcPTCDoRCG4/1y0W16U1O5eyTgSxjuJfWTui3vz65MNvNxlJ20+DZ8BXmV3M0y93t/Fubog==, tarball: https://npm.pkg.github.com/download/@cultureamp/next-head-hook/1.1.11/5444465f7d6ce0d79ba33d60180245ed245956ad}
@@ -1210,6 +1202,9 @@ packages:
   '@cultureamp/redirect-to-login@2.0.3':
     resolution: {integrity: sha512-OFJffYRJbB3e0LO3daRZuP7dMhvpQbmiQNu/lnlWWqi5YCCdAgjoozC7feQFqwDBbtPcTHxt4qcJ8Do3RbRs5Q==, tarball: https://npm.pkg.github.com/download/@cultureamp/redirect-to-login/2.0.3/26afa69493a04cb23a5333dccf5b922afd4a333c}
 
+  '@date-fns/tz@1.2.0':
+    resolution: {integrity: sha512-LBrd7MiJZ9McsOgxqWX7AaxrDjcFVjWH/tIKJd7pnR7McaslGYOP1QmmiBXdJH/H/yLCT+rcQ7FaPBUxRGUtrg==}
+
   '@dual-bundle/import-meta-resolve@4.1.0':
     resolution: {integrity: sha512-+nxncfwHM5SgAtrVzgpzJOI1ol0PkumhVo469KCf9lUi21IGcY90G98VuHm9VRrUypmAzawAHO9bs6hqeADaVg==}
 
@@ -1218,6 +1213,9 @@ packages:
 
   '@emnapi/runtime@1.3.1':
     resolution: {integrity: sha512-kEBmG8KyqtxJZv+ygbEim+KCGtIq1fC22Ms3S4ziXmYKm8uyoLX0MHONVKwp+9opg390VaKRNt4a7A9NwmpNhw==}
+
+  '@emnapi/runtime@1.4.3':
+    resolution: {integrity: sha512-pBPWdu6MLKROBX05wSNKcNb++m5Er+KQ9QkB+WVM+pW2Kx9hoSrVTnu3BdkI5eBLZoKu/J6mW/B6i6bJB2ytXQ==}
 
   '@emnapi/wasi-threads@1.0.1':
     resolution: {integrity: sha512-iIBu7mwkq4UQGeMEM8bLwNK962nXdhodeScX4slfQnRhEMMzvYivHhutCIk8uojvmASXXPC2WNEjwxFWk72Oqw==}
@@ -4495,6 +4493,9 @@ packages:
   caniuse-lite@1.0.30001706:
     resolution: {integrity: sha512-3ZczoTApMAZwPKYWmwVbQMFpXBDds3/0VciVoUwPUbldlYyVLmRVuRs/PcUZtHpbLRpzzDvrvnFuREsGt6lUug==}
 
+  caniuse-lite@1.0.30001715:
+    resolution: {integrity: sha512-7ptkFGMm2OAOgvZpwgA4yjQ5SQbrNVGdRjzH0pBdy1Fasvcr+KAeECmbCAECzTuDuoX0FCY8KzUxjf9+9kfZEw==}
+
   capital-case@1.0.4:
     resolution: {integrity: sha512-ds37W8CytHgwnhGGTi88pcPyR15qoNkOpYwmMMfnWqqWgESapLqvDx6huFjQ5vqWSn2Z06173XNA7LtMOeUh1A==}
 
@@ -4962,6 +4963,9 @@ packages:
 
   dataloader@1.4.0:
     resolution: {integrity: sha512-68s5jYdlvasItOJnCuI2Q9s4q98g0pCyL3HrcKJu8KNugUl8ahgmZYg38ysLTgQjjXX3H8CJLkAvWrclWfcalw==}
+
+  date-fns-jalali@4.1.0-0:
+    resolution: {integrity: sha512-hTIP/z+t+qKwBDcmmsnmjWTduxCg+5KfdqWQvb2X/8C9+knYY6epN/pfxdDuyVlSVeFz0sM5eEfwIUQ70U4ckg==}
 
   date-fns@3.6.0:
     resolution: {integrity: sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==}
@@ -7499,8 +7503,8 @@ packages:
     resolution: {integrity: sha512-4jbtZXNAsfZbAHiiqjLPBiCl16dES1zI4Hpzzxw61Tk+loF+sBDBKx1ICKKKwIqQ7M0mFn1TmkN7euSncWgHiQ==}
     engines: {node: '>=0.10.0'}
 
-  nwsapi@2.2.19:
-    resolution: {integrity: sha512-94bcyI3RsqiZufXjkr3ltkI86iEl+I7uiHVDtcq9wJUTwYQJ5odHDeSzkkrRzi80jJ8MaeZgqKjH1bAWAFw9bA==}
+  nwsapi@2.2.20:
+    resolution: {integrity: sha512-/ieB+mDe4MrrKMT8z+mQL8klXydZWGR5Dowt4RAGKbJ3kIGEx3X4ljUo+6V73IXtUPWgfOlU5B9MlGxFO5T+cA==}
 
   nyc@15.1.0:
     resolution: {integrity: sha512-jMW04n9SxKdKi1ZMGhvUTHBN0EICCRkHemEoE5jm6mTYcqcdas0ATzgUgejlQUHMvpnOZqGB5Xxsv9KxJW1j8A==}
@@ -8520,11 +8524,11 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
 
-  react-day-picker@8.10.1:
-    resolution: {integrity: sha512-TMx7fNbhLk15eqcMt+7Z7S2KF7mfTId/XJDjKE8f+IUcFn0l08/kI4FiYTL/0yuOLmEcbR4Fwe3GJf/NiiMnPA==}
+  react-day-picker@9.6.7:
+    resolution: {integrity: sha512-rCSt6X8FXQWpjykns/azRXjJk3cMSzkzGbDEXuEveFGNZgOjZULdJQ5wsu8Zfyo8ZgPBoYCBKQ5wRrgJfhJGbg==}
+    engines: {node: '>=18'}
     peerDependencies:
-      date-fns: ^2.28.0 || ^3.0.0
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+      react: '>=16.8.0'
 
   react-docgen-typescript@2.2.2:
     resolution: {integrity: sha512-tvg2ZtOpOi6QDwsb3GZhOjDkkX0h8Z2gipvTg6OVMUyoYoURhEiRNePT8NZItTVCDh39JJHnLdfCOkzoLbFnTg==}
@@ -10778,11 +10782,26 @@ snapshots:
       '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-tokenizer': 3.0.3
 
+  '@csstools/postcss-cascade-layers@5.0.1(postcss@8.4.49)':
+    dependencies:
+      '@csstools/selector-specificity': 5.0.0(postcss-selector-parser@7.0.0)
+      postcss: 8.4.49
+      postcss-selector-parser: 7.0.0
+
   '@csstools/postcss-cascade-layers@5.0.1(postcss@8.5.3)':
     dependencies:
       '@csstools/selector-specificity': 5.0.0(postcss-selector-parser@7.0.0)
       postcss: 8.5.3
       postcss-selector-parser: 7.0.0
+
+  '@csstools/postcss-color-function@4.0.8(postcss@8.4.49)':
+    dependencies:
+      '@csstools/css-color-parser': 3.0.8(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-tokenizer': 3.0.3
+      '@csstools/postcss-progressive-custom-properties': 4.0.0(postcss@8.4.49)
+      '@csstools/utilities': 2.0.0(postcss@8.4.49)
+      postcss: 8.4.49
 
   '@csstools/postcss-color-function@4.0.8(postcss@8.5.3)':
     dependencies:
@@ -10793,6 +10812,15 @@ snapshots:
       '@csstools/utilities': 2.0.0(postcss@8.5.3)
       postcss: 8.5.3
 
+  '@csstools/postcss-color-mix-function@3.0.8(postcss@8.4.49)':
+    dependencies:
+      '@csstools/css-color-parser': 3.0.8(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-tokenizer': 3.0.3
+      '@csstools/postcss-progressive-custom-properties': 4.0.0(postcss@8.4.49)
+      '@csstools/utilities': 2.0.0(postcss@8.4.49)
+      postcss: 8.4.49
+
   '@csstools/postcss-color-mix-function@3.0.8(postcss@8.5.3)':
     dependencies:
       '@csstools/css-color-parser': 3.0.8(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
@@ -10802,6 +10830,14 @@ snapshots:
       '@csstools/utilities': 2.0.0(postcss@8.5.3)
       postcss: 8.5.3
 
+  '@csstools/postcss-content-alt-text@2.0.4(postcss@8.4.49)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-tokenizer': 3.0.3
+      '@csstools/postcss-progressive-custom-properties': 4.0.0(postcss@8.4.49)
+      '@csstools/utilities': 2.0.0(postcss@8.4.49)
+      postcss: 8.4.49
+
   '@csstools/postcss-content-alt-text@2.0.4(postcss@8.5.3)':
     dependencies:
       '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
@@ -10810,6 +10846,13 @@ snapshots:
       '@csstools/utilities': 2.0.0(postcss@8.5.3)
       postcss: 8.5.3
 
+  '@csstools/postcss-exponential-functions@2.0.7(postcss@8.4.49)':
+    dependencies:
+      '@csstools/css-calc': 2.1.2(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-tokenizer': 3.0.3
+      postcss: 8.4.49
+
   '@csstools/postcss-exponential-functions@2.0.7(postcss@8.5.3)':
     dependencies:
       '@csstools/css-calc': 2.1.2(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
@@ -10817,11 +10860,24 @@ snapshots:
       '@csstools/css-tokenizer': 3.0.3
       postcss: 8.5.3
 
+  '@csstools/postcss-font-format-keywords@4.0.0(postcss@8.4.49)':
+    dependencies:
+      '@csstools/utilities': 2.0.0(postcss@8.4.49)
+      postcss: 8.4.49
+      postcss-value-parser: 4.2.0
+
   '@csstools/postcss-font-format-keywords@4.0.0(postcss@8.5.3)':
     dependencies:
       '@csstools/utilities': 2.0.0(postcss@8.5.3)
       postcss: 8.5.3
       postcss-value-parser: 4.2.0
+
+  '@csstools/postcss-gamut-mapping@2.0.8(postcss@8.4.49)':
+    dependencies:
+      '@csstools/css-color-parser': 3.0.8(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-tokenizer': 3.0.3
+      postcss: 8.4.49
 
   '@csstools/postcss-gamut-mapping@2.0.8(postcss@8.5.3)':
     dependencies:
@@ -10829,6 +10885,15 @@ snapshots:
       '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-tokenizer': 3.0.3
       postcss: 8.5.3
+
+  '@csstools/postcss-gradients-interpolation-method@5.0.8(postcss@8.4.49)':
+    dependencies:
+      '@csstools/css-color-parser': 3.0.8(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-tokenizer': 3.0.3
+      '@csstools/postcss-progressive-custom-properties': 4.0.0(postcss@8.4.49)
+      '@csstools/utilities': 2.0.0(postcss@8.4.49)
+      postcss: 8.4.49
 
   '@csstools/postcss-gradients-interpolation-method@5.0.8(postcss@8.5.3)':
     dependencies:
@@ -10839,6 +10904,15 @@ snapshots:
       '@csstools/utilities': 2.0.0(postcss@8.5.3)
       postcss: 8.5.3
 
+  '@csstools/postcss-hwb-function@4.0.8(postcss@8.4.49)':
+    dependencies:
+      '@csstools/css-color-parser': 3.0.8(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-tokenizer': 3.0.3
+      '@csstools/postcss-progressive-custom-properties': 4.0.0(postcss@8.4.49)
+      '@csstools/utilities': 2.0.0(postcss@8.4.49)
+      postcss: 8.4.49
+
   '@csstools/postcss-hwb-function@4.0.8(postcss@8.5.3)':
     dependencies:
       '@csstools/css-color-parser': 3.0.8(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
@@ -10848,6 +10922,13 @@ snapshots:
       '@csstools/utilities': 2.0.0(postcss@8.5.3)
       postcss: 8.5.3
 
+  '@csstools/postcss-ic-unit@4.0.0(postcss@8.4.49)':
+    dependencies:
+      '@csstools/postcss-progressive-custom-properties': 4.0.0(postcss@8.4.49)
+      '@csstools/utilities': 2.0.0(postcss@8.4.49)
+      postcss: 8.4.49
+      postcss-value-parser: 4.2.0
+
   '@csstools/postcss-ic-unit@4.0.0(postcss@8.5.3)':
     dependencies:
       '@csstools/postcss-progressive-custom-properties': 4.0.0(postcss@8.5.3)
@@ -10855,15 +10936,33 @@ snapshots:
       postcss: 8.5.3
       postcss-value-parser: 4.2.0
 
+  '@csstools/postcss-initial@2.0.1(postcss@8.4.49)':
+    dependencies:
+      postcss: 8.4.49
+
   '@csstools/postcss-initial@2.0.1(postcss@8.5.3)':
     dependencies:
       postcss: 8.5.3
+
+  '@csstools/postcss-is-pseudo-class@5.0.1(postcss@8.4.49)':
+    dependencies:
+      '@csstools/selector-specificity': 5.0.0(postcss-selector-parser@7.0.0)
+      postcss: 8.4.49
+      postcss-selector-parser: 7.0.0
 
   '@csstools/postcss-is-pseudo-class@5.0.1(postcss@8.5.3)':
     dependencies:
       '@csstools/selector-specificity': 5.0.0(postcss-selector-parser@7.0.0)
       postcss: 8.5.3
       postcss-selector-parser: 7.0.0
+
+  '@csstools/postcss-light-dark-function@2.0.7(postcss@8.4.49)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-tokenizer': 3.0.3
+      '@csstools/postcss-progressive-custom-properties': 4.0.0(postcss@8.4.49)
+      '@csstools/utilities': 2.0.0(postcss@8.4.49)
+      postcss: 8.4.49
 
   '@csstools/postcss-light-dark-function@2.0.7(postcss@8.5.3)':
     dependencies:
@@ -10873,28 +10972,59 @@ snapshots:
       '@csstools/utilities': 2.0.0(postcss@8.5.3)
       postcss: 8.5.3
 
+  '@csstools/postcss-logical-float-and-clear@3.0.0(postcss@8.4.49)':
+    dependencies:
+      postcss: 8.4.49
+
   '@csstools/postcss-logical-float-and-clear@3.0.0(postcss@8.5.3)':
     dependencies:
       postcss: 8.5.3
+
+  '@csstools/postcss-logical-overflow@2.0.0(postcss@8.4.49)':
+    dependencies:
+      postcss: 8.4.49
 
   '@csstools/postcss-logical-overflow@2.0.0(postcss@8.5.3)':
     dependencies:
       postcss: 8.5.3
 
+  '@csstools/postcss-logical-overscroll-behavior@2.0.0(postcss@8.4.49)':
+    dependencies:
+      postcss: 8.4.49
+
   '@csstools/postcss-logical-overscroll-behavior@2.0.0(postcss@8.5.3)':
     dependencies:
       postcss: 8.5.3
+
+  '@csstools/postcss-logical-resize@3.0.0(postcss@8.4.49)':
+    dependencies:
+      postcss: 8.4.49
+      postcss-value-parser: 4.2.0
 
   '@csstools/postcss-logical-resize@3.0.0(postcss@8.5.3)':
     dependencies:
       postcss: 8.5.3
       postcss-value-parser: 4.2.0
 
+  '@csstools/postcss-logical-viewport-units@3.0.3(postcss@8.4.49)':
+    dependencies:
+      '@csstools/css-tokenizer': 3.0.3
+      '@csstools/utilities': 2.0.0(postcss@8.4.49)
+      postcss: 8.4.49
+
   '@csstools/postcss-logical-viewport-units@3.0.3(postcss@8.5.3)':
     dependencies:
       '@csstools/css-tokenizer': 3.0.3
       '@csstools/utilities': 2.0.0(postcss@8.5.3)
       postcss: 8.5.3
+
+  '@csstools/postcss-media-minmax@2.0.7(postcss@8.4.49)':
+    dependencies:
+      '@csstools/css-calc': 2.1.2(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-tokenizer': 3.0.3
+      '@csstools/media-query-list-parser': 4.0.2(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
+      postcss: 8.4.49
 
   '@csstools/postcss-media-minmax@2.0.7(postcss@8.5.3)':
     dependencies:
@@ -10904,6 +11034,13 @@ snapshots:
       '@csstools/media-query-list-parser': 4.0.2(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
       postcss: 8.5.3
 
+  '@csstools/postcss-media-queries-aspect-ratio-number-values@3.0.4(postcss@8.4.49)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-tokenizer': 3.0.3
+      '@csstools/media-query-list-parser': 4.0.2(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
+      postcss: 8.4.49
+
   '@csstools/postcss-media-queries-aspect-ratio-number-values@3.0.4(postcss@8.5.3)':
     dependencies:
       '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
@@ -10911,16 +11048,36 @@ snapshots:
       '@csstools/media-query-list-parser': 4.0.2(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
       postcss: 8.5.3
 
+  '@csstools/postcss-nested-calc@4.0.0(postcss@8.4.49)':
+    dependencies:
+      '@csstools/utilities': 2.0.0(postcss@8.4.49)
+      postcss: 8.4.49
+      postcss-value-parser: 4.2.0
+
   '@csstools/postcss-nested-calc@4.0.0(postcss@8.5.3)':
     dependencies:
       '@csstools/utilities': 2.0.0(postcss@8.5.3)
       postcss: 8.5.3
       postcss-value-parser: 4.2.0
 
+  '@csstools/postcss-normalize-display-values@4.0.0(postcss@8.4.49)':
+    dependencies:
+      postcss: 8.4.49
+      postcss-value-parser: 4.2.0
+
   '@csstools/postcss-normalize-display-values@4.0.0(postcss@8.5.3)':
     dependencies:
       postcss: 8.5.3
       postcss-value-parser: 4.2.0
+
+  '@csstools/postcss-oklab-function@4.0.8(postcss@8.4.49)':
+    dependencies:
+      '@csstools/css-color-parser': 3.0.8(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-tokenizer': 3.0.3
+      '@csstools/postcss-progressive-custom-properties': 4.0.0(postcss@8.4.49)
+      '@csstools/utilities': 2.0.0(postcss@8.4.49)
+      postcss: 8.4.49
 
   '@csstools/postcss-oklab-function@4.0.8(postcss@8.5.3)':
     dependencies:
@@ -10931,10 +11088,22 @@ snapshots:
       '@csstools/utilities': 2.0.0(postcss@8.5.3)
       postcss: 8.5.3
 
+  '@csstools/postcss-progressive-custom-properties@4.0.0(postcss@8.4.49)':
+    dependencies:
+      postcss: 8.4.49
+      postcss-value-parser: 4.2.0
+
   '@csstools/postcss-progressive-custom-properties@4.0.0(postcss@8.5.3)':
     dependencies:
       postcss: 8.5.3
       postcss-value-parser: 4.2.0
+
+  '@csstools/postcss-random-function@1.0.3(postcss@8.4.49)':
+    dependencies:
+      '@csstools/css-calc': 2.1.2(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-tokenizer': 3.0.3
+      postcss: 8.4.49
 
   '@csstools/postcss-random-function@1.0.3(postcss@8.5.3)':
     dependencies:
@@ -10942,6 +11111,15 @@ snapshots:
       '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-tokenizer': 3.0.3
       postcss: 8.5.3
+
+  '@csstools/postcss-relative-color-syntax@3.0.8(postcss@8.4.49)':
+    dependencies:
+      '@csstools/css-color-parser': 3.0.8(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-tokenizer': 3.0.3
+      '@csstools/postcss-progressive-custom-properties': 4.0.0(postcss@8.4.49)
+      '@csstools/utilities': 2.0.0(postcss@8.4.49)
+      postcss: 8.4.49
 
   '@csstools/postcss-relative-color-syntax@3.0.8(postcss@8.5.3)':
     dependencies:
@@ -10952,10 +11130,22 @@ snapshots:
       '@csstools/utilities': 2.0.0(postcss@8.5.3)
       postcss: 8.5.3
 
+  '@csstools/postcss-scope-pseudo-class@4.0.1(postcss@8.4.49)':
+    dependencies:
+      postcss: 8.4.49
+      postcss-selector-parser: 7.0.0
+
   '@csstools/postcss-scope-pseudo-class@4.0.1(postcss@8.5.3)':
     dependencies:
       postcss: 8.5.3
       postcss-selector-parser: 7.0.0
+
+  '@csstools/postcss-sign-functions@1.1.2(postcss@8.4.49)':
+    dependencies:
+      '@csstools/css-calc': 2.1.2(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-tokenizer': 3.0.3
+      postcss: 8.4.49
 
   '@csstools/postcss-sign-functions@1.1.2(postcss@8.5.3)':
     dependencies:
@@ -10964,6 +11154,13 @@ snapshots:
       '@csstools/css-tokenizer': 3.0.3
       postcss: 8.5.3
 
+  '@csstools/postcss-stepped-value-functions@4.0.7(postcss@8.4.49)':
+    dependencies:
+      '@csstools/css-calc': 2.1.2(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-tokenizer': 3.0.3
+      postcss: 8.4.49
+
   '@csstools/postcss-stepped-value-functions@4.0.7(postcss@8.5.3)':
     dependencies:
       '@csstools/css-calc': 2.1.2(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
@@ -10971,11 +11168,24 @@ snapshots:
       '@csstools/css-tokenizer': 3.0.3
       postcss: 8.5.3
 
+  '@csstools/postcss-text-decoration-shorthand@4.0.2(postcss@8.4.49)':
+    dependencies:
+      '@csstools/color-helpers': 5.0.2
+      postcss: 8.4.49
+      postcss-value-parser: 4.2.0
+
   '@csstools/postcss-text-decoration-shorthand@4.0.2(postcss@8.5.3)':
     dependencies:
       '@csstools/color-helpers': 5.0.2
       postcss: 8.5.3
       postcss-value-parser: 4.2.0
+
+  '@csstools/postcss-trigonometric-functions@4.0.7(postcss@8.4.49)':
+    dependencies:
+      '@csstools/css-calc': 2.1.2(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-tokenizer': 3.0.3
+      postcss: 8.4.49
 
   '@csstools/postcss-trigonometric-functions@4.0.7(postcss@8.5.3)':
     dependencies:
@@ -10983,6 +11193,10 @@ snapshots:
       '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-tokenizer': 3.0.3
       postcss: 8.5.3
+
+  '@csstools/postcss-unset-value@4.0.0(postcss@8.4.49)':
+    dependencies:
+      postcss: 8.4.49
 
   '@csstools/postcss-unset-value@4.0.0(postcss@8.5.3)':
     dependencies:
@@ -11000,6 +11214,10 @@ snapshots:
     dependencies:
       postcss-selector-parser: 7.1.0
 
+  '@csstools/utilities@2.0.0(postcss@8.4.49)':
+    dependencies:
+      postcss: 8.4.49
+
   '@csstools/utilities@2.0.0(postcss@8.5.3)':
     dependencies:
       postcss: 8.5.3
@@ -11016,6 +11234,7 @@ snapshots:
   '@cultureamp/frontend-apis@13.2.5(@cultureamp/next-head-hook@1.1.11(next@15.2.5(@babel/core@7.26.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.79.6)))(next@15.2.5(@babel/core@7.26.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.79.6))(react@19.1.0)(typescript@5.8.3)':
     dependencies:
       '@cultureamp/frontend-env': 2.1.3
+      '@cultureamp/next-head-hook': 1.1.11(next@15.2.5(@babel/core@7.26.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.79.6))
       '@cultureamp/redirect-to-login': 2.0.3
       '@readme/openapi-parser': 2.6.0(openapi-types@12.1.3)
       '@tanstack/react-query': 5.60.5(react@19.1.0)
@@ -11030,6 +11249,7 @@ snapshots:
       js-yaml: 4.1.0
       jsrsasign: 11.1.0
       msw: 2.2.14(typescript@5.8.3)
+      next: 15.2.5(@babel/core@7.26.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.79.6)
       openapi-types: 12.1.3
       openapi-typescript: 6.7.6
       react: 19.1.0
@@ -11038,9 +11258,6 @@ snapshots:
       url-parse: 1.5.10
       uuid: 9.0.1
       yargs: 17.7.2
-    optionalDependencies:
-      '@cultureamp/next-head-hook': 1.1.11(next@15.2.5(@babel/core@7.26.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.79.6))
-      next: 15.2.5(@babel/core@7.26.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.79.6)
     transitivePeerDependencies:
       - '@chromatic-com/cypress'
       - '@chromatic-com/playwright'
@@ -11066,12 +11283,11 @@ snapshots:
       isomorphic-resolve: 1.0.0
       json-stable-stringify: 1.2.1
       limiter-es6-compat: 2.1.2
+      next: 15.2.5(@babel/core@7.26.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.79.6)
       react: 19.1.0
       react-intl: 6.8.9(react@19.1.0)(typescript@5.8.3)
       smartling-api-sdk-nodejs: 2.11.0(encoding@0.1.13)
       yargs: 17.7.2
-    optionalDependencies:
-      next: 15.2.5(@babel/core@7.26.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.79.6)
     transitivePeerDependencies:
       - '@glimmer/env'
       - '@glimmer/reference'
@@ -11091,7 +11307,32 @@ snapshots:
     dependencies:
       next: 15.2.5(@babel/core@7.26.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.79.6)
       react: 18.3.1
-    optional: true
+
+  '@cultureamp/package-bundler@2.1.0(@babel/core@7.26.0)(@types/babel__core@7.20.5)(postcss-preset-env@10.1.5(postcss@8.4.49))(postcss@8.4.49)(rollup@4.39.0)(ts-node@10.9.2(@swc/core@1.7.10(@swc/helpers@0.5.15))(@types/node@22.13.10)(typescript@5.8.3))(tslib@2.8.1)(typescript@5.8.3)':
+    dependencies:
+      '@babel/plugin-transform-react-pure-annotations': 7.25.9(@babel/core@7.26.0)
+      '@rollup/plugin-alias': 5.1.1(rollup@4.39.0)
+      '@rollup/plugin-babel': 6.0.4(@babel/core@7.26.0)(@types/babel__core@7.20.5)(rollup@4.39.0)
+      '@rollup/plugin-commonjs': 28.0.3(rollup@4.39.0)
+      '@rollup/plugin-node-resolve': 16.0.1(rollup@4.39.0)
+      '@rollup/plugin-typescript': 12.1.2(rollup@4.39.0)(tslib@2.8.1)(typescript@5.8.3)
+      babel-plugin-pure-static-props: 0.2.0(@babel/core@7.26.0)
+      concat-cli: 4.0.0
+      postcss: 8.4.49
+      postcss-preset-env: 10.1.5(postcss@8.4.49)
+      rollup: 4.39.0
+      rollup-plugin-ignore: 1.0.10
+      rollup-plugin-node-externals: 8.0.0(rollup@4.39.0)
+      rollup-plugin-postcss: 4.0.2(postcss@8.4.49)(ts-node@10.9.2(@swc/core@1.7.10(@swc/helpers@0.5.15))(@types/node@22.13.10)(typescript@5.8.3))
+      ts-patch: 3.3.0
+      tslib: 2.8.1
+      typescript: 5.8.3
+      typescript-transform-paths: 3.5.5(typescript@5.8.3)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@types/babel__core'
+      - supports-color
+      - ts-node
 
   '@cultureamp/package-bundler@2.1.0(@babel/core@7.26.0)(@types/babel__core@7.20.5)(postcss-preset-env@10.1.5(postcss@8.5.3))(postcss@8.5.3)(rollup@4.39.0)(ts-node@10.9.2(@swc/core@1.7.10(@swc/helpers@0.5.15))(@types/node@22.13.10)(typescript@5.8.3))(tslib@2.8.1)(typescript@5.8.3)':
     dependencies:
@@ -11121,6 +11362,8 @@ snapshots:
 
   '@cultureamp/redirect-to-login@2.0.3': {}
 
+  '@date-fns/tz@1.2.0': {}
+
   '@dual-bundle/import-meta-resolve@4.1.0': {}
 
   '@emnapi/core@1.3.1':
@@ -11130,6 +11373,11 @@ snapshots:
     optional: true
 
   '@emnapi/runtime@1.3.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/runtime@1.4.3':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -11680,7 +11928,7 @@ snapshots:
 
   '@img/sharp-wasm32@0.33.5':
     dependencies:
-      '@emnapi/runtime': 1.3.1
+      '@emnapi/runtime': 1.4.3
     optional: true
 
   '@img/sharp-win32-ia32@0.33.5':
@@ -12009,8 +12257,7 @@ snapshots:
       '@tybys/wasm-util': 0.9.0
     optional: true
 
-  '@next/env@15.2.5':
-    optional: true
+  '@next/env@15.2.5': {}
 
   '@next/swc-darwin-arm64@15.2.5':
     optional: true
@@ -14673,6 +14920,16 @@ snapshots:
 
   asynckit@0.4.0: {}
 
+  autoprefixer@10.4.21(postcss@8.4.49):
+    dependencies:
+      browserslist: 4.24.4
+      caniuse-lite: 1.0.30001706
+      fraction.js: 4.3.7
+      normalize-range: 0.1.2
+      picocolors: 1.1.1
+      postcss: 8.4.49
+      postcss-value-parser: 4.2.0
+
   autoprefixer@10.4.21(postcss@8.5.3):
     dependencies:
       browserslist: 4.24.4
@@ -14940,7 +15197,6 @@ snapshots:
   busboy@1.6.0:
     dependencies:
       streamsearch: 1.1.0
-    optional: true
 
   cac@6.7.14: {}
 
@@ -15016,6 +15272,8 @@ snapshots:
       lodash.uniq: 4.5.0
 
   caniuse-lite@1.0.30001706: {}
+
+  caniuse-lite@1.0.30001715: {}
 
   capital-case@1.0.4:
     dependencies:
@@ -15356,10 +15614,19 @@ snapshots:
       randombytes: 2.1.0
       randomfill: 1.0.4
 
+  css-blank-pseudo@7.0.1(postcss@8.4.49):
+    dependencies:
+      postcss: 8.4.49
+      postcss-selector-parser: 7.0.0
+
   css-blank-pseudo@7.0.1(postcss@8.5.3):
     dependencies:
       postcss: 8.5.3
       postcss-selector-parser: 7.0.0
+
+  css-declaration-sorter@6.4.1(postcss@8.4.49):
+    dependencies:
+      postcss: 8.4.49
 
   css-declaration-sorter@6.4.1(postcss@8.5.3):
     dependencies:
@@ -15367,12 +15634,23 @@ snapshots:
 
   css-functions-list@3.2.3: {}
 
+  css-has-pseudo@7.0.2(postcss@8.4.49):
+    dependencies:
+      '@csstools/selector-specificity': 5.0.0(postcss-selector-parser@7.1.0)
+      postcss: 8.4.49
+      postcss-selector-parser: 7.1.0
+      postcss-value-parser: 4.2.0
+
   css-has-pseudo@7.0.2(postcss@8.5.3):
     dependencies:
       '@csstools/selector-specificity': 5.0.0(postcss-selector-parser@7.1.0)
       postcss: 8.5.3
       postcss-selector-parser: 7.1.0
       postcss-value-parser: 4.2.0
+
+  css-prefers-color-scheme@10.0.0(postcss@8.4.49):
+    dependencies:
+      postcss: 8.4.49
 
   css-prefers-color-scheme@10.0.0(postcss@8.5.3):
     dependencies:
@@ -15422,6 +15700,39 @@ snapshots:
 
   cssesc@3.0.0: {}
 
+  cssnano-preset-default@5.2.14(postcss@8.4.49):
+    dependencies:
+      css-declaration-sorter: 6.4.1(postcss@8.4.49)
+      cssnano-utils: 3.1.0(postcss@8.4.49)
+      postcss: 8.4.49
+      postcss-calc: 8.2.4(postcss@8.4.49)
+      postcss-colormin: 5.3.1(postcss@8.4.49)
+      postcss-convert-values: 5.1.3(postcss@8.4.49)
+      postcss-discard-comments: 5.1.2(postcss@8.4.49)
+      postcss-discard-duplicates: 5.1.0(postcss@8.4.49)
+      postcss-discard-empty: 5.1.1(postcss@8.4.49)
+      postcss-discard-overridden: 5.1.0(postcss@8.4.49)
+      postcss-merge-longhand: 5.1.7(postcss@8.4.49)
+      postcss-merge-rules: 5.1.4(postcss@8.4.49)
+      postcss-minify-font-values: 5.1.0(postcss@8.4.49)
+      postcss-minify-gradients: 5.1.1(postcss@8.4.49)
+      postcss-minify-params: 5.1.4(postcss@8.4.49)
+      postcss-minify-selectors: 5.2.1(postcss@8.4.49)
+      postcss-normalize-charset: 5.1.0(postcss@8.4.49)
+      postcss-normalize-display-values: 5.1.0(postcss@8.4.49)
+      postcss-normalize-positions: 5.1.1(postcss@8.4.49)
+      postcss-normalize-repeat-style: 5.1.1(postcss@8.4.49)
+      postcss-normalize-string: 5.1.0(postcss@8.4.49)
+      postcss-normalize-timing-functions: 5.1.0(postcss@8.4.49)
+      postcss-normalize-unicode: 5.1.1(postcss@8.4.49)
+      postcss-normalize-url: 5.1.0(postcss@8.4.49)
+      postcss-normalize-whitespace: 5.1.1(postcss@8.4.49)
+      postcss-ordered-values: 5.1.3(postcss@8.4.49)
+      postcss-reduce-initial: 5.1.2(postcss@8.4.49)
+      postcss-reduce-transforms: 5.1.0(postcss@8.4.49)
+      postcss-svgo: 5.1.0(postcss@8.4.49)
+      postcss-unique-selectors: 5.1.1(postcss@8.4.49)
+
   cssnano-preset-default@5.2.14(postcss@8.5.3):
     dependencies:
       css-declaration-sorter: 6.4.1(postcss@8.5.3)
@@ -15455,9 +15766,20 @@ snapshots:
       postcss-svgo: 5.1.0(postcss@8.5.3)
       postcss-unique-selectors: 5.1.1(postcss@8.5.3)
 
+  cssnano-utils@3.1.0(postcss@8.4.49):
+    dependencies:
+      postcss: 8.4.49
+
   cssnano-utils@3.1.0(postcss@8.5.3):
     dependencies:
       postcss: 8.5.3
+
+  cssnano@5.1.15(postcss@8.4.49):
+    dependencies:
+      cssnano-preset-default: 5.2.14(postcss@8.4.49)
+      lilconfig: 2.1.0
+      postcss: 8.4.49
+      yaml: 1.10.2
 
   cssnano@5.1.15(postcss@8.5.3):
     dependencies:
@@ -15544,6 +15866,8 @@ snapshots:
       is-data-view: 1.0.2
 
   dataloader@1.4.0: {}
+
+  date-fns-jalali@4.1.0-0: {}
 
   date-fns@3.6.0: {}
 
@@ -16973,6 +17297,10 @@ snapshots:
 
   icss-replace-symbols@1.1.0: {}
 
+  icss-utils@5.1.0(postcss@8.4.49):
+    dependencies:
+      postcss: 8.4.49
+
   icss-utils@5.1.0(postcss@8.5.3):
     dependencies:
       postcss: 8.5.3
@@ -17878,7 +18206,7 @@ snapshots:
       http-proxy-agent: 5.0.0
       https-proxy-agent: 5.0.1
       is-potential-custom-element-name: 1.0.1
-      nwsapi: 2.2.19
+      nwsapi: 2.2.20
       parse5: 7.2.1
       saxes: 6.0.0
       symbol-tree: 3.2.4
@@ -18618,8 +18946,7 @@ snapshots:
 
   nanoid@3.3.10: {}
 
-  nanoid@3.3.11:
-    optional: true
+  nanoid@3.3.11: {}
 
   nanoid@3.3.7: {}
 
@@ -18648,7 +18975,7 @@ snapshots:
       '@swc/counter': 0.1.3
       '@swc/helpers': 0.5.15
       busboy: 1.6.0
-      caniuse-lite: 1.0.30001706
+      caniuse-lite: 1.0.30001715
       postcss: 8.4.31
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
@@ -18667,7 +18994,6 @@ snapshots:
     transitivePeerDependencies:
       - '@babel/core'
       - babel-plugin-macros
-    optional: true
 
   no-case@3.0.4:
     dependencies:
@@ -18792,7 +19118,7 @@ snapshots:
 
   number-is-nan@1.0.1: {}
 
-  nwsapi@2.2.19:
+  nwsapi@2.2.20:
     optional: true
 
   nyc@15.1.0:
@@ -19231,15 +19557,31 @@ snapshots:
 
   possible-typed-array-names@1.0.0: {}
 
+  postcss-attribute-case-insensitive@7.0.1(postcss@8.4.49):
+    dependencies:
+      postcss: 8.4.49
+      postcss-selector-parser: 7.0.0
+
   postcss-attribute-case-insensitive@7.0.1(postcss@8.5.3):
     dependencies:
       postcss: 8.5.3
       postcss-selector-parser: 7.0.0
 
+  postcss-calc@8.2.4(postcss@8.4.49):
+    dependencies:
+      postcss: 8.4.49
+      postcss-selector-parser: 6.1.2
+      postcss-value-parser: 4.2.0
+
   postcss-calc@8.2.4(postcss@8.5.3):
     dependencies:
       postcss: 8.5.3
       postcss-selector-parser: 6.1.2
+      postcss-value-parser: 4.2.0
+
+  postcss-clamp@4.1.0(postcss@8.4.49):
+    dependencies:
+      postcss: 8.4.49
       postcss-value-parser: 4.2.0
 
   postcss-clamp@4.1.0(postcss@8.5.3):
@@ -19265,6 +19607,15 @@ snapshots:
       - jiti
       - tsx
 
+  postcss-color-functional-notation@7.0.8(postcss@8.4.49):
+    dependencies:
+      '@csstools/css-color-parser': 3.0.8(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-tokenizer': 3.0.3
+      '@csstools/postcss-progressive-custom-properties': 4.0.0(postcss@8.4.49)
+      '@csstools/utilities': 2.0.0(postcss@8.4.49)
+      postcss: 8.4.49
+
   postcss-color-functional-notation@7.0.8(postcss@8.5.3):
     dependencies:
       '@csstools/css-color-parser': 3.0.8(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
@@ -19274,16 +19625,36 @@ snapshots:
       '@csstools/utilities': 2.0.0(postcss@8.5.3)
       postcss: 8.5.3
 
+  postcss-color-hex-alpha@10.0.0(postcss@8.4.49):
+    dependencies:
+      '@csstools/utilities': 2.0.0(postcss@8.4.49)
+      postcss: 8.4.49
+      postcss-value-parser: 4.2.0
+
   postcss-color-hex-alpha@10.0.0(postcss@8.5.3):
     dependencies:
       '@csstools/utilities': 2.0.0(postcss@8.5.3)
       postcss: 8.5.3
       postcss-value-parser: 4.2.0
 
+  postcss-color-rebeccapurple@10.0.0(postcss@8.4.49):
+    dependencies:
+      '@csstools/utilities': 2.0.0(postcss@8.4.49)
+      postcss: 8.4.49
+      postcss-value-parser: 4.2.0
+
   postcss-color-rebeccapurple@10.0.0(postcss@8.5.3):
     dependencies:
       '@csstools/utilities': 2.0.0(postcss@8.5.3)
       postcss: 8.5.3
+      postcss-value-parser: 4.2.0
+
+  postcss-colormin@5.3.1(postcss@8.4.49):
+    dependencies:
+      browserslist: 4.24.3
+      caniuse-api: 3.0.0
+      colord: 2.9.3
+      postcss: 8.4.49
       postcss-value-parser: 4.2.0
 
   postcss-colormin@5.3.1(postcss@8.5.3):
@@ -19294,11 +19665,25 @@ snapshots:
       postcss: 8.5.3
       postcss-value-parser: 4.2.0
 
+  postcss-convert-values@5.1.3(postcss@8.4.49):
+    dependencies:
+      browserslist: 4.24.3
+      postcss: 8.4.49
+      postcss-value-parser: 4.2.0
+
   postcss-convert-values@5.1.3(postcss@8.5.3):
     dependencies:
       browserslist: 4.24.3
       postcss: 8.5.3
       postcss-value-parser: 4.2.0
+
+  postcss-custom-media@11.0.5(postcss@8.4.49):
+    dependencies:
+      '@csstools/cascade-layer-name-parser': 2.0.4(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-tokenizer': 3.0.3
+      '@csstools/media-query-list-parser': 4.0.2(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
+      postcss: 8.4.49
 
   postcss-custom-media@11.0.5(postcss@8.5.3):
     dependencies:
@@ -19307,6 +19692,15 @@ snapshots:
       '@csstools/css-tokenizer': 3.0.3
       '@csstools/media-query-list-parser': 4.0.2(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
       postcss: 8.5.3
+
+  postcss-custom-properties@14.0.4(postcss@8.4.49):
+    dependencies:
+      '@csstools/cascade-layer-name-parser': 2.0.4(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-tokenizer': 3.0.3
+      '@csstools/utilities': 2.0.0(postcss@8.4.49)
+      postcss: 8.4.49
+      postcss-value-parser: 4.2.0
 
   postcss-custom-properties@14.0.4(postcss@8.5.3):
     dependencies:
@@ -19317,6 +19711,14 @@ snapshots:
       postcss: 8.5.3
       postcss-value-parser: 4.2.0
 
+  postcss-custom-selectors@8.0.4(postcss@8.4.49):
+    dependencies:
+      '@csstools/cascade-layer-name-parser': 2.0.4(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-tokenizer': 3.0.3
+      postcss: 8.4.49
+      postcss-selector-parser: 7.0.0
+
   postcss-custom-selectors@8.0.4(postcss@8.5.3):
     dependencies:
       '@csstools/cascade-layer-name-parser': 2.0.4(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
@@ -19325,26 +19727,54 @@ snapshots:
       postcss: 8.5.3
       postcss-selector-parser: 7.0.0
 
+  postcss-dir-pseudo-class@9.0.1(postcss@8.4.49):
+    dependencies:
+      postcss: 8.4.49
+      postcss-selector-parser: 7.0.0
+
   postcss-dir-pseudo-class@9.0.1(postcss@8.5.3):
     dependencies:
       postcss: 8.5.3
       postcss-selector-parser: 7.0.0
 
+  postcss-discard-comments@5.1.2(postcss@8.4.49):
+    dependencies:
+      postcss: 8.4.49
+
   postcss-discard-comments@5.1.2(postcss@8.5.3):
     dependencies:
       postcss: 8.5.3
+
+  postcss-discard-duplicates@5.1.0(postcss@8.4.49):
+    dependencies:
+      postcss: 8.4.49
 
   postcss-discard-duplicates@5.1.0(postcss@8.5.3):
     dependencies:
       postcss: 8.5.3
 
+  postcss-discard-empty@5.1.1(postcss@8.4.49):
+    dependencies:
+      postcss: 8.4.49
+
   postcss-discard-empty@5.1.1(postcss@8.5.3):
     dependencies:
       postcss: 8.5.3
 
+  postcss-discard-overridden@5.1.0(postcss@8.4.49):
+    dependencies:
+      postcss: 8.4.49
+
   postcss-discard-overridden@5.1.0(postcss@8.5.3):
     dependencies:
       postcss: 8.5.3
+
+  postcss-double-position-gradients@6.0.0(postcss@8.4.49):
+    dependencies:
+      '@csstools/postcss-progressive-custom-properties': 4.0.0(postcss@8.4.49)
+      '@csstools/utilities': 2.0.0(postcss@8.4.49)
+      postcss: 8.4.49
+      postcss-value-parser: 4.2.0
 
   postcss-double-position-gradients@6.0.0(postcss@8.5.3):
     dependencies:
@@ -19353,9 +19783,19 @@ snapshots:
       postcss: 8.5.3
       postcss-value-parser: 4.2.0
 
+  postcss-focus-visible@10.0.1(postcss@8.4.49):
+    dependencies:
+      postcss: 8.4.49
+      postcss-selector-parser: 7.0.0
+
   postcss-focus-visible@10.0.1(postcss@8.5.3):
     dependencies:
       postcss: 8.5.3
+      postcss-selector-parser: 7.0.0
+
+  postcss-focus-within@9.0.1(postcss@8.4.49):
+    dependencies:
+      postcss: 8.4.49
       postcss-selector-parser: 7.0.0
 
   postcss-focus-within@9.0.1(postcss@8.5.3):
@@ -19363,13 +19803,27 @@ snapshots:
       postcss: 8.5.3
       postcss-selector-parser: 7.0.0
 
+  postcss-font-variant@5.0.0(postcss@8.4.49):
+    dependencies:
+      postcss: 8.4.49
+
   postcss-font-variant@5.0.0(postcss@8.5.3):
     dependencies:
       postcss: 8.5.3
 
+  postcss-gap-properties@6.0.0(postcss@8.4.49):
+    dependencies:
+      postcss: 8.4.49
+
   postcss-gap-properties@6.0.0(postcss@8.5.3):
     dependencies:
       postcss: 8.5.3
+
+  postcss-image-set-function@7.0.0(postcss@8.4.49):
+    dependencies:
+      '@csstools/utilities': 2.0.0(postcss@8.4.49)
+      postcss: 8.4.49
+      postcss-value-parser: 4.2.0
 
   postcss-image-set-function@7.0.0(postcss@8.5.3):
     dependencies:
@@ -19396,6 +19850,15 @@ snapshots:
       camelcase-css: 2.0.1
       postcss: 8.4.49
 
+  postcss-lab-function@7.0.8(postcss@8.4.49):
+    dependencies:
+      '@csstools/css-color-parser': 3.0.8(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-tokenizer': 3.0.3
+      '@csstools/postcss-progressive-custom-properties': 4.0.0(postcss@8.4.49)
+      '@csstools/utilities': 2.0.0(postcss@8.4.49)
+      postcss: 8.4.49
+
   postcss-lab-function@7.0.8(postcss@8.5.3):
     dependencies:
       '@csstools/css-color-parser': 3.0.8(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
@@ -19404,6 +19867,14 @@ snapshots:
       '@csstools/postcss-progressive-custom-properties': 4.0.0(postcss@8.5.3)
       '@csstools/utilities': 2.0.0(postcss@8.5.3)
       postcss: 8.5.3
+
+  postcss-load-config@3.1.4(postcss@8.4.49)(ts-node@10.9.2(@swc/core@1.7.10(@swc/helpers@0.5.15))(@types/node@22.13.10)(typescript@5.8.3)):
+    dependencies:
+      lilconfig: 2.1.0
+      yaml: 1.10.2
+    optionalDependencies:
+      postcss: 8.4.49
+      ts-node: 10.9.2(@swc/core@1.7.10(@swc/helpers@0.5.15))(@types/node@22.13.10)(typescript@5.8.3)
 
   postcss-load-config@3.1.4(postcss@8.5.3)(ts-node@10.9.2(@swc/core@1.7.10(@swc/helpers@0.5.15))(@types/node@22.13.10)(typescript@5.8.3)):
     dependencies:
@@ -19430,6 +19901,11 @@ snapshots:
       postcss: 8.5.3
       tsx: 4.19.3
 
+  postcss-logical@8.1.0(postcss@8.4.49):
+    dependencies:
+      postcss: 8.4.49
+      postcss-value-parser: 4.2.0
+
   postcss-logical@8.1.0(postcss@8.5.3):
     dependencies:
       postcss: 8.5.3
@@ -19437,11 +19913,25 @@ snapshots:
 
   postcss-media-query-parser@0.2.3: {}
 
+  postcss-merge-longhand@5.1.7(postcss@8.4.49):
+    dependencies:
+      postcss: 8.4.49
+      postcss-value-parser: 4.2.0
+      stylehacks: 5.1.1(postcss@8.4.49)
+
   postcss-merge-longhand@5.1.7(postcss@8.5.3):
     dependencies:
       postcss: 8.5.3
       postcss-value-parser: 4.2.0
       stylehacks: 5.1.1(postcss@8.5.3)
+
+  postcss-merge-rules@5.1.4(postcss@8.4.49):
+    dependencies:
+      browserslist: 4.24.3
+      caniuse-api: 3.0.0
+      cssnano-utils: 3.1.0(postcss@8.4.49)
+      postcss: 8.4.49
+      postcss-selector-parser: 6.1.2
 
   postcss-merge-rules@5.1.4(postcss@8.5.3):
     dependencies:
@@ -19451,9 +19941,21 @@ snapshots:
       postcss: 8.5.3
       postcss-selector-parser: 6.1.2
 
+  postcss-minify-font-values@5.1.0(postcss@8.4.49):
+    dependencies:
+      postcss: 8.4.49
+      postcss-value-parser: 4.2.0
+
   postcss-minify-font-values@5.1.0(postcss@8.5.3):
     dependencies:
       postcss: 8.5.3
+      postcss-value-parser: 4.2.0
+
+  postcss-minify-gradients@5.1.1(postcss@8.4.49):
+    dependencies:
+      colord: 2.9.3
+      cssnano-utils: 3.1.0(postcss@8.4.49)
+      postcss: 8.4.49
       postcss-value-parser: 4.2.0
 
   postcss-minify-gradients@5.1.1(postcss@8.5.3):
@@ -19463,6 +19965,13 @@ snapshots:
       postcss: 8.5.3
       postcss-value-parser: 4.2.0
 
+  postcss-minify-params@5.1.4(postcss@8.4.49):
+    dependencies:
+      browserslist: 4.24.3
+      cssnano-utils: 3.1.0(postcss@8.4.49)
+      postcss: 8.4.49
+      postcss-value-parser: 4.2.0
+
   postcss-minify-params@5.1.4(postcss@8.5.3):
     dependencies:
       browserslist: 4.24.3
@@ -19470,14 +19979,30 @@ snapshots:
       postcss: 8.5.3
       postcss-value-parser: 4.2.0
 
+  postcss-minify-selectors@5.2.1(postcss@8.4.49):
+    dependencies:
+      postcss: 8.4.49
+      postcss-selector-parser: 6.1.2
+
   postcss-minify-selectors@5.2.1(postcss@8.5.3):
     dependencies:
       postcss: 8.5.3
       postcss-selector-parser: 6.1.2
 
+  postcss-modules-extract-imports@3.1.0(postcss@8.4.49):
+    dependencies:
+      postcss: 8.4.49
+
   postcss-modules-extract-imports@3.1.0(postcss@8.5.3):
     dependencies:
       postcss: 8.5.3
+
+  postcss-modules-local-by-default@4.0.5(postcss@8.4.49):
+    dependencies:
+      icss-utils: 5.1.0(postcss@8.4.49)
+      postcss: 8.4.49
+      postcss-selector-parser: 6.1.2
+      postcss-value-parser: 4.2.0
 
   postcss-modules-local-by-default@4.0.5(postcss@8.5.3):
     dependencies:
@@ -19486,15 +20011,37 @@ snapshots:
       postcss-selector-parser: 6.1.2
       postcss-value-parser: 4.2.0
 
+  postcss-modules-scope@3.2.0(postcss@8.4.49):
+    dependencies:
+      postcss: 8.4.49
+      postcss-selector-parser: 6.1.2
+
   postcss-modules-scope@3.2.0(postcss@8.5.3):
     dependencies:
       postcss: 8.5.3
       postcss-selector-parser: 6.1.2
 
+  postcss-modules-values@4.0.0(postcss@8.4.49):
+    dependencies:
+      icss-utils: 5.1.0(postcss@8.4.49)
+      postcss: 8.4.49
+
   postcss-modules-values@4.0.0(postcss@8.5.3):
     dependencies:
       icss-utils: 5.1.0(postcss@8.5.3)
       postcss: 8.5.3
+
+  postcss-modules@4.3.1(postcss@8.4.49):
+    dependencies:
+      generic-names: 4.0.0
+      icss-replace-symbols: 1.1.0
+      lodash.camelcase: 4.3.0
+      postcss: 8.4.49
+      postcss-modules-extract-imports: 3.1.0(postcss@8.4.49)
+      postcss-modules-local-by-default: 4.0.5(postcss@8.4.49)
+      postcss-modules-scope: 3.2.0(postcss@8.4.49)
+      postcss-modules-values: 4.0.0(postcss@8.4.49)
+      string-hash: 1.1.3
 
   postcss-modules@4.3.1(postcss@8.5.3):
     dependencies:
@@ -19513,6 +20060,13 @@ snapshots:
       postcss: 8.4.49
       postcss-selector-parser: 6.1.2
 
+  postcss-nesting@13.0.1(postcss@8.4.49):
+    dependencies:
+      '@csstools/selector-resolve-nested': 3.0.0(postcss-selector-parser@7.0.0)
+      '@csstools/selector-specificity': 5.0.0(postcss-selector-parser@7.0.0)
+      postcss: 8.4.49
+      postcss-selector-parser: 7.0.0
+
   postcss-nesting@13.0.1(postcss@8.5.3):
     dependencies:
       '@csstools/selector-resolve-nested': 3.0.0(postcss-selector-parser@7.0.0)
@@ -19520,13 +20074,27 @@ snapshots:
       postcss: 8.5.3
       postcss-selector-parser: 7.0.0
 
+  postcss-normalize-charset@5.1.0(postcss@8.4.49):
+    dependencies:
+      postcss: 8.4.49
+
   postcss-normalize-charset@5.1.0(postcss@8.5.3):
     dependencies:
       postcss: 8.5.3
 
+  postcss-normalize-display-values@5.1.0(postcss@8.4.49):
+    dependencies:
+      postcss: 8.4.49
+      postcss-value-parser: 4.2.0
+
   postcss-normalize-display-values@5.1.0(postcss@8.5.3):
     dependencies:
       postcss: 8.5.3
+      postcss-value-parser: 4.2.0
+
+  postcss-normalize-positions@5.1.1(postcss@8.4.49):
+    dependencies:
+      postcss: 8.4.49
       postcss-value-parser: 4.2.0
 
   postcss-normalize-positions@5.1.1(postcss@8.5.3):
@@ -19534,9 +20102,19 @@ snapshots:
       postcss: 8.5.3
       postcss-value-parser: 4.2.0
 
+  postcss-normalize-repeat-style@5.1.1(postcss@8.4.49):
+    dependencies:
+      postcss: 8.4.49
+      postcss-value-parser: 4.2.0
+
   postcss-normalize-repeat-style@5.1.1(postcss@8.5.3):
     dependencies:
       postcss: 8.5.3
+      postcss-value-parser: 4.2.0
+
+  postcss-normalize-string@5.1.0(postcss@8.4.49):
+    dependencies:
+      postcss: 8.4.49
       postcss-value-parser: 4.2.0
 
   postcss-normalize-string@5.1.0(postcss@8.5.3):
@@ -19544,9 +20122,20 @@ snapshots:
       postcss: 8.5.3
       postcss-value-parser: 4.2.0
 
+  postcss-normalize-timing-functions@5.1.0(postcss@8.4.49):
+    dependencies:
+      postcss: 8.4.49
+      postcss-value-parser: 4.2.0
+
   postcss-normalize-timing-functions@5.1.0(postcss@8.5.3):
     dependencies:
       postcss: 8.5.3
+      postcss-value-parser: 4.2.0
+
+  postcss-normalize-unicode@5.1.1(postcss@8.4.49):
+    dependencies:
+      browserslist: 4.24.3
+      postcss: 8.4.49
       postcss-value-parser: 4.2.0
 
   postcss-normalize-unicode@5.1.1(postcss@8.5.3):
@@ -19555,10 +20144,21 @@ snapshots:
       postcss: 8.5.3
       postcss-value-parser: 4.2.0
 
+  postcss-normalize-url@5.1.0(postcss@8.4.49):
+    dependencies:
+      normalize-url: 6.1.0
+      postcss: 8.4.49
+      postcss-value-parser: 4.2.0
+
   postcss-normalize-url@5.1.0(postcss@8.5.3):
     dependencies:
       normalize-url: 6.1.0
       postcss: 8.5.3
+      postcss-value-parser: 4.2.0
+
+  postcss-normalize-whitespace@5.1.1(postcss@8.4.49):
+    dependencies:
+      postcss: 8.4.49
       postcss-value-parser: 4.2.0
 
   postcss-normalize-whitespace@5.1.1(postcss@8.5.3):
@@ -19566,9 +20166,19 @@ snapshots:
       postcss: 8.5.3
       postcss-value-parser: 4.2.0
 
+  postcss-opacity-percentage@3.0.0(postcss@8.4.49):
+    dependencies:
+      postcss: 8.4.49
+
   postcss-opacity-percentage@3.0.0(postcss@8.5.3):
     dependencies:
       postcss: 8.5.3
+
+  postcss-ordered-values@5.1.3(postcss@8.4.49):
+    dependencies:
+      cssnano-utils: 3.1.0(postcss@8.4.49)
+      postcss: 8.4.49
+      postcss-value-parser: 4.2.0
 
   postcss-ordered-values@5.1.3(postcss@8.5.3):
     dependencies:
@@ -19576,19 +20186,100 @@ snapshots:
       postcss: 8.5.3
       postcss-value-parser: 4.2.0
 
+  postcss-overflow-shorthand@6.0.0(postcss@8.4.49):
+    dependencies:
+      postcss: 8.4.49
+      postcss-value-parser: 4.2.0
+
   postcss-overflow-shorthand@6.0.0(postcss@8.5.3):
     dependencies:
       postcss: 8.5.3
       postcss-value-parser: 4.2.0
 
+  postcss-page-break@3.0.4(postcss@8.4.49):
+    dependencies:
+      postcss: 8.4.49
+
   postcss-page-break@3.0.4(postcss@8.5.3):
     dependencies:
       postcss: 8.5.3
+
+  postcss-place@10.0.0(postcss@8.4.49):
+    dependencies:
+      postcss: 8.4.49
+      postcss-value-parser: 4.2.0
 
   postcss-place@10.0.0(postcss@8.5.3):
     dependencies:
       postcss: 8.5.3
       postcss-value-parser: 4.2.0
+
+  postcss-preset-env@10.1.5(postcss@8.4.49):
+    dependencies:
+      '@csstools/postcss-cascade-layers': 5.0.1(postcss@8.4.49)
+      '@csstools/postcss-color-function': 4.0.8(postcss@8.4.49)
+      '@csstools/postcss-color-mix-function': 3.0.8(postcss@8.4.49)
+      '@csstools/postcss-content-alt-text': 2.0.4(postcss@8.4.49)
+      '@csstools/postcss-exponential-functions': 2.0.7(postcss@8.4.49)
+      '@csstools/postcss-font-format-keywords': 4.0.0(postcss@8.4.49)
+      '@csstools/postcss-gamut-mapping': 2.0.8(postcss@8.4.49)
+      '@csstools/postcss-gradients-interpolation-method': 5.0.8(postcss@8.4.49)
+      '@csstools/postcss-hwb-function': 4.0.8(postcss@8.4.49)
+      '@csstools/postcss-ic-unit': 4.0.0(postcss@8.4.49)
+      '@csstools/postcss-initial': 2.0.1(postcss@8.4.49)
+      '@csstools/postcss-is-pseudo-class': 5.0.1(postcss@8.4.49)
+      '@csstools/postcss-light-dark-function': 2.0.7(postcss@8.4.49)
+      '@csstools/postcss-logical-float-and-clear': 3.0.0(postcss@8.4.49)
+      '@csstools/postcss-logical-overflow': 2.0.0(postcss@8.4.49)
+      '@csstools/postcss-logical-overscroll-behavior': 2.0.0(postcss@8.4.49)
+      '@csstools/postcss-logical-resize': 3.0.0(postcss@8.4.49)
+      '@csstools/postcss-logical-viewport-units': 3.0.3(postcss@8.4.49)
+      '@csstools/postcss-media-minmax': 2.0.7(postcss@8.4.49)
+      '@csstools/postcss-media-queries-aspect-ratio-number-values': 3.0.4(postcss@8.4.49)
+      '@csstools/postcss-nested-calc': 4.0.0(postcss@8.4.49)
+      '@csstools/postcss-normalize-display-values': 4.0.0(postcss@8.4.49)
+      '@csstools/postcss-oklab-function': 4.0.8(postcss@8.4.49)
+      '@csstools/postcss-progressive-custom-properties': 4.0.0(postcss@8.4.49)
+      '@csstools/postcss-random-function': 1.0.3(postcss@8.4.49)
+      '@csstools/postcss-relative-color-syntax': 3.0.8(postcss@8.4.49)
+      '@csstools/postcss-scope-pseudo-class': 4.0.1(postcss@8.4.49)
+      '@csstools/postcss-sign-functions': 1.1.2(postcss@8.4.49)
+      '@csstools/postcss-stepped-value-functions': 4.0.7(postcss@8.4.49)
+      '@csstools/postcss-text-decoration-shorthand': 4.0.2(postcss@8.4.49)
+      '@csstools/postcss-trigonometric-functions': 4.0.7(postcss@8.4.49)
+      '@csstools/postcss-unset-value': 4.0.0(postcss@8.4.49)
+      autoprefixer: 10.4.21(postcss@8.4.49)
+      browserslist: 4.24.4
+      css-blank-pseudo: 7.0.1(postcss@8.4.49)
+      css-has-pseudo: 7.0.2(postcss@8.4.49)
+      css-prefers-color-scheme: 10.0.0(postcss@8.4.49)
+      cssdb: 8.2.3
+      postcss: 8.4.49
+      postcss-attribute-case-insensitive: 7.0.1(postcss@8.4.49)
+      postcss-clamp: 4.1.0(postcss@8.4.49)
+      postcss-color-functional-notation: 7.0.8(postcss@8.4.49)
+      postcss-color-hex-alpha: 10.0.0(postcss@8.4.49)
+      postcss-color-rebeccapurple: 10.0.0(postcss@8.4.49)
+      postcss-custom-media: 11.0.5(postcss@8.4.49)
+      postcss-custom-properties: 14.0.4(postcss@8.4.49)
+      postcss-custom-selectors: 8.0.4(postcss@8.4.49)
+      postcss-dir-pseudo-class: 9.0.1(postcss@8.4.49)
+      postcss-double-position-gradients: 6.0.0(postcss@8.4.49)
+      postcss-focus-visible: 10.0.1(postcss@8.4.49)
+      postcss-focus-within: 9.0.1(postcss@8.4.49)
+      postcss-font-variant: 5.0.0(postcss@8.4.49)
+      postcss-gap-properties: 6.0.0(postcss@8.4.49)
+      postcss-image-set-function: 7.0.0(postcss@8.4.49)
+      postcss-lab-function: 7.0.8(postcss@8.4.49)
+      postcss-logical: 8.1.0(postcss@8.4.49)
+      postcss-nesting: 13.0.1(postcss@8.4.49)
+      postcss-opacity-percentage: 3.0.0(postcss@8.4.49)
+      postcss-overflow-shorthand: 6.0.0(postcss@8.4.49)
+      postcss-page-break: 3.0.4(postcss@8.4.49)
+      postcss-place: 10.0.0(postcss@8.4.49)
+      postcss-pseudo-class-any-link: 10.0.1(postcss@8.4.49)
+      postcss-replace-overflow-wrap: 4.0.0(postcss@8.4.49)
+      postcss-selector-not: 8.0.1(postcss@8.4.49)
 
   postcss-preset-env@10.1.5(postcss@8.5.3):
     dependencies:
@@ -19657,10 +20348,21 @@ snapshots:
       postcss-replace-overflow-wrap: 4.0.0(postcss@8.5.3)
       postcss-selector-not: 8.0.1(postcss@8.5.3)
 
+  postcss-pseudo-class-any-link@10.0.1(postcss@8.4.49):
+    dependencies:
+      postcss: 8.4.49
+      postcss-selector-parser: 7.0.0
+
   postcss-pseudo-class-any-link@10.0.1(postcss@8.5.3):
     dependencies:
       postcss: 8.5.3
       postcss-selector-parser: 7.0.0
+
+  postcss-reduce-initial@5.1.2(postcss@8.4.49):
+    dependencies:
+      browserslist: 4.24.3
+      caniuse-api: 3.0.0
+      postcss: 8.4.49
 
   postcss-reduce-initial@5.1.2(postcss@8.5.3):
     dependencies:
@@ -19668,10 +20370,19 @@ snapshots:
       caniuse-api: 3.0.0
       postcss: 8.5.3
 
+  postcss-reduce-transforms@5.1.0(postcss@8.4.49):
+    dependencies:
+      postcss: 8.4.49
+      postcss-value-parser: 4.2.0
+
   postcss-reduce-transforms@5.1.0(postcss@8.5.3):
     dependencies:
       postcss: 8.5.3
       postcss-value-parser: 4.2.0
+
+  postcss-replace-overflow-wrap@4.0.0(postcss@8.4.49):
+    dependencies:
+      postcss: 8.4.49
 
   postcss-replace-overflow-wrap@4.0.0(postcss@8.5.3):
     dependencies:
@@ -19693,6 +20404,11 @@ snapshots:
     dependencies:
       postcss: 8.5.3
 
+  postcss-selector-not@8.0.1(postcss@8.4.49):
+    dependencies:
+      postcss: 8.4.49
+      postcss-selector-parser: 7.0.0
+
   postcss-selector-not@8.0.1(postcss@8.5.3):
     dependencies:
       postcss: 8.5.3
@@ -19713,11 +20429,22 @@ snapshots:
       cssesc: 3.0.0
       util-deprecate: 1.0.2
 
+  postcss-svgo@5.1.0(postcss@8.4.49):
+    dependencies:
+      postcss: 8.4.49
+      postcss-value-parser: 4.2.0
+      svgo: 2.8.0
+
   postcss-svgo@5.1.0(postcss@8.5.3):
     dependencies:
       postcss: 8.5.3
       postcss-value-parser: 4.2.0
       svgo: 2.8.0
+
+  postcss-unique-selectors@5.1.1(postcss@8.4.49):
+    dependencies:
+      postcss: 8.4.49
+      postcss-selector-parser: 6.1.2
 
   postcss-unique-selectors@5.1.1(postcss@8.5.3):
     dependencies:
@@ -19731,7 +20458,6 @@ snapshots:
       nanoid: 3.3.11
       picocolors: 1.1.1
       source-map-js: 1.2.1
-    optional: true
 
   postcss@8.4.49:
     dependencies:
@@ -19999,9 +20725,11 @@ snapshots:
       '@babel/runtime': 7.25.0
       react: 19.1.0
 
-  react-day-picker@8.10.1(date-fns@4.1.0)(react@19.1.0):
+  react-day-picker@9.6.7(react@19.1.0):
     dependencies:
+      '@date-fns/tz': 1.2.0
       date-fns: 4.1.0
+      date-fns-jalali: 4.1.0-0
       react: 19.1.0
 
   react-docgen-typescript@2.2.2(typescript@5.8.3):
@@ -20203,7 +20931,6 @@ snapshots:
   react@18.3.1:
     dependencies:
       loose-envify: 1.4.0
-    optional: true
 
   react@19.1.0: {}
 
@@ -20398,6 +21125,25 @@ snapshots:
   rollup-plugin-node-externals@8.0.0(rollup@4.39.0):
     dependencies:
       rollup: 4.39.0
+
+  rollup-plugin-postcss@4.0.2(postcss@8.4.49)(ts-node@10.9.2(@swc/core@1.7.10(@swc/helpers@0.5.15))(@types/node@22.13.10)(typescript@5.8.3)):
+    dependencies:
+      chalk: 4.1.2
+      concat-with-sourcemaps: 1.1.0
+      cssnano: 5.1.15(postcss@8.4.49)
+      import-cwd: 3.0.0
+      p-queue: 6.6.2
+      pify: 5.0.0
+      postcss: 8.4.49
+      postcss-load-config: 3.1.4(postcss@8.4.49)(ts-node@10.9.2(@swc/core@1.7.10(@swc/helpers@0.5.15))(@types/node@22.13.10)(typescript@5.8.3))
+      postcss-modules: 4.3.1(postcss@8.4.49)
+      promise.series: 0.2.0
+      resolve: 1.22.8
+      rollup-pluginutils: 2.8.2
+      safe-identifier: 0.4.2
+      style-inject: 0.3.0
+    transitivePeerDependencies:
+      - ts-node
 
   rollup-plugin-postcss@4.0.2(postcss@8.5.3)(ts-node@10.9.2(@swc/core@1.7.10(@swc/helpers@0.5.15))(@types/node@22.13.10)(typescript@5.8.3)):
     dependencies:
@@ -20815,8 +21561,7 @@ snapshots:
       readable-stream: 3.6.2
       xtend: 4.0.2
 
-  streamsearch@1.1.0:
-    optional: true
+  streamsearch@1.1.0: {}
 
   strict-event-emitter@0.5.1: {}
 
@@ -20976,7 +21721,12 @@ snapshots:
       react: 19.1.0
     optionalDependencies:
       '@babel/core': 7.26.0
-    optional: true
+
+  stylehacks@5.1.1(postcss@8.4.49):
+    dependencies:
+      browserslist: 4.24.3
+      postcss: 8.4.49
+      postcss-selector-parser: 6.1.2
 
   stylehacks@5.1.1(postcss@8.5.3):
     dependencies:


### PR DESCRIPTION
Update react-day-picker to version 9.6.7 and update all dependent components to work with the new API. Changes include:

## Why

To support react 19 we need to update react-day-picker to v9

## What

- Refactor component props to use the updated type definitions
- Update component rendering to match the new API requirements
- Modify CSS modules to accommodate new class naming conventions
- Adjust navigation components to use the new Chevron component API
- Add new styles for proper range highlighting and hidden requirements

react-day-picker changed quite a lot between major versions and how it applies class names to the table cell and button based on the type it is, so had to adjust some styles to target button children in some instances.

### UX change

Behaviour between v8 and v9 in respect to how it handles clicking the first day of an active date range has changed.

Instead if clearing the range like it did in v8 the range is now set to the first day.
To better understand what I mean I have two demos:

- v8: <https://codesandbox.io/p/devbox/rdp-v9-docs-example-forked-9d7kl5?file=/src/App.tsx&workspaceId=ws_B237FHzyHgonmzEroF4SKD>
- v9: <https://codesandbox.io/p/sandbox/nkmfsk?file=/src/App.tsx>

If you click the first day in each demo of the active range you'll see the difference.

https://github.com/user-attachments/assets/8eb636d2-1cb8-4cc0-acbd-72c31e437beb
