### PR TITLE
fix: use ts-patch before building components

### DIFF
--- a/.changeset/funny-rivers-camp.md
+++ b/.changeset/funny-rivers-camp.md
@@ -1,0 +1,5 @@
+---
+'@kaizen/components': patch
+---
+
+Fix an issue where types exported doesn't have alias converted.

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -103,7 +103,7 @@
   },
   "scripts": {
     "lint:ts": "tsc --noEmit",
-    "build": "pnpm package-bundler build-shared-ui && pnpm build:styles",
+    "build": "ts-patch install -s && pnpm package-bundler build-shared-ui && pnpm build:styles",
     "build:global-styles": "postcss ./styles/global.css --output dist/global.css",
     "build:combine-styles": "concat-cli -f ./dist/global.css ./dist/styles.css -o ./dist/styles.css && rm ./dist/global.css",
     "build:styles": "pnpm build:global-styles && pnpm build:combine-styles",
@@ -197,6 +197,7 @@
     "serialize-query-params": "^2.0.2",
     "svgo": "^3.3.2",
     "tslib": "^2.8.1",
+    "ts-patch": "^3.3.0",
     "tsx": "^4.19.3"
   },
   "devDependenciesComments": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -488,6 +488,9 @@ importers:
       svgo:
         specifier: ^3.3.2
         version: 3.3.2
+      ts-patch:
+        specifier: ^3.3.0
+        version: 3.3.0
       tslib:
         specifier: ^2.8.1
         version: 2.8.1
@@ -10414,7 +10417,7 @@ snapshots:
       outdent: 0.5.0
       prettier: 2.8.8
       resolve-from: 5.0.0
-      semver: 7.6.3
+      semver: 7.7.1
 
   '@changesets/assemble-release-plan@6.0.6':
     dependencies:
@@ -10423,7 +10426,7 @@ snapshots:
       '@changesets/should-skip-package': 0.1.2
       '@changesets/types': 6.1.0
       '@manypkg/get-packages': 1.1.3
-      semver: 7.6.3
+      semver: 7.7.1
 
   '@changesets/changelog-git@0.2.1':
     dependencies:
@@ -10487,7 +10490,7 @@ snapshots:
       '@changesets/types': 6.1.0
       '@manypkg/get-packages': 1.1.3
       picocolors: 1.1.1
-      semver: 7.6.3
+      semver: 7.7.1
 
   '@changesets/get-github-info@0.6.0(encoding@0.1.13)':
     dependencies:
@@ -21048,7 +21051,7 @@ snapshots:
       global-prefix: 4.0.0
       minimist: 1.2.8
       resolve: 1.22.8
-      semver: 7.6.3
+      semver: 7.7.1
       strip-ansi: 6.0.1
 
   tsconfig-paths@3.15.0:


### PR DESCRIPTION
## Important: Request PR reviews on Slack

Please reach out to the design system team on Slack in `#prod_design_system` for PR reviews. GitHub notifications (e.g. from tagging a person) are not actively monitored.

## Why

postinstall ts-patch is not running in CI.

## What

Installed ts-patch in components and run it before build
