### PR TITLE
fix(AIMoment): add z index 0 on base aiMoment class

### DIFF
--- a/.changeset/metal-papers-take.md
+++ b/.changeset/metal-papers-take.md
@@ -1,0 +1,5 @@
+---
+'@kaizen/components': patch
+---
+
+Add `z-index: 0` to aiMoment shared styles to fix `Well` and `Card` gradient borders not appearing.

--- a/packages/components/styles/utils/AIMoment.module.css
+++ b/packages/components/styles/utils/AIMoment.module.css
@@ -18,6 +18,7 @@
   position: relative;
   border: 1px solid transparent;
   border-radius: var(--border-borderless-border-radius);
+  z-index: 0;
 }
 
 /* This absolute element is used to give the illusion of a gradient border without expanding the size of the Well/Card */


### PR DESCRIPTION
## Important: Request PR reviews on Slack

Please reach out to the design system team on Slack in `#prod_design_system` for PR reviews. GitHub notifications (e.g. from tagging a person) are not actively monitored.

## Why
Jay reported an issue with the floating gradient borders not appearing in the latest release.

This appeared to be due to the z-index of the not being able to layer correctly off the `relative` parent. The interim fix was to add a `z-[0]` to the `classNameOveride`. This PR will mean they don't have to set this value.

## What
- adds `z-index: 0` to `aiMoment` class 

### No z-index

<img width="995" alt="Screenshot 2025-05-02 at 11 37 40 am" src="https://github.com/user-attachments/assets/3015af64-a445-4869-a06b-bce1dc1625dc" />

### z-index: 0

<img width="1097" alt="Screenshot 2025-05-02 at 11 37 22 am" src="https://github.com/user-attachments/assets/c9b352dc-33bc-41e4-8b24-5d72d3d8bc8a" />

### Canary

Since this was an issue locally, I tested a canary (`0.0.0-canary-fix-zindex-ai-moment-20250502014154`) in the local dev for `ai-ui` and can confirm the z-index no longer is required in`classNameOveride`