### PR TITLE
fix: remove root-level React dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,10 +36,6 @@
     "i18n:extract": "pnpm pkg:aio i18n:extract",
     "i18n:extract:remove-obsolete": "pnpm pkg:aio i18n:extract --deleteObsoleteTranslations"
   },
-  "dependencies": {
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0"
-  },
   "devDependencies": {
     "@changesets/cli": "^2.28.1",
     "@cultureamp/changelog-github": "^0.1.1",
@@ -104,11 +100,25 @@
         "@popper/core>react-dom": "19",
         "@reach/tabs>react": "19",
         "@reach/tabs>react-dom": "19",
+        "@reach/auto-id>react": "19",
+        "@reach/auto-id>react-dom": "19",
+        "@reach/utils>react": "19",
+        "@reach/utils>react-dom": "19",
+        "@reach/descendants>react": "19",
+        "@reach/descendants>react-dom": "19",
+        "@reach/polymorphic>react": "19",
+        "@reach/polymorphic>react-dom": "19",
         "eslint": "9",
         "react-focus-on>react": "19",
         "react-focus-on>react-dom": "19",
         "react-popper>react": "19",
         "react-popper>react-dom": "19",
+        "react-remove-scroll>react": "19",
+        "react-remove-scroll>react-dom": "19",
+        "react-remove-scroll-bar>react": "19",
+        "react-remove-scroll-bar>react-dom": "19",
+        "react-style-singleton>react": "19",
+        "react-style-singleton>react-dom": "19",
         "react-textfit>react": "19",
         "react-textfit>react-dom": "19"
       }

--- a/packages/tailwind/package.json
+++ b/packages/tailwind/package.json
@@ -38,6 +38,8 @@
     "tslib": "^2.8.1"
   },
   "peerDependencies": {
-    "tailwindcss": ">=3.4.7"
+    "tailwindcss": ">=3.4.7",
+    "react": "^18.3.1 || ^19.0.0",
+    "react-dom": "^18.3.1 || ^19.0.0"
   }
 }

--- a/packages/tailwind/package.json
+++ b/packages/tailwind/package.json
@@ -34,6 +34,8 @@
     "@cultureamp/package-bundler": "^2.1.0",
     "classnames": "^2.5.1",
     "rollup": "^4.39.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
     "tailwindcss": "^3.4.17",
     "tslib": "^2.8.1"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -571,12 +571,6 @@ importers:
       '@kaizen/design-tokens':
         specifier: workspace:*
         version: link:../design-tokens
-      react:
-        specifier: ^18.3.1 || ^19.0.0
-        version: 19.1.0
-      react-dom:
-        specifier: ^18.3.1 || ^19.0.0
-        version: 19.1.0(react@19.1.0)
     devDependencies:
       '@cultureamp/package-bundler':
         specifier: ^2.1.0
@@ -584,6 +578,12 @@ importers:
       classnames:
         specifier: ^2.5.1
         version: 2.5.1
+      react:
+        specifier: ^19.0.0
+        version: 19.1.0
+      react-dom:
+        specifier: ^19.0.0
+        version: 19.1.0(react@19.1.0)
       rollup:
         specifier: ^4.39.0
         version: 4.39.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,13 +10,6 @@ overrides:
 importers:
 
   .:
-    dependencies:
-      react:
-        specifier: ^19.0.0
-        version: 19.1.0
-      react-dom:
-        specifier: ^19.0.0
-        version: 19.1.0(react@19.1.0)
     devDependencies:
       '@changesets/cli':
         specifier: ^2.28.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -571,6 +571,12 @@ importers:
       '@kaizen/design-tokens':
         specifier: workspace:*
         version: link:../design-tokens
+      react:
+        specifier: ^18.3.1 || ^19.0.0
+        version: 19.1.0
+      react-dom:
+        specifier: ^18.3.1 || ^19.0.0
+        version: 19.1.0(react@19.1.0)
     devDependencies:
       '@cultureamp/package-bundler':
         specifier: ^2.1.0


### PR DESCRIPTION
## Why

To support react 19 

## What

There seems to hard dependency on react and react-dom in the top level package.json that may be left over from pre KAIO days. From my testing there seems to be no real use for it to be there.
