### PR TITLE
Force white-space: pre-wrap on RichTextContent

### DIFF
--- a/.changeset/twelve-wombats-write.md
+++ b/.changeset/twelve-wombats-write.md
@@ -1,0 +1,10 @@
+---
+'@kaizen/components': patch
+---
+
+Update `RichTextContent` styles for Tailwind 4 compatibility
+
+With Tailwind 4 we will need to load Kaizen into a CSS Cascade Layer, which
+will prevent its styles from overriding the default styles injected into the
+page by ProseMirror/TipTap at runtime. Where we want to override these, Kaizen
+must therefore now declare these styles as `!important`.

--- a/packages/components/src/RichTextEditor/_mixins.scss
+++ b/packages/components/src/RichTextEditor/_mixins.scss
@@ -9,7 +9,8 @@
   line-height: $typography-paragraph-body-line-height;
   letter-spacing: $typography-paragraph-body-letter-spacing;
   position: relative;
-  white-space: pre-wrap;
+  /* stylelint-disable-next-line declaration-no-important */
+  white-space: pre-wrap !important; // Override unlayered TipTap styles from within components layer
   box-sizing: content-box;
   color: $color-purple-800;
 


### PR DESCRIPTION
## Why

Kaizen will soon be loaded into a `components` layer in consuming apps using Tailwind 4 (see cultureamp/performance-review-cycles-ui#3392).

Once this happens, the `white-space: pre-wrap` style on the `RichTextContent` component would be overridden by the un-layered styles injected into the page by ProseMirror/TipTap at runtime.

## What

To resolve the above issue, this adds `!important` to the `white-space: pre-wrap` style on the `RichTextContent` component.