### PR TITLE
[KZN-3168] Tooltip keyboard interaction test

### DIFF
--- a/packages/components/src/__next__/Tooltip/_docs/Tooltip.spec.stories.tsx
+++ b/packages/components/src/__next__/Tooltip/_docs/Tooltip.spec.stories.tsx
@@ -45,16 +45,18 @@ export const OnButton: Story = {
     const button = canvas.queryByRole('button') ?? canvas.getByRole('link')
 
     await step('Hover shows', async () => {
-      await waitFor(() => userEvent.unhover(button))
+      await waitFor(() => userEvent.click(canvasElement)) // needed to refocus the browser window
+
       await userEvent.hover(button)
-      const tooltip = canvas.findByRole('tooltip')
-      await expect(await tooltip).toBeInTheDocument()
-      await expect((await tooltip).checkVisibility()).toBe(true)
+      await expect(await canvas.findByRole('tooltip')).toBeInTheDocument()
+      await expect((await canvas.findByRole('tooltip')).checkVisibility()).toBe(true)
       await expect(button).toHaveAttribute('aria-describedby', canvas.getByRole('tooltip').id)
       await userEvent.unhover(button)
     })
 
     await step('Focus shows', async () => {
+      await waitFor(() => userEvent.click(canvasElement)) // needed to refocus the browser window
+
       await userEvent.tab() // focus
       await expect((await canvas.findByRole('tooltip')).checkVisibility()).toBe(true)
       await expect(await canvas.findByRole('tooltip')).toBeInTheDocument()
@@ -64,6 +66,8 @@ export const OnButton: Story = {
     })
 
     await step('Escape closes', async () => {
+      await waitFor(() => userEvent.click(canvasElement)) // needed to refocus the browser window
+
       await userEvent.tab() // focus
       await waitFor(() => expect(canvas.getByRole('tooltip')).toBeVisible())
       await userEvent.keyboard('{Escape}')

--- a/packages/components/src/__next__/Tooltip/_docs/Tooltip.spec.stories.tsx
+++ b/packages/components/src/__next__/Tooltip/_docs/Tooltip.spec.stories.tsx
@@ -56,9 +56,11 @@ export const OnButton: Story = {
 
     await step('Focus shows', async () => {
       await userEvent.tab() // focus
-      await waitFor(() => expect(canvas.getByRole('tooltip')).toBeVisible())
+      await expect((await canvas.findByRole('tooltip')).checkVisibility()).toBe(true)
+      await expect(await canvas.findByRole('tooltip')).toBeInTheDocument()
       await userEvent.tab() // unfocus
-      await waitFor(() => expect(canvas.queryByRole('tooltip')).toBeNull())
+      waitFor(() => expect(canvas.queryByRole('tooltip')).toBeNull())
+      waitFor(async () => expect(await canvas.queryByText('Tooltip content')).toBeNull())
     })
 
     await step('Escape closes', async () => {


### PR DESCRIPTION
## Why

Tooltip next tests have still been failing intermittently even after updating the Tooltip next tests and having them pass locally, as well as on the [PR](https://github.com/cultureamp/kaizen-design-system/pull/5791). 

## What

The tests seem to be failing when the browser loses focus. I've added a click event to each of the tests as a workaround to refocusing the canvas - allowing the tests to pass. As the Tooltip next tests are run as one test, updating the test runner preVisit to refocus the page wouldn't work. 
