### PR TITLE
[KZN-3362] replace RAC onSelectionChange

### DIFF
--- a/.changeset/warm-insects-show.md
+++ b/.changeset/warm-insects-show.md
@@ -1,0 +1,5 @@
+---
+'@kaizen/components': patch
+---
+
+Revising the type `onSelectionChange` in the Select next component to align with previous versions

--- a/packages/components/src/__next__/Select/Select.tsx
+++ b/packages/components/src/__next__/Select/Select.tsx
@@ -119,7 +119,7 @@ export const Select = <Option extends SelectOption = SelectOption>({
     description,
     placeholder,
     isDisabled,
-    onSelectionChange: onSelectionChange ? (key) => onSelectionChange(key as Key) : undefined,
+    onSelectionChange: onSelectionChange ? (key) => onSelectionChange(key!) : undefined,
     ...restProps,
   }
 

--- a/packages/components/src/__next__/Select/Select.tsx
+++ b/packages/components/src/__next__/Select/Select.tsx
@@ -25,7 +25,7 @@ import { getDisabledKeysFromItems } from './utils/getDisabledKeysFromItems'
 import { transformSelectItemToCollectionElement } from './utils/transformSelectItemToCollectionElement'
 import styles from './Select.module.scss'
 
-type OmittedAriaSelectProps = 'children' | 'items'
+type OmittedAriaSelectProps = 'children' | 'items' | 'onSelectionChange'
 
 export type SelectProps<Option extends SelectOption = SelectOption> = {
   /**
@@ -70,6 +70,10 @@ export type SelectProps<Option extends SelectOption = SelectOption> = {
    * Use the `labelText` prop to provide a concise name, and the `description` prop for any help text.
    */
   placeholder?: string
+  /**
+   * Handler that is called when the selection changes.
+   */
+  onSelectionChange?: (key: Key) => void
 } & OverrideClassName<Omit<AriaSelectProps<Option>, OmittedAriaSelectProps>>
 
 /**
@@ -92,6 +96,7 @@ export const Select = <Option extends SelectOption = SelectOption>({
   description,
   placeholder = '',
   isDisabled,
+  onSelectionChange,
   portalContainerId,
   ...restProps
 }: SelectProps<Option>): JSX.Element => {
@@ -114,6 +119,7 @@ export const Select = <Option extends SelectOption = SelectOption>({
     description,
     placeholder,
     isDisabled,
+    onSelectionChange: onSelectionChange ? (key) => onSelectionChange(key as Key) : undefined,
     ...restProps,
   }
 


### PR DESCRIPTION
## Why

RAC types update for `onSelectionChange` has broken teams implementations 

## What

Updating the `Select` next's `onSelectionChange` prop so that it now only takes a `Key` again instead of `Key | null`
