### PR TITLE
[KKZ-3349] Select next overlay bug - dropdown closes when clicking on scrollbar

### DIFF
--- a/.changeset/deep-owls-sink.md
+++ b/.changeset/deep-owls-sink.md
@@ -1,0 +1,5 @@
+---
+'@kaizen/components': patch
+---
+
+Fixes bug in Select next overlay, was closing overlay when clicking on scroll

--- a/packages/components/src/__next__/Select/Select.tsx
+++ b/packages/components/src/__next__/Select/Select.tsx
@@ -25,7 +25,7 @@ import { getDisabledKeysFromItems } from './utils/getDisabledKeysFromItems'
 import { transformSelectItemToCollectionElement } from './utils/transformSelectItemToCollectionElement'
 import styles from './Select.module.scss'
 
-type OmittedAriaSelectProps = 'children' | 'items'
+type OmittedAriaSelectProps = 'children' | 'items' | 'onSelectionChange'
 
 export type SelectProps<Option extends SelectOption = SelectOption> = {
   /**
@@ -70,6 +70,10 @@ export type SelectProps<Option extends SelectOption = SelectOption> = {
    * Use the `labelText` prop to provide a concise name, and the `description` prop for any help text.
    */
   placeholder?: string
+  /**
+   * Handler that is called when the selection changes.
+   */
+  onSelectionChange?: (key: Key) => void
 } & OverrideClassName<Omit<AriaSelectProps<Option>, OmittedAriaSelectProps>>
 
 /**
@@ -92,6 +96,7 @@ export const Select = <Option extends SelectOption = SelectOption>({
   description,
   placeholder = '',
   isDisabled,
+  onSelectionChange,
   portalContainerId,
   ...restProps
 }: SelectProps<Option>): JSX.Element => {
@@ -114,6 +119,7 @@ export const Select = <Option extends SelectOption = SelectOption>({
     description,
     placeholder,
     isDisabled,
+    onSelectionChange: onSelectionChange ? (key) => onSelectionChange(key!) : undefined,
     ...restProps,
   }
 
@@ -177,7 +183,9 @@ export const Select = <Option extends SelectOption = SelectOption>({
         {state.isOpen && (
           <Popover id={popoverId} portalContainer={portalContainer} refs={refs}>
             <SelectProvider<Option> state={state}>
-              <SelectPopoverContents menuProps={menuProps}>{children}</SelectPopoverContents>
+              <SelectPopoverContents menuProps={menuProps} popoverRef={refs.floating}>
+                {children}
+              </SelectPopoverContents>
             </SelectProvider>
           </Popover>
         )}

--- a/packages/components/src/__next__/Select/subcomponents/Overlay/Overlay.tsx
+++ b/packages/components/src/__next__/Select/subcomponents/Overlay/Overlay.tsx
@@ -7,11 +7,13 @@ import { type SelectOption } from '../../types'
 
 export type OverlayProps = OverrideClassName<HTMLAttributes<HTMLDivElement>> & {
   children: React.ReactNode
+  popoverRef?: React.RefObject<Element | null>
 }
 
 export const Overlay = <Option extends SelectOption>({
   children,
   classNameOverride,
+  popoverRef,
   ...restProps
 }: OverlayProps): JSX.Element => {
   const { state } = useSelectContext<Option>()
@@ -21,7 +23,7 @@ export const Overlay = <Option extends SelectOption>({
   const overlayRef = React.useRef<HTMLDivElement>(null)
   const { overlayProps } = useOverlay(
     { isDismissable: true, isOpen: state.isOpen, onClose: state.close },
-    overlayRef,
+    popoverRef ?? overlayRef,
   )
 
   // Wrap in <FocusScope> so that focus is restored back to the trigger when the menu is closed
@@ -29,7 +31,7 @@ export const Overlay = <Option extends SelectOption>({
   // In addition, add hidden <DismissButton> components at the start and end of the list
   // to allow screen reader users to dismiss the popup easily.
   return (
-    <div ref={overlayRef} className={classNameOverride} {...overlayProps} {...restProps}>
+    <div className={classNameOverride} {...overlayProps} {...restProps}>
       {/* eslint-disable-next-line jsx-a11y/no-autofocus */}
       <FocusScope autoFocus={false} restoreFocus>
         <DismissButton onDismiss={state.close} />

--- a/packages/components/src/__next__/Select/subcomponents/SelectPopoverContents/SelectPopoverContents.tsx
+++ b/packages/components/src/__next__/Select/subcomponents/SelectPopoverContents/SelectPopoverContents.tsx
@@ -10,11 +10,13 @@ import styles from './SelectPopoverContents.module.scss'
 export type SelectPopoverContentsProps<Option extends SelectOption> = {
   children?: (args: { items: SelectItemNode<Option>[] }) => React.ReactNode
   menuProps: AriaListBoxOptions<SelectItem<Option>>
+  popoverRef?: React.RefObject<Element | null>
 }
 
 export const SelectPopoverContents = <Option extends SelectOption>({
   children,
   menuProps,
+  popoverRef,
 }: SelectPopoverContentsProps<Option>): JSX.Element => {
   const { state } = useSelectContext<Option>()
 
@@ -26,7 +28,7 @@ export const SelectPopoverContents = <Option extends SelectOption>({
 
   return (
     <div className={styles.selectPopoverContents}>
-      <Overlay<Option>>
+      <Overlay<Option> popoverRef={popoverRef}>
         <ListBox<Option> menuProps={menuProps}>
           {children ? children({ items: itemNodes }) : <ListItems<Option> items={itemNodes} />}
         </ListBox>


### PR DESCRIPTION
## Why
Fixes: https://cultureamp.atlassian.net/browse/KZN-3349
When a user interacts with the Select scrollbar, or the padding of the popover the dropdown closes -> it should stay open

https://github.com/user-attachments/assets/63930d2c-ee11-4734-a036-c0b8dc543f6a

Issue was reported in January by Coles
## What
I've updated the `Overlay` component which handles closing the dropdown giving it the ref of the parent `Popover` component. Now the overlay won't close the dropdown if the popover is clicked, which includes the padding space and the scrollbar. 

https://github.com/user-attachments/assets/a4c6bc43-a86d-4fc0-8f11-c011a92fde09



