### PR TITLE
[KZN-3197] remove Tag next from KAIO V2

### DIFF
--- a/docs/pages/upcoming-releases.mdx
+++ b/docs/pages/upcoming-releases.mdx
@@ -46,15 +46,6 @@ Components from the `@kaizen/components/next` entry point taking the place of co
       <td>Coming soon</td>
     </tr>
     <tr>
-      <td>[`Tag`](?path=/docs/components-tag-tag-deprecated--docs)</td>
-      <td>
-        [`Tag`](?path=/docs/components-tag-tag-next--docs)
-        [`RemovableTag`](?path=/docs/components-tag-tag-next-removabletag--docs)
-      </td>
-      <td>Feasibility TBD</td>
-      <td>[Migration guide](?path=/docs/components-tag-migration-guide--docs)</td>
-    </tr>
-    <tr>
       <td>[`Tabs`](?path=/docs/components-tabs-tabs-deprecated--docs)</td>
       <td>[`Tabs`](?path=/docs/components-tabs-tabs-next-api-specification--docs)</td>
       <td>Manual change required</td>


### PR DESCRIPTION
## Why

Removes the `Tag` next component from our KAIO V2 upcoming releases documentation

## What

The `Tag` next component doesn't have feature parity with the previous `Tag`, so we can't remove the old version until it can be fully replaced. 