### PR TITLE
[KZN-3337] handles async loading of tabs

### DIFF
--- a/packages/components/src/__next__/Tabs/subcomponents/TabList/TabList.tsx
+++ b/packages/components/src/__next__/Tabs/subcomponents/TabList/TabList.tsx
@@ -100,7 +100,7 @@ export const TabList = (props: TabListProps): JSX.Element => {
       firstTabObserver.disconnect()
       lastTabObserver.disconnect()
     }
-  }, [isDocumentReady, containerElement, isRTL])
+  }, [isDocumentReady, containerElement, isRTL, tabListContext?.collection.size])
 
   useEffect(() => {
     if (!isDocumentReady) {


### PR DESCRIPTION
## Why

When multiple tabs are rendered asynchronously we are not updating where the right/left chevrons should intersect. Therefore if you start with one tab and load more the extra tabs will not cause the chevron to render. 

## What

Updating the use effect so that it re-renders based on the number of tabs. 
