### PR TITLE
chore: remove LinearB Cycle Time plugin

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -36,9 +36,3 @@ steps:
           entrypoint: '/bin/bash'
           propagate-environment: true
           propagate-aws-auth-tokens: true
-
-  - name: 'LinearB: Record deployment time'
-    command: bin/ci_noop
-    branches: 'main'
-    plugins:
-      - cultureamp/linearb-cycle-time#v1.1.3: ~


### PR DESCRIPTION
This PR removes the LinearB Cycle Time plugin from the pipeline. It required that we remove this as we are shutting down our account with LinearB shortly.
This change should not affect the functionality of the pipeline, but it will remove the dependency on the LinearB Cycle Time plugin.
Please merge this PR as soon as possible to avoid any issues with the pipeline.
