### PR TITLE
docs: Add migration guide for tooltip

### DIFF
--- a/docs/pages/upcoming-releases.mdx
+++ b/docs/pages/upcoming-releases.mdx
@@ -55,7 +55,7 @@ Components from the `@kaizen/components/next` entry point taking the place of co
       <td>[`Tooltip`](?path=/docs/components-tooltip-tooltip-deprecated--docs)</td>
       <td>[`Tooltip`](?path=/docs/components-tooltip-tooltip-next-api-specification--docs)</td>
       <td>Feasibility TBD</td>
-      <td>Coming soon</td>
+      <td>[Migration guide](?path=/docs/components-tooltip-migration-guide--docs)</td>
     </tr>
   </tbody>
 </table>

--- a/packages/components/src/__next__/Button/_docs/Button--migration-guide.mdx
+++ b/packages/components/src/__next__/Button/_docs/Button--migration-guide.mdx
@@ -1,11 +1,18 @@
-import { Canvas, Meta, Controls, Story } from '@storybook/blocks'
-import { ResourceLinks, KAIOInstallation } from '~storybook/components'
+import { Meta } from '@storybook/blocks'
 
-<Meta title="Components/Button/Migration Guide" />
+<Meta title="Components/Button/Migration guide" />
 
-# Button Migration Guide (next)
+# Button migration guide
 
-This is a short guide to assist in migration from the old to new `Button` and `LinkButton` component.
+## Audience
+
+This guide is relevant for Kaizen All-In-One (KAIO) v1 consumers.
+
+## Purpose
+
+This guide provides instructions for migrating button usage from `deprecated` (`@kaizen/components`) `Button` and `IconButton` components to `next` (`@kaizen/components/next`) `Button` and `LinkButton` components.
+
+This migration is a prerequisite for [migrating to KAIO v2](/docs/releases-upcoming-major-releases--docs).
 
 ## Key API differences
 

--- a/packages/components/src/__next__/Icon/_docs/Icon--migration-guide.mdx
+++ b/packages/components/src/__next__/Icon/_docs/Icon--migration-guide.mdx
@@ -1,12 +1,20 @@
-import { Canvas, Meta, Controls, Story } from '@storybook/blocks'
-import { ResourceLinks, KAIOInstallation, LinkTo } from '~storybook/components'
+import { Meta, Story } from '@storybook/blocks'
+import { LinkTo } from '~storybook/components'
 import * as IconStories from './Icon.docs.stories'
 
 <Meta title="Components/Icon/Migration guide" />
 
 # Icon migration guide
 
-This is a short guide to assist in migration from the old to new Icon component.
+## Audience
+
+This guide is relevant for Kaizen All-In-One (KAIO) v1 consumers.
+
+## Purpose
+
+This guide provides instructions for migrating icon usage from the `deprecated` (`@kaizen/components`) `*Icon` components to the `next` (`@kaizen/components/next`) `Icon` component.
+
+This migration is a prerequisite for [migrating to KAIO v2](/docs/releases-upcoming-major-releases--docs).
 
 ## Codemod
 

--- a/packages/components/src/__next__/Tabs/_docs/Tabs--migration-guide.mdx
+++ b/packages/components/src/__next__/Tabs/_docs/Tabs--migration-guide.mdx
@@ -2,9 +2,17 @@ import { Meta } from '@storybook/blocks'
 
 <Meta title="Components/Tabs/Migration guide" />
 
-# Next Tabs migration guide
+# Tabs migration guide
 
-A brief guide on how and why to migrate from Kaizen's current `Tabs` to the `next` release.
+## Audience
+
+This guide is relevant for Kaizen All-In-One (KAIO) v1 consumers.
+
+## Purpose
+
+This guide provides instructions for migrating tabs usage from the `deprecated` (`@kaizen/components`) `Tabs` component to the `next` (`@kaizen/components/next`) `Tabs` component.
+
+This migration is a prerequisite for [migrating to KAIO v2](/docs/releases-upcoming-major-releases--docs).
 
 ## Why the change?
 

--- a/packages/components/src/__next__/Tooltip/_docs/Tooltip--migration-guide.mdx
+++ b/packages/components/src/__next__/Tooltip/_docs/Tooltip--migration-guide.mdx
@@ -1,0 +1,62 @@
+import { Meta } from '@storybook/blocks'
+
+<Meta title="Components/Tooltip/Migration guide" />
+
+# Tooltip migration guide
+
+## Audience
+
+This guide is relevant for Kaizen All-In-One (KAIO) v1 consumers.
+
+## Purpose
+
+This guide provides instructions for migrating tooltip usage from the `deprecated` (`@kaizen/components`) `Tooltip` component to the `next` (`@kaizen/components/next`) `Tooltip` component.
+
+This migration is a prerequisite for [migrating to KAIO v2](/docs/releases-upcoming-major-releases--docs).
+
+## Key API changes
+
+The `next` tooltip separates its functionality into two distinct components:
+
+- `TooltipTrigger` component wraps the `Tooltip` component and its trigger element, and controls open and close interactions.
+- `Tooltip` component provides the tooltip's content and controls its placement.
+
+Other notable changes:
+
+- `animationDuration` prop is retired
+- `children` prop becomes `TooltipTrigger.Children`
+- `display` prop is retired
+- `isInitiallyVisible` prop becomes `Tooltip.defaultOpen`
+- `mood` prop is retired
+  - This change aligns with a broader move towards more judicious use of colour
+- `portalSelector` prop is retired
+  - Where needed, [PortalProvider](https://react-spectrum.adobe.com/react-aria/PortalProvider.html) can be used to control portalling behaviour
+- `position` prop becomes `Tooltip.placement`, and values are mapped as follows:
+  - `above` becomes `top`
+  - `below` becomes `bottom`
+  - `left` becomes `start`
+  - `right` becomes `end`
+- `text` prop becomes `Tooltip.Children`
+
+## Migration example
+
+### Before
+
+```tsx
+<Tooltip text="Content" position="above">
+  <Button>Trigger</Button>
+</Tooltip>
+```
+
+### After
+
+```tsx
+<TooltipTrigger>
+  <Button>Trigger</Button>
+  <Tooltip placement="top">Content</Tooltip>
+</TooltipTrigger>
+```
+
+## More information
+
+More information about the `next` `Tooltip` component can be found at [API Specification](/docs/components-tooltip-tooltip-next-api-specification--docs) and [Usage Guidelines](/docs/components-tooltip-tooltip-next-usage-guidelines--docs).


### PR DESCRIPTION
## Why

KAIO consumers are uplifting their repos to be KAIO v2 compatible, but we currently don't provide a migration guidance for next/Tooltip. This creates friction to our goal of teams being KAIO v2 ready by 1 Sep 2025.

Jira ticket: [KZN-3037](https://cultureamp.atlassian.net/browse/KZN-3037)

## What

- Added a Tooltip migration guide
- Linked new Tooltip migration guide to the KAIO v2 migration page
- Updated existing Button, Icon and Tabs migration guides, as follows:
  - Standardise title case
  - Define audience (KAIO v1 consumers getting ready for KAIO v2) - some repos (e.g. Murmur) are still heavily using legacy packages and might feasibly need to migrate through multiple KAIO versions at once

[KZN-3037]: https://cultureamp.atlassian.net/browse/KZN-3037?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ