### PR TITLE
Remove aria-haspopup from StatelessMenu

### DIFF
--- a/.changeset/clean-buses-serve.md
+++ b/.changeset/clean-buses-serve.md
@@ -1,0 +1,5 @@
+---
+'@kaizen/components': patch
+---
+
+Removes aria-haspopup from v1 Menu. This was a partial implementation of the menu aria pattern and does not have the corresponding arrow controls functionality so was confusing to SR users.

--- a/packages/components/src/Menu/subcomponents/StatelessMenu/StatelessMenu.tsx
+++ b/packages/components/src/Menu/subcomponents/StatelessMenu/StatelessMenu.tsx
@@ -46,7 +46,6 @@ export type StatelessMenuProps = {
   'renderButton': (args: {
     'onClick': (e: any) => void
     'onMouseDown': (e: any) => void
-    'aria-haspopup': boolean
     'aria-expanded': boolean
   }) => React.ReactElement
   'onClick'?: (event: SyntheticEvent) => void
@@ -76,7 +75,6 @@ export const StatelessMenu = ({
       toggleMenuDropdown()
     },
     'onMouseDown': (e: React.MouseEvent<Element, MouseEvent>) => e.preventDefault(),
-    'aria-haspopup': true,
     'aria-expanded': isMenuVisible,
   })
 


### PR DESCRIPTION
## Why
`aria-haspopup` is used to indicate a menu pattern to screen readers - this however has always been a partial implementation of that [pattern](https://www.w3.org/WAI/ARIA/apg/patterns/menubar/) and does not have the required arrow key navigation to satisfy that spec.

This was flagged in the recent round of audits from Intopia, where the recommended approach was to remove the property as it was confusing the JAWs users. The open and close behavior is still communicated by the `aria-expanded` property (See CUL-739 in [the report](https://reports.intopia.digital/report/cul-732 and exert below).

<img width="1123" alt="Screenshot 2025-06-13 at 11 04 03 am" src="https://github.com/user-attachments/assets/e41c3fbc-aec3-4db5-a9f8-b3835f2fc462" />

The better migration path off this is refactor usages of Menu V1 to the Menu/next component, but this is not a straight forward fix and will need to be implemented when more time is available.

## What
- removes `aria-haspopup` from StatelessMenu props

