### PR TITLE
fix(AIMoment): re-add missing z-index from stylesheet

### DIFF
--- a/.changeset/fine-berries-repeat.md
+++ b/.changeset/fine-berries-repeat.md
@@ -1,0 +1,5 @@
+---
+'@kaizen/components': patch
+---
+
+Re-add missing z-index from AIMoment stylesheet

--- a/packages/components/styles/utils/AIMoment.module.css
+++ b/packages/components/styles/utils/AIMoment.module.css
@@ -19,6 +19,7 @@
     position: relative;
     border: 1px solid transparent;
     border-radius: var(--border-borderless-border-radius);
+    z-index: 0;
   }
 
   /* This absolute element is used to give the illusion of a gradient border without expanding the size of the Well/Card */


### PR DESCRIPTION
## Why
The z-index added to the AIMoment clas was a fix to ensure that animated border rendered correctly in implementations across the platform.

This was unintentionally removed when merging the the CSS layers PR so I'm re-adding this.

## What
- re-add z-index to AIMoment class
