### PR TITLE
Update BrandMomentCaptureIntro animation toggle

### DIFF
--- a/.changeset/sweet-news-search.md
+++ b/.changeset/sweet-news-search.md
@@ -1,0 +1,10 @@
+---
+'@kaizen/components': patch
+---
+
+Add optional prop to `VideoPlayer` and update `BrandMomentCaptureIntro` to always display the animation toggle.
+
+- Add `hasVisibleAnimationToggle` prop to `VideoPlayer`
+- Update VideoPlayer to next `Button` component
+- Remove redundant styles from button migration
+- Add i18n strings for play/pause labels

--- a/packages/components/locales/en.json
+++ b/packages/components/locales/en.json
@@ -188,5 +188,13 @@
   "splitButton.dropdownButton.label": {
     "description": "Label for a dropdown menu holding additional actions",
     "message": "Additional actions"
+  },
+  "videoPlayer.pausePlayBtn.pauseLabel": {
+    "description": "Label for the pausing / stopping an animation",
+    "message": "Play animation"
+  },
+  "videoPlayer.pausePlayBtn.playLabel": {
+    "description": "Label for the starting / playing an animation",
+    "message": "Play animation"
   }
 }

--- a/packages/components/src/Illustration/Scene/BrandMomentCaptureIntro/BrandMomentCaptureIntro.tsx
+++ b/packages/components/src/Illustration/Scene/BrandMomentCaptureIntro/BrandMomentCaptureIntro.tsx
@@ -32,7 +32,7 @@ export const BrandMomentCaptureIntro = ({
     return (
       <VideoPlayer
         {...otherProps}
-        hasVisiblePlayButton
+        hasVisibleAnimationToggle
         aspectRatio={aspectRatio}
         fallback="illustrations/heart/scene/brand-moments-capture-intro-loop"
         source="illustrations/heart/scene/brand-moments-capture-intro-loop"
@@ -45,7 +45,7 @@ export const BrandMomentCaptureIntro = ({
     <VideoPlayer
       {...otherProps}
       aspectRatio={aspectRatio}
-      hasVisiblePlayButton
+      hasVisibleAnimationToggle
       fallback="illustrations/heart/scene/brand-moments-capture-intro"
       source="illustrations/heart/scene/brand-moments-capture-intro"
       onEnded={(): void => setFirstAnimationComplete(true)}

--- a/packages/components/src/Illustration/Scene/BrandMomentCaptureIntro/BrandMomentCaptureIntro.tsx
+++ b/packages/components/src/Illustration/Scene/BrandMomentCaptureIntro/BrandMomentCaptureIntro.tsx
@@ -32,6 +32,7 @@ export const BrandMomentCaptureIntro = ({
     return (
       <VideoPlayer
         {...otherProps}
+        hasVisiblePlayButton
         aspectRatio={aspectRatio}
         fallback="illustrations/heart/scene/brand-moments-capture-intro-loop"
         source="illustrations/heart/scene/brand-moments-capture-intro-loop"
@@ -44,6 +45,7 @@ export const BrandMomentCaptureIntro = ({
     <VideoPlayer
       {...otherProps}
       aspectRatio={aspectRatio}
+      hasVisiblePlayButton
       fallback="illustrations/heart/scene/brand-moments-capture-intro"
       source="illustrations/heart/scene/brand-moments-capture-intro"
       onEnded={(): void => setFirstAnimationComplete(true)}

--- a/packages/components/src/Illustration/Scene/BrandMomentCaptureIntro/_docs/BrandMomentCaptureIntro.mdx
+++ b/packages/components/src/Illustration/Scene/BrandMomentCaptureIntro/_docs/BrandMomentCaptureIntro.mdx
@@ -45,3 +45,9 @@ Will render the a looped animation. Should be used with `isAnimated` to render t
 If false will render the animation paused. This can be re-enabled clicking the pause sign on hover.
 
 <Canvas of={BrandMomentCaptureIntroStories.Autoplay} />
+
+## Example
+
+This is not an exact template, rather an example of the component in use with a looping animation.
+
+<Canvas of={BrandMomentCaptureIntroStories.CaptureExample} />

--- a/packages/components/src/Illustration/Scene/BrandMomentCaptureIntro/_docs/BrandMomentCaptureIntro.stories.tsx
+++ b/packages/components/src/Illustration/Scene/BrandMomentCaptureIntro/_docs/BrandMomentCaptureIntro.stories.tsx
@@ -1,4 +1,9 @@
+import React from 'react'
 import { type Meta, type StoryObj } from '@storybook/react'
+import { Heading } from '~components/Heading'
+import { Link } from '~components/Link'
+import { Text } from '~components/Text'
+import { Button, Icon } from '~components/__next__'
 import { BrandMomentCaptureIntro } from '../index'
 
 const meta = {
@@ -40,4 +45,40 @@ export const Autoplay: Story = {
     loop: true,
     autoplay: false,
   },
+}
+
+// This is an example that provides a closer representation of how the component is used in the product.
+export const CaptureExample: Story = {
+  args: {
+    isAnimated: true,
+    loop: true,
+    autoplay: true,
+  },
+  render: (args) => (
+    <div className="bg-blue-200 flex justify-center gap-24 p-16">
+      <div className="flex justify-center items-center w-[50%]">
+        <BrandMomentCaptureIntro {...args} />
+      </div>
+      <div className="flex flex-col justify-center w-[50%]">
+        <Heading classNameOverride="mb-64" variant="display-0">
+          Survey Title
+        </Heading>
+        <Text classNameOverride="mb-32" variant="body">
+          You have been asked to provide feedback for Demonstration Employee.
+        </Text>
+        <Text classNameOverride="mb-32" variant="body">
+          The setting for this survey control how your responses can be used by Hooli.
+        </Text>
+        <Text classNameOverride="mb-32" variant="body">
+          Your information will be stored and processed in accordance with Culture Amp’s{' '}
+          <Link href="#">Privacy Policy</Link>. <Link href="#">More on managing information</Link>.
+        </Text>
+        <div>
+          <Button icon={<Icon name={'arrow_forward'} isPresentational />} iconPosition="end">
+            Take survey
+          </Button>
+        </div>
+      </div>
+    </div>
+  ),
 }

--- a/packages/components/src/Illustration/Scene/_docs/Scene.mdx
+++ b/packages/components/src/Illustration/Scene/_docs/Scene.mdx
@@ -20,3 +20,9 @@ import * as SceneStories from './Scene.stories'
 <Controls of={SceneStories.Playground} />
 
 <Canvas of={Stickersheets.StickerSheetDefault} />
+
+### Animated scenes
+
+Some Scene illustrations have animated versions. Looped animation should be used sparingly as it can be distracting for users, especially those with motion sensitivity. Consider also the WCAG spec for [non-essential animations](https://www.w3.org/WAI/WCAG22/Understanding/animation-from-interactions.html).
+
+<Canvas of={SceneStories.AnimatedScenes} />

--- a/packages/components/src/Illustration/Scene/_docs/Scene.stories.tsx
+++ b/packages/components/src/Illustration/Scene/_docs/Scene.stories.tsx
@@ -1,6 +1,16 @@
+import React from 'react'
 import { type Meta, type StoryObj } from '@storybook/react'
 
-import { BrandMomentPositiveOutro } from '../index'
+import {
+  BrandMomentError,
+  BrandMomentLogin,
+  BrandMomentPositiveOutro,
+  EmptyStatesAction,
+  EmptyStatesInformative,
+  EmptyStatesNegative,
+  EmptyStatesNeutral,
+  EmptyStatesPositive,
+} from '../index'
 
 const meta = {
   title: 'Components/Illustrations/Scene',
@@ -19,4 +29,38 @@ export const Playground: Story = {
       },
     },
   },
+}
+
+export const AnimatedScenes: Story = {
+  parameters: {
+    docs: {
+      canvas: {
+        sourceState: 'shown',
+      },
+    },
+  },
+  args: {
+    isAnimated: true,
+    loop: true,
+    autoplay: true,
+  },
+  render: (args) => (
+    <>
+      <EmptyStatesAction {...args} />
+      <EmptyStatesInformative {...args} />
+      <EmptyStatesNegative {...args} />
+      <EmptyStatesNeutral {...args} />
+      <EmptyStatesPositive {...args} />
+      <BrandMomentPositiveOutro {...args} />
+      <BrandMomentLogin {...args} />
+      <BrandMomentError {...args} />
+    </>
+  ),
+  decorators: [
+    (Story) => (
+      <div className="flex flex-col justify-center gap-16 max-w-[400px]">
+        <Story />
+      </div>
+    ),
+  ],
 }

--- a/packages/components/src/Illustration/subcomponents/Base/Base.module.scss
+++ b/packages/components/src/Illustration/subcomponents/Base/Base.module.scss
@@ -32,7 +32,7 @@
     }
   }
 
-  .figure .pausePlayButton.hasVisiblePlayButton {
+  .figure .pausePlayButton.hasVisibleAnimationToggle {
     opacity: 100%;
 
     svg {

--- a/packages/components/src/Illustration/subcomponents/Base/Base.module.scss
+++ b/packages/components/src/Illustration/subcomponents/Base/Base.module.scss
@@ -1,6 +1,3 @@
-@import '~@kaizen/design-tokens/sass/color';
-@import '~@kaizen/design-tokens/sass/animation';
-
 @layer kz-components {
   .wrapper {
     width: 100%;
@@ -18,28 +15,28 @@
     position: absolute;
     right: 1rem;
     bottom: 1rem;
-    /* stylelint-disable declaration-no-important */
-    background-color: $color-white !important;
-    border: 1px solid $color-gray-400;
-    transition: all $animation-duration-immediate;
+    border-width: 1px;
+    transition: opacity var(--animation-duration-immediate);
 
     @media (hover: none) and (pointer: coarse) {
       opacity: 100%;
     }
 
-    svg {
-      color: $color-purple-800;
-      opacity: 70%;
-    }
-
     &:hover,
     &:focus {
       opacity: 100%;
-      background-color: $color-gray-200 !important;
 
       svg {
         opacity: 100%;
       }
+    }
+  }
+
+  .figure .pausePlayButton.hasVisiblePlayButton {
+    opacity: 100%;
+
+    svg {
+      opacity: 100%;
     }
   }
 

--- a/packages/components/src/Illustration/subcomponents/VideoPlayer/VideoPlayer.tsx
+++ b/packages/components/src/Illustration/subcomponents/VideoPlayer/VideoPlayer.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useRef } from 'react'
 import classnames from 'classnames'
-import { IconButton } from '~components/Button'
+import { VisuallyHidden } from '~components/VisuallyHidden'
+import { Button } from '~components/__next__'
 import { assetUrl } from '~components/utils/hostedAssets'
 import { canPlayWebm } from '../../utils/canPlayWebm'
 import { usePausePlay } from '../../utils/usePausePlay'
@@ -37,8 +38,14 @@ export type VideoPlayerProps = {
    */
   aspectRatio?: 'landscape' | 'portrait' | 'square'
 
+  /**
+   * This render the play/pause button with 100% visibility, instead of relying on hover/focus interactions. This is useful for satisfying the a11y requirements for animations that last longer than 5 seconds. @default false.
+   */
+  hasVisiblePlayButton?: boolean
   onEnded?: () => void
 }
+
+// hasVisiblePlayButton is an interim solution to resolve an a11y issue with the animation player only showing the play/pause button on hover/focus. This ideally will be resolved through a design solution or updated pattern.
 
 export const VideoPlayer = ({
   autoplay = true,
@@ -47,6 +54,7 @@ export const VideoPlayer = ({
   source,
   aspectRatio,
   onEnded,
+  hasVisiblePlayButton = false, //
 }: VideoPlayerProps): JSX.Element => {
   const videoRef = useRef<HTMLVideoElement>(null)
   const [prefersReducedMotion, setPrefersReducedMotion] = React.useState<boolean>(true)
@@ -181,12 +189,18 @@ export const VideoPlayer = ({
         {isWebmCompatible && <source src={assetUrl(`${source}.webm`)} type="video/webm" />}
         <source src={assetUrl(`${source}.mp4`)} type="video/mp4" />
       </video>
-      <IconButton
-        onClick={(): void => pausePlay.toggle()}
+      <Button
+        className={classnames(
+          styles.pausePlayButton,
+          hasVisiblePlayButton && styles.hasVisiblePlayButton,
+        )}
+        variant="secondary"
         icon={pausePlay.icon}
-        label={pausePlay.label}
-        classNameOverride={styles.pausePlayButton}
-      />
+        onPress={(): void => pausePlay.toggle()}
+        hasHiddenLabel
+      >
+        <VisuallyHidden>{pausePlay.label}</VisuallyHidden>
+      </Button>
     </figure>
   )
 }

--- a/packages/components/src/Illustration/subcomponents/VideoPlayer/VideoPlayer.tsx
+++ b/packages/components/src/Illustration/subcomponents/VideoPlayer/VideoPlayer.tsx
@@ -41,11 +41,11 @@ export type VideoPlayerProps = {
   /**
    * This render the play/pause button with 100% visibility, instead of relying on hover/focus interactions. This is useful for satisfying the a11y requirements for animations that last longer than 5 seconds. @default false.
    */
-  hasVisiblePlayButton?: boolean
+  hasVisibleAnimationToggle?: boolean
   onEnded?: () => void
 }
 
-// hasVisiblePlayButton is an interim solution to resolve an a11y issue with the animation player only showing the play/pause button on hover/focus. This ideally will be resolved through a design solution or updated pattern.
+// hasVisibleAnimationToggle is an interim solution to resolve an a11y issue with the animation player only showing the play/pause button on hover/focus. This ideally will be resolved through a design solution or updated pattern.
 
 export const VideoPlayer = ({
   autoplay = true,
@@ -54,7 +54,7 @@ export const VideoPlayer = ({
   source,
   aspectRatio,
   onEnded,
-  hasVisiblePlayButton = false, //
+  hasVisibleAnimationToggle = false,
 }: VideoPlayerProps): JSX.Element => {
   const videoRef = useRef<HTMLVideoElement>(null)
   const [prefersReducedMotion, setPrefersReducedMotion] = React.useState<boolean>(true)
@@ -192,7 +192,7 @@ export const VideoPlayer = ({
       <Button
         className={classnames(
           styles.pausePlayButton,
-          hasVisiblePlayButton && styles.hasVisiblePlayButton,
+          hasVisibleAnimationToggle && styles.hasVisibleAnimationToggle,
         )}
         variant="secondary"
         icon={pausePlay.icon}

--- a/packages/components/src/Illustration/utils/usePausePlay.tsx
+++ b/packages/components/src/Illustration/utils/usePausePlay.tsx
@@ -1,4 +1,5 @@
 import React, { useState, type RefObject } from 'react'
+import { useIntl } from '@cultureamp/i18n-react-intl'
 import { Icon } from '~components/__next__/Icon'
 
 export type usePausePlayHook = {
@@ -8,7 +9,20 @@ export type usePausePlayHook = {
 }
 
 export const usePausePlay = (videoRef: RefObject<HTMLVideoElement>): usePausePlayHook => {
+  const { formatMessage } = useIntl()
   const [isPaused, setPaused] = useState(false)
+
+  const playAnimationLabel = formatMessage({
+    id: 'videoPlayer.pausePlayBtn.playLabel',
+    defaultMessage: 'Play animation',
+    description: 'Label for the starting / playing an animation',
+  })
+
+  const pauseAnimationLabel = formatMessage({
+    id: 'videoPlayer.pausePlayBtn.pauseLabel',
+    defaultMessage: 'Play animation',
+    description: 'Label for the pausing / stopping an animation',
+  })
 
   return {
     toggle: (): void => {
@@ -22,7 +36,7 @@ export const usePausePlay = (videoRef: RefObject<HTMLVideoElement>): usePausePla
         videoRef.current.pause()
       }
     },
-    icon: <Icon name={isPaused ? 'play_circle' : 'pause'} isPresentational isFilled />,
-    label: isPaused ? 'Play animation' : 'Pause animation',
+    icon: <Icon name={isPaused ? 'play_circle' : 'pause_circle'} isPresentational isFilled />,
+    label: isPaused ? playAnimationLabel : pauseAnimationLabel,
   }
 }


### PR DESCRIPTION
## Why
In the current implementation of `BrandMomentCaptureIntro` the toggle to stop the loop animation is hidden behind a hover or focus event. 

This presents an issue for individuals that have motion sensitivity as they may not know they can pause the animation. This was flagged as a [medium severity issue](https://cultureamp.atlassian.net/wiki/spaces/DesignSystem/pages/5043421650/A11Y+-+Survey+Capture+Intopia+Audit+Review) in the recent Intopia Audit of the Capture Survey experience.

While this is technically the case with all of our animate-able `Scene` components, this PR only addresses the `BrandMomentCaptureIntro` component to limit the scope of impact. This is to allow for a potential design solution or rethink of the animation toggle styles and position that has design curators approval, before it is rolled out across the product.

## What

- Adds optional `hasVisibleAnimationToggle` prop to `VideoPlayer`
  - This enabled a style override in the `BrandMomentCaptureIntro` component that removes the initial opacity 0% that hides the animation toggle
  - 
