### PR TITLE
POC: update button to tertiary and add onClick to player

### DIFF
--- a/packages/components/src/Illustration/Scene/_docs/Scene.stories.tsx
+++ b/packages/components/src/Illustration/Scene/_docs/Scene.stories.tsx
@@ -64,3 +64,22 @@ export const AnimatedScenes: Story = {
     ),
   ],
 }
+
+export const AnimatedScenesHover: Story = {
+  ...AnimatedScenes,
+  parameters: {
+    pseudo: {
+      hover: ['[data-sb-pseudo-styles="hover"]', '[data-sb-pseudo-styles="hover"] figure'],
+    },
+  },
+  decorators: [
+    (Story) => (
+      <div
+        className="flex flex-col justify-center gap-16 max-w-[400px]"
+        data-sb-pseudo-styles="hover"
+      >
+        <Story />
+      </div>
+    ),
+  ],
+}

--- a/packages/components/src/Illustration/subcomponents/Base/Base.module.scss
+++ b/packages/components/src/Illustration/subcomponents/Base/Base.module.scss
@@ -14,9 +14,9 @@
     opacity: 0%;
     position: absolute;
     right: 1rem;
-    bottom: 1rem;
+    top: 1rem;
     border-width: 1px;
-    transition: opacity var(--animation-duration-immediate);
+    transition: all var(--animation-duration-immediate);
 
     @media (hover: none) and (pointer: coarse) {
       opacity: 100%;
@@ -43,6 +43,8 @@
   .figure:hover {
     .pausePlayButton {
       opacity: 100%;
+      background: var(--color-blue-200);
+      color: var(--color-blue-500);
     }
   }
 

--- a/packages/components/src/Illustration/subcomponents/VideoPlayer/VideoPlayer.tsx
+++ b/packages/components/src/Illustration/subcomponents/VideoPlayer/VideoPlayer.tsx
@@ -185,6 +185,7 @@ export const VideoPlayer = ({
         autoPlay={prefersReducedMotion ? false : autoplay}
         playsInline={true}
         tabIndex={-1}
+        onClick={(): void => pausePlay.toggle()}
       >
         {isWebmCompatible && <source src={assetUrl(`${source}.webm`)} type="video/webm" />}
         <source src={assetUrl(`${source}.mp4`)} type="video/mp4" />
@@ -194,8 +195,7 @@ export const VideoPlayer = ({
           styles.pausePlayButton,
           hasVisibleAnimationToggle && styles.hasVisibleAnimationToggle,
         )}
-        variant="secondary"
-        size="large"
+        variant="tertiary"
         icon={pausePlay.icon}
         onPress={(): void => pausePlay.toggle()}
         hasHiddenLabel


### PR DESCRIPTION
## Why
Creating this to demo the less aggressive play button on the VideoPlayer for scene illustrations, specially BrandMomentCaptureIntro.

## What
- change `Button` size to `small`
- change `Button` variant to `tertiary`
- add onClick to whole video player and update hover state on `Button`
