### PR TITLE
Reduce TabList z-index so it is lower than modal z-index

### DIFF
--- a/.changeset/rich-rings-run.md
+++ b/.changeset/rich-rings-run.md
@@ -1,0 +1,5 @@
+---
+'@kaizen/components': patch
+---
+
+Reduce TabList z-index so it is lower than modal z-index

--- a/packages/components/src/__next__/Tabs/subcomponents/TabList/TabList.module.css
+++ b/packages/components/src/__next__/Tabs/subcomponents/TabList/TabList.module.css
@@ -26,7 +26,7 @@
     align-items: center;
     justify-content: center;
     position: absolute;
-    z-index: 10000;
+    z-index: 1030;
     background: var(--color-white);
     inset-block: 0 1px;
     width: 48px;


### PR DESCRIPTION
## Important: Request PR reviews on Slack

Please reach out to the design system team on Slack in `#prod_design_system` for PR reviews. GitHub notifications (e.g. from tagging a person) are not actively monitored.

## Why
Refers to [this thread](https://cultureamp.slack.com/archives/C0189KBPM4Y/p1750893904919409)
Tab's arrows are showing on top of Kaizen Modal
https://files.slack.com/files-pri/T02S77EMD-F092WR45W2X/image.png

<!-- Why have you created this PR? - Is it a new feature, or a bug fix? Or something else? -->
<!-- Reference any relevant Jira tickets so your reviewer can find more context if needed. -->
<!-- Fixing a GitHub issue? Add "Fixes [issue URL]". -->

## What

<!-- What do your changes do? How do they change/fix the current behavior? -->
<!-- Add screenshots, GIFs or videos to illustrate the changes.  -->
