### PR TITLE
fix(a11y): Backport a11y fixes for 1.78.x

### DIFF
--- a/.changeset/angry-animals-behave.md
+++ b/.changeset/angry-animals-behave.md
@@ -2,4 +2,4 @@
 '@kaizen/components': patch
 ---
 
-Update Select/next to pass aria-required into the Select trigger props.
+Backported fixes for pre-1.79.0 release: Update Select/next to pass aria-required into the Select trigger props.

--- a/.changeset/angry-animals-behave.md
+++ b/.changeset/angry-animals-behave.md
@@ -1,0 +1,5 @@
+---
+'@kaizen/components': patch
+---
+
+Update Select/next to pass aria-required into the Select trigger props.

--- a/.changeset/clean-buses-serve.md
+++ b/.changeset/clean-buses-serve.md
@@ -1,0 +1,5 @@
+---
+'@kaizen/components': patch
+---
+
+Removes aria-haspopup from v1 Menu. This was a partial implementation of the menu aria pattern and does not have the corresponding arrow controls functionality so was confusing to SR users.

--- a/.changeset/clean-buses-serve.md
+++ b/.changeset/clean-buses-serve.md
@@ -2,4 +2,4 @@
 '@kaizen/components': patch
 ---
 
-Removes aria-haspopup from v1 Menu. This was a partial implementation of the menu aria pattern and does not have the corresponding arrow controls functionality so was confusing to SR users.
+Backported fixes for pre-1.79.0 release: Removes aria-haspopup from v1 Menu. This was a partial implementation of the menu aria pattern and does not have the corresponding arrow controls functionality so was confusing to SR users.

--- a/.changeset/kind-carrots-battle.md
+++ b/.changeset/kind-carrots-battle.md
@@ -1,5 +1,0 @@
----
-'@kaizen/components': patch
----
-
-Backport accessibility fixes for Menu, LirketScale and Select/next pre-1.79.0 release

--- a/.changeset/kind-carrots-battle.md
+++ b/.changeset/kind-carrots-battle.md
@@ -1,0 +1,5 @@
+---
+'@kaizen/components': patch
+---
+
+Backport accessibility fixes for Menu, LirketScale and Select/next pre-1.79.0 release

--- a/.changeset/lucky-carrots-approve.md
+++ b/.changeset/lucky-carrots-approve.md
@@ -2,4 +2,4 @@
 '@kaizen/components': patch
 ---
 
-Add optianl isRequired support to LikertScaleLegacy component to ensure mandatory questions are correctly rendered with aria-required in HTML.
+Backported fixes for pre-1.79.0 release: Add optianl isRequired support to LikertScaleLegacy component to ensure mandatory questions are correctly rendered with aria-required in HTML.

--- a/.changeset/lucky-carrots-approve.md
+++ b/.changeset/lucky-carrots-approve.md
@@ -1,0 +1,5 @@
+---
+'@kaizen/components': patch
+---
+
+Add optianl isRequired support to LikertScaleLegacy component to ensure mandatory questions are correctly rendered with aria-required in HTML.

--- a/packages/components/src/LikertScaleLegacy/LikertScaleLegacy.spec.tsx
+++ b/packages/components/src/LikertScaleLegacy/LikertScaleLegacy.spec.tsx
@@ -36,6 +36,7 @@ const LikertScaleLegacyWrapper = (props: Partial<LikertScaleProps>): JSX.Element
     labelId="test__likert-scale"
     selectedItem={null}
     onSelect={(): void => undefined}
+    isRequired
     {...props}
   />
 )

--- a/packages/components/src/LikertScaleLegacy/LikertScaleLegacy.tsx
+++ b/packages/components/src/LikertScaleLegacy/LikertScaleLegacy.tsx
@@ -25,6 +25,10 @@ export type LikertScaleProps = {
   'colorSchema'?: ColorSchema | 'classical'
   'validationMessage'?: string
   'status'?: 'default' | 'error'
+  /**
+   * Sets aria-required value on radiogroup for assistive technologies. Validation must still be handled.
+   */
+  'isRequired'?: boolean
   'onSelect': (value: ScaleItem | null) => void
 }
 
@@ -46,6 +50,7 @@ export const LikertScaleLegacy = ({
   validationMessage,
   status,
   labelId,
+  isRequired,
 }: LikertScaleProps): JSX.Element => {
   const [hoveredItem, setHoveredItem] = useState<ScaleItem | null>(null)
   const itemRefs: ItemRefs = scale.map((s) => ({
@@ -104,11 +109,12 @@ export const LikertScaleLegacy = ({
         reversed && [styles.reversed],
         hoveredItem !== null && styles.hovered,
       )}
-      aria-labelledby={labelId}
+      aria-labelledby={isRequired ? `${labelId}` : labelId}
       role="radiogroup"
       tabIndex={-1}
       aria-describedby={validationMessageId}
       data-testid={dataTestId}
+      aria-required={isRequired}
     >
       <div className={styles.legend} data-testid={dataTestId && `${dataTestId}-legend`}>
         <Text variant="small" color={reversed ? 'white' : 'dark'}>

--- a/packages/components/src/LikertScaleLegacy/_docs/LikertScaleLegacy.mdx
+++ b/packages/components/src/LikertScaleLegacy/_docs/LikertScaleLegacy.mdx
@@ -21,3 +21,11 @@ Likert scale radio buttons let people select one option in a Likert scale rangin
 
 <Canvas of={LikertScaleLegacyStories.Playground} />
 <Controls of={LikertScaleLegacyStories.Playground} />
+
+## API
+
+### isRequired
+
+Sets aria-required value on radiogroup for assistive technologies. An accessible label must be provided and validation must still be handled within implementations.
+
+<Canvas of={LikertScaleLegacyStories.IsRequired} />

--- a/packages/components/src/LikertScaleLegacy/_docs/LikertScaleLegacy.stories.tsx
+++ b/packages/components/src/LikertScaleLegacy/_docs/LikertScaleLegacy.stories.tsx
@@ -1,5 +1,7 @@
 import React, { useState } from 'react'
 import { type Meta, type StoryObj } from '@storybook/react'
+import { expect, within } from '@storybook/test'
+import { VisuallyHidden } from '~components/VisuallyHidden'
 import { LikertScaleLegacy } from '../index'
 import { type Scale, type ScaleItem } from '../types'
 
@@ -57,7 +59,7 @@ export const Playground: Story = {
         code: `
   const SatisfactionExample = () => {
     const [selectedItem, setSelectedItem] = useState<ScaleItem | null>(null)
-  
+
     return (
       <LikertScaleLegacy
         scale={[
@@ -80,5 +82,32 @@ export const Playground: Story = {
         sourceState: 'shown',
       },
     },
+  },
+}
+
+export const IsRequired: Story = {
+  render: (args) => {
+    const [selectedItem, setSelectedItem] = useState<ScaleItem | null>(null)
+    const labelId = React.useId()
+    return (
+      <div>
+        <VisuallyHidden id={labelId}>Likert scale label</VisuallyHidden>
+        <LikertScaleLegacy
+          {...args}
+          labelId={labelId}
+          selectedItem={selectedItem}
+          onSelect={setSelectedItem}
+        />
+      </div>
+    )
+  },
+  args: {
+    isRequired: true,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement.parentElement!)
+    const likertScale = canvas.getByRole('radiogroup', { name: 'Likert scale label' })
+
+    expect(likertScale).toHaveAttribute('aria-required', 'true')
   },
 }

--- a/packages/components/src/Menu/subcomponents/StatelessMenu/StatelessMenu.tsx
+++ b/packages/components/src/Menu/subcomponents/StatelessMenu/StatelessMenu.tsx
@@ -46,7 +46,6 @@ export type StatelessMenuProps = {
   'renderButton': (args: {
     'onClick': (e: any) => void
     'onMouseDown': (e: any) => void
-    'aria-haspopup': boolean
     'aria-expanded': boolean
   }) => React.ReactElement
   'onClick'?: (event: SyntheticEvent) => void
@@ -76,7 +75,6 @@ export const StatelessMenu = ({
       toggleMenuDropdown()
     },
     'onMouseDown': (e: React.MouseEvent<Element, MouseEvent>) => e.preventDefault(),
-    'aria-haspopup': true,
     'aria-expanded': isMenuVisible,
   })
 

--- a/packages/components/src/__next__/Select/Select.tsx
+++ b/packages/components/src/__next__/Select/Select.tsx
@@ -85,6 +85,7 @@ export const Select = <Option extends SelectOption = SelectOption>({
   status,
   validationMessage,
   isReversed,
+  isRequired = false,
   isFullWidth,
   disabledValues,
   classNameOverride,
@@ -93,6 +94,7 @@ export const Select = <Option extends SelectOption = SelectOption>({
   placeholder = '',
   isDisabled,
   portalContainerId,
+  onSelectionChange,
   ...restProps
 }: SelectProps<Option>): JSX.Element => {
   const { refs } = useFloating<HTMLButtonElement>()
@@ -114,6 +116,8 @@ export const Select = <Option extends SelectOption = SelectOption>({
     description,
     placeholder,
     isDisabled,
+    isRequired,
+    onSelectionChange: onSelectionChange ? (key) => onSelectionChange(key!) : undefined,
     ...restProps,
   }
 
@@ -153,6 +157,7 @@ export const Select = <Option extends SelectOption = SelectOption>({
     isReversed,
     'ref': refs.setReference,
     'aria-describedby': classnames(validationMessage && validationId, description && descriptionId),
+    'aria-required': isRequired,
   }
 
   const [portalContainer, setPortalContainer] = useState<HTMLElement>()

--- a/packages/components/src/__next__/Select/_docs/Select.mdx
+++ b/packages/components/src/__next__/Select/_docs/Select.mdx
@@ -92,6 +92,14 @@ Add validation messages using `status` and `validationMessage`.
 
 <Canvas of={SelectStories.Validation} />
 
+#### isRequired and validationBehavior
+
+When using the `isRequired` property you can also specify the `validationBehavior` to change from `aria` to `native` form validation.
+
+<Canvas of={SelectStories.SelectNativeValidationBehavior} />
+
+While both use `aria-required` to announce whether the field has to have a value to assistive technologies, the `native` will option will prevent form submissions if the `selectedKey` is `undefined`.
+
 ### Full width
 
 Set `isFullWidth` to `true` to have the Select span the full width of its container.


### PR DESCRIPTION
## Why
Backports accessibility fixes for pre-1.79.0 as migration to the latest release with CSS layers is proving to be difficult in murmur.

## What
- Cherry picks accessibility fixes for Menu, Select/next and LikertScale

Merging this into 1.78.xx *should* create a patch version release.

