### PR TITLE
feat: add Split Button Replacement story and docs to Button & Menu

### DIFF
--- a/.changeset/empty-grapes-try.md
+++ b/.changeset/empty-grapes-try.md
@@ -1,5 +1,5 @@
 ---
-'@kaizen/components': patch
+'@docs/storybook': patch
 ---
 
 add Split Button Replacement story and docs to Button & Menu sections

--- a/.changeset/fifty-snails-do.md
+++ b/.changeset/fifty-snails-do.md
@@ -1,0 +1,5 @@
+---
+'@kaizen/components': patch
+---
+
+add Split Button Replacement story and docs to Button & Menu sections

--- a/packages/components/src/__next__/Button/_docs/Button--api-specification.mdx
+++ b/packages/components/src/__next__/Button/_docs/Button--api-specification.mdx
@@ -156,6 +156,15 @@ If a button is statically the full width of a container you can use the `isFullW
 
 For resizing on smaller screens, consider using the `className` prop to leverage CSS media or container queries, ie: `<Button className="w-full md:w-[initial]">Label</Button>`.
 
+## Split Button Replacement
+
+[Deprecating Split Buttons](https://cultureamp.atlassian.net/wiki/spaces/DES/pages/4286611457/Deprecating+Split+Buttons+-+Design+Request+for+Comment+RFC) in favour of a composed, two Button overflow approach, supported by guidelines:
+
+1. A Button with text
+2. A Button with a meatball icon (three dots) placed adjacent to the first button
+
+<Canvas className="mb-24" of={exampleStories.SplitButtonReplacement} />
+
 ## Additional API options
 
 The following table is a collection of additional React Aria and native HTML props that are exposed from the React Aria API. These are not required for the implementation of `Button` but can be used to extend its functionality. Refer back to the [overview section](#overview) for the core props that enable most use cases.

--- a/packages/components/src/__next__/Button/_docs/Button--api-specification.mdx
+++ b/packages/components/src/__next__/Button/_docs/Button--api-specification.mdx
@@ -156,14 +156,11 @@ If a button is statically the full width of a container you can use the `isFullW
 
 For resizing on smaller screens, consider using the `className` prop to leverage CSS media or container queries, ie: `<Button className="w-full md:w-[initial]">Label</Button>`.
 
-## Split Button Replacement
+## Use a menu to show additional actions
 
-[Deprecating Split Buttons](https://cultureamp.atlassian.net/wiki/spaces/DES/pages/4286611457/Deprecating+Split+Buttons+-+Design+Request+for+Comment+RFC) in favour of a composed, two Button overflow approach, supported by guidelines:
+Instead of a split button (now a [deprecated component](https://cultureamp.atlassian.net/wiki/spaces/DES/pages/4286611457/Deprecating+Split+Buttons+-+Design+Request+for+Comment+RFC)), use a Button with text followed by a Menu to show any additional actions related to the most critical action.
 
-1. A Button with text
-2. A Button with a meatball icon (three dots) placed adjacent to the first button
-
-<Canvas className="mb-24" of={exampleStories.SplitButtonReplacement} />
+<Canvas className="mb-24" of={exampleStories.ButtonMenuPattern} />
 
 ## Additional API options
 

--- a/packages/components/src/__next__/Button/_docs/Button.docs.stories.tsx
+++ b/packages/components/src/__next__/Button/_docs/Button.docs.stories.tsx
@@ -392,7 +392,8 @@ export const DontExampleTertiaryButtonWithIcons: Story = {
   },
 }
 
-export const SplitButtonReplacement: Story = {
+export const ButtonMenuPattern: Story = {
+  name: 'Button + Menu Pattern',
   render: () => (
     <div className="flex gap-4">
       <Button size="large" variant="secondary">

--- a/packages/components/src/__next__/Button/_docs/Button.docs.stories.tsx
+++ b/packages/components/src/__next__/Button/_docs/Button.docs.stories.tsx
@@ -391,3 +391,31 @@ export const DontExampleTertiaryButtonWithIcons: Story = {
     variant: 'tertiary',
   },
 }
+
+export const SplitButtonReplacement: Story = {
+  render: () => (
+    <div className="flex gap-4">
+      <Button size="large" variant="secondary">
+        Edit Survey
+      </Button>
+      <MenuTrigger>
+        <Button
+          size="large"
+          icon={<Icon name="more_horiz" isPresentational />}
+          variant="secondary"
+          hasHiddenLabel
+        >
+          More surveys
+        </Button>
+        <MenuPopover>
+          <Menu>
+            <MenuItem>Survey 1</MenuItem>
+            <MenuItem>Survey 2</MenuItem>
+            <MenuItem>Survey 3</MenuItem>
+            <MenuItem>Survey 4</MenuItem>
+          </Menu>
+        </MenuPopover>
+      </MenuTrigger>
+    </div>
+  ),
+}

--- a/packages/components/src/__next__/Menu/_docs/Menu--api-specification.mdx
+++ b/packages/components/src/__next__/Menu/_docs/Menu--api-specification.mdx
@@ -84,11 +84,8 @@ By default, the open/closed state of the menu is handled under the hood. In case
 
 <Canvas className="mb-24" of={exampleStories.Controlled} />
 
-## Split Button Replacement
+## Use a menu to show additional actions
 
-[Deprecating Split Buttons](https://cultureamp.atlassian.net/wiki/spaces/DES/pages/4286611457/Deprecating+Split+Buttons+-+Design+Request+for+Comment+RFC) in favour of a composed, two Button overflow approach, supported by guidelines:
+Instead of a split button (now a [deprecated component](https://cultureamp.atlassian.net/wiki/spaces/DES/pages/4286611457/Deprecating+Split+Buttons+-+Design+Request+for+Comment+RFC)), use a Button with text followed by a Menu to show any additional actions related to the most critical action.
 
-1. A Button with text
-2. A Button with a meatball icon (three dots) placed adjacent to the first button
-
-<Canvas className="mb-24" of={exampleStories.SplitButtonReplacement} />
+<Canvas className="mb-24" of={exampleStories.ButtonMenuPattern} />

--- a/packages/components/src/__next__/Menu/_docs/Menu--api-specification.mdx
+++ b/packages/components/src/__next__/Menu/_docs/Menu--api-specification.mdx
@@ -83,3 +83,12 @@ Menu items can be disabled with the `isDisabled` prop.
 By default, the open/closed state of the menu is handled under the hood. In cases where you need control over the open state, use the `isOpen` and `onOpenChange` props on the `MenuTrigger` component (both props must be used for this to work).
 
 <Canvas className="mb-24" of={exampleStories.Controlled} />
+
+## Split Button Replacement
+
+[Deprecating Split Buttons](https://cultureamp.atlassian.net/wiki/spaces/DES/pages/4286611457/Deprecating+Split+Buttons+-+Design+Request+for+Comment+RFC) in favour of a composed, two Button overflow approach, supported by guidelines:
+
+1. A Button with text
+2. A Button with a meatball icon (three dots) placed adjacent to the first button
+
+<Canvas className="mb-24" of={exampleStories.SplitButtonReplacement} />

--- a/packages/components/src/__next__/Menu/_docs/Menu.stories.tsx
+++ b/packages/components/src/__next__/Menu/_docs/Menu.stories.tsx
@@ -129,7 +129,8 @@ export const Sections: Story = {
   ),
 }
 
-export const SplitButtonReplacement: Story = {
+export const ButtonMenuPattern: Story = {
+  name: 'Button + Menu Pattern',
   render: ({ defaultOpen: _, ...args }) => (
     <div className="flex gap-4">
       <Button size="large" variant="secondary">

--- a/packages/components/src/__next__/Menu/_docs/Menu.stories.tsx
+++ b/packages/components/src/__next__/Menu/_docs/Menu.stories.tsx
@@ -128,3 +128,31 @@ export const Sections: Story = {
     </MenuTrigger>
   ),
 }
+
+export const SplitButtonReplacement: Story = {
+  render: ({ defaultOpen: _, ...args }) => (
+    <div className="flex gap-4">
+      <Button size="large" variant="secondary">
+        Edit Survey
+      </Button>
+      <MenuTrigger {...args}>
+        <Button
+          size="large"
+          icon={<Icon name="more_horiz" isPresentational />}
+          variant="secondary"
+          hasHiddenLabel
+        >
+          More surveys
+        </Button>
+        <MenuPopover>
+          <Menu>
+            <MenuItem>Survey 1</MenuItem>
+            <MenuItem>Survey 2</MenuItem>
+            <MenuItem>Survey 3</MenuItem>
+            <MenuItem>Survey 4</MenuItem>
+          </Menu>
+        </MenuPopover>
+      </MenuTrigger>
+    </div>
+  ),
+}


### PR DESCRIPTION
## Why

Split Button is being deprecated so we need a path forward for existing usage

## What

Added stories and API spec docs to both Menu and Button sections