### PR TITLE
Avatar component will only render the image when it loads successfully

### DIFF
--- a/.changeset/empty-spies-wear.md
+++ b/.changeset/empty-spies-wear.md
@@ -1,0 +1,5 @@
+---
+'@kaizen/components': patch
+---
+
+Avatar will render img only if it is available and loaded successfully

--- a/packages/components/src/Avatar/Avatar.spec.tsx
+++ b/packages/components/src/Avatar/Avatar.spec.tsx
@@ -14,6 +14,7 @@ describe('<Avatar />', () => {
     fireEvent.error(screen.getByRole('img'))
 
     expect(screen.getByText('JD')).toBeInTheDocument()
+    expect(screen.queryByRole('img')).not.toBeInTheDocument()
   })
 
   describe('full name provided contains more than two names', () => {

--- a/packages/components/src/Avatar/Avatar.tsx
+++ b/packages/components/src/Avatar/Avatar.tsx
@@ -156,13 +156,13 @@ export const Avatar = ({
       )}
       {...restProps}
     >
-      {avatarState !== 'none' && (
+      {avatarState !== 'none' && avatarState !== 'error' && (
         <img
           ref={image}
           className={classnames(
             styles.avatarImage,
             isCompany && styles.companyAvatarImage,
-            (avatarState === 'loading' || avatarState === 'error') && styles.loading,
+            avatarState === 'loading' && styles.loading,
           )}
           src={avatarSrc}
           onError={onImageFailure}


### PR DESCRIPTION
## Important: Request PR reviews on Slack

Please reach out to the design system team on Slack in `#prod_design_system` for PR reviews. GitHub notifications (e.g. from tagging a person) are not actively monitored.

## Why
When the avatarSrc does not exist, an `img` is still getting rendered. There is no problem visually, but it isn't ideal to have a broken img in the DOM.
https://cultureamp.slack.com/archives/C0189KBPM4Y/p1752472765353019


## What

This change means `avatarState` of `error` will not render an `img` element. Only the initials will render