### PR TITLE
Updates to DocHeading

### DIFF
--- a/docs/components/DocHeading/DocHeading.tsx
+++ b/docs/components/DocHeading/DocHeading.tsx
@@ -1,5 +1,5 @@
-import React, { type HTMLAttributes } from 'react'
-import { Unstyled, useOf } from '@storybook/blocks'
+import React, { useContext, type HTMLAttributes } from 'react'
+import { DocsContext, Unstyled } from '@storybook/blocks'
 import classnames from 'classnames'
 import { Heading } from '~components/Heading'
 import { Tag } from '~components/__next__/Tag'
@@ -29,9 +29,15 @@ export const DocHeading = ({
   className,
   ...otherProps
 }: DocHeadingProps): JSX.Element => {
-  // Storybook doesn't expose a typed value here
-  const { preparedMeta } = useOf('meta') as any
-  const tags = preparedMeta.tags ?? []
+  const context = useContext(DocsContext)
+  let tags: string[] = []
+  try {
+    // @ts-expect-error Storybook doesn't expose a typed value
+    const csf = context.storyIdToCSFFile.values().next().value
+    tags = csf?.meta?.tags ?? []
+  } catch {
+    tags = []
+  }
 
   const versionTag = tags.find((tag: string): tag is VersionTag =>
     ['next', 'alpha', 'deprecated'].includes(tag),

--- a/packages/components/src/Card/_docs/Card--api-specification.mdx
+++ b/packages/components/src/Card/_docs/Card--api-specification.mdx
@@ -2,7 +2,7 @@ import { Canvas, Controls, Meta } from '@storybook/blocks'
 import { ResourceLinks, KAIOInstallation, DocHeading } from '~storybook/components'
 import * as CardStories from './Card.stories'
 
-<Meta title="Components/Card/API Specification" of={CardStories} />
+<Meta title="Components/Card/API Specification" />
 
 <DocHeading title="Card" docTags={['dev docs']} />
 

--- a/packages/components/src/Card/_docs/Card--usage-guidelines.mdx
+++ b/packages/components/src/Card/_docs/Card--usage-guidelines.mdx
@@ -2,7 +2,7 @@ import { Canvas, Controls, Meta } from '@storybook/blocks'
 import { ResourceLinks, KAIOInstallation, DocHeading } from '~storybook/components'
 import * as CardStories from './Card.stories'
 
-<Meta title="Components/Card/Usage Guidelines" of={CardStories} />
+<Meta title="Components/Card/Usage Guidelines" />
 
 <DocHeading title="Card" docTags={['design docs']} />
 

--- a/packages/components/src/Filter/FilterButton/_docs/filter-buttons.mdx
+++ b/packages/components/src/Filter/FilterButton/_docs/filter-buttons.mdx
@@ -3,7 +3,7 @@ import { KAIOInstallation, ResourceLinks, DocHeading } from '~storybook/componen
 import * as FilterButtonExamples from './FilterButton.stories'
 import * as FilterButtonRemovableExamples from './FilterButtonRemovable.stories'
 
-<Meta title="Components/Filter Base/Filter Buttons" of={FilterButtonExamples} />
+<Meta title="Components/Filter Base/Filter Buttons" />
 
 <DocHeading title="Filter Buttons" docTags={['dev docs']} />
 

--- a/packages/components/src/Focusable/_docs/ApiSpecification.mdx
+++ b/packages/components/src/Focusable/_docs/ApiSpecification.mdx
@@ -2,7 +2,7 @@ import { Canvas, Controls, Meta } from '@storybook/blocks'
 import { KAIOInstallation, ResourceLinks, DocHeading } from '~storybook/components'
 import * as exampleStories from './Focusable.stories'
 
-<Meta title="Components/Focusable/API Specification" of={exampleStories} />
+<Meta title="Components/Focusable/API Specification" />
 
 <DocHeading title="Focusable" docTags={['dev docs']} />
 

--- a/packages/components/src/Link/_docs/Link--api-specification.mdx
+++ b/packages/components/src/Link/_docs/Link--api-specification.mdx
@@ -2,7 +2,7 @@ import { Canvas, Meta, Controls, ArgTypes, DocsStory } from '@storybook/blocks'
 import { ResourceLinks, KAIOInstallation, LinkTo, DocHeading } from '~storybook/components'
 import * as LinkStories from './Link.doc.stories'
 
-<Meta title="Components/Link/API Specification" of={LinkStories} />
+<Meta title="Components/Link/API Specification" />
 
 <DocHeading title="Link" docTags={['dev docs']} />
 

--- a/packages/components/src/Link/_docs/Link--api-usage-guidelines.mdx
+++ b/packages/components/src/Link/_docs/Link--api-usage-guidelines.mdx
@@ -9,7 +9,7 @@ import {
 } from '~storybook/components'
 import * as LinkStories from './Link.doc.stories'
 
-<Meta title="Components/Link/Usage Guidelines" of={LinkStories} />
+<Meta title="Components/Link/Usage Guidelines" />
 
 <DocHeading title="Link" docTags={['design docs']} />
 

--- a/packages/components/src/LinkButton/_docs/LinkButton--api-specification.mdx
+++ b/packages/components/src/LinkButton/_docs/LinkButton--api-specification.mdx
@@ -2,7 +2,7 @@ import { Canvas, Meta, Controls, ArgTypes, DocsStory } from '@storybook/blocks'
 import { ResourceLinks, KAIOInstallation, LinkTo, DocHeading } from '~storybook/components'
 import * as exampleStories from './LinkButton.doc.stories'
 
-<Meta title="Components/LinkButton/API Specification" of={exampleStories} />
+<Meta title="Components/LinkButton/API Specification" />
 
 <DocHeading title="LinkButton" docTags={['dev docs']} />
 

--- a/packages/components/src/LinkButton/_docs/LinkButton--usage-guidelines.mdx
+++ b/packages/components/src/LinkButton/_docs/LinkButton--usage-guidelines.mdx
@@ -2,7 +2,7 @@ import { Canvas, Meta, Controls } from '@storybook/blocks'
 import { ResourceLinks, KAIOInstallation, LinkTo, DocHeading } from '~storybook/components'
 import * as LinkButton from './LinkButton.doc.stories'
 
-<Meta title="Components/LinkButton/Usage Guidelines" of={LinkButton} />
+<Meta title="Components/LinkButton/Usage Guidelines" />
 
 <DocHeading title="LinkButton" docTags={['design docs']} />
 

--- a/packages/components/src/Well/_docs/Well--api-specification.mdx
+++ b/packages/components/src/Well/_docs/Well--api-specification.mdx
@@ -2,7 +2,7 @@ import { Canvas, Controls, Meta, Source } from '@storybook/blocks'
 import { ResourceLinks, KAIOInstallation, DocHeading } from '~storybook/components'
 import * as WellStories from './Well.stories'
 
-<Meta title="Components/Well/API Specification" of={WellStories} />
+<Meta title="Components/Well/API Specification" />
 
 <DocHeading title="Well" docTags={['dev docs']} />
 

--- a/packages/components/src/Well/_docs/Well--usage-guidelines.mdx
+++ b/packages/components/src/Well/_docs/Well--usage-guidelines.mdx
@@ -2,7 +2,7 @@ import { Canvas, Controls, Meta } from '@storybook/blocks'
 import { ResourceLinks, KAIOInstallation, DocHeading } from '~storybook/components'
 import * as WellStories from './Well.stories'
 
-<Meta title="Components/Well/Usage Guidelines" of={WellStories} />
+<Meta title="Components/Well/Usage Guidelines" />
 
 <DocHeading title="Well" docTags={['design docs']} />
 

--- a/packages/components/src/__next__/Button/_docs/Button--api-specification.mdx
+++ b/packages/components/src/__next__/Button/_docs/Button--api-specification.mdx
@@ -3,7 +3,7 @@ import { ResourceLinks, KAIOInstallation, LinkTo, DocHeading } from '~storybook/
 import * as exampleStories from './Button.docs.stories'
 import * as specStories from './Button.spec.stories'
 
-<Meta title="Components/Button (next)/API Specification" tags={['next']} of={exampleStories} />
+<Meta title="Components/Button (next)/API Specification" tags={['next']} />
 
 <DocHeading title="Button" docTags={['dev docs']} />
 

--- a/packages/components/src/__next__/Button/_docs/Button--usage-guidelines.mdx
+++ b/packages/components/src/__next__/Button/_docs/Button--usage-guidelines.mdx
@@ -12,7 +12,7 @@ import ButtonIconSpec from './assets/button_icon_spec.png'
 import ButtonSpec from './assets/button_spec.png'
 import ButtonAnatomy from './assets/button_anatomy.png'
 
-<Meta title="Components/Button (next)/Usage Guidelines" tags={['next']} of={Button} />
+<Meta title="Components/Button (next)/Usage Guidelines" tags={['next']} />
 
 <DocHeading title="Button" docTags={['design docs']} />
 

--- a/packages/components/src/__next__/Icon/_docs/Icon--api-specification.mdx
+++ b/packages/components/src/__next__/Icon/_docs/Icon--api-specification.mdx
@@ -2,7 +2,7 @@ import { Canvas, Meta, Controls, Story } from '@storybook/blocks'
 import { ResourceLinks, KAIOInstallation, DocHeading } from '~storybook/components'
 import * as IconStories from './Icon.docs.stories'
 
-<Meta title="Components/Icon (next)/API Specification" tags={['next']} of={IconStories} />
+<Meta title="Components/Icon (next)/API Specification" tags={['next']} />
 
 <DocHeading title="Icon" docTags={['dev docs']} />
 

--- a/packages/components/src/__next__/Icon/_docs/Icon--usage-guidelines.mdx
+++ b/packages/components/src/__next__/Icon/_docs/Icon--usage-guidelines.mdx
@@ -8,7 +8,7 @@ import {
 } from '~storybook/components'
 import * as IconStories from './Icon.docs.stories'
 
-<Meta title="Components/Icon (next)/Usage Guidelines" tags={['next']} of={IconStories} />
+<Meta title="Components/Icon (next)/Usage Guidelines" tags={['next']} />
 
 <DocHeading title="Icon" docTags={['design docs']} />
 

--- a/packages/components/src/__next__/Menu/_docs/Menu--api-specification.mdx
+++ b/packages/components/src/__next__/Menu/_docs/Menu--api-specification.mdx
@@ -3,7 +3,7 @@ import { KAIOInstallation, ResourceLinks, DocHeading } from '~storybook/componen
 import * as docsStories from './Menu.docs.stories'
 import * as exampleStories from './Menu.stories'
 
-<Meta title="Components/Menu (next)/API Specification" tags={['next']} of={exampleStories} />
+<Meta title="Components/Menu (next)/API Specification" tags={['next']} />
 
 <DocHeading title="Menu" docTags={['dev docs']} />
 

--- a/packages/components/src/__next__/Menu/_docs/Menu--usage-guidelines.mdx
+++ b/packages/components/src/__next__/Menu/_docs/Menu--usage-guidelines.mdx
@@ -9,7 +9,7 @@ import {
 import * as MenuDocsStories from './Menu.docs.stories'
 import * as MenuStories from './Menu.stories'
 
-<Meta title="Components/Menu (next)/Usage Guidelines" tags={['next']} of={MenuStories} />
+<Meta title="Components/Menu (next)/Usage Guidelines" tags={['next']} />
 
 <DocHeading title="Menu" docTags={['design docs']} />
 

--- a/packages/components/src/__next__/Tabs/_docs/Tabs--api-specification.mdx
+++ b/packages/components/src/__next__/Tabs/_docs/Tabs--api-specification.mdx
@@ -2,7 +2,7 @@ import { Canvas, Controls, Meta } from '@storybook/blocks'
 import { ResourceLinks, KAIOInstallation, DocHeading } from '~storybook/components'
 import * as TabsStories from './Tabs.stories'
 
-<Meta title="Components/Tabs (next)/API Specification" tags={['next']} of={TabsStories} />
+<Meta title="Components/Tabs (next)/API Specification" tags={['next']} />
 
 <DocHeading title="Tabs" docTags={['dev docs']} />
 

--- a/packages/components/src/__next__/Tooltip/_docs/ApiSpecification.mdx
+++ b/packages/components/src/__next__/Tooltip/_docs/ApiSpecification.mdx
@@ -3,7 +3,7 @@ import { KAIOInstallation, ResourceLinks, DocHeading } from '~storybook/componen
 import * as docsStories from './Tooltip.docs.stories'
 import * as exampleStories from './Tooltip.stories'
 
-<Meta title="Components/Tooltip (next)/API Specification" tags={['next']} of={exampleStories} />
+<Meta title="Components/Tooltip (next)/API Specification" tags={['next']} />
 
 <DocHeading title="Tooltip" docTags={['dev docs']} />
 

--- a/packages/components/src/__next__/Tooltip/_docs/Tooltip.mdx
+++ b/packages/components/src/__next__/Tooltip/_docs/Tooltip.mdx
@@ -12,7 +12,7 @@ import PlacementPng from './assets/tooltip_placement.png'
 import DesignSpecPng from './assets/tooltip_spec.png'
 import WhenToUsePng from './assets/tooltip_variant.png'
 
-<Meta title="Components/Tooltip (next)/Usage Guidelines" tags={['next']} of={TooltipStories} />
+<Meta title="Components/Tooltip (next)/Usage Guidelines" tags={['next']} />
 
 <DocHeading title="Tooltip" docTags={['design docs']} />
 


### PR DESCRIPTION
Fixes the broken side nav naming in Storybook
The side nav files in Storybook were getting their name from the direct file instead of the named title

This refactors the DocHeading component so that we don't have to pass `of={exmapleStories}` to the `Meta` component
