### PR TITLE
[KZN-3487] styling Link component in notifications

### DIFF
--- a/.changeset/tricky-radios-clap.md
+++ b/.changeset/tricky-radios-clap.md
@@ -1,0 +1,5 @@
+---
+'@kaizen/components': patch
+---
+
+Bug fix for notifications, removing duplicate styling for Link component

--- a/packages/components/src/Notification/GlobalNotification/_docs/GlobalNotification.stickersheet.stories.tsx
+++ b/packages/components/src/Notification/GlobalNotification/_docs/GlobalNotification.stickersheet.stories.tsx
@@ -73,7 +73,9 @@ const StickerSheetTemplate: StickerSheetStory = {
       children: (
         <span>
           {"This survey status has been changed to 'Archived'. "}
-          <Link href="/">View all</Link>
+          <Link href="/" size="small">
+            View all
+          </Link>
         </span>
       ),
     } satisfies Partial<GlobalNotificationProps>

--- a/packages/components/src/Notification/GlobalNotification/_docs/GlobalNotification.stickersheet.stories.tsx
+++ b/packages/components/src/Notification/GlobalNotification/_docs/GlobalNotification.stickersheet.stories.tsx
@@ -73,9 +73,7 @@ const StickerSheetTemplate: StickerSheetStory = {
       children: (
         <span>
           {"This survey status has been changed to 'Archived'. "}
-          <Link href="/" size="small">
-            View all
-          </Link>
+          <Link href="/">View all</Link>
         </span>
       ),
     } satisfies Partial<GlobalNotificationProps>

--- a/packages/components/src/Notification/GlobalNotification/_docs/GlobalNotification.stickersheet.stories.tsx
+++ b/packages/components/src/Notification/GlobalNotification/_docs/GlobalNotification.stickersheet.stories.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { type Meta } from '@storybook/react'
+import { Link } from '~components/Link'
 import { StickerSheet, type StickerSheetStory } from '~storybook/components/StickerSheet'
 import { GlobalNotification, type GlobalNotificationProps } from '../GlobalNotification'
 
@@ -72,7 +73,7 @@ const StickerSheetTemplate: StickerSheetStory = {
       children: (
         <span>
           {"This survey status has been changed to 'Archived'. "}
-          <a href="/">View all</a>
+          <Link href="/">View all</Link>
         </span>
       ),
     } satisfies Partial<GlobalNotificationProps>

--- a/packages/components/src/Notification/InlineNotification/_docs/InlineNotification.stickersheet.stories.tsx
+++ b/packages/components/src/Notification/InlineNotification/_docs/InlineNotification.stickersheet.stories.tsx
@@ -20,7 +20,9 @@ const DEFAULT_PROPS = {
   children: (
     <span>
       New user data, imported by mackenzie@hooli.com has successfully uploaded.{' '}
-      <Link href="/">Manage users is now available</Link>
+      <Link href="/" size="small">
+        Manage users is now available
+      </Link>
     </span>
   ),
 } satisfies Partial<InlineNotificationProps>

--- a/packages/components/src/Notification/InlineNotification/_docs/InlineNotification.stickersheet.stories.tsx
+++ b/packages/components/src/Notification/InlineNotification/_docs/InlineNotification.stickersheet.stories.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { type Meta } from '@storybook/react'
+import { Link } from '~components/index'
 import { StickerSheet, type StickerSheetStory } from '~storybook/components/StickerSheet'
 import { InlineNotification, type InlineNotificationProps } from '../InlineNotification'
 
@@ -19,7 +20,7 @@ const DEFAULT_PROPS = {
   children: (
     <span>
       New user data, imported by mackenzie@hooli.com has successfully uploaded.{' '}
-      <a href="/">Manage users is now available</a>
+      <Link href="/">Manage users is now available</Link>
     </span>
   ),
 } satisfies Partial<InlineNotificationProps>

--- a/packages/components/src/Notification/ToastNotification/_docs/ToastNotification.stickersheet.stories.tsx
+++ b/packages/components/src/Notification/ToastNotification/_docs/ToastNotification.stickersheet.stories.tsx
@@ -17,27 +17,40 @@ const StickerSheetTemplate: StickerSheetStory = {
     <>
       <ToastNotification variant="success" title="Success">
         New user data, imported by mackenzie@hooli.com has successfully uploaded.{' '}
-        <Link href="/">Manage users is now available</Link>
+        <Link href="/" size="small">
+          Manage users is now available
+        </Link>
       </ToastNotification>
       <ToastNotification type="positive" title="Positive (Deprecated)">
         New user data, imported by mackenzie@hooli.com has successfully uploaded.{' '}
-        <Link href="/">Manage users is now available</Link>
+        <Link href="/" size="small">
+          Manage users is now available
+        </Link>
       </ToastNotification>
       <ToastNotification variant="informative" title="Informative">
         New user data is currently being processed. We&apos;ll let you know when the process is
-        completed. <Link href="/">Manage users</Link>
+        completed.{' '}
+        <Link href="/" size="small">
+          Manage users
+        </Link>
       </ToastNotification>
       <ToastNotification variant="cautionary" title="Cautionary">
         New user data, imported by mackenzie@hooli.com has uploaded with some minor issues.{' '}
-        <Link href="/">View issues</Link>
+        <Link href="/" size="small">
+          View issues
+        </Link>
       </ToastNotification>
       <ToastNotification variant="warning" title="Warning">
         Results hidden to protect confidentiality of individuals and small groups.{' '}
-        <Link href="/">Learn more</Link>
+        <Link href="/" size="small">
+          Learn more
+        </Link>
       </ToastNotification>
       <ToastNotification type="negative" title="Negative (Deprecated)">
         New user data, imported by mackenzie@hooli.com has successfully uploaded.{' '}
-        <Link href="/">Manage users is now available</Link>
+        <Link href="/" size="small">
+          Manage users is now available
+        </Link>
       </ToastNotification>
       <ToastNotification
         variant="security"

--- a/packages/components/src/Notification/ToastNotification/_docs/ToastNotification.stickersheet.stories.tsx
+++ b/packages/components/src/Notification/ToastNotification/_docs/ToastNotification.stickersheet.stories.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { type Meta } from '@storybook/react'
+import { Link } from '~components/Link'
 import { type StickerSheetStory } from '~storybook/components/StickerSheet'
 import { ToastNotification } from '../ToastNotification'
 
@@ -16,27 +17,27 @@ const StickerSheetTemplate: StickerSheetStory = {
     <>
       <ToastNotification variant="success" title="Success">
         New user data, imported by mackenzie@hooli.com has successfully uploaded.{' '}
-        <a href="/">Manage users is now available</a>
+        <Link href="/">Manage users is now available</Link>
       </ToastNotification>
       <ToastNotification type="positive" title="Positive (Deprecated)">
         New user data, imported by mackenzie@hooli.com has successfully uploaded.{' '}
-        <a href="/">Manage users is now available</a>
+        <Link href="/">Manage users is now available</Link>
       </ToastNotification>
       <ToastNotification variant="informative" title="Informative">
         New user data is currently being processed. We&apos;ll let you know when the process is
-        completed. <a href="/">Manage users</a>
+        completed. <Link href="/">Manage users</Link>
       </ToastNotification>
       <ToastNotification variant="cautionary" title="Cautionary">
         New user data, imported by mackenzie@hooli.com has uploaded with some minor issues.{' '}
-        <a href="/">View issues</a>
+        <Link href="/">View issues</Link>
       </ToastNotification>
       <ToastNotification variant="warning" title="Warning">
         Results hidden to protect confidentiality of individuals and small groups.{' '}
-        <a href="/">Learn more</a>
+        <Link href="/">Learn more</Link>
       </ToastNotification>
       <ToastNotification type="negative" title="Negative (Deprecated)">
         New user data, imported by mackenzie@hooli.com has successfully uploaded.{' '}
-        <a href="/">Manage users is now available</a>
+        <Link href="/">Manage users is now available</Link>
       </ToastNotification>
       <ToastNotification
         variant="security"

--- a/packages/components/src/Notification/subcomponents/GenericNotification/_mixins.scss
+++ b/packages/components/src/Notification/subcomponents/GenericNotification/_mixins.scss
@@ -266,7 +266,6 @@ $notification-slide-right: transform 300ms ease-out;
       border-bottom: var(--spacing-1) solid $color-blue-500;
       text-decoration: none;
       color: $color-blue-500;
-      text-decoration: none;
 
       &:hover {
         text-decoration: none;

--- a/packages/components/src/Notification/subcomponents/GenericNotification/_mixins.scss
+++ b/packages/components/src/Notification/subcomponents/GenericNotification/_mixins.scss
@@ -263,12 +263,14 @@ $notification-slide-right: transform 300ms ease-out;
     }
 
     a[href] {
+      border-bottom: var(--spacing-1) solid $color-blue-500;
+      text-decoration: none;
       color: $color-blue-500;
-      text-decoration: underline;
+      text-decoration: none;
 
       &:hover {
-        color: $color-blue-500;
         text-decoration: none;
+        color: $color-blue-600;
       }
     }
 

--- a/packages/components/src/Notification/subcomponents/GenericNotification/_mixins.scss
+++ b/packages/components/src/Notification/subcomponents/GenericNotification/_mixins.scss
@@ -262,7 +262,7 @@ $notification-slide-right: transform 300ms ease-out;
       letter-spacing: $typography-paragraph-body-letter-spacing;
     }
 
-    a[href] {
+    a[href]:not([data-rac]) {
       border-bottom: var(--spacing-1) solid $color-blue-500;
       text-decoration: none;
       color: $color-blue-500;
@@ -270,6 +270,7 @@ $notification-slide-right: transform 300ms ease-out;
       &:hover {
         text-decoration: none;
         color: $color-blue-600;
+        border-bottom: var(--spacing-1) solid $color-blue-600;
       }
     }
 


### PR DESCRIPTION
## Why

Passing the `Link` component into any of our notifications was breaking the styling and giving the link 2 underlines. 
<img width="300" alt="toast new link before" src="https://github.com/user-attachments/assets/126eaccd-e37f-4e34-85a2-4454eeb51a10" />


## What

Updating the styling to fix the implementation when using the `Link` component without breaking the older implementations that use a link`<a href="/" >` 

`Link` component passed
<img width="300" alt="Screenshot 2025-07-30 at 10 10 12 am" src="https://github.com/user-attachments/assets/9306d951-3c89-4bde-9229-f62246e13b8a" />


`<a href="/" >` passed
<img width="300" alt="toast old link after" src="https://github.com/user-attachments/assets/33d42e02-e2d1-468e-b074-1fe1aa8d5ff3" />

