### PR TITLE
feat: Add chromatic triggering on label

### DIFF
--- a/.github/workflows/chromatic-pr.yaml
+++ b/.github/workflows/chromatic-pr.yaml
@@ -9,6 +9,7 @@ on:
       - opened
       - synchronize
       - ready_for_review
+      - labeled
 
   # When Changesets opens a PR it does not trigger GitHub actions,
   # because its token does not have permission to. This is a hack
@@ -25,7 +26,10 @@ on:
 jobs:
   run-check:
     name: Check if we should run Chromatic tests
-    if: github.head_ref != 'changeset-release/main' && github.event.pull_request.draft == false && github.base_ref == 'main'
+    if:
+      github.head_ref != 'changeset-release/main' && github.event.pull_request.draft == false && github.base_ref == 'main'
+      || github.event_name == 'pull_request' && github.event.action == 'labeled' && contains(github.event.pull_request.labels.*.name, 'run_chromatic')
+
     runs-on: ubuntu-latest
     timeout-minutes: 3
     steps:


### PR DESCRIPTION
## Why

We're not always merging to main so we need to be able to manually trigger chromatic runs

## What

Add an or statement to the chromatic workflow to check if a `run_chromatic` label has been added
