### PR TITLE
fix: Ensure front tile ui elements are not clickable when the back tile is displayed.

### DIFF
--- a/packages/components/src/Tile/subcomponents/GenericTile/GenericTile.module.scss
+++ b/packages/components/src/Tile/subcomponents/GenericTile/GenericTile.module.scss
@@ -153,5 +153,9 @@
     justify-content: center;
     margin-top: $spacing-sm;
     height: $spacing-xl;
+
+    .isFlipped & {
+      pointer-events: none;
+    }
   }
 }


### PR DESCRIPTION
## Why

This is a bugfix required to resolve an issue on the Survey Template page in Murmur.

This page uses the MultiActionTile component (which uses the GenericTile component under the hood).

When the tile is "flipped", any buttons that were inserted into the front tile via the footer component are still clickable.

**See the issue in Murmur below**

(Note when clicking the left side of the "View available languages" button, the "Select" button from the front side is triggered).

https://github.com/user-attachments/assets/1fee7f49-3863-4a00-9e79-30b08c5a432c

**This is also visible in the Kaizen storybook docs.**

(note the pointer cursor appears when hovering over the place where the front side button is).

https://github.com/user-attachments/assets/f887635e-6b8a-4a43-b714-213b64d26749

## What

Adds some css to ensure the footer isn't clickable when flipped. The footer only displays when the component is in an "unflipped" (front side visible) state anyway.

**After fix**


https://github.com/user-attachments/assets/a8a97143-fab6-4be2-a6de-dbd671f732ce

