### PR TITLE
update migrateV2NextToCurrent transform path

### DIFF
--- a/.changeset/forty-symbols-unite.md
+++ b/.changeset/forty-symbols-unite.md
@@ -1,0 +1,7 @@
+---
+'@kaizen/components': patch
+---
+
+Update codemod transform path for react-aria libs
+
+- updates `migrateV2NextToCurrent` transform path to `@kaizen/components/libs/react-aria` to match with recent V2 entry point changes.

--- a/packages/components/codemods/migrateV2NextToCurrent/migrateV2NextToCurrent.spec.ts
+++ b/packages/components/codemods/migrateV2NextToCurrent/migrateV2NextToCurrent.spec.ts
@@ -500,7 +500,7 @@ import type { Menu as KZMenu, MenuItem as KZMenuItem } from "@kaizen/components"
   describe('Module path transformations', () => {
     it('should transform react-aria module path', () => {
       const inputAst = parseJsx(`import { Button } from "@kaizen/components/v3/react-aria"`)
-      const expectedAst = parseJsx(`import { Button } from "@kaizen/components/react-aria"`)
+      const expectedAst = parseJsx(`import { Button } from "@kaizen/components/libs/react-aria"`)
 
       const result = transformComponents(inputAst)
       expect(result).toBe(printAst(expectedAst))
@@ -511,7 +511,7 @@ import type { Menu as KZMenu, MenuItem as KZMenuItem } from "@kaizen/components"
         `import { TextField } from "@kaizen/components/v3/react-aria-components"`,
       )
       const expectedAst = parseJsx(
-        `import { TextField } from "@kaizen/components/react-aria-components"`,
+        `import { TextField } from "@kaizen/components/libs/react-aria-components"`,
       )
 
       const result = transformComponents(inputAst)
@@ -520,7 +520,9 @@ import type { Menu as KZMenu, MenuItem as KZMenuItem } from "@kaizen/components"
 
     it('should handle multiple imports from react-aria modules', () => {
       const inputAst = parseJsx(`import { Button, Link } from "@kaizen/components/v3/react-aria"`)
-      const expectedAst = parseJsx(`import { Button, Link } from "@kaizen/components/react-aria"`)
+      const expectedAst = parseJsx(
+        `import { Button, Link } from "@kaizen/components/libs/react-aria"`,
+      )
 
       const result = transformComponents(inputAst)
       expect(result).toBe(printAst(expectedAst))
@@ -531,7 +533,7 @@ import type { Menu as KZMenu, MenuItem as KZMenuItem } from "@kaizen/components"
         `import { Button as AriaButton } from "@kaizen/components/v3/react-aria"`,
       )
       const expectedAst = parseJsx(
-        `import { Button as AriaButton } from "@kaizen/components/react-aria"`,
+        `import { Button as AriaButton } from "@kaizen/components/libs/react-aria"`,
       )
 
       const result = transformComponents(inputAst)
@@ -545,7 +547,7 @@ import { Button } from "@kaizen/components/v3/react-aria"
 `)
       const expectedAst = parseJsx(`
 import { Menu } from "@kaizen/components"
-import { Button } from "@kaizen/components/react-aria"
+import { Button } from "@kaizen/components/libs/react-aria"
 `)
 
       const result = transformComponents(inputAst)

--- a/packages/components/codemods/migrateV2NextToCurrent/migrateV2NextToCurrent.ts
+++ b/packages/components/codemods/migrateV2NextToCurrent/migrateV2NextToCurrent.ts
@@ -49,8 +49,8 @@ const componentGroups: ComponentGroup[] = [
 const renameMap = createRenameMapFromGroups(componentGroups)
 
 const modulePathMap = new Map([
-  ['@kaizen/components/v3/react-aria', '@kaizen/components/react-aria'],
-  ['@kaizen/components/v3/react-aria-components', '@kaizen/components/react-aria-components'],
+  ['@kaizen/components/v3/react-aria', '@kaizen/components/libs/react-aria'],
+  ['@kaizen/components/v3/react-aria-components', '@kaizen/components/libs/react-aria-components'],
 ])
 
 export const migrateV2NextToCurrent =


### PR DESCRIPTION
## Why
We needed to update the `migrateV2NextToCurrent` codemod to ensure it reflect the recent update to the v2 feature branch, whereby react-aria and react-aria-components will be exported from a `/libs` entry point.

## What
- update path transform in `migrateV2NextToCurrent1`