### PR TITLE
fix: remove @deprecated comment from TitleBlock

### DIFF
--- a/packages/components/src/TitleBlock/TitleBlock.tsx
+++ b/packages/components/src/TitleBlock/TitleBlock.tsx
@@ -228,9 +228,6 @@ const renderNavigationTabs = (
 )
 
 /**
- * @deprecated This component will be renamed to TitleBlock in v2.
- * Start importing as TitleBlock instead.
- *
  * {@link https://cultureamp.atlassian.net/wiki/spaces/DesignSystem/pages/3075605782/Title+Block Guidance} |
  * {@link https://cultureamp.design/?path=/story/components-titleblock--docs Storybook}
  */


### PR DESCRIPTION
## Why

v2 readiness

## What

TitleBlock is not deprecated this comment was left over from the rename PR, only  saw it due to my editor complaining  in the canary implementation test.
