### PR TITLE
adding three new spot illustrations for effectiveness templates

### DIFF
--- a/.changeset/polite-years-swim.md
+++ b/.changeset/polite-years-swim.md
@@ -1,0 +1,5 @@
+---
+'@kaizen/components': minor
+---
+
+Added three new spot illustrations

--- a/packages/components/src/Illustration/Spot/Spot.tsx
+++ b/packages/components/src/Illustration/Spot/Spot.tsx
@@ -67,13 +67,16 @@ const createSpotIllustration =
  * Template Library / Performance
  */
 /* prettier-ignore */ export const Individual360 = createSpotIllustration("template-library-individual-360.svg")
+/* prettier-ignore */ export const Individual360Pulse = createSpotIllustration("template-library-individual-360-pulse.svg")
 /* prettier-ignore */ export const Leadership360 = createSpotIllustration("template-library-leadership-360.svg")
 /* prettier-ignore */ export const Manager360 = createSpotIllustration("template-library-manager-360.svg")
+/* prettier-ignore */ export const Manager360Pulse = createSpotIllustration("template-library-manager-360-pulse.svg")
 /* prettier-ignore */ export const Individual180 = createSpotIllustration("template-library-individual-180.svg")
 /* prettier-ignore */ export const Leadership180 = createSpotIllustration("template-library-leadership-180.svg")
 /* prettier-ignore */ export const Manager180 = createSpotIllustration("template-library-manager-180.svg")
 /* prettier-ignore */ export const TeamEffectiveness1 = createSpotIllustration("template-library-team-effectiveness-1.svg")
 /* prettier-ignore */ export const TeamEffectiveness2 = createSpotIllustration("template-library-team-effectiveness-2.svg")
+/* prettier-ignore */ export const TeamEffectiveness3 = createSpotIllustration("template-library-team-effectiveness-3.svg")
 
 /**
  * Offices

--- a/packages/components/src/Illustration/Spot/_docs/Spot.stickersheet.stories.tsx
+++ b/packages/components/src/Illustration/Spot/_docs/Spot.stickersheet.stories.tsx
@@ -54,6 +54,7 @@ import {
   InclusionSurvey,
   Individual180,
   Individual360,
+  Individual360Pulse,
   InfluentialCommunication,
   Informative,
   Insights,
@@ -67,6 +68,7 @@ import {
   London,
   Manager180,
   Manager360,
+  Manager360Pulse,
   ManagerLearning,
   ManagerReportSharing,
   MeetingVoices,
@@ -113,6 +115,7 @@ import {
   Team2,
   TeamEffectiveness1,
   TeamEffectiveness2,
+  TeamEffectiveness3,
   Templates,
   Timezone,
   TrafficCone,
@@ -270,12 +273,20 @@ const performanceSpots = [
     name: 'Individual360',
   },
   {
+    Component: Individual360Pulse,
+    name: 'Individual360Pulse',
+  },
+  {
     Component: Leadership360,
     name: 'Leadership360',
   },
   {
     Component: Manager360,
     name: 'Manager360',
+  },
+  {
+    Component: Manager360Pulse,
+    name: 'Manager360Pulse',
   },
   {
     Component: Individual180,
@@ -296,6 +307,10 @@ const performanceSpots = [
   {
     Component: TeamEffectiveness2,
     name: 'TeamEffectiveness2',
+  },
+  {
+    Component: TeamEffectiveness3,
+    name: 'TeamEffectiveness3',
   },
 ]
 


### PR DESCRIPTION
## Important: Request PR reviews on Slack

Please reach out to the design system team on Slack in `#prod_design_system` for PR reviews. GitHub notifications (e.g. from tagging a person) are not actively monitored.

## Why

Add 3 new illustrations for the new effectiveness templates

## What

<!-- What do your changes do? How do they change/fix the current behavior? -->
<!-- Add screenshots, GIFs or videos to illustrate the changes.  -->
