### PR TITLE
re-add v3 RA library exports to v2

### DIFF
--- a/packages/components/libs/react-aria/package.json
+++ b/packages/components/libs/react-aria/package.json
@@ -1,5 +1,5 @@
 {
   "main": "../../dist/cjs/reactAriaKZ.cjs",
   "module": "../../dist/esm/reactAriaKZ.mjs",
-  "types": "../../dist/types/__react-aria__/index.d.ts"
+  "types": "../../dist/types/__libs__/react-aria/index.d.ts"
 }

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -18,6 +18,7 @@
     "future",
     "next",
     "libs",
+    "v3",
     "dist",
     "icons",
     "locales",
@@ -49,6 +50,16 @@
       "types": "./dist/types/__libs__/react-aria-components/index.d.ts",
       "import": "./dist/esm/reactAriaComponentsKZ.mjs",
       "require": "./dist/cjs/reactAriaComponentsKZ.cjs"
+    },
+    "./v3/react-aria": {
+      "types": "./dist/types/__react-aria__/index.d.ts",
+      "import": "./dist/esm/reactAriaV3.mjs",
+      "require": "./dist/cjs/reactAriaV3.cjs"
+    },
+    "./v3/react-aria-components": {
+      "types": "./dist/types/__react-aria-components__/index.d.ts",
+      "import": "./dist/esm/reactAriaComponentsV3.mjs",
+      "require": "./dist/cjs/reactAriaComponentsV3.cjs"
     },
     "./dist/styles.css": {
       "style": "./dist/styles.css",

--- a/packages/components/rollup.config.mjs
+++ b/packages/components/rollup.config.mjs
@@ -7,6 +7,8 @@ export default rollupConfig({
     alpha: './src/__alpha__/index.ts',
     reactAriaKZ: './src/__libs__/react-aria/index.ts',
     reactAriaComponentsKZ: './src/__libs__/react-aria-components/index.ts',
+    reactAriaV3: './src/__react-aria__/index.ts',
+    reactAriaComponentsV3: './src/__react-aria-components__/index.ts',
   },
   plugins: pluginsSharedUi,
 })

--- a/packages/components/src/__react-aria-components__/index.ts
+++ b/packages/components/src/__react-aria-components__/index.ts
@@ -1,0 +1,1 @@
+export * from 'react-aria-components'

--- a/packages/components/src/__react-aria__/index.ts
+++ b/packages/components/src/__react-aria__/index.ts
@@ -1,0 +1,1 @@
+export * from 'react-aria'

--- a/packages/components/v3/react-aria-components/package.json
+++ b/packages/components/v3/react-aria-components/package.json
@@ -1,0 +1,5 @@
+{
+  "main": "../../dist/cjs/reactAriaComponentsV3.cjs",
+  "module": "../../dist/esm/reactAriaComponentsV3.mjs",
+  "types": "../../dist/types/__react-aria-components__/index.d.ts"
+}

--- a/packages/components/v3/react-aria/package.json
+++ b/packages/components/v3/react-aria/package.json
@@ -1,0 +1,5 @@
+{
+  "main": "../../dist/cjs/reactAriaV3.cjs",
+  "module": "../../dist/esm/reactAriaV3.mjs",
+  "types": "../../dist/types/__react-aria__/index.d.ts"
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -495,6 +495,10 @@ importers:
 
   packages/components/libs/react-aria-components: {}
 
+  packages/components/v3/react-aria: {}
+
+  packages/components/v3/react-aria-components: {}
+
   packages/design-tokens:
     dependencies:
       color-string:
@@ -552,8 +556,6 @@ importers:
       tsx:
         specifier: ^4.20.3
         version: 4.20.3
-
-  packages/hosted-assets: {}
 
   packages/tailwind:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,3 +5,4 @@ packages:
   - '!packages/components/alpha'
   - '!packages/components/libs'
   - '!packages/design-tokens/js'
+  - '!packages/components/v3'


### PR DESCRIPTION
## Why
Top reduce the risk of compatibility issues with shared libraries that have not upgraded to KAIO V2 (ie: next-services, goals-shared-ui) we should still export `react-aria` and `react-aria-components` from the V3 endpoint as well as the libs.

This will allow us to remove this as a minor release in the future and will not make the upgrade those packages as a hard dependency for v2.

## What
- re-adds endpoint for v3 with only react-aria and react-aria components exported
- small fix to the types path for the libs export of react-aria
