### PR TITLE
docs: v1 docs link

### DIFF
--- a/docs/pages/v2-migration-guide.mdx
+++ b/docs/pages/v2-migration-guide.mdx
@@ -199,7 +199,7 @@ This codemod migrates import paths for:
 ## Getting Help
 
 - Check the Kaizen Design System documentation for the latest component APIs
-- To refer to v1.x.x docs please go here:
+- [v1 docs](https://www.chromatic.com/library?appId=60a1e4a102f0cb003b5d19d6&branch=kaio-v1)
 - Reach out on #help_design_system
 
 ## Migration Checklist

--- a/docs/pages/v2-migration-guide.mdx
+++ b/docs/pages/v2-migration-guide.mdx
@@ -199,7 +199,7 @@ This codemod migrates import paths for:
 ## Getting Help
 
 - Check the Kaizen Design System documentation for the latest component APIs
-- [v1 docs](https://www.chromatic.com/library?appId=60a1e4a102f0cb003b5d19d6&branch=kaio-v1)
+- [v1 docs](https://www.chromatic.com/library?appId=60a1e4a102f0cb003b5d19d6&branch=kaio-v1) - Use the Storybook link within the Chromatic dashboard
 - Reach out on #help_design_system
 
 ## Migration Checklist


### PR DESCRIPTION
## Why

v2 readiness

## What

Add link to v1 docs in v2 migration guide
