### PR TITLE
[KZN-3439] Clear selected item button

### DIFF
--- a/packages/components/locales/en.json
+++ b/packages/components/locales/en.json
@@ -185,6 +185,18 @@
     "description": "Prompts user to interact with button to hide information",
     "message": "Hide information:"
   },
+  "singleSelect.clearButtonAlt": {
+    "description": "Alt text for the clear selection button",
+    "message": "Clear selection"
+  },
+  "singleSelect.toggleButtonClose": {
+    "description": "Alt text for button that closes list",
+    "message": "close"
+  },
+  "singleSelect.toggleButtonOpen": {
+    "description": "Alt text for button that opens list",
+    "message": "open"
+  },
   "splitButton.dropdownButton.label": {
     "description": "Label for a dropdown menu holding additional actions",
     "message": "Additional actions"

--- a/packages/components/locales/en.json
+++ b/packages/components/locales/en.json
@@ -189,6 +189,10 @@
     "description": "Alt text for the clear selection button",
     "message": "Clear {field} selection"
   },
+  "singleSelect.dropdownButton": {
+    "description": "Aria label text for the SingleSelect button to open and close suggestions list",
+    "message": "Show {field} suggestions"
+  },
   "splitButton.dropdownButton.label": {
     "description": "Label for a dropdown menu holding additional actions",
     "message": "Additional actions"

--- a/packages/components/locales/en.json
+++ b/packages/components/locales/en.json
@@ -187,15 +187,7 @@
   },
   "singleSelect.clearButtonAlt": {
     "description": "Alt text for the clear selection button",
-    "message": "Clear selection"
-  },
-  "singleSelect.toggleButtonClose": {
-    "description": "Alt text for button that closes list",
-    "message": "close"
-  },
-  "singleSelect.toggleButtonOpen": {
-    "description": "Alt text for button that opens list",
-    "message": "open"
+    "message": "Clear {field} selection"
   },
   "splitButton.dropdownButton.label": {
     "description": "Label for a dropdown menu holding additional actions",

--- a/packages/components/locales/en.json
+++ b/packages/components/locales/en.json
@@ -191,7 +191,7 @@
   },
   "singleSelect.dropdownButton": {
     "description": "Aria label text for the SingleSelect button to open and close suggestions list",
-    "message": "Show {field} suggestions"
+    "message": "Show suggestions for {field}"
   },
   "splitButton.dropdownButton.label": {
     "description": "Label for a dropdown menu holding additional actions",

--- a/packages/components/src/__alpha__/SingleSelect/_docs/SingleSelect.spec.stories.tsx
+++ b/packages/components/src/__alpha__/SingleSelect/_docs/SingleSelect.spec.stories.tsx
@@ -76,3 +76,21 @@ export const KeyboardEscapeClosesPopover: Story = {
     await waitFor(() => expect(trigger).toHaveAttribute('aria-expanded', 'false'))
   },
 }
+
+export const XButtonClearsSelection: Story = {
+  args: { ...args, isComboBox: true },
+  play: async () => {
+    const input = screen.getByRole('combobox')
+
+    await userEvent.type(input, 'short')
+    const options = await screen.findAllByRole('option')
+    await userEvent.click(options[0])
+
+    const clearButton = await screen.findByRole('button', { name: 'Clear selection' })
+    await waitFor(() => expect(clearButton).toBeVisible())
+    await userEvent.click(clearButton)
+    await waitFor(() => {
+      expect(input).toHaveValue('')
+    })
+  },
+}

--- a/packages/components/src/__alpha__/SingleSelect/_docs/SingleSelect.spec.stories.tsx
+++ b/packages/components/src/__alpha__/SingleSelect/_docs/SingleSelect.spec.stories.tsx
@@ -86,7 +86,9 @@ export const XButtonClearsSelection: Story = {
     const options = await screen.findAllByRole('option')
     await userEvent.click(options[0])
 
-    const clearButton = await screen.findByRole('button', { name: 'Clear selection' })
+    const clearButton = await screen.findByRole('button', {
+      name: 'Clear Choose a coffee selection',
+    })
     await waitFor(() => expect(clearButton).toBeVisible())
     await userEvent.click(clearButton)
     await waitFor(() => {

--- a/packages/components/src/__alpha__/SingleSelect/context/SingleSelectContext.tsx
+++ b/packages/components/src/__alpha__/SingleSelect/context/SingleSelectContext.tsx
@@ -7,11 +7,13 @@ type SingleSelectContextType =
       anchorName: string
       state: ComboBoxState<object>
       isComboBox: true
+      fieldLabel: React.ReactNode
     }
   | {
       anchorName: string
       state: SelectState<object>
       isComboBox: false
+      fieldLabel: React.ReactNode
     }
 
 export const SingleSelectContext = createContext<SingleSelectContextType | undefined>(undefined)

--- a/packages/components/src/__alpha__/SingleSelect/subcomponents/ComboBox.tsx
+++ b/packages/components/src/__alpha__/SingleSelect/subcomponents/ComboBox.tsx
@@ -45,6 +45,7 @@ export const ComboBox = <T extends SelectItem>(props: ComboBoxProps<T>): JSX.Ele
         anchorName,
         state,
         isComboBox: true,
+        fieldLabel: label,
       }}
     >
       <div style={{ display: 'inline-block' }}>

--- a/packages/components/src/__alpha__/SingleSelect/subcomponents/ComboBox.tsx
+++ b/packages/components/src/__alpha__/SingleSelect/subcomponents/ComboBox.tsx
@@ -24,6 +24,7 @@ export const ComboBox = <T extends SelectItem>(props: ComboBoxProps<T>): JSX.Ele
   const popoverRef = useRef<HTMLDivElement>(null)
   const listBoxRef = useRef<HTMLUListElement>(null)
   const buttonRef = useRef<HTMLButtonElement>(null)
+  const clearButtonRef = useRef<HTMLButtonElement>(null)
 
   const { labelProps, inputProps, listBoxProps, buttonProps } = useComboBox(
     {
@@ -57,10 +58,16 @@ export const ComboBox = <T extends SelectItem>(props: ComboBoxProps<T>): JSX.Ele
             inputRef={inputRef}
             buttonRef={buttonRef}
             buttonProps={buttonProps}
+            clearButtonRef={clearButtonRef}
           />
         </div>
 
-        <Popover state={state} triggerRef={inputRef} popoverRef={popoverRef}>
+        <Popover
+          state={state}
+          triggerRef={inputRef}
+          popoverRef={popoverRef}
+          clearButtonRef={clearButtonRef}
+        >
           <List listBoxOptions={listBoxProps} state={state} listBoxRef={listBoxRef} />
         </Popover>
       </div>

--- a/packages/components/src/__alpha__/SingleSelect/subcomponents/ComboBoxTrigger/ComboBoxTrigger.module.css
+++ b/packages/components/src/__alpha__/SingleSelect/subcomponents/ComboBoxTrigger/ComboBoxTrigger.module.css
@@ -42,4 +42,19 @@
     padding: 0;
     display: flex;
   }
+
+  .clearButton {
+    background: none;
+    padding: 0;
+    display: flex;
+
+    &:focus-visible {
+      outline: var(--spacing-2) solid var(--color-blue-500);
+      border-radius: 50%;
+    }
+  }
+
+  .hidden {
+    visibility: hidden;
+  }
 }

--- a/packages/components/src/__alpha__/SingleSelect/subcomponents/ComboBoxTrigger/ComboBoxTrigger.tsx
+++ b/packages/components/src/__alpha__/SingleSelect/subcomponents/ComboBoxTrigger/ComboBoxTrigger.tsx
@@ -59,14 +59,14 @@ const DropdownButton = (props: DropdownButtonProps): JSX.Element => {
   const dropdownButton = formatMessage(
     {
       id: 'singleSelect.dropdownButton',
-      defaultMessage: 'Show {field} suggestions',
+      defaultMessage: 'Show suggestions for {field}',
       description: 'Aria label text for the SingleSelect button to open and close suggestions list',
     },
     { field: fieldLabel },
   )
 
   const { buttonProps } = useButton(
-    { ...props, 'aria-label': String(dropdownButton) },
+    { ...props, 'aria-label': String(dropdownButton), 'aria-labelledby': undefined },
     props.buttonRef,
   )
 

--- a/packages/components/src/__alpha__/SingleSelect/subcomponents/ComboBoxTrigger/ComboBoxTrigger.tsx
+++ b/packages/components/src/__alpha__/SingleSelect/subcomponents/ComboBoxTrigger/ComboBoxTrigger.tsx
@@ -3,6 +3,7 @@ import { useIntl } from '@cultureamp/i18n-react-intl'
 import classNames from 'classnames'
 import { useButton } from 'react-aria'
 import { Icon } from '~components/Icon'
+import { VisuallyHidden } from '~components/VisuallyHidden'
 import { useSingleSelectContext } from '../../context'
 import {
   type ClearButtonProps,
@@ -12,25 +13,27 @@ import {
 import styles from './ComboBoxTrigger.module.css'
 
 const ClearButton = ({ clearButtonRef, inputRef }: ClearButtonProps): JSX.Element => {
-  const { state, isComboBox } = useSingleSelectContext()
+  const { state, isComboBox, fieldLabel } = useSingleSelectContext()
 
   const { formatMessage } = useIntl()
 
-  const clearButtonAlt = formatMessage({
-    id: 'singleSelect.clearButtonAlt',
-    defaultMessage: 'Clear selection',
-    description: 'Alt text for the clear selection button',
-  })
+  const clearButtonAlt = formatMessage(
+    {
+      id: 'singleSelect.clearButtonAlt',
+      defaultMessage: 'Clear {field} selection',
+      description: 'Alt text for the clear selection button',
+    },
+    { field: fieldLabel },
+  )
 
   const { buttonProps } = useButton(
     {
-      'onPress': () => {
+      onPress: () => {
         if (isComboBox) {
           state.setSelectedKey(null)
         }
         inputRef.current?.focus()
       },
-      'aria-label': clearButtonAlt,
     },
     clearButtonRef,
   )
@@ -44,6 +47,7 @@ const ClearButton = ({ clearButtonRef, inputRef }: ClearButtonProps): JSX.Elemen
       tabIndex={0}
     >
       <Icon name="cancel" isPresentational isFilled />
+      <VisuallyHidden>{clearButtonAlt}</VisuallyHidden>
     </button>
   )
 }
@@ -51,19 +55,6 @@ const ClearButton = ({ clearButtonRef, inputRef }: ClearButtonProps): JSX.Elemen
 const DropdownButton = (props: DropdownButtonProps): JSX.Element => {
   const { state } = useSingleSelectContext()
   const { buttonProps } = useButton(props, props.buttonRef)
-  const { formatMessage } = useIntl()
-
-  const chevronButtonClose = formatMessage({
-    id: 'singleSelect.toggleButtonClose',
-    defaultMessage: 'close',
-    description: 'Alt text for button that closes list',
-  })
-
-  const chevronButtonOpen = formatMessage({
-    id: 'singleSelect.toggleButtonOpen',
-    defaultMessage: 'open',
-    description: 'Alt text for button that opens list',
-  })
 
   return (
     <button
@@ -73,10 +64,7 @@ const DropdownButton = (props: DropdownButtonProps): JSX.Element => {
       className={styles.button}
       tabIndex={-1}
     >
-      <Icon
-        alt={state.isOpen ? chevronButtonClose : chevronButtonOpen}
-        name={state.isOpen ? 'keyboard_arrow_up' : 'keyboard_arrow_down'}
-      />
+      <Icon isPresentational name={state.isOpen ? 'keyboard_arrow_up' : 'keyboard_arrow_down'} />
     </button>
   )
 }

--- a/packages/components/src/__alpha__/SingleSelect/subcomponents/ComboBoxTrigger/ComboBoxTrigger.tsx
+++ b/packages/components/src/__alpha__/SingleSelect/subcomponents/ComboBoxTrigger/ComboBoxTrigger.tsx
@@ -1,13 +1,71 @@
 import React from 'react'
+import { useIntl } from '@cultureamp/i18n-react-intl'
+import classNames from 'classnames'
 import { useButton } from 'react-aria'
 import { Icon } from '~components/Icon'
 import { useSingleSelectContext } from '../../context'
 import { type ComboBoxTriggerProps, type DropdownButtonProps } from '../../types'
 import styles from './ComboBoxTrigger.module.css'
 
+const ClearButton = ({
+  clearButtonRef,
+  inputRef,
+}: {
+  clearButtonRef: React.RefObject<HTMLButtonElement>
+  inputRef: React.RefObject<HTMLInputElement>
+}): JSX.Element => {
+  const { state, isComboBox } = useSingleSelectContext()
+
+  const { formatMessage } = useIntl()
+
+  const clearButtonAlt = formatMessage({
+    id: 'singleSelect.clearButtonAlt',
+    defaultMessage: 'Clear selection',
+    description: 'Alt text for the clear selection button',
+  })
+
+  const { buttonProps } = useButton(
+    {
+      'onPress': () => {
+        if (isComboBox) {
+          state.setSelectedKey(null)
+        }
+        inputRef.current?.focus()
+      },
+      'aria-label': clearButtonAlt,
+    },
+    clearButtonRef,
+  )
+
+  return (
+    <button
+      {...buttonProps}
+      ref={clearButtonRef}
+      type="button"
+      className={classNames(styles.clearButton, { [styles.hidden]: !state.selectedKey })}
+      tabIndex={0}
+    >
+      <Icon name="cancel" isPresentational isFilled />
+    </button>
+  )
+}
+
 const DropdownButton = (props: DropdownButtonProps): JSX.Element => {
   const { state } = useSingleSelectContext()
   const { buttonProps } = useButton(props, props.buttonRef)
+  const { formatMessage } = useIntl()
+
+  const chevronButtonClose = formatMessage({
+    id: 'singleSelect.toggleButtonClose',
+    defaultMessage: 'close',
+    description: 'Alt text for button that closes list',
+  })
+
+  const chevronButtonOpen = formatMessage({
+    id: 'singleSelect.toggleButtonOpen',
+    defaultMessage: 'open',
+    description: 'Alt text for button that opens list',
+  })
 
   return (
     <button
@@ -18,7 +76,7 @@ const DropdownButton = (props: DropdownButtonProps): JSX.Element => {
       tabIndex={-1}
     >
       <Icon
-        alt={state.isOpen ? 'close' : 'open'}
+        alt={state.isOpen ? chevronButtonClose : chevronButtonOpen}
         name={state.isOpen ? 'keyboard_arrow_up' : 'keyboard_arrow_down'}
       />
     </button>
@@ -30,12 +88,14 @@ export const ComboBoxTrigger = ({
   inputRef,
   buttonProps,
   buttonRef,
+  clearButtonRef,
 }: ComboBoxTriggerProps): JSX.Element => {
   const { anchorName } = useSingleSelectContext()
 
   return (
     <div style={{ '--anchor-name': anchorName } as React.CSSProperties} className={styles.trigger}>
       <input {...inputProps} ref={inputRef} className={styles.input} />
+      <ClearButton clearButtonRef={clearButtonRef} inputRef={inputRef} />
       <DropdownButton {...buttonProps} buttonRef={buttonRef} />
     </div>
   )

--- a/packages/components/src/__alpha__/SingleSelect/subcomponents/ComboBoxTrigger/ComboBoxTrigger.tsx
+++ b/packages/components/src/__alpha__/SingleSelect/subcomponents/ComboBoxTrigger/ComboBoxTrigger.tsx
@@ -4,16 +4,14 @@ import classNames from 'classnames'
 import { useButton } from 'react-aria'
 import { Icon } from '~components/Icon'
 import { useSingleSelectContext } from '../../context'
-import { type ComboBoxTriggerProps, type DropdownButtonProps } from '../../types'
+import {
+  type ClearButtonProps,
+  type ComboBoxTriggerProps,
+  type DropdownButtonProps,
+} from '../../types'
 import styles from './ComboBoxTrigger.module.css'
 
-const ClearButton = ({
-  clearButtonRef,
-  inputRef,
-}: {
-  clearButtonRef: React.RefObject<HTMLButtonElement>
-  inputRef: React.RefObject<HTMLInputElement>
-}): JSX.Element => {
+const ClearButton = ({ clearButtonRef, inputRef }: ClearButtonProps): JSX.Element => {
   const { state, isComboBox } = useSingleSelectContext()
 
   const { formatMessage } = useIntl()

--- a/packages/components/src/__alpha__/SingleSelect/subcomponents/ComboBoxTrigger/ComboBoxTrigger.tsx
+++ b/packages/components/src/__alpha__/SingleSelect/subcomponents/ComboBoxTrigger/ComboBoxTrigger.tsx
@@ -53,8 +53,22 @@ const ClearButton = ({ clearButtonRef, inputRef }: ClearButtonProps): JSX.Elemen
 }
 
 const DropdownButton = (props: DropdownButtonProps): JSX.Element => {
-  const { state } = useSingleSelectContext()
-  const { buttonProps } = useButton(props, props.buttonRef)
+  const { state, fieldLabel } = useSingleSelectContext()
+  const { formatMessage } = useIntl()
+
+  const dropdownButton = formatMessage(
+    {
+      id: 'singleSelect.dropdownButton',
+      defaultMessage: 'Show {field} suggestions',
+      description: 'Aria label text for the SingleSelect button to open and close suggestions list',
+    },
+    { field: fieldLabel },
+  )
+
+  const { buttonProps } = useButton(
+    { ...props, 'aria-label': String(dropdownButton) },
+    props.buttonRef,
+  )
 
   return (
     <button

--- a/packages/components/src/__alpha__/SingleSelect/subcomponents/Popover/Popover.tsx
+++ b/packages/components/src/__alpha__/SingleSelect/subcomponents/Popover/Popover.tsx
@@ -10,6 +10,7 @@ export const Popover = <T extends SelectItem>({
   state,
   popoverRef,
   children,
+  clearButtonRef,
   ...restProps
 }: PopoverProps<T>): React.ReactElement => {
   const { anchorName } = useSingleSelectContext()
@@ -19,6 +20,12 @@ export const Popover = <T extends SelectItem>({
     {
       ...restProps,
       popoverRef,
+      shouldCloseOnInteractOutside: (element) => {
+        if (clearButtonRef?.current?.contains(element)) {
+          return false
+        }
+        return true
+      },
     },
     state,
   )

--- a/packages/components/src/__alpha__/SingleSelect/subcomponents/Select.tsx
+++ b/packages/components/src/__alpha__/SingleSelect/subcomponents/Select.tsx
@@ -37,6 +37,7 @@ export const Select = <T extends SelectItem>(props: SelectProps<T>): JSX.Element
         anchorName,
         state,
         isComboBox: false,
+        fieldLabel: label,
       }}
     >
       <div style={{ display: 'inline-block' }}>

--- a/packages/components/src/__alpha__/SingleSelect/types.ts
+++ b/packages/components/src/__alpha__/SingleSelect/types.ts
@@ -47,6 +47,11 @@ export type DropdownButtonProps = AriaButtonProps<'button'> & {
   buttonRef: React.MutableRefObject<HTMLButtonElement | null>
 }
 
+export type ClearButtonProps = {
+  clearButtonRef: React.RefObject<HTMLButtonElement>
+  inputRef: React.RefObject<HTMLInputElement>
+}
+
 // Popover
 
 export type PopoverProps<T extends SelectItem> = AriaPopoverProps & {

--- a/packages/components/src/__alpha__/SingleSelect/types.ts
+++ b/packages/components/src/__alpha__/SingleSelect/types.ts
@@ -40,6 +40,7 @@ export type ComboBoxTriggerProps = {
   inputRef: React.MutableRefObject<HTMLInputElement | null>
   buttonProps: AriaButtonProps<'button'>
   buttonRef: React.MutableRefObject<HTMLButtonElement | null>
+  clearButtonRef: React.MutableRefObject<HTMLButtonElement | null>
 }
 
 export type DropdownButtonProps = AriaButtonProps<'button'> & {


### PR DESCRIPTION
## What

Added a `ClearButton` to the combobox - which clears the selected state of the input
The button is only seen once an item has been selected
Clicking the button will clear the selection
The `ClearButton` is accessible via keyboard and can be tabbed to. Once the button is interacted with focus is moved back to the input

Item Selected
<img width="303" height="87" alt="Screenshot 2025-09-12 at 8 13 43 am" src="https://github.com/user-attachments/assets/90bd78d9-1a54-416c-b241-ffdf87cf0ce8" />

ClearButton focused
<img width="297" height="107" alt="Screenshot 2025-09-12 at 8 13 52 am" src="https://github.com/user-attachments/assets/8426c5f5-ee16-481b-a29a-2ae79a250ecb" />
