### PR TITLE
[KZN-3416] Fix popover regressions

### DIFF
--- a/packages/components/src/__alpha__/SingleSelect/subcomponents/ComboBox.tsx
+++ b/packages/components/src/__alpha__/SingleSelect/subcomponents/ComboBox.tsx
@@ -24,6 +24,7 @@ export const ComboBox = <T extends SelectItem>(props: ComboBoxProps<T>): JSX.Ele
   const popoverRef = useRef<HTMLDivElement>(null)
   const listBoxRef = useRef<HTMLUListElement>(null)
   const buttonRef = useRef<HTMLButtonElement>(null)
+  const triggerWrapperRef = useRef<HTMLDivElement>(null)
 
   const { labelProps, inputProps, listBoxProps, buttonProps } = useComboBox(
     {
@@ -57,10 +58,11 @@ export const ComboBox = <T extends SelectItem>(props: ComboBoxProps<T>): JSX.Ele
             inputRef={inputRef}
             buttonRef={buttonRef}
             buttonProps={buttonProps}
+            triggerWrapperRef={triggerWrapperRef}
           />
         </div>
 
-        <Popover state={state} triggerRef={inputRef} popoverRef={popoverRef}>
+        <Popover state={state} triggerRef={triggerWrapperRef} popoverRef={popoverRef}>
           <List listBoxOptions={listBoxProps} state={state} listBoxRef={listBoxRef} />
         </Popover>
       </div>

--- a/packages/components/src/__alpha__/SingleSelect/subcomponents/ComboBoxTrigger/ComboBoxTrigger.tsx
+++ b/packages/components/src/__alpha__/SingleSelect/subcomponents/ComboBoxTrigger/ComboBoxTrigger.tsx
@@ -30,11 +30,16 @@ export const ComboBoxTrigger = ({
   inputRef,
   buttonProps,
   buttonRef,
+  triggerWrapperRef,
 }: ComboBoxTriggerProps): JSX.Element => {
   const { anchorName } = useSingleSelectContext()
 
   return (
-    <div style={{ '--anchor-name': anchorName } as React.CSSProperties} className={styles.trigger}>
+    <div
+      style={{ '--anchor-name': anchorName } as React.CSSProperties}
+      className={styles.trigger}
+      ref={triggerWrapperRef}
+    >
       <input {...inputProps} ref={inputRef} className={styles.input} />
       <DropdownButton {...buttonProps} buttonRef={buttonRef} />
     </div>

--- a/packages/components/src/__alpha__/SingleSelect/subcomponents/Popover/Popover.tsx
+++ b/packages/components/src/__alpha__/SingleSelect/subcomponents/Popover/Popover.tsx
@@ -38,24 +38,32 @@ export const Popover = <T extends SelectItem>({
   )
 
   useLayoutEffect(() => {
-    if (!supportsAnchorPositioning) return
-    if (!state.isOpen) return
+    if (!supportsAnchorPositioning || !state.isOpen) return
 
     updatePosition()
-  }, [updatePosition, supportsAnchorPositioning, state.isOpen])
-
-  useLayoutEffect(() => {
-    if (!supportsAnchorPositioning) return
 
     const popover = manualPopoverRef?.current
-    if (!popover?.showPopover || !popover?.hidePopover) return
 
-    if (state.isOpen) {
+    if (popover?.showPopover) {
       popover.showPopover()
-    } else {
+    }
+
+    return () => {
+      if (popover?.hidePopover) {
+        popover.hidePopover()
+      }
+    }
+  }, [state.isOpen, supportsAnchorPositioning, updatePosition, isPositioned])
+
+  useLayoutEffect(() => {
+    if (!supportsAnchorPositioning || state.isOpen) return
+
+    const popover = manualPopoverRef?.current
+
+    if (popover?.hidePopover) {
       popover.hidePopover()
     }
-  }, [supportsAnchorPositioning, state.isOpen, isPositioned])
+  }, [state.isOpen, supportsAnchorPositioning])
 
   const manualPopover = (
     <div

--- a/packages/components/src/__alpha__/SingleSelect/subcomponents/Popover/Popover.tsx
+++ b/packages/components/src/__alpha__/SingleSelect/subcomponents/Popover/Popover.tsx
@@ -24,11 +24,18 @@ export const Popover = <T extends SelectItem>({
   )
 
   const supportsAnchorPositioning = useSupportsAnchorPositioning()
-  const { popoverStyle, isPositioned } = usePositioningStyles(
+  const { popoverStyle, isPositioned, updatePosition } = usePositioningStyles(
     restProps.triggerRef as React.RefObject<HTMLElement>,
     manualPopoverRef,
     anchorName,
   )
+
+  useLayoutEffect(() => {
+    if (!supportsAnchorPositioning) return
+    if (!state.isOpen) return
+
+    updatePosition()
+  }, [updatePosition, supportsAnchorPositioning, state.isOpen])
 
   useLayoutEffect(() => {
     if (!supportsAnchorPositioning) return

--- a/packages/components/src/__alpha__/SingleSelect/subcomponents/Popover/utils/usePopoverPositioning.ts
+++ b/packages/components/src/__alpha__/SingleSelect/subcomponents/Popover/utils/usePopoverPositioning.ts
@@ -11,7 +11,7 @@ export function usePopoverPositioning({
   direction = 'ltr',
   offset = 4,
   preferredPlacement = 'bottom',
-}: UsePopoverPositioningProps): Position & { isPositioned: boolean } {
+}: UsePopoverPositioningProps): Position & { isPositioned: boolean; updatePosition: () => void } {
   const [position, setPosition] = useState<Position>({
     top: preferredPlacement === 'bottom' ? offset : 'auto',
     bottom: preferredPlacement === 'top' ? offset : 'auto',
@@ -104,5 +104,5 @@ export function usePopoverPositioning({
     }
   }, [updatePosition, triggerRef])
 
-  return { ...position, isPositioned }
+  return { ...position, isPositioned, updatePosition }
 }

--- a/packages/components/src/__alpha__/SingleSelect/subcomponents/Popover/utils/usePositioningStyles.ts
+++ b/packages/components/src/__alpha__/SingleSelect/subcomponents/Popover/utils/usePositioningStyles.ts
@@ -42,16 +42,17 @@ export const usePositioningStyles = (
   buttonRef: React.RefObject<HTMLElement>,
   popoverRef: React.RefObject<HTMLDivElement>,
   anchorName: string,
-): { popoverStyle: React.CSSProperties; isPositioned: boolean } => {
+): { popoverStyle: React.CSSProperties; isPositioned: boolean; updatePosition: () => void } => {
   const { direction } = useLocale()
   const hasAnchorSupport = useSupportsAnchorPositioning()
 
-  const { top, bottom, insetInlineStart, maxHeight, isPositioned } = usePopoverPositioning({
-    triggerRef: buttonRef,
-    popoverRef,
-    direction,
-    preferredPlacement: 'bottom',
-  })
+  const { top, bottom, insetInlineStart, maxHeight, isPositioned, updatePosition } =
+    usePopoverPositioning({
+      triggerRef: buttonRef,
+      popoverRef,
+      direction,
+      preferredPlacement: 'bottom',
+    })
 
   const positionData = useMemo(
     () => ({
@@ -71,5 +72,5 @@ export const usePositioningStyles = (
     return getAnchorPositioningStyles(anchorName, positionData)
   }, [hasAnchorSupport, anchorName, positionData])
 
-  return { popoverStyle, isPositioned }
+  return { popoverStyle, isPositioned, updatePosition }
 }

--- a/packages/components/src/__alpha__/SingleSelect/types.ts
+++ b/packages/components/src/__alpha__/SingleSelect/types.ts
@@ -40,6 +40,7 @@ export type ComboBoxTriggerProps = {
   inputRef: React.MutableRefObject<HTMLInputElement | null>
   buttonProps: AriaButtonProps<'button'>
   buttonRef: React.MutableRefObject<HTMLButtonElement | null>
+  triggerWrapperRef: React.MutableRefObject<HTMLDivElement | null>
 }
 
 export type DropdownButtonProps = AriaButtonProps<'button'> & {
@@ -50,7 +51,7 @@ export type DropdownButtonProps = AriaButtonProps<'button'> & {
 
 export type PopoverProps<T extends SelectItem> = AriaPopoverProps & {
   state: ComboBoxState<T> | SelectState<T>
-  triggerRef: React.RefObject<HTMLInputElement> | React.RefObject<HTMLButtonElement>
+  triggerRef: React.RefObject<HTMLElement>
   popoverRef: React.RefObject<HTMLDivElement>
   clearButtonRef?: React.RefObject<HTMLButtonElement>
   children: React.ReactNode


### PR DESCRIPTION
## Why

Recent work done to refactor the alpha `SingleSelect` to manage state instead of using components caused 2 regressions in the popover component. 

1. The popover itself was rendering before all the items loaded - causing the list to render on the bottom even in situations where it would be cutoff.

<img width="273" height="226" alt="Screenshot 2025-09-12 at 8 40 38 am" src="https://github.com/user-attachments/assets/7297ef84-69fa-49c7-a5d9-08b03db93b58" />

2. Combobox was not rendering correctly: because the inputRef was being passed to the popover instead of the triggerWrapper 


## What

This PR fixes both of these regressions. Calling the updatePosition once the popover has rendered, and passing the correct wrapper ref to the popover for the combobox
