### PR TITLE
[KZN-3556] Inline notification: hideCloseIcon 

### DIFF
--- a/.changeset/spicy-carpets-laugh.md
+++ b/.changeset/spicy-carpets-laugh.md
@@ -1,0 +1,5 @@
+---
+'@kaizen/components': patch
+---
+
+Fixes InlineNotification bug with hideCloseIcon

--- a/packages/components/src/Notification/InlineNotification/InlineNotification.tsx
+++ b/packages/components/src/Notification/InlineNotification/InlineNotification.tsx
@@ -35,7 +35,7 @@ export const InlineNotification = forwardRef<HTMLDivElement, InlineNotificationP
   ): JSX.Element => (
     <GenericNotification
       style="inline"
-      persistent={persistent ?? hideCloseIcon}
+      persistent={persistent || hideCloseIcon}
       classNameOverride={classnames(classNameOverride, [isSubtle && styles.subtle])}
       ref={ref}
       {...otherProps}


### PR DESCRIPTION
## Why
https://cultureamp.slack.com/archives/C0189KBPM4Y/p1758088320927829
A bug was raised around `InlineNotification` and the `hideCloseIcon` not working as intended. When `hideCloseIcon="true"` was passed the icon was still shown

## What

Replaced the `??` nullish coalescing operator with the `||` logical or operator, so that the `hideCloseIcon` would be passed correctly. The `persistent` prop was being passed with a default of false, meaning that with the `??` operator the `hideCloseIcon` would never be passed. 

Before
<img width="1001" height="439" alt="Screenshot 2025-09-18 at 8 10 17 am" src="https://github.com/user-attachments/assets/aca15757-01ca-40b4-975a-636305519a72" />

After
<img width="1012" height="422" alt="Screenshot 2025-09-18 at 8 09 53 am" src="https://github.com/user-attachments/assets/716007ff-3a56-45fa-aa8a-028893454227" />
