### PR TITLE
feat: patch rollup-plugin-postcss to handle multiple inputs determini…

### DIFF
--- a/.changeset/fine-parrots-return.md
+++ b/.changeset/fine-parrots-return.md
@@ -1,0 +1,5 @@
+---
+'@kaizen/components': patch
+---
+
+CSS ordering fix - Patch rollup-plugin-postcss to handle multi inputs correctly

--- a/package.json
+++ b/package.json
@@ -125,6 +125,9 @@
     },
     "overrides": {
       "@storybook/icons": "1.4.0"
+    },
+    "patchedDependencies": {
+      "rollup-plugin-postcss@4.0.2": "patches/rollup-plugin-postcss@4.0.2.patch"
     }
   }
 }

--- a/patches/rollup-plugin-postcss@4.0.2.patch
+++ b/patches/rollup-plugin-postcss@4.0.2.patch
@@ -1,0 +1,66 @@
+diff --git a/dist/index.js b/dist/index.js
+index 8ca4cf35ac17b3874f116a5620c6816854311099..6d1e83ad379c9bb18351f36ca4e61d0642bdf4a2 100644
+--- a/dist/index.js
++++ b/dist/index.js
+@@ -765,13 +765,19 @@ function inferOption(option, defaultValue) {
+  * Recursively get the correct import order from rollup
+  * We only process a file once
+  *
+- * @param {string} id
++ * @param {Array<string>} ids
+  * @param {Function} getModuleInfo
+  * @param {Set<string>} seen
+  */
+ 
+ 
+-function getRecursiveImportOrder(id, getModuleInfo, seen = new Set()) {
++function getRecursiveImportOrder(ids, getModuleInfo, seen = new Set()) {
++  return ids.flatMap(id => {
++    return getRecursiveImportOrderForModule(id, getModuleInfo, seen);
++  });
++}
++
++function getRecursiveImportOrderForModule(id, getModuleInfo, seen = new Set()) {
+   if (seen.has(id)) {
+     return [];
+   }
+@@ -779,7 +785,7 @@ function getRecursiveImportOrder(id, getModuleInfo, seen = new Set()) {
+   seen.add(id);
+   const result = [id];
+   getModuleInfo(id).importedIds.forEach(importFile => {
+-    result.push(...getRecursiveImportOrder(importFile, getModuleInfo, seen));
++    result.push(...getRecursiveImportOrderForModule(importFile, getModuleInfo, seen));
+   });
+   return result;
+ }
+@@ -917,6 +923,7 @@ var index = ((options = {}) => {
+ 
+         const dir = options_.dir || path__default['default'].dirname(options_.file);
+         const file = options_.file || path__default['default'].join(options_.dir, Object.keys(bundle).find(fileName => bundle[fileName].isEntry));
++        const entryFiles = options_.file ? [options_.file] : Object.keys(bundle).filter(fileName => bundle[fileName].isEntry).map(fileName => path__default['default'].join(options_.dir, fileName));
+ 
+         const getExtracted = () => {
+           let fileName = `${path__default['default'].basename(file, path__default['default'].extname(file))}.css`;
+@@ -927,12 +934,16 @@ var index = ((options = {}) => {
+ 
+           const concat = new Concat__default['default'](true, fileName, '\n');
+           const entries = [...extracted.values()];
+-          const _bundle$normalizePath = bundle[normalizePath(path__default['default'].relative(dir, file))],
+-                modules = _bundle$normalizePath.modules,
+-                facadeModuleId = _bundle$normalizePath.facadeModuleId;
+-
+-          if (modules) {
+-            const moduleIds = getRecursiveImportOrder(facadeModuleId, _this2.getModuleInfo);
++          const facadeModuleIds = entryFiles.map(entryFile => {
++            const _bundle$normalizePath = bundle[normalizePath(path__default['default'].relative(dir, entryFile))],
++                  modules = _bundle$normalizePath.modules,
++                  facadeModuleId = _bundle$normalizePath.facadeModuleId;
++            if (modules) return facadeModuleId;
++            return false;
++          }).filter(n => n);
++
++          if (facadeModuleIds.length > 0) {
++            const moduleIds = getRecursiveImportOrder(facadeModuleIds, _this2.getModuleInfo);
+             entries.sort((a, b) => moduleIds.indexOf(a.id) - moduleIds.indexOf(b.id));
+           }
+ 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,11 @@ settings:
 overrides:
   '@storybook/icons': 1.4.0
 
+patchedDependencies:
+  rollup-plugin-postcss@4.0.2:
+    hash: mgchv4wdy47o33wyddtx4ix2ey
+    path: patches/rollup-plugin-postcss@4.0.2.patch
+
 importers:
 
   .:
@@ -1227,6 +1232,11 @@ packages:
       '@cultureamp/next-head-hook': '>=1 || ~0.0.0'
       next: '>=13.5.0'
       react: '>=16.14.0'
+    peerDependenciesMeta:
+      '@cultureamp/next-head-hook':
+        optional: true
+      next:
+        optional: true
 
   '@cultureamp/frontend-env@2.1.4':
     resolution: {integrity: sha512-L0vTlxa7Fvlr04T0tRmIhNovWanofAGcH4ZKM9PMtIzzKbdQdH9WzVJMRfxDmYAecQpRW98igBGC85pdt2BaCQ==, tarball: https://npm.pkg.github.com/download/@cultureamp/frontend-env/2.1.4/d6905082c185f2f4a932b1a16431b599156ee76f}
@@ -1238,6 +1248,9 @@ packages:
       '@cultureamp/frontend-apis': '>=13 || ~0.0.0'
       next: '>=13.5.0'
       react: ^18.3.1 || ^19.0.0
+    peerDependenciesMeta:
+      next:
+        optional: true
 
   '@cultureamp/next-head-hook@1.1.11':
     resolution: {integrity: sha512-FyaCA3oKHnxZ+pPHcPTCDoRCG4/1y0W16U1O5eyTgSxjuJfWTui3vz65MNvNxlJ20+DZ8BXmV3M0y93t/Fubog==, tarball: https://npm.pkg.github.com/download/@cultureamp/next-head-hook/1.1.11/5444465f7d6ce0d79ba33d60180245ed245956ad}
@@ -1254,6 +1267,9 @@ packages:
       ts-patch: ^3.3.0
       tslib: '>=2.6.2'
       typescript: 5.8.3
+    peerDependenciesMeta:
+      ts-patch:
+        optional: true
 
   '@cultureamp/redirect-to-login@2.0.3':
     resolution: {integrity: sha512-OFJffYRJbB3e0LO3daRZuP7dMhvpQbmiQNu/lnlWWqi5YCCdAgjoozC7feQFqwDBbtPcTHxt4qcJ8Do3RbRs5Q==, tarball: https://npm.pkg.github.com/download/@cultureamp/redirect-to-login/2.0.3/26afa69493a04cb23a5333dccf5b922afd4a333c}
@@ -11207,7 +11223,6 @@ snapshots:
   '@cultureamp/frontend-apis@13.3.0(@cultureamp/next-head-hook@1.1.11(next@15.2.5(@babel/core@7.28.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.79.6)))(next@15.2.5(@babel/core@7.28.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.79.6))(react@19.1.0)(typescript@5.8.3)':
     dependencies:
       '@cultureamp/frontend-env': 2.1.4
-      '@cultureamp/next-head-hook': 1.1.11(next@15.2.5(@babel/core@7.28.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.79.6))
       '@cultureamp/redirect-to-login': 2.0.3
       '@readme/openapi-parser': 2.7.0(openapi-types@12.1.3)
       '@tanstack/react-query': 5.76.2(react@19.1.0)
@@ -11222,7 +11237,6 @@ snapshots:
       js-yaml: 4.1.0
       jsrsasign: 11.1.0
       msw: 2.2.14(typescript@5.8.3)
-      next: 15.2.5(@babel/core@7.28.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.79.6)
       openapi-types: 12.1.3
       openapi-typescript: 6.7.6
       react: 19.1.0
@@ -11231,6 +11245,9 @@ snapshots:
       url-parse: 1.5.10
       uuid: 9.0.1
       yargs: 17.7.2
+    optionalDependencies:
+      '@cultureamp/next-head-hook': 1.1.11(next@15.2.5(@babel/core@7.28.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.79.6))
+      next: 15.2.5(@babel/core@7.28.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.79.6)
     transitivePeerDependencies:
       - '@chromatic-com/cypress'
       - '@chromatic-com/playwright'
@@ -11256,11 +11273,12 @@ snapshots:
       isomorphic-resolve: 1.0.0
       json-stable-stringify: 1.2.1
       limiter-es6-compat: 2.1.2
-      next: 15.2.5(@babel/core@7.28.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.79.6)
       react: 19.1.0
       react-intl: 7.1.11(react@19.1.0)(typescript@5.8.3)
       smartling-api-sdk-nodejs: 2.11.0(encoding@0.1.13)
       yargs: 17.7.2
+    optionalDependencies:
+      next: 15.2.5(@babel/core@7.28.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.79.6)
     transitivePeerDependencies:
       - '@glimmer/env'
       - '@glimmer/reference'
@@ -11280,6 +11298,7 @@ snapshots:
     dependencies:
       next: 15.2.5(@babel/core@7.28.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.79.6)
       react: 18.3.1
+    optional: true
 
   '@cultureamp/package-bundler@2.3.2(@babel/core@7.28.0)(@types/babel__core@7.20.5)(postcss-preset-env@10.2.4(postcss@8.5.6))(postcss@8.5.6)(rollup@4.46.2)(ts-node@10.9.2(@swc/core@1.7.10(@swc/helpers@0.5.15))(@types/node@22.15.21)(typescript@5.8.3))(ts-patch@3.3.0)(tslib@2.8.1)(typescript@5.8.3)':
     dependencies:
@@ -11297,11 +11316,12 @@ snapshots:
       rollup: 4.46.2
       rollup-plugin-ignore: 1.0.10
       rollup-plugin-node-externals: 8.0.0(rollup@4.46.2)
-      rollup-plugin-postcss: 4.0.2(postcss@8.5.6)(ts-node@10.9.2(@swc/core@1.7.10(@swc/helpers@0.5.15))(@types/node@22.15.21)(typescript@5.8.3))
-      ts-patch: 3.3.0
+      rollup-plugin-postcss: 4.0.2(patch_hash=mgchv4wdy47o33wyddtx4ix2ey)(postcss@8.5.6)(ts-node@10.9.2(@swc/core@1.7.10(@swc/helpers@0.5.15))(@types/node@22.15.21)(typescript@5.8.3))
       tslib: 2.8.1
       typescript: 5.8.3
       typescript-transform-paths: 3.5.5(typescript@5.8.3)
+    optionalDependencies:
+      ts-patch: 3.3.0
     transitivePeerDependencies:
       - '@babel/core'
       - '@types/babel__core'
@@ -11324,11 +11344,12 @@ snapshots:
       rollup: 4.46.2
       rollup-plugin-ignore: 1.0.10
       rollup-plugin-node-externals: 8.0.0(rollup@4.46.2)
-      rollup-plugin-postcss: 4.0.2(postcss@8.5.6)(ts-node@10.9.2(@swc/core@1.7.10(@swc/helpers@0.5.15))(@types/node@22.15.21)(typescript@5.9.2))
-      ts-patch: 3.3.0
+      rollup-plugin-postcss: 4.0.2(patch_hash=mgchv4wdy47o33wyddtx4ix2ey)(postcss@8.5.6)(ts-node@10.9.2(@swc/core@1.7.10(@swc/helpers@0.5.15))(@types/node@22.15.21)(typescript@5.9.2))
       tslib: 2.8.1
       typescript: 5.9.2
       typescript-transform-paths: 3.5.5(typescript@5.9.2)
+    optionalDependencies:
+      ts-patch: 3.3.0
     transitivePeerDependencies:
       - '@babel/core'
       - '@types/babel__core'
@@ -12139,7 +12160,8 @@ snapshots:
       '@tybys/wasm-util': 0.9.0
     optional: true
 
-  '@next/env@15.2.5': {}
+  '@next/env@15.2.5':
+    optional: true
 
   '@next/swc-darwin-arm64@15.2.5':
     optional: true
@@ -15210,6 +15232,7 @@ snapshots:
   busboy@1.6.0:
     dependencies:
       streamsearch: 1.1.0
+    optional: true
 
   cac@6.7.14: {}
 
@@ -16448,7 +16471,7 @@ snapshots:
       - bluebird
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.38.0(eslint@9.18.0(jiti@1.21.6))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@4.4.4(eslint-plugin-import@2.32.0)(eslint@9.18.0(jiti@1.21.6)))(eslint@9.18.0(jiti@1.21.6)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.38.0(eslint@9.18.0(jiti@1.21.6))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@4.4.4)(eslint@9.18.0(jiti@1.21.6)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -16488,7 +16511,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.18.0(jiti@1.21.6)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.38.0(eslint@9.18.0(jiti@1.21.6))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@4.4.4(eslint-plugin-import@2.32.0)(eslint@9.18.0(jiti@1.21.6)))(eslint@9.18.0(jiti@1.21.6))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.38.0(eslint@9.18.0(jiti@1.21.6))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@4.4.4)(eslint@9.18.0(jiti@1.21.6))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -19063,6 +19086,7 @@ snapshots:
     transitivePeerDependencies:
       - '@babel/core'
       - babel-plugin-macros
+    optional: true
 
   no-case@3.0.4:
     dependencies:
@@ -20126,6 +20150,7 @@ snapshots:
       nanoid: 3.3.11
       picocolors: 1.1.1
       source-map-js: 1.2.1
+    optional: true
 
   postcss@8.4.49:
     dependencies:
@@ -20590,6 +20615,7 @@ snapshots:
   react@18.3.1:
     dependencies:
       loose-envify: 1.4.0
+    optional: true
 
   react@19.1.0: {}
 
@@ -20785,7 +20811,7 @@ snapshots:
     dependencies:
       rollup: 4.46.2
 
-  rollup-plugin-postcss@4.0.2(postcss@8.5.6)(ts-node@10.9.2(@swc/core@1.7.10(@swc/helpers@0.5.15))(@types/node@22.15.21)(typescript@5.8.3)):
+  rollup-plugin-postcss@4.0.2(patch_hash=mgchv4wdy47o33wyddtx4ix2ey)(postcss@8.5.6)(ts-node@10.9.2(@swc/core@1.7.10(@swc/helpers@0.5.15))(@types/node@22.15.21)(typescript@5.8.3)):
     dependencies:
       chalk: 4.1.2
       concat-with-sourcemaps: 1.1.0
@@ -20804,7 +20830,7 @@ snapshots:
     transitivePeerDependencies:
       - ts-node
 
-  rollup-plugin-postcss@4.0.2(postcss@8.5.6)(ts-node@10.9.2(@swc/core@1.7.10(@swc/helpers@0.5.15))(@types/node@22.15.21)(typescript@5.9.2)):
+  rollup-plugin-postcss@4.0.2(patch_hash=mgchv4wdy47o33wyddtx4ix2ey)(postcss@8.5.6)(ts-node@10.9.2(@swc/core@1.7.10(@swc/helpers@0.5.15))(@types/node@22.15.21)(typescript@5.9.2)):
     dependencies:
       chalk: 4.1.2
       concat-with-sourcemaps: 1.1.0
@@ -21226,7 +21252,8 @@ snapshots:
       readable-stream: 3.6.2
       xtend: 4.0.2
 
-  streamsearch@1.1.0: {}
+  streamsearch@1.1.0:
+    optional: true
 
   strict-event-emitter@0.5.1: {}
 
@@ -21380,6 +21407,7 @@ snapshots:
       react: 19.1.0
     optionalDependencies:
       '@babel/core': 7.28.0
+    optional: true
 
   stylehacks@5.1.1(postcss@8.5.6):
     dependencies:


### PR DESCRIPTION
## Why

Our css order seems random and not deterministic usually it's fine but sometimes it's not and it breaks our consumers and css specificity

## What

We need to patch rollup-plugin-postcss to be aware of multi inputs within the rollup config otherwise it doesn't place the css in the right order.

Tried this on a few internal projects and am getting correct results.
