### PR TITLE
CSS ordering fix - Patch rollup-plugin-postess to handle multi inputs…

### DIFF
--- a/.changeset/flat-books-sink.md
+++ b/.changeset/flat-books-sink.md
@@ -1,0 +1,5 @@
+---
+'@kaizen/components': patch
+---
+
+CSS ordering fix - Patch rollup-plugin-postcss to handle multi inputs correctly

--- a/package.json
+++ b/package.json
@@ -125,6 +125,9 @@
     },
     "overrides": {
       "@storybook/icons": "1.4.0"
+    },
+    "patchedDependencies": {
+      "rollup-plugin-postcss": "patches/rollup-plugin-postcss.patch"
     }
   }
 }

--- a/patches/rollup-plugin-postcss.patch
+++ b/patches/rollup-plugin-postcss.patch
@@ -1,0 +1,66 @@
+diff --git a/dist/index.js b/dist/index.js
+index 8ca4cf35ac17b3874f116a5620c6816854311099..6d1e83ad379c9bb18351f36ca4e61d0642bdf4a2 100644
+--- a/dist/index.js
++++ b/dist/index.js
+@@ -765,13 +765,19 @@ function inferOption(option, defaultValue) {
+  * Recursively get the correct import order from rollup
+  * We only process a file once
+  *
+- * @param {string} id
++ * @param {Array<string>} ids
+  * @param {Function} getModuleInfo
+  * @param {Set<string>} seen
+  */
+ 
+ 
+-function getRecursiveImportOrder(id, getModuleInfo, seen = new Set()) {
++function getRecursiveImportOrder(ids, getModuleInfo, seen = new Set()) {
++  return ids.flatMap(id => {
++    return getRecursiveImportOrderForModule(id, getModuleInfo, seen);
++  });
++}
++
++function getRecursiveImportOrderForModule(id, getModuleInfo, seen = new Set()) {
+   if (seen.has(id)) {
+     return [];
+   }
+@@ -779,7 +785,7 @@ function getRecursiveImportOrder(id, getModuleInfo, seen = new Set()) {
+   seen.add(id);
+   const result = [id];
+   getModuleInfo(id).importedIds.forEach(importFile => {
+-    result.push(...getRecursiveImportOrder(importFile, getModuleInfo, seen));
++    result.push(...getRecursiveImportOrderForModule(importFile, getModuleInfo, seen));
+   });
+   return result;
+ }
+@@ -917,6 +923,7 @@ var index = ((options = {}) => {
+ 
+         const dir = options_.dir || path__default['default'].dirname(options_.file);
+         const file = options_.file || path__default['default'].join(options_.dir, Object.keys(bundle).find(fileName => bundle[fileName].isEntry));
++        const entryFiles = options_.file ? [options_.file] : Object.keys(bundle).filter(fileName => bundle[fileName].isEntry).map(fileName => path__default['default'].join(options_.dir, fileName));
+ 
+         const getExtracted = () => {
+           let fileName = `${path__default['default'].basename(file, path__default['default'].extname(file))}.css`;
+@@ -927,12 +934,16 @@ var index = ((options = {}) => {
+ 
+           const concat = new Concat__default['default'](true, fileName, '\n');
+           const entries = [...extracted.values()];
+-          const _bundle$normalizePath = bundle[normalizePath(path__default['default'].relative(dir, file))],
+-                modules = _bundle$normalizePath.modules,
+-                facadeModuleId = _bundle$normalizePath.facadeModuleId;
+-
+-          if (modules) {
+-            const moduleIds = getRecursiveImportOrder(facadeModuleId, _this2.getModuleInfo);
++          const facadeModuleIds = entryFiles.map(entryFile => {
++            const _bundle$normalizePath = bundle[normalizePath(path__default['default'].relative(dir, entryFile))],
++                  modules = _bundle$normalizePath.modules,
++                  facadeModuleId = _bundle$normalizePath.facadeModuleId;
++            if (modules) return facadeModuleId;
++            return false;
++          }).filter(n => n);
++
++          if (facadeModuleIds.length > 0) {
++            const moduleIds = getRecursiveImportOrder(facadeModuleIds, _this2.getModuleInfo);
+             entries.sort((a, b) => moduleIds.indexOf(a.id) - moduleIds.indexOf(b.id));
+           }
+ 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,11 @@ settings:
 overrides:
   '@storybook/icons': 1.4.0
 
+patchedDependencies:
+  rollup-plugin-postcss:
+    hash: mgchv4wdy47o33wyddtx4ix2ey
+    path: patches/rollup-plugin-postcss.patch
+
 importers:
 
   .:
@@ -11360,7 +11365,7 @@ snapshots:
       rollup: 4.46.2
       rollup-plugin-ignore: 1.0.10
       rollup-plugin-node-externals: 8.0.0(rollup@4.46.2)
-      rollup-plugin-postcss: 4.0.2(postcss@8.5.6)(ts-node@10.9.2(@swc/core@1.7.10(@swc/helpers@0.5.15))(@types/node@22.15.21)(typescript@5.9.2))
+      rollup-plugin-postcss: 4.0.2(patch_hash=mgchv4wdy47o33wyddtx4ix2ey)(postcss@8.5.6)(ts-node@10.9.2(@swc/core@1.7.10(@swc/helpers@0.5.15))(@types/node@22.15.21)(typescript@5.9.2))
       tslib: 2.8.1
       typescript: 5.9.2
       typescript-transform-paths: 3.5.5(typescript@5.9.2)
@@ -16681,7 +16686,7 @@ snapshots:
       - bluebird
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.38.0(eslint@9.18.0(jiti@1.21.6))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@4.4.4(eslint-plugin-import@2.32.0)(eslint@9.18.0(jiti@1.21.6)))(eslint@9.18.0(jiti@1.21.6)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.38.0(eslint@9.18.0(jiti@1.21.6))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@4.4.4)(eslint@9.18.0(jiti@1.21.6)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -16721,7 +16726,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.18.0(jiti@1.21.6)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.38.0(eslint@9.18.0(jiti@1.21.6))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@4.4.4(eslint-plugin-import@2.32.0)(eslint@9.18.0(jiti@1.21.6)))(eslint@9.18.0(jiti@1.21.6))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.38.0(eslint@9.18.0(jiti@1.21.6))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@4.4.4)(eslint@9.18.0(jiti@1.21.6))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -20940,7 +20945,7 @@ snapshots:
     dependencies:
       rollup: 4.46.2
 
-  rollup-plugin-postcss@4.0.2(postcss@8.5.6)(ts-node@10.9.2(@swc/core@1.7.10(@swc/helpers@0.5.15))(@types/node@22.15.21)(typescript@5.9.2)):
+  rollup-plugin-postcss@4.0.2(patch_hash=mgchv4wdy47o33wyddtx4ix2ey)(postcss@8.5.6)(ts-node@10.9.2(@swc/core@1.7.10(@swc/helpers@0.5.15))(@types/node@22.15.21)(typescript@5.9.2)):
     dependencies:
       chalk: 4.1.2
       concat-with-sourcemaps: 1.1.0


### PR DESCRIPTION
## Why

Our css order seems random and not deterministic usually it's fine but sometimes it's not and it breaks our consumers and css specificity.

## What

See #6116 we rolled this out in v1 first to solve the present issue in v1.81.1