### PR TITLE
[ESR-2405]-Restore focus to trigger button when pressing Escape

### DIFF
--- a/.changeset/fix-menu-escape-focus.md
+++ b/.changeset/fix-menu-escape-focus.md
@@ -1,0 +1,9 @@
+---
+'@kaizen/components': patch
+---
+
+Fix Menu dropdown not returning focus to trigger button when pressing Escape
+
+Previously, pressing Escape to close a Menu would lose focus because the focus restoration was targeting the positioning wrapper element instead of the actual button. This affected components like the Export button in TitleBlock.
+
+No changes required for consumers - this is a bug fix.

--- a/packages/components/src/MenuV1/Menu.spec.tsx
+++ b/packages/components/src/MenuV1/Menu.spec.tsx
@@ -60,4 +60,26 @@ describe('Dropdown', () => {
       expect(onMouseDown).toBeCalled()
     })
   })
+
+  it('returns focus to the button when pressing Escape', async () => {
+    render(
+      <Menu button={<Button label="Button" />}>
+        <div>Item</div>
+      </Menu>,
+    )
+
+    const button = screen.getByRole('button', { name: 'Button' })
+    await user.click(button)
+
+    await waitFor(() => {
+      expect(screen.getByText('Item')).toBeVisible()
+    })
+
+    await user.keyboard('{Escape}')
+
+    await waitFor(() => {
+      expect(screen.queryByText('Item')).not.toBeInTheDocument()
+      expect(button).toHaveFocus()
+    })
+  })
 })

--- a/packages/components/src/MenuV1/Menu.tsx
+++ b/packages/components/src/MenuV1/Menu.tsx
@@ -1,10 +1,24 @@
-import React, { useState } from 'react'
+import React, { useState, type Ref } from 'react'
 import type { ButtonProps } from '~components/ButtonV1'
+import type { ButtonRef } from '~components/ButtonV1/GenericButton'
 import { StatelessMenu, type StatelessMenuProps } from './subcomponents/StatelessMenu'
+
+const mergeRefs =
+  <T,>(...refs: Array<Ref<T> | undefined>) =>
+  (value: T | null): void => {
+    refs.forEach((ref) => {
+      if (typeof ref === 'function') {
+        ref(value)
+      } else if (ref && typeof ref === 'object') {
+        ;(ref as React.MutableRefObject<T | null>).current = value
+      }
+    })
+  }
 
 type ButtonPropsWithOptionalAria = ButtonProps & {
   'aria-haspopup'?: boolean
   'aria-expanded'?: boolean
+  'ref'?: Ref<ButtonRef>
 }
 
 export type MenuProps = Omit<
@@ -61,6 +75,10 @@ export const Menu = ({ button, menuVisible = false, ...rest }: MenuProps): JSX.E
             props.onMouseDown(e)
             button.props.onMouseDown?.(e)
           },
+          ref: mergeRefs<ButtonRef>(
+            props.ref as Ref<ButtonRef>,
+            button.props.ref as Ref<ButtonRef> | undefined,
+          ),
         })
       }
     />

--- a/packages/components/src/MenuV1/Menu.tsx
+++ b/packages/components/src/MenuV1/Menu.tsx
@@ -4,7 +4,7 @@ import type { ButtonRef } from '~components/ButtonV1/GenericButton'
 import { StatelessMenu, type StatelessMenuProps } from './subcomponents/StatelessMenu'
 
 const mergeRefs =
-  <T,>(...refs: Array<Ref<T> | undefined>) =>
+  <T,>(...refs: (Ref<T> | undefined)[]) =>
   (value: T | null): void => {
     refs.forEach((ref) => {
       if (typeof ref === 'function') {

--- a/packages/components/src/MenuV1/subcomponents/MenuDropdown/MenuDropdown.tsx
+++ b/packages/components/src/MenuV1/subcomponents/MenuDropdown/MenuDropdown.tsx
@@ -18,11 +18,13 @@ export type MenuDropdownProps = {
   autoHide?: 'on' | 'outside-click-only' | 'off'
   children: React.ReactNode
   referenceElement: HTMLElement | null
+  buttonRef?: React.RefObject<{ focus: () => void } | null>
 }
 
 export const MenuDropdown = ({
   children,
   referenceElement,
+  buttonRef,
   id,
   hideMenuDropdown,
   autoHide = 'on',
@@ -104,7 +106,11 @@ export const MenuDropdown = ({
       shards={referenceElement ? [referenceElement] : undefined}
       onEscapeKey={hideMenuDropdown}
       returnFocus={() => {
-        referenceElement?.focus()
+        if (buttonRef?.current) {
+          buttonRef.current.focus()
+        } else {
+          referenceElement?.focus()
+        }
         return false
       }}
     >

--- a/packages/components/src/MenuV1/subcomponents/StatelessMenu/StatelessMenu.tsx
+++ b/packages/components/src/MenuV1/subcomponents/StatelessMenu/StatelessMenu.tsx
@@ -43,6 +43,7 @@ export type StatelessMenuProps = {
     'onClick': (e: any) => void
     'onMouseDown': (e: any) => void
     'aria-expanded': boolean
+    'ref': React.RefObject<{ focus: () => void } | null>
   }) => React.ReactElement
   'onClick'?: (event: SyntheticEvent) => void
 }
@@ -62,6 +63,7 @@ export const StatelessMenu = ({
   onClick,
 }: StatelessMenuProps): JSX.Element => {
   const [referenceElement, setReferenceElement] = useState<HTMLSpanElement | null>(null)
+  const buttonRef = useRef<{ focus: () => void } | null>(null)
   const portalSelectorElementRef = useRef<Element | null>(null)
 
   const menuButton = renderButton({
@@ -72,6 +74,7 @@ export const StatelessMenu = ({
     },
     'onMouseDown': (e: React.MouseEvent<Element, MouseEvent>) => e.preventDefault(),
     'aria-expanded': isMenuVisible,
+    'ref': buttonRef,
   })
 
   useEffect(() => {
@@ -90,6 +93,7 @@ export const StatelessMenu = ({
   const menu = isMenuVisible ? (
     <MenuDropdown
       referenceElement={referenceElement}
+      buttonRef={buttonRef}
       align={align}
       hideMenuDropdown={hideMenuDropdown}
       width={dropdownWidth}


### PR DESCRIPTION
### Why
                                                                                                                                                                                      
  When pressing Escape to close a Menu dropdown (e.g., the Export button in TitleBlock), focus was being lost instead of returning to the trigger button. This is an accessibility
  issue as keyboard users lose their place in the page.






  Related ticket: [Export button lost focus on hitting the Esc key](https://cultureamp.atlassian.net/browse/ESR-2405 )                                                                                                                   
   
 ### What                                                                                                                                                                                
                                                            
  The root cause was that the returnFocus callback in MenuDropdown was calling focus() on referenceElement, which is a wrapper <div> used for Popper positioning - not the actual
  focusable button.

  Changes:
  - Added a buttonRef to track the button's imperative handle ({ focus: () => void })
  - Pass this ref through StatelessMenu → MenuDropdown                               
  - Use buttonRef.current.focus() in the returnFocus callback, with fallback to referenceElement for backwards compatibility
  - Added mergeRefs utility in Menu to preserve any existing ref on the button (e.g., AddFiltersMenu uses its own ref)      
  - Added test case verifying focus returns to button on Escape                                                                                                                       
                                                                                                                                                                                      
  ## Before: Focus lost when pressing Escape

https://github.com/user-attachments/assets/78a1d447-44f2-4c35-b187-8dfc100b3716
                                                                                                                                             
  ## After: Focus returns to the trigger button  


https://github.com/user-attachments/assets/686e9813-103c-4e43-858f-e9d318105f25


