### PR TITLE
fix: cssnano sorts css properties alphabetically

### DIFF
--- a/.changeset/fair-tips-vanish.md
+++ b/.changeset/fair-tips-vanish.md
@@ -1,0 +1,5 @@
+---
+'@kaizen/components': patch
+---
+
+Turn of CSS declaration sorting in cssnano plugin used by postcss as it caused a regression with some logical properties in RTL mode

--- a/packages/components/postcss.config.mjs
+++ b/packages/components/postcss.config.mjs
@@ -2,5 +2,5 @@ import cssnano from 'cssnano'
 import postcssImport from 'postcss-import'
 
 export default {
-  plugins: [postcssImport, cssnano({ preset: 'default' })],
+  plugins: [postcssImport, cssnano({ preset: ['default', { cssDeclarationSorter: false }] })],
 }


### PR DESCRIPTION
## Why

The current build was sorting css properties alphabetically, we don't want this as it caused a regression with our logical properties with use with non-logical properties

## What

This came from the package-bundler upgrade where the rollup-plugin-styler plugin uses cssnano that defaults to sorting alphabetically which causes some rtl logical properties to sort before the non-logical properties, so we turn or sorting
