### PR TITLE
WIP: feat: Make top strip of title block opt in sticky

### DIFF
--- a/.changeset/smooth-doodles-follow.md
+++ b/.changeset/smooth-doodles-follow.md
@@ -1,0 +1,5 @@
+---
+'@kaizen/components': patch
+---
+
+Add sticky top strip prop to TitleBlock to allow it to stick the viewport when scrolled

--- a/.changeset/smooth-doodles-follow.md
+++ b/.changeset/smooth-doodles-follow.md
@@ -2,4 +2,4 @@
 '@kaizen/components': patch
 ---
 
-Add sticky top strip prop to TitleBlock to allow it to stick the viewport when scrolled
+Add `sticky` prop to TitleBlock. When enabled, the top strip sticks to the top of its scrollable container as the content scrolls, offset below the app-chrome nav via the `--app-chrome-sticky-offset` and `--titleblock-sticky-offset` CSS variables.

--- a/packages/components/src/TitleBlock/TitleBlock.module.scss
+++ b/packages/components/src/TitleBlock/TitleBlock.module.scss
@@ -61,6 +61,31 @@
     display: flex;
     width: 100%;
     justify-content: center;
+    position: relative;
+  }
+
+  .stickyTopStripWithinContainer {
+    display: contents;
+
+    .titleRow {
+      z-index: 1;
+      position: sticky;
+      top: 0;
+    }
+
+    .rowBelowSeparator {
+      z-index: 0;
+    }
+  }
+
+  .stickyTopStripWithinContainer .titleRow,
+  .stickyTopStripWithinContainer .rowBelowSeparator {
+    background-color: $dt-color-background-color-default;
+  }
+
+  .stickyTopStripWithinContainer.lightVariant .titleRow,
+  .stickyTopStripWithinContainer.lightVariant .rowBelowSeparator {
+    background-color: $color-white;
   }
 
   .lightVariant .titleRow {
@@ -69,6 +94,19 @@
 
   .adminVariant .titleRow {
     background-color: $color-white;
+  }
+
+  .stickyTopStripWithinContainer.adminVariant .titleRow {
+    background-color: $color-white;
+  }
+
+  .stickyTopStripWithinContainer.adminVariant .rowBelowSeparator {
+    background-color: $dt-color-background-color-admin;
+  }
+
+  .stickyTopStripWithinContainer.educationVariant .titleRow,
+  .stickyTopStripWithinContainer.educationVariant .rowBelowSeparator {
+    background-color: $dt-color-background-color-eduction;
   }
 
   %titleBlockInner {

--- a/packages/components/src/TitleBlock/TitleBlock.module.scss
+++ b/packages/components/src/TitleBlock/TitleBlock.module.scss
@@ -64,16 +64,16 @@
     position: relative;
   }
 
-  .stickyTopStripWithinContainer {
+  .sticky {
     display: contents;
 
     .titleRow {
       z-index: 5;
       position: sticky;
-      top: calc(var(--app-chrome-sticky-offset, 72px) + var(--titleblock-sticky-offset, 0px));
+      top: calc(var(--app-chrome-sticky-offset, 72px) + var(--titleblock-sticky-offset, 0));
 
       @media (width < 1080px) {
-        top: var(--titleblock-sticky-offset, 0px);
+        top: var(--titleblock-sticky-offset, 0);
       }
     }
 
@@ -82,13 +82,13 @@
     }
   }
 
-  .stickyTopStripWithinContainer .titleRow,
-  .stickyTopStripWithinContainer .rowBelowSeparator {
+  .sticky .titleRow,
+  .sticky .rowBelowSeparator {
     background-color: $dt-color-background-color-default;
   }
 
-  .stickyTopStripWithinContainer.lightVariant .titleRow,
-  .stickyTopStripWithinContainer.lightVariant .rowBelowSeparator {
+  .sticky.lightVariant .titleRow,
+  .sticky.lightVariant .rowBelowSeparator {
     background-color: $color-white;
   }
 
@@ -100,16 +100,16 @@
     background-color: $color-white;
   }
 
-  .stickyTopStripWithinContainer.adminVariant .titleRow {
+  .sticky.adminVariant .titleRow {
     background-color: $color-white;
   }
 
-  .stickyTopStripWithinContainer.adminVariant .rowBelowSeparator {
+  .sticky.adminVariant .rowBelowSeparator {
     background-color: $dt-color-background-color-admin;
   }
 
-  .stickyTopStripWithinContainer.educationVariant .titleRow,
-  .stickyTopStripWithinContainer.educationVariant .rowBelowSeparator {
+  .sticky.educationVariant .titleRow,
+  .sticky.educationVariant .rowBelowSeparator {
     background-color: $dt-color-background-color-eduction;
   }
 

--- a/packages/components/src/TitleBlock/TitleBlock.module.scss
+++ b/packages/components/src/TitleBlock/TitleBlock.module.scss
@@ -70,7 +70,11 @@
     .titleRow {
       z-index: 1;
       position: sticky;
-      top: 0;
+      top: $layout-navigation-bar-height;
+
+      @media (width < 1080px) {
+        top: 0;
+      }
     }
 
     .rowBelowSeparator {

--- a/packages/components/src/TitleBlock/TitleBlock.module.scss
+++ b/packages/components/src/TitleBlock/TitleBlock.module.scss
@@ -70,7 +70,7 @@
     .titleRow {
       z-index: 1;
       position: sticky;
-      top: $layout-navigation-bar-height;
+      top: var(--app-chrome-sticky-offset, 72px);
 
       @media (width < 1080px) {
         top: 0;

--- a/packages/components/src/TitleBlock/TitleBlock.module.scss
+++ b/packages/components/src/TitleBlock/TitleBlock.module.scss
@@ -70,10 +70,10 @@
     .titleRow {
       z-index: 5;
       position: sticky;
-      top: var(--app-chrome-sticky-offset, 72px);
+      top: calc(var(--app-chrome-sticky-offset, 72px) + var(--titleblock-sticky-offset, 0px));
 
       @media (width < 1080px) {
-        top: 0;
+        top: var(--titleblock-sticky-offset, 0px);
       }
     }
 

--- a/packages/components/src/TitleBlock/TitleBlock.module.scss
+++ b/packages/components/src/TitleBlock/TitleBlock.module.scss
@@ -68,7 +68,7 @@
     display: contents;
 
     .titleRow {
-      z-index: 1;
+      z-index: 5;
       position: sticky;
       top: var(--app-chrome-sticky-offset, 72px);
 

--- a/packages/components/src/TitleBlock/TitleBlock.tsx
+++ b/packages/components/src/TitleBlock/TitleBlock.tsx
@@ -248,7 +248,7 @@ export const TitleBlock = ({
   secondaryOverflowMenuItems,
   navigationTabs,
   collapseNavigationAreaWhenPossible = false,
-  stickyTopStripWithinContainer = false,
+  sticky = false,
   textDirection,
   surveyStatus,
   id,
@@ -281,7 +281,7 @@ export const TitleBlock = ({
           collapseNavigationArea &&
             !(sectionTitle ?? sectionTitleDescription ?? renderSectionTitle) &&
             styles.collapseNavigationArea,
-          stickyTopStripWithinContainer && styles.stickyTopStripWithinContainer,
+          sticky && styles.sticky,
           title && title.length >= 30 && styles.hasLongTitle,
           subtitle &&
             typeof subtitle === 'string' &&

--- a/packages/components/src/TitleBlock/TitleBlock.tsx
+++ b/packages/components/src/TitleBlock/TitleBlock.tsx
@@ -248,6 +248,7 @@ export const TitleBlock = ({
   secondaryOverflowMenuItems,
   navigationTabs,
   collapseNavigationAreaWhenPossible = false,
+  stickyTopStripWithinContainer = false,
   textDirection,
   surveyStatus,
   id,
@@ -280,6 +281,7 @@ export const TitleBlock = ({
           collapseNavigationArea &&
             !(sectionTitle ?? sectionTitleDescription ?? renderSectionTitle) &&
             styles.collapseNavigationArea,
+          stickyTopStripWithinContainer && styles.stickyTopStripWithinContainer,
           title && title.length >= 30 && styles.hasLongTitle,
           subtitle &&
             typeof subtitle === 'string' &&

--- a/packages/components/src/TitleBlock/_docs/TitleBlock.stories.tsx
+++ b/packages/components/src/TitleBlock/_docs/TitleBlock.stories.tsx
@@ -118,12 +118,44 @@ const meta = {
       <NavigationTab key="5" text="Label" href="#" />,
       <NavigationTab key="6" text="Label" href="#" />,
     ],
+    stickyTopStripWithinContainer: true,
   },
 } satisfies Meta<typeof TitleBlock>
 
 export default meta
 
 type Story = StoryObj<typeof meta>
+
+const STICKY_SCROLLABLE_CONTAINER_STYLES = {
+  height: '200px',
+  overflowY: 'auto' as const,
+  backgroundColor: '#fff',
+}
+
+const STICKY_SCROLLABLE_FRAME_STYLES = {
+  margin: '0 auto',
+  maxWidth: '1200px',
+  border: '1px solid #d8dde3',
+  borderRadius: '12px',
+  overflow: 'hidden' as const,
+  backgroundColor: '#fff',
+}
+
+const renderStickyScrollableTitleBlock = (
+  args: React.ComponentProps<typeof TitleBlock>,
+): JSX.Element => (
+  <div style={STICKY_SCROLLABLE_FRAME_STYLES}>
+    <div data-scroll-container="sticky-top-strip" style={STICKY_SCROLLABLE_CONTAINER_STYLES}>
+      <TitleBlock {...args} />
+
+      <div
+        style={{
+          height: '100px',
+        }}
+      />
+    </div>
+  </div>
+)
 
 export const Playground: Story = {
   parameters: {
@@ -690,5 +722,106 @@ export const WithOnlySecondaryActions: Story = {
     sectionTitleDescription: undefined,
     breadcrumb: undefined,
     avatar: undefined,
+  },
+}
+
+export const StickyTopStripInScrollableContainer: Story = {
+  name: 'Sticker Sheet (Sticky Top Strip In Scrollable Container)',
+  parameters: {
+    viewport: viewports,
+    chromatic: chromaticViewports,
+  },
+  args: {
+    stickyTopStripWithinContainer: true,
+  },
+  render: (args) => {
+    const { variant: _variant, ...argsWithoutVariant } = args
+
+    return (
+      <StickerSheet title="Sticky top strip within a scrollable container">
+        <StickerSheet.Row header="Default (Purple background)">
+          {renderStickyScrollableTitleBlock({
+            ...argsWithoutVariant,
+            title: 'Default Variant',
+            subtitle: 'Sticky top strip inside a scrollable content area',
+            breadcrumb: {
+              path: '#',
+              text: 'Back to home',
+            },
+            navigationTabs: [
+              <NavigationTab key="1" text="Overview" href="#" active />,
+              <NavigationTab key="2" text="Settings" href="#" />,
+            ],
+          })}
+        </StickerSheet.Row>
+        <StickerSheet.Row header="Education (Blue background)">
+          {renderStickyScrollableTitleBlock({
+            ...argsWithoutVariant,
+            variant: 'education',
+            title: 'Education Variant',
+            subtitle: 'Sticky top strip inside a scrollable content area',
+            breadcrumb: {
+              path: '#',
+              text: 'Back to courses',
+            },
+            navigationTabs: [
+              <NavigationTab key="1" variant="education" text="Lessons" href="#" active />,
+              <NavigationTab key="2" variant="education" text="Assignments" href="#" />,
+            ],
+          })}
+        </StickerSheet.Row>
+        <StickerSheet.Row header="Admin (White background)">
+          {renderStickyScrollableTitleBlock({
+            ...argsWithoutVariant,
+            variant: 'admin',
+            title: 'Admin Variant',
+            subtitle: 'Sticky top strip inside a scrollable content area',
+            breadcrumb: {
+              path: '#',
+              text: 'Back to dashboard',
+            },
+            navigationTabs: [
+              <NavigationTab key="1" variant="admin" text="Users" href="#" active />,
+              <NavigationTab key="2" variant="admin" text="Settings" href="#" />,
+            ],
+          })}
+        </StickerSheet.Row>
+        <StickerSheet.Row header="Light (White background)">
+          {renderStickyScrollableTitleBlock({
+            ...argsWithoutVariant,
+            variant: 'light',
+            title: 'Light Variant',
+            subtitle: 'Sticky top strip inside a scrollable content area',
+            breadcrumb: {
+              path: '#',
+              text: 'Back to overview',
+            },
+            navigationTabs: [
+              <NavigationTab key="1" variant="light" text="Details" href="#" active />,
+              <NavigationTab key="2" variant="light" text="Analytics" href="#" />,
+            ],
+          })}
+        </StickerSheet.Row>
+      </StickerSheet>
+    )
+  },
+  play: async ({ canvasElement, step }) => {
+    await step('scroll each sticky container before snapshot', async () => {
+      const scrollContainers = canvasElement.querySelectorAll<HTMLElement>(
+        '[data-scroll-container="sticky-top-strip"]',
+      )
+
+      scrollContainers.forEach((scrollContainer) => {
+        scrollContainer.scrollTo({
+          top: scrollContainer.scrollHeight - scrollContainer.clientHeight,
+        })
+      })
+
+      await waitFor(() => {
+        scrollContainers.forEach((scrollContainer) => {
+          expect(scrollContainer.scrollTop).toBeGreaterThan(0)
+        })
+      })
+    })
   },
 }

--- a/packages/components/src/TitleBlock/_docs/TitleBlock.stories.tsx
+++ b/packages/components/src/TitleBlock/_docs/TitleBlock.stories.tsx
@@ -130,16 +130,16 @@ type Story = StoryObj<typeof meta>
 const STICKY_SCROLLABLE_CONTAINER_STYLES = {
   height: '200px',
   overflowY: 'auto' as const,
-  backgroundColor: '#fff',
+  backgroundColor: 'var(--color-white)',
 }
 
 const STICKY_SCROLLABLE_FRAME_STYLES = {
   margin: '0 auto',
   maxWidth: '1200px',
-  border: '1px solid #d8dde3',
+  border: '1px solid var(--border-solid-border-color)',
   borderRadius: '12px',
   overflow: 'hidden' as const,
-  backgroundColor: '#fff',
+  backgroundColor: 'var(--color-white)',
 }
 
 const renderStickyScrollableTitleBlock = (

--- a/packages/components/src/TitleBlock/_docs/TitleBlock.stories.tsx
+++ b/packages/components/src/TitleBlock/_docs/TitleBlock.stories.tsx
@@ -3,9 +3,11 @@ import { type Meta, type StoryObj } from '@storybook/react'
 import { expect, waitFor, within } from '@storybook/test'
 import { Heading } from 'react-aria-components'
 import { Icon } from '~components/Icon'
+import { GlobalNotification } from '~components/Notification'
 import { assetUrl } from '~components/utils/hostedAssets'
 import { StickerSheet } from '~storybook/components/StickerSheet'
 import { NavigationTab, TitleBlock } from '../index'
+import stickyBannerStyles from './stickyBanner.module.css'
 
 const SECONDARY_ACTIONS = [
   {
@@ -145,12 +147,25 @@ const renderStickyScrollableTitleBlock = (
   args: React.ComponentProps<typeof TitleBlock>,
 ): JSX.Element => (
   <div style={STICKY_SCROLLABLE_FRAME_STYLES}>
-    <div data-scroll-container="sticky-top-strip" style={STICKY_SCROLLABLE_CONTAINER_STYLES}>
+    <div
+      data-scroll-container="sticky-top-strip"
+      className={stickyBannerStyles.scrollContainer}
+      style={{
+        ...STICKY_SCROLLABLE_CONTAINER_STYLES,
+        // Taller than the shared default so the fake nav and the TitleBlock
+        // content fit without cramping.
+        height: '400px',
+      }}
+    >
+      <div className={stickyBannerStyles.fakeAppChromeNav}>Fake app chrome nav (72px)</div>
+
       <TitleBlock {...args} />
 
       <div
         style={{
-          height: '100px',
+          // Taller than the container so it overflows and the sticky behaviour
+          // (+ the play() scroll assertion) stays exercised.
+          height: '500px',
         }}
       />
     </div>
@@ -807,6 +822,99 @@ export const StickyTopStripInScrollableContainer: Story = {
   },
   play: async ({ canvasElement, step }) => {
     await step('scroll each sticky container before snapshot', async () => {
+      const scrollContainers = canvasElement.querySelectorAll<HTMLElement>(
+        '[data-scroll-container="sticky-top-strip"]',
+      )
+
+      scrollContainers.forEach((scrollContainer) => {
+        scrollContainer.scrollTo({
+          top: scrollContainer.scrollHeight - scrollContainer.clientHeight,
+        })
+      })
+
+      await waitFor(() => {
+        scrollContainers.forEach((scrollContainer) => {
+          expect(scrollContainer.scrollTop).toBeGreaterThan(0)
+        })
+      })
+    })
+  },
+}
+
+/**
+ * Sticky banner (GlobalNotification) above a sticky TitleBlock.
+ *
+ * Follows the additive-offset pattern: the banner pins below the app-chrome
+ * bar by *reading* the shared `--app-chrome-sticky-offset` (never reassigning
+ * it), and the TitleBlock strip reserves space for the banner via the opt-in
+ * `--titleblock-sticky-offset`, set on a `display: contents` wrapper right
+ * around the TitleBlock. The banner height is measured with a ResizeObserver
+ * and fed into that variable so the strip stays flush at any banner height.
+ */
+const StickyBannerAboveTitleBlock = (
+  args: React.ComponentProps<typeof TitleBlock>,
+): JSX.Element => {
+  const containerRef = React.useRef<HTMLDivElement>(null)
+  const [bannerHeight, setBannerHeight] = React.useState(0)
+
+  React.useEffect(() => {
+    // GlobalNotification doesn't forward a ref, so grab its DOM node by the
+    // data attribute to measure the banner height.
+    const el = containerRef.current?.querySelector<HTMLElement>('[data-sticky-banner]')
+    if (!el) return
+    const update = (): void => setBannerHeight(el.offsetHeight)
+    update()
+    const observer = new ResizeObserver(update)
+    observer.observe(el)
+    return () => observer.disconnect()
+  }, [])
+
+  return (
+    <div
+      ref={containerRef}
+      data-scroll-container="sticky-top-strip"
+      className={stickyBannerStyles.scrollContainer}
+      style={{
+        height: '500px',
+        overflowY: 'auto',
+      }}
+    >
+      <div className={stickyBannerStyles.fakeAppChromeNav}>Fake app chrome nav (72px)</div>
+      <GlobalNotification
+        variant="informative"
+        persistent
+        data-sticky-banner
+        classNameOverride={stickyBannerStyles.stickyBanner}
+      >
+        This global notification renders directly above the TitleBlock.
+      </GlobalNotification>
+      <div
+        style={{
+          display: 'contents',
+          ['--titleblock-sticky-offset' as string]: `${bannerHeight}px`,
+        }}
+      >
+        <TitleBlock {...args} />
+      </div>
+
+      {/* Taller than the container so it overflows and the sticky behaviour
+          (+ the play() scroll assertion) stays exercised. */}
+      <div style={{ height: '600px' }} />
+    </div>
+  )
+}
+
+export const WithGlobalNotificationAbove: Story = {
+  parameters: {
+    viewport: viewports,
+    chromatic: chromaticViewports,
+  },
+  args: {
+    stickyTopStripWithinContainer: true,
+  },
+  render: (args) => <StickyBannerAboveTitleBlock {...args} />,
+  play: async ({ canvasElement, step }) => {
+    await step('scroll the sticky container before snapshot', async () => {
       const scrollContainers = canvasElement.querySelectorAll<HTMLElement>(
         '[data-scroll-container="sticky-top-strip"]',
       )

--- a/packages/components/src/TitleBlock/_docs/TitleBlock.stories.tsx
+++ b/packages/components/src/TitleBlock/_docs/TitleBlock.stories.tsx
@@ -120,7 +120,7 @@ const meta = {
       <NavigationTab key="5" text="Label" href="#" />,
       <NavigationTab key="6" text="Label" href="#" />,
     ],
-    stickyTopStripWithinContainer: true,
+    sticky: true,
   },
 } satisfies Meta<typeof TitleBlock>
 
@@ -747,7 +747,7 @@ export const StickyTopStripInScrollableContainer: Story = {
     chromatic: chromaticViewports,
   },
   args: {
-    stickyTopStripWithinContainer: true,
+    sticky: true,
   },
   render: (args) => {
     const { variant: _variant, ...argsWithoutVariant } = args
@@ -910,7 +910,7 @@ export const WithGlobalNotificationAbove: Story = {
     chromatic: chromaticViewports,
   },
   args: {
-    stickyTopStripWithinContainer: true,
+    sticky: true,
   },
   render: (args) => <StickyBannerAboveTitleBlock {...args} />,
   play: async ({ canvasElement, step }) => {

--- a/packages/components/src/TitleBlock/_docs/TitleBlock.stories.tsx
+++ b/packages/components/src/TitleBlock/_docs/TitleBlock.stories.tsx
@@ -120,7 +120,6 @@ const meta = {
       <NavigationTab key="5" text="Label" href="#" />,
       <NavigationTab key="6" text="Label" href="#" />,
     ],
-    sticky: true,
   },
 } satisfies Meta<typeof TitleBlock>
 

--- a/packages/components/src/TitleBlock/_docs/stickyBanner.module.css
+++ b/packages/components/src/TitleBlock/_docs/stickyBanner.module.css
@@ -28,8 +28,8 @@
   align-items: center;
   height: 72px;
   padding-inline: 16px;
-  background-color: #2f1a4c;
-  color: #fff;
+  background-color: var(--color-purple-800);
+  color: var(--color-white);
   font-weight: 600;
 }
 

--- a/packages/components/src/TitleBlock/_docs/stickyBanner.module.css
+++ b/packages/components/src/TitleBlock/_docs/stickyBanner.module.css
@@ -1,0 +1,44 @@
+.stickyBanner {
+  position: sticky;
+  /* Pin below the app-chrome bar by reading the shared offset (read-only). */
+  top: var(--app-chrome-sticky-offset, 72px);
+  z-index: 5;
+}
+
+/*
+ * Stand-in for the AppChrome content scroll area. Sets the shared
+ * `--app-chrome-sticky-offset` that the sticky titleRow and banner read.
+ * Below 1080px the AppChrome nav collapses to a hamburger (no persistent top
+ * bar), so the offset drops to 0 — matching kaizen's own
+ * `@media (width < 1080px)` rule on the titleRow.
+ */
+.scrollContainer {
+  --app-chrome-sticky-offset: 72px;
+}
+
+/*
+ * Fake AppChrome top nav — a sticky bar at >=1080px, removed below that
+ * (the real nav becomes a hamburger with no top bar).
+ */
+.fakeAppChromeNav {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  display: flex;
+  align-items: center;
+  height: 72px;
+  padding-inline: 16px;
+  background-color: #2f1a4c;
+  color: #fff;
+  font-weight: 600;
+}
+
+@media (width < 1080px) {
+  .scrollContainer {
+    --app-chrome-sticky-offset: 0px;
+  }
+
+  .fakeAppChromeNav {
+    display: none;
+  }
+}

--- a/packages/components/src/TitleBlock/_docs/stickyBanner.module.css
+++ b/packages/components/src/TitleBlock/_docs/stickyBanner.module.css
@@ -1,6 +1,6 @@
+/* Pin below the app-chrome bar by reading the shared offset (read-only). */
 .stickyBanner {
   position: sticky;
-  /* Pin below the app-chrome bar by reading the shared offset (read-only). */
   top: var(--app-chrome-sticky-offset, 72px);
   z-index: 5;
 }
@@ -35,7 +35,7 @@
 
 @media (width < 1080px) {
   .scrollContainer {
-    --app-chrome-sticky-offset: 0px;
+    --app-chrome-sticky-offset: 0;
   }
 
   .fakeAppChromeNav {

--- a/packages/components/src/TitleBlock/types.ts
+++ b/packages/components/src/TitleBlock/types.ts
@@ -32,6 +32,7 @@ export type TitleBlockProps = {
   secondaryOverflowMenuItems?: TitleBlockMenuItemProps[]
   navigationTabs?: NavigationTabs
   collapseNavigationAreaWhenPossible?: boolean
+  stickyTopStripWithinContainer?: boolean
   textDirection?: TextDirection
   surveyStatus?: SurveyStatus
   id?: string

--- a/packages/components/src/TitleBlock/types.ts
+++ b/packages/components/src/TitleBlock/types.ts
@@ -32,7 +32,17 @@ export type TitleBlockProps = {
   secondaryOverflowMenuItems?: TitleBlockMenuItemProps[]
   navigationTabs?: NavigationTabs
   collapseNavigationAreaWhenPossible?: boolean
-  stickyTopStripWithinContainer?: boolean
+  /**
+   * Makes the top strip stick to the top of its scrollable container as the
+   * content scrolls. The TitleBlock must be rendered inside a scrollable
+   * ancestor. When enabled the root becomes `display: contents` so the strip
+   * pins as a sibling of the scrolling content; its offset is
+   * `--app-chrome-sticky-offset` (owned by AppChrome, read-only) plus the
+   * opt-in `--titleblock-sticky-offset` a consumer sets to reserve space for a
+   * banner above it. Below 1080px the app-chrome offset is dropped to match the
+   * collapsed hamburger nav.
+   */
+  sticky?: boolean
   textDirection?: TextDirection
   surveyStatus?: SurveyStatus
   id?: string


### PR DESCRIPTION
This uses position sticky by setting titleblock container to display: contents this might break stuff, and be an a11y issue. 

Testing is needed

https://github.com/user-attachments/assets/0f29419a-f777-48f3-8498-361f2acdf866


## Important: Request PR reviews on Slack

Please reach out to the design system team on Slack in `#help_design_system` for PR reviews. GitHub notifications (e.g. from tagging a person) are not actively monitored.

## Why

<!-- Why have you created this PR? - Is it a new feature, or a bug fix? Or something else? -->
<!-- Reference any relevant Jira tickets so your reviewer can find more context if needed. -->
<!-- Fixing a GitHub issue? Add "Fixes [issue URL]". -->

## What

<!-- What do your changes do? How do they change/fix the current behavior? -->
<!-- Add screenshots, GIFs or videos to illustrate the changes.  -->
