### PR TITLE
feat(BrandMoment, ErrorPage): add optional tag prop

### DIFF
--- a/.changeset/add-optional-tag-brand-moment.md
+++ b/.changeset/add-optional-tag-brand-moment.md
@@ -1,0 +1,5 @@
+---
+'@kaizen/components': minor
+---
+
+Add optional `tag` prop to BrandMoment and ErrorPage components to allow overriding the default `main` HTML element

--- a/packages/components/src/BrandMoment/BrandMoment.spec.tsx
+++ b/packages/components/src/BrandMoment/BrandMoment.spec.tsx
@@ -1,0 +1,44 @@
+import React from 'react'
+import { render } from '@testing-library/react'
+import { vi } from 'vitest'
+import { BrandMoment } from './BrandMoment'
+
+describe('<BrandMoment />', () => {
+  beforeAll(() => {
+    window.matchMedia = vi.fn().mockImplementation(() => ({
+      media: '',
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      matches: false,
+    }))
+  })
+
+  it('renders a main element by default', () => {
+    const { container } = render(
+      <BrandMoment
+        variant="informative"
+        illustration={<div>illustration</div>}
+        header={<div>header</div>}
+        text={{ title: 'Title' }}
+      />,
+    )
+    expect(container.querySelector('main')).toBeInTheDocument()
+  })
+
+  it('renders the specified tag when provided', () => {
+    const { container } = render(
+      <BrandMoment
+        variant="informative"
+        illustration={<div>illustration</div>}
+        header={<div>header</div>}
+        tag="section"
+        text={{ title: 'Title' }}
+      />,
+    )
+    expect(container.querySelector('section')).toBeInTheDocument()
+    expect(container.querySelector('main')).not.toBeInTheDocument()
+  })
+})

--- a/packages/components/src/BrandMoment/BrandMoment.tsx
+++ b/packages/components/src/BrandMoment/BrandMoment.tsx
@@ -1,4 +1,9 @@
-import React, { type ElementType, type HTMLAttributes, type ReactElement, type ReactNode } from 'react'
+import React, {
+  type ElementType,
+  type HTMLAttributes,
+  type ReactElement,
+  type ReactNode,
+} from 'react'
 import classnames from 'classnames'
 import { Button, type ButtonProps } from '~components/ButtonV1'
 import { Heading } from '~components/Heading'

--- a/packages/components/src/BrandMoment/BrandMoment.tsx
+++ b/packages/components/src/BrandMoment/BrandMoment.tsx
@@ -1,4 +1,4 @@
-import React, { type HTMLAttributes, type ReactElement, type ReactNode } from 'react'
+import React, { type ElementType, type HTMLAttributes, type ReactElement, type ReactNode } from 'react'
 import classnames from 'classnames'
 import { Button, type ButtonProps } from '~components/ButtonV1'
 import { Heading } from '~components/Heading'
@@ -19,6 +19,7 @@ export type BrandMomentProps = {
   body?: ReactNode
   primaryAction?: ButtonProps
   secondaryAction?: ButtonProps
+  tag?: ElementType
   text: {
     title: ReactNode
     subtitle?: ReactNode
@@ -39,16 +40,18 @@ export const BrandMoment = ({
   body,
   primaryAction,
   secondaryAction,
+  tag,
   text,
   classNameOverride,
   ...restProps
 }: BrandMomentProps): JSX.Element => {
   const { queries } = useMediaQueries()
+  const Tag = tag ?? 'main'
 
   return (
     <div className={classnames(styles.body, styles[variant], classNameOverride)} {...restProps}>
       <header className={styles.header}>{header}</header>
-      <main className={styles.main}>
+      <Tag className={styles.main}>
         <div className={styles.container}>
           <div className={styles.mainInner}>
             <div className={styles.left}>
@@ -88,7 +91,7 @@ export const BrandMoment = ({
             </div>
           </div>
         </div>
-      </main>
+      </Tag>
       {text.footer && (
         <footer className={styles.footer}>
           <div className={styles.container}>

--- a/packages/components/src/ErrorPage/ErrorPage.spec.tsx
+++ b/packages/components/src/ErrorPage/ErrorPage.spec.tsx
@@ -127,4 +127,15 @@ describe('<ErrorPage />', () => {
       expect(screen.getByText('Error code 504')).toBeVisible()
     })
   })
+
+  it('renders a main element by default', () => {
+    const { container } = render(<ErrorPage code="404" />)
+    expect(container.querySelector('main')).toBeInTheDocument()
+  })
+
+  it('passes tag prop to BrandMoment', () => {
+    const { container } = render(<ErrorPage code="404" tag="section" />)
+    expect(container.querySelector('section')).toBeInTheDocument()
+    expect(container.querySelector('main')).not.toBeInTheDocument()
+  })
 })

--- a/packages/components/src/ErrorPage/ErrorPage.tsx
+++ b/packages/components/src/ErrorPage/ErrorPage.tsx
@@ -1,4 +1,4 @@
-import React, { type HTMLAttributes } from 'react'
+import React, { type ElementType, type HTMLAttributes } from 'react'
 import { FormattedMessage, useIntl } from '@cultureamp/i18n-react-intl'
 import classNames from 'classnames'
 import { BrandMoment } from '~components/BrandMoment'
@@ -26,6 +26,7 @@ export type ErrorPageProps = {
     onContactSupport: () => void
     homeHref?: string
   }
+  tag?: ElementType
 } & OverrideClassName<HTMLAttributes<HTMLDivElement>>
 
 export const ErrorPage = ({
@@ -33,6 +34,7 @@ export const ErrorPage = ({
   title,
   message,
   callToAction,
+  tag,
   classNameOverride,
 }: ErrorPageProps): JSX.Element => {
   const { formatMessage } = useIntl()
@@ -48,6 +50,7 @@ export const ErrorPage = ({
   return (
     <div className={classNames(classNameOverride)}>
       <BrandMoment
+        tag={tag}
         header={<></>}
         body={
           <>


### PR DESCRIPTION
## Summary

- Adds an optional `tag` prop (`ElementType`) to `BrandMoment` that allows consumers to override the default `<main>` HTML element rendered by the component
- Adds the same optional `tag` prop to `ErrorPage`, which passes it through to the underlying `BrandMoment`
- Both props default to `main` when not provided, so existing usage is unaffected

## Motivation

When `BrandMoment` or `ErrorPage` is used in a context where a `<main>` element already exists (or is semantically inappropriate), consumers need a way to swap it for a different element like `<section>` or `<div>`. This is needed for the `AppChrome` rollout, where repos have errorpages wrapped in the old nav, now moving to the `AppChrome` which comes with it's own `<main>` element

## Test plan

- [x] Added `BrandMoment.spec.tsx` with tests for default `main` rendering and custom tag override
- [x] Added tests to `ErrorPage.spec.tsx` verifying the `tag` prop passes through to `BrandMoment`
- [x] All 13 tests pass
- [x] TypeScript compiles with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)