### PR TITLE
Add tagColor configuration for multi-value Select tags

### DIFF
--- a/.changeset/great-adults-juggle.md
+++ b/.changeset/great-adults-juggle.md
@@ -1,0 +1,5 @@
+---
+'@kaizen/components': minor
+---
+
+Add optional tagColor field to multi-value Select options, allowing consumers to configure individual tag colour variants.

--- a/packages/components/src/Select/Select.tsx
+++ b/packages/components/src/Select/Select.tsx
@@ -12,7 +12,14 @@ import { FieldMessage } from '~components/FieldMessage'
 import { Icon } from '~components/Icon'
 import { Label } from '~components/Label'
 import { Tag } from '~components/Tag'
+import { type TagVariants } from '~components/Tag/types'
 import styles from './Select.module.scss'
+
+export type SelectOption = {
+  value: string
+  label: string
+  tagColor?: (typeof TagVariants)[number]
+}
 
 export type SelectProps = {
   /**
@@ -217,7 +224,12 @@ const SingleValue: typeof components.SingleValue = (props) => (
 
 const MultiValue: typeof components.MultiValue = (props) => (
   <div className={styles.multiValue}>
-    <Tag variant="default" dismissible inline onDismiss={props.removeProps.onClick}>
+    <Tag
+      variant={(props.data as SelectOption)?.tagColor ?? 'default'}
+      dismissible
+      inline
+      onDismiss={props.removeProps.onClick}
+    >
       {props.children}
     </Tag>
   </div>

--- a/packages/components/src/Select/_docs/Select.stories.tsx
+++ b/packages/components/src/Select/_docs/Select.stories.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { type Meta, type StoryObj } from '@storybook/react'
 import { Label } from '~components/Label'
-import { AsyncSelect, Select } from '../index'
+import { AsyncSelect, Select, type SelectOption } from '../index'
 
 const OPTIONS = [
   { value: 'Mindy', label: 'Mindy' },
@@ -67,6 +67,38 @@ export const Grouped: Story = {
 
 export const Disabled: Story = {
   args: { options: DISABLED_OPTIONS },
+}
+
+const COLORED_OPTIONS: SelectOption[] = [
+  { value: 'default', label: 'Default' },
+  { value: 'statusLive', label: 'Status Live', tagColor: 'statusLive' },
+  { value: 'statusDraft', label: 'Status Draft', tagColor: 'statusDraft' },
+  { value: 'statusClosed', label: 'Status Closed', tagColor: 'statusClosed' },
+  { value: 'statusAction', label: 'Status Action', tagColor: 'statusAction' },
+  { value: 'sentimentPositive', label: 'Sentiment Positive', tagColor: 'sentimentPositive' },
+  { value: 'sentimentNeutral', label: 'Sentiment Neutral', tagColor: 'sentimentNeutral' },
+  { value: 'sentimentNegative', label: 'Sentiment Negative', tagColor: 'sentimentNegative' },
+  { value: 'sentimentNone', label: 'Sentiment None', tagColor: 'sentimentNone' },
+  { value: 'validationPositive', label: 'Validation Positive', tagColor: 'validationPositive' },
+  {
+    value: 'validationInformative',
+    label: 'Validation Informative',
+    tagColor: 'validationInformative',
+  },
+  { value: 'validationNegative', label: 'Validation Negative', tagColor: 'validationNegative' },
+  {
+    value: 'validationCautionary',
+    label: 'Validation Cautionary',
+    tagColor: 'validationCautionary',
+  },
+]
+
+export const MultiSelectWithTagColors: Story = {
+  args: {
+    isMulti: true,
+    options: COLORED_OPTIONS,
+    defaultValue: COLORED_OPTIONS,
+  },
 }
 
 export const Async: Story = {


### PR DESCRIPTION
## Why

Allow consumers to configure the colour of individual tags in a multi-value Select.

https://cultureamp.atlassian.net/browse/ESD-4027

## What

- Export a `SelectOption` helper type with an optional `tagColor` field, strictly typed to existing `TagVariants`
- Update the `MultiValue` component to read `tagColor` from option data and pass it as the `variant` prop to `<Tag>` (falls back to `"default"`)
- Works for both `Select` and `AsyncSelect` (they share the `MultiValue` component)
- Add a Storybook story demonstrating all 13 tag colour variants in a multi-select