### PR TITLE
feat(components): add ref props to TextField, TextAreaFIeld, DatePicker and TimeField

### DIFF
--- a/.changeset/sour-monkeys-stop.md
+++ b/.changeset/sour-monkeys-stop.md
@@ -1,5 +1,5 @@
 ---
-'@kaizen/components': patch
+'@kaizen/components': minor
 ---
 
-Widen inputRef/textAreaRef prop types from RefObject to Ref for react-hook-form Controller compatibility
+Add inputRef prop to TimeField and DatePicker for react-hook-form Controller compatibility

--- a/.changeset/sour-monkeys-stop.md
+++ b/.changeset/sour-monkeys-stop.md
@@ -1,0 +1,5 @@
+---
+'@kaizen/components': patch
+---
+
+Widen inputRef/textAreaRef prop types from RefObject to Ref for react-hook-form Controller compatibility

--- a/.changeset/sour-monkeys-stop.md
+++ b/.changeset/sour-monkeys-stop.md
@@ -2,4 +2,4 @@
 '@kaizen/components': minor
 ---
 
-Add inputRef prop to TimeField and DatePicker for react-hook-form Controller compatibility
+Add inputRef prop to TimeField and DatePicker and widened TextField ref types for react-hook-form Controller compatibility

--- a/packages/components/src/DateInput/DateInput/DateInput.tsx
+++ b/packages/components/src/DateInput/DateInput/DateInput.tsx
@@ -2,7 +2,6 @@ import React from 'react'
 import classnames from 'classnames'
 import { Input, type InputProps } from '~components/Input'
 import { Label } from '~components/Label'
-import { isRefObject } from '~components/utils/isRefObject'
 import styles from './DateInput.module.css'
 
 type OmittedInputProps = 'reversed' | 'type' | 'inputRef'
@@ -23,7 +22,7 @@ export const DateInput = React.forwardRef<HTMLInputElement, DateInputProps>(
         disabled={disabled}
       />
       <Input
-        inputRef={isRefObject(ref) ? ref : undefined}
+        inputRef={ref}
         id={id}
         type="text"
         autoComplete="off"

--- a/packages/components/src/DateInput/DateInputWithIconButton/DateInputWithIconButton.tsx
+++ b/packages/components/src/DateInput/DateInputWithIconButton/DateInputWithIconButton.tsx
@@ -13,8 +13,8 @@ export type DateInputWithIconButtonProps = {
 } & Omit<DateInputProps, 'startIconAdornment' | 'endIconAdornment'>
 
 export type DateInputWithIconButtonRefs = {
-  inputRef?: React.RefObject<HTMLInputElement>
-  buttonRef?: React.RefObject<HTMLButtonElement>
+  inputRef?: React.Ref<HTMLInputElement>
+  buttonRef?: React.Ref<HTMLButtonElement>
 }
 
 export const DateInputWithIconButton = React.forwardRef<

--- a/packages/components/src/DatePicker/DatePicker.tsx
+++ b/packages/components/src/DatePicker/DatePicker.tsx
@@ -1,6 +1,6 @@
-import React, { useEffect, useId, useMemo, useRef, useState, type RefObject } from 'react'
-import { mergeRefs } from '@react-aria/utils'
+import React, { useEffect, useId, useRef, useState, type RefObject } from 'react'
 import { useIntl } from '@cultureamp/i18n-react-intl'
+import { mergeRefs } from '@react-aria/utils'
 import { type DayEventHandler } from 'react-day-picker'
 import { FocusOn } from 'react-focus-on'
 import {

--- a/packages/components/src/DatePicker/DatePicker.tsx
+++ b/packages/components/src/DatePicker/DatePicker.tsx
@@ -1,4 +1,5 @@
-import React, { useEffect, useId, useRef, useState, type RefObject } from 'react'
+import React, { useEffect, useId, useMemo, useRef, useState, type RefObject } from 'react'
+import { mergeRefs } from '@react-aria/utils'
 import { useIntl } from '@cultureamp/i18n-react-intl'
 import { type DayEventHandler } from 'react-day-picker'
 import { FocusOn } from 'react-focus-on'
@@ -35,6 +36,7 @@ type OmittedDateInputFieldProps =
 
 export type DatePickerProps = {
   id?: string
+  inputRef?: React.Ref<HTMLInputElement>
   buttonRef?: RefObject<HTMLButtonElement>
   onInputClick?: DateInputFieldProps['onClick']
   onInputFocus?: DateInputFieldProps['onFocus']
@@ -81,6 +83,7 @@ export type DatePickerProps = {
  */
 export const DatePicker = ({
   id: propsId,
+  inputRef: propsInputRef,
   buttonRef: propsButtonRef,
   locale: propsLocale = 'en-AU',
   disabledDates,
@@ -115,11 +118,11 @@ export const DatePicker = ({
   const id = propsId ?? reactId
 
   const containerRef = useRef<HTMLInputElement>(null)
-  const inputRef = useRef<HTMLInputElement>(null)
+  const internalInputRef = useRef<HTMLInputElement>(null)
   const fallbackButtonRef = useRef<HTMLButtonElement>(null)
   const buttonRef = propsButtonRef ?? fallbackButtonRef
   const dateInputRefs = useRef({
-    inputRef,
+    inputRef: mergeRefs<HTMLInputElement>(internalInputRef, propsInputRef),
     buttonRef,
   })
   const [inputValue, setInputValue] = useState<string>('')
@@ -239,7 +242,7 @@ export const DatePicker = ({
 
   const handleReturnFocus = (): void => {
     if (lastTrigger === 'inputKeydown' || lastTrigger === 'inputFocus') {
-      return inputRef.current?.focus()
+      return internalInputRef.current?.focus()
     }
     buttonRef.current?.focus()
   }

--- a/packages/components/src/Input/Input/Input.tsx
+++ b/packages/components/src/Input/Input/Input.tsx
@@ -8,7 +8,7 @@ export type InputType = (typeof InputTypes)[number]
 export type InputStatusType = (typeof InputStatus)[number]
 
 export type InputProps = {
-  inputRef?: React.RefObject<HTMLInputElement>
+  inputRef?: React.Ref<HTMLInputElement>
   status?: InputStatusType
   startIconAdornment?: React.ReactNode
   endIconAdornment?: React.ReactNode

--- a/packages/components/src/TextArea/TextArea.tsx
+++ b/packages/components/src/TextArea/TextArea.tsx
@@ -4,7 +4,7 @@ import { type OverrideClassName } from '~components/types/OverrideClassName'
 import styles from './TextArea.module.css'
 
 export type TextAreaProps = {
-  textAreaRef?: React.RefObject<HTMLTextAreaElement>
+  textAreaRef?: React.Ref<HTMLTextAreaElement>
   status?: 'default' | 'error' | 'caution'
   /**
    * Grows the input height as more content is added

--- a/packages/components/src/TimeField/TimeField.tsx
+++ b/packages/components/src/TimeField/TimeField.tsx
@@ -117,7 +117,7 @@ const TimeFieldComponent = ({
               state={state}
               inputRef={i === firstEditableIndex ? inputRef : undefined}
               hasPadding={![8294, 8297].includes(segment.text.charCodeAt(0))}
-            // ^react-aria includes these characters to ensure correct RTL behaviour, but we want to avoid these adding random spacing
+              // ^react-aria includes these characters to ensure correct RTL behaviour, but we want to avoid these adding random spacing
             />
           ))}
           <div className={styles.focusRing} />

--- a/packages/components/src/TimeField/TimeField.tsx
+++ b/packages/components/src/TimeField/TimeField.tsx
@@ -2,6 +2,7 @@ import React, { useId, useMemo } from 'react'
 import { Time } from '@internationalized/date'
 import { useTimeField } from '@react-aria/datepicker'
 import { I18nProvider } from '@react-aria/i18n'
+import { mergeRefs } from '@react-aria/utils';
 import { useTimeFieldState, type TimeFieldStateOptions } from '@react-stately/datepicker'
 import classnames from 'classnames'
 import { FieldMessage } from '~components/FieldMessage'
@@ -27,6 +28,7 @@ export type TimeFieldProps = {
   value: ValueType | null
   status?: StatusType
   validationMessage?: React.ReactNode
+  inputRef?: React.Ref<HTMLDivElement>
 } & OverrideClassName<Omit<TimeFieldStateOptions, OmittedTimeFieldProps>>
 
 // This needed to be placed directly below the props because
@@ -49,6 +51,7 @@ const TimeFieldComponent = ({
   validationMessage,
   isDisabled,
   classNameOverride,
+  inputRef,
   ...restProps
 }: TimeFieldProps): JSX.Element => {
   const reactId = useId()
@@ -79,7 +82,7 @@ const TimeFieldComponent = ({
   const hasError = !!validationMessage && status === 'error'
   const descriptionId = hasError ? `${id}-field-message` : undefined
 
-  const inputRef = React.useRef(null)
+  const internalRef = React.useRef<HTMLDivElement>(null)
   const { fieldProps, labelProps } = useTimeField(
     {
       ...restProps,
@@ -88,7 +91,7 @@ const TimeFieldComponent = ({
       'aria-describedby': descriptionId,
     },
     state,
-    inputRef,
+    internalRef,
   )
   return (
     <div className={classNameOverride}>
@@ -96,11 +99,10 @@ const TimeFieldComponent = ({
         {label}
       </Label>
       <div className={styles.wrapper}>
-        {}
         <div
           {...fieldProps}
           id={id}
-          ref={inputRef}
+          ref={mergeRefs<HTMLDivElement>(internalRef, inputRef)}
           className={classnames(
             styles.input,
             state.isDisabled && styles.isDisabled,
@@ -114,7 +116,7 @@ const TimeFieldComponent = ({
                 segment={segment}
                 state={state}
                 hasPadding={![8294, 8297].includes(segment.text.charCodeAt(0))}
-                // ^react-aria includes these characters to ensure correct RTL behaviour, but we want to avoid these adding random spacing
+              // ^react-aria includes these characters to ensure correct RTL behaviour, but we want to avoid these adding random spacing
               />
             )
           })}

--- a/packages/components/src/TimeField/TimeField.tsx
+++ b/packages/components/src/TimeField/TimeField.tsx
@@ -92,6 +92,8 @@ const TimeFieldComponent = ({
     state,
     internalRef,
   )
+  const firstEditableIndex = state.segments.findIndex((s) => s.isEditable)
+
   return (
     <div className={classNameOverride}>
       <Label disabled={state.isDisabled} {...labelProps} classNameOverride={styles.label}>
@@ -108,18 +110,16 @@ const TimeFieldComponent = ({
             status === 'error' && styles.error,
           )}
         >
-          {state.segments.map((segment, i) => {
-            return (
-              <TimeSegment
-                key={i}
-                segment={segment}
-                state={state}
-                hasPadding={![8294, 8297].includes(segment.text.charCodeAt(0))}
-                // ^react-aria includes these characters to ensure correct RTL behaviour, but we want to avoid these adding random spacing
-                inputRef={i === 0 ? inputRef : undefined}
-              />
-            )
-          })}
+          {state.segments.map((segment, i) => (
+            <TimeSegment
+              key={i}
+              segment={segment}
+              state={state}
+              inputRef={i === firstEditableIndex ? inputRef : undefined}
+              hasPadding={![8294, 8297].includes(segment.text.charCodeAt(0))}
+            // ^react-aria includes these characters to ensure correct RTL behaviour, but we want to avoid these adding random spacing
+            />
+          ))}
           <div className={styles.focusRing} />
         </div>
       </div>

--- a/packages/components/src/TimeField/TimeField.tsx
+++ b/packages/components/src/TimeField/TimeField.tsx
@@ -2,7 +2,7 @@ import React, { useId, useMemo } from 'react'
 import { Time } from '@internationalized/date'
 import { useTimeField } from '@react-aria/datepicker'
 import { I18nProvider } from '@react-aria/i18n'
-import { mergeRefs } from '@react-aria/utils';
+import { mergeRefs } from '@react-aria/utils'
 import { useTimeFieldState, type TimeFieldStateOptions } from '@react-stately/datepicker'
 import classnames from 'classnames'
 import { FieldMessage } from '~components/FieldMessage'
@@ -116,7 +116,7 @@ const TimeFieldComponent = ({
                 segment={segment}
                 state={state}
                 hasPadding={![8294, 8297].includes(segment.text.charCodeAt(0))}
-              // ^react-aria includes these characters to ensure correct RTL behaviour, but we want to avoid these adding random spacing
+                // ^react-aria includes these characters to ensure correct RTL behaviour, but we want to avoid these adding random spacing
               />
             )
           })}

--- a/packages/components/src/TimeField/TimeField.tsx
+++ b/packages/components/src/TimeField/TimeField.tsx
@@ -2,7 +2,6 @@ import React, { useId, useMemo } from 'react'
 import { Time } from '@internationalized/date'
 import { useTimeField } from '@react-aria/datepicker'
 import { I18nProvider } from '@react-aria/i18n'
-import { mergeRefs } from '@react-aria/utils'
 import { useTimeFieldState, type TimeFieldStateOptions } from '@react-stately/datepicker'
 import classnames from 'classnames'
 import { FieldMessage } from '~components/FieldMessage'
@@ -28,7 +27,7 @@ export type TimeFieldProps = {
   value: ValueType | null
   status?: StatusType
   validationMessage?: React.ReactNode
-  inputRef?: React.Ref<HTMLDivElement>
+  inputRef?: React.Ref<HTMLSpanElement>
 } & OverrideClassName<Omit<TimeFieldStateOptions, OmittedTimeFieldProps>>
 
 // This needed to be placed directly below the props because
@@ -102,7 +101,7 @@ const TimeFieldComponent = ({
         <div
           {...fieldProps}
           id={id}
-          ref={mergeRefs<HTMLDivElement>(internalRef, inputRef)}
+          ref={internalRef}
           className={classnames(
             styles.input,
             state.isDisabled && styles.isDisabled,
@@ -117,6 +116,7 @@ const TimeFieldComponent = ({
                 state={state}
                 hasPadding={![8294, 8297].includes(segment.text.charCodeAt(0))}
                 // ^react-aria includes these characters to ensure correct RTL behaviour, but we want to avoid these adding random spacing
+                inputRef={i === 0 ? inputRef : undefined}
               />
             )
           })}

--- a/packages/components/src/TimeField/subcomponents/TimeSegment/TimeSegment.tsx
+++ b/packages/components/src/TimeField/subcomponents/TimeSegment/TimeSegment.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { useDateSegment } from '@react-aria/datepicker'
+import { mergeRefs } from '@react-aria/utils'
 import { type DateFieldState, type DateSegment } from '@react-stately/datepicker'
 import classnames from 'classnames'
 import { generateSegmentDisplayText } from './utils/generateSegmentDisplayText'
@@ -9,15 +10,17 @@ export type TimeSegmentProps = {
   segment: DateSegment
   state: DateFieldState
   hasPadding?: boolean
+  inputRef?: React.Ref<HTMLSpanElement>
 }
 
 export const TimeSegment = ({
   segment,
   state,
   hasPadding = true,
+  inputRef,
 }: TimeSegmentProps): JSX.Element => {
-  const ref = React.useRef<HTMLDivElement>(null)
-  const { segmentProps } = useDateSegment(segment, state, ref)
+  const internalRef = React.useRef<HTMLSpanElement>(null)
+  const { segmentProps } = useDateSegment(segment, state, internalRef)
 
   // Chrome has a bug where `contenteditable` elements receive focus from external clicks.
   // This (in combination with the invisible character &#8203;) creates boundaries
@@ -28,7 +31,7 @@ export const TimeSegment = ({
       &#8203;
       <span
         {...segmentProps}
-        ref={ref}
+        ref={mergeRefs<HTMLSpanElement>(internalRef, inputRef)}
         className={classnames(
           styles.timeSegment,
           segment.type === 'literal' && styles.literal,


### PR DESCRIPTION
## Why

React Hook Form's Controller component provides `field.ref` as a callback ref (a function), but our form field components currently only accept `RefObject` type. Other components are missing the ref prop altogether, forcing consumers to write workarounds. 

## What

- Added props `inputRef` to components DatePicker and Timefield
- Widened the ref prop types from `React.RefObject` to `React.Ref` for TextField. This is backwards compatible — existing RefObject usage continues to work

## Example: Using with react-hook-form

Before this change, this common pattern fails with a type error:
```
import { Controller } from "react-hook-form"
import { TextField } from "@kaizen/components"

<Controller
  name="email"
  control={control}
  render={({ field }) => (
    <TextField
      {...field}
      inputRef={field.ref}  // ❌ Type error: RefCallBack is not assignable to RefObject
    />
  )}
/>

```
After this change, the same code works as expected.

## Demo

Using the prop, we can programatically focus on these fields using RHF `setFocus` method. Here is very simple demo:

https://github.com/user-attachments/assets/5ebd934d-d0e9-4941-8a09-b16db8df37a8


In the real world it will get used to focus when errors occur.

## Out of scope

I didn't add the ref prop to component Rich Text Editor because it uses a 3rd party library. Because it's based on vanilla JS and not React it has no concept of refs. Adding a ref will involve a workaround, or some kind of anti pattern that I'll leave to separate PR.