### PR TITLE
Fix flaky Chromatic snapshots of Avatar

### DIFF
--- a/.changeset/modern-hands-win.md
+++ b/.changeset/modern-hands-win.md
@@ -1,0 +1,5 @@
+---
+'@kaizen/components': patch
+---
+
+Fix flaky Chromatic snapshots of Avatar initials for long names in Chromatic

--- a/packages/components/src/Avatar/Avatar.tsx
+++ b/packages/components/src/Avatar/Avatar.tsx
@@ -61,10 +61,10 @@ const getInitials = (fullName?: string, max2Characters: boolean = false): string
   fullName == null
     ? ''
     : fullName
-        .split(/\s/)
-        .reduce((acc, name) => `${acc}${name.slice(0, 1)}`, '')
-        .toUpperCase()
-        .substring(0, max2Characters ? 2 : 8)
+      .split(/\s/)
+      .reduce((acc, name) => `${acc}${name.slice(0, 1)}`, '')
+      .toUpperCase()
+      .substring(0, max2Characters ? 2 : 8)
 
 const getMaxFontSizePixels: (size: AvatarSizes) => number = (size) => {
   if (size === 'small') return 8
@@ -97,7 +97,10 @@ const renderInitials = (
     <abbr className={classnames(styles.initials, isLongName && styles.longName)} title={alt}>
       {isLongName ? (
         // Only called if 3 or more initials, fits text width for long names
-        <Textfit mode="single" max={getMaxFontSizePixels(size)}>
+        //
+        // Ignore Chromatic diffs since the font-size calculation has shown itself to be slightly non-deterministic,
+        // causing flaky tests.
+        <Textfit mode="single" max={getMaxFontSizePixels(size)} data-chromatic="ignore">
           {initials}
         </Textfit>
       ) : (

--- a/packages/components/src/Avatar/Avatar.tsx
+++ b/packages/components/src/Avatar/Avatar.tsx
@@ -61,10 +61,10 @@ const getInitials = (fullName?: string, max2Characters: boolean = false): string
   fullName == null
     ? ''
     : fullName
-      .split(/\s/)
-      .reduce((acc, name) => `${acc}${name.slice(0, 1)}`, '')
-      .toUpperCase()
-      .substring(0, max2Characters ? 2 : 8)
+        .split(/\s/)
+        .reduce((acc, name) => `${acc}${name.slice(0, 1)}`, '')
+        .toUpperCase()
+        .substring(0, max2Characters ? 2 : 8)
 
 const getMaxFontSizePixels: (size: AvatarSizes) => number = (size) => {
   if (size === 'small') return 8


### PR DESCRIPTION
## Why

When a name has 3 or more letters in its initials, the dynamic font size calculation has shown itself to be slightly non-deterministic in our Chromatic tests, causing flaky builds like [this one in performance-review-cycles-ui](https://www.chromatic.com/test?appId=64e3014e1714e564244b7bf5&id=6a2a5ffa188bc968351e3c91) (note the difference in font size in the DOM diff at the bottom of the page).

<img width="308" height="168" alt="CleanShot 2026-06-11 at 17 31 37@2x" src="https://github.com/user-attachments/assets/deed019e-9281-46fa-89c4-1728f0dcded5" />

## What

This change tells Chromatic to ignore those 3+ letter initials to avoid these flaky test results.

## Verification

- [x] Checked Storybook preview of Avatar with long initials to confirm the rendered DOM contains `data-chromatic=ignore`