### PR TITLE
fix(Tabs): only scroll selected tab into view on selection change

### DIFF
--- a/.changeset/tabs-scroll-into-view-on-change.md
+++ b/.changeset/tabs-scroll-into-view-on-change.md
@@ -1,0 +1,5 @@
+---
+'@kaizen/components': patch
+---
+
+`Tabs` no longer scrolls the selected tab into view on mount. Scrolling now only happens when the selection changes via user interaction, so rendering `Tabs` below the fold no longer scrolls the page on load.

--- a/packages/components/src/Tabs/_docs/Tabs.spec.stories.tsx
+++ b/packages/components/src/Tabs/_docs/Tabs.spec.stories.tsx
@@ -117,6 +117,45 @@ export const ArrowsShowingAndHidingRTL: Story = {
   },
 }
 
+let scrollIntoViewCalls = 0
+const originalScrollIntoView = HTMLElement.prototype.scrollIntoView
+
+/**
+ * The selected tab must NOT be scrolled into view on mount (KZN-3363) — only when
+ * the selection changes via user interaction. This protects users who render Tabs
+ * below the fold from having the page jump on load.
+ */
+export const ScrollsIntoViewOnSelectionOnly: Story = {
+  name: 'Scrolls into view on selection only',
+  beforeEach: () => {
+    scrollIntoViewCalls = 0
+    HTMLElement.prototype.scrollIntoView = function (): void {
+      scrollIntoViewCalls += 1
+    }
+    return () => {
+      HTMLElement.prototype.scrollIntoView = originalScrollIntoView
+    }
+  },
+  render: (args) => (
+    <div style={{ maxWidth: '500px' }}>
+      <Tabs defaultSelectedKey="one" {...args} />
+    </div>
+  ),
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement.parentElement!)
+
+    await step('No scroll into view on mount', async () => {
+      expect(scrollIntoViewCalls).toBe(0)
+    })
+
+    await step('Scrolls into view when a tab is selected', async () => {
+      const tabFour = await canvas.findByRole('tab', { name: 'Tab 4' })
+      await userEvent.click(tabFour)
+      await waitFor(() => expect(scrollIntoViewCalls).toBeGreaterThan(0))
+    })
+  },
+}
+
 export const AsyncLoaded: Story = {
   render: () => {
     const [selectedKey, setSelectedKey] = useState<Key>(0)

--- a/packages/components/src/Tabs/_docs/Tabs.stories.tsx
+++ b/packages/components/src/Tabs/_docs/Tabs.stories.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react'
 import { type Meta, type StoryObj } from '@storybook/react'
-import { Button } from '~components/ButtonV1'
+import { Button } from '~components/Button'
 import { Text } from '~components/Text'
 import { Tab, TabList, TabPanel, Tabs, type Key } from '../index'
 
@@ -82,8 +82,44 @@ export const Controlled: Story = {
             <Text variant="body">Content 2</Text>
           </TabPanel>
         </Tabs>
-        <Button label="Switch to tab 2" onClick={(): void => setSelectedKey('two')} />
+        <Button onClick={(): void => setSelectedKey('two')}>Switch to tab 2</Button>
       </>
     )
   },
+}
+
+/**
+ * When a tab is selected via user interaction, `TabList` scrolls the selected tab
+ * into view within its horizontal strip. It deliberately does *not* do this on
+ * mount — so when `Tabs` render below the fold, landing on the page does not scroll
+ * the tabs into view or jump the page.
+ *
+ * This story pushes the `Tabs` below the fold with a full-viewport spacer. On load
+ * the page stays at the top. Scroll down and select a tab — only then does the
+ * selected tab scroll into view within the strip.
+ */
+export const BelowTheFold: Story = {
+  render: () => (
+    <div style={{ maxWidth: '760px' }}>
+      <div style={{ height: '100dvh' }}>
+        <Text variant="body">Scroll down — the tabs are rendered below the fold.</Text>
+      </div>
+      <Tabs defaultSelectedKey="tab-0">
+        <TabList aria-label="Lorem ipsum tabs">
+          {Array.from({ length: 8 }, (_, i) => (
+            <Tab key={i} id={`tab-${i}`}>
+              Lorem {i + 1}
+            </Tab>
+          ))}
+        </TabList>
+        {Array.from({ length: 8 }, (_, i) => (
+          <TabPanel key={i} id={`tab-${i}`} className="p-24">
+            <Text variant="body">
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit — panel {i + 1}.
+            </Text>
+          </TabPanel>
+        ))}
+      </Tabs>
+    </div>
+  ),
 }

--- a/packages/components/src/Tabs/subcomponents/TabList/TabList.tsx
+++ b/packages/components/src/Tabs/subcomponents/TabList/TabList.tsx
@@ -44,6 +44,7 @@ export const TabList = (props: TabListProps): JSX.Element => {
   const [containerElement, setContainerElement] = useState<HTMLElement | null>()
   const tabListContext = useContext(TabListStateContext)
   const selectedKey = tabListContext?.selectedKey
+  const prevSelectedKey = useRef(selectedKey)
 
   useEffect(() => {
     if (!isDocumentReady) {
@@ -107,7 +108,14 @@ export const TabList = (props: TabListProps): JSX.Element => {
       return
     }
 
-    // Scroll selected tab into view
+    // Only scroll the selected tab into view when the selection actually changes
+    // (i.e. user interaction). Skipping the no-op runs avoids scrolling the page
+    // on mount when the Tabs sit below the fold.
+    if (prevSelectedKey.current === selectedKey) {
+      return
+    }
+    prevSelectedKey.current = selectedKey
+
     containerElement
       ?.querySelector('[role="tab"][data-selected=true]')
       ?.scrollIntoView({ block: 'nearest', inline: 'center' })


### PR DESCRIPTION
## Summary

`Tabs` scrolled the selected tab into view on **mount**, which jumped the page for consumers rendering `Tabs` below the fold ([KZN-3363](https://cultureamp.atlassian.net/browse/KZN-3363)). The scroll effect now runs only when the selection actually changes via user interaction.

## Change

- [`TabList.tsx`](packages/components/src/Tabs/subcomponents/TabList/TabList.tsx) — guard the `scrollIntoView` effect with the previous `selectedKey`. On mount (and on `containerElement`/`isDocumentReady` settling) `prev === current`, so it no-ops. A genuine selection change scrolls as before.

## Behaviour

- **Land on a page with Tabs below the fold** → page stays put, no jump.
- **Select a tab** → selected tab scrolls into view within the horizontal strip.

## Stories / tests

- `Components/Tabs → Below The Fold` — placeholder page content pushes the Tabs below the fold; demonstrates no scroll on load, scroll on selection.
- `Components/Tabs/Tabs tests → Scrolls into view on selection only` — play test spying on `scrollIntoView`: asserts **0 calls on mount**, **>0 after selecting a tab**.

## Changeset

Patch — `@kaizen/components`.

Closes KZN-3363

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[KZN-3363]: https://cultureamp.atlassian.net/browse/KZN-3363?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ