### PR TITLE
feat(Notification): export NotificationVariant from package root

### DIFF
--- a/.changeset/export-notification-variant.md
+++ b/.changeset/export-notification-variant.md
@@ -1,0 +1,5 @@
+---
+'@kaizen/components': patch
+---
+
+`NotificationVariant` is now exported from the package root. Previously it was declared in `Notification/types.ts` but not re-exported by the `Notification` index, so consumers could not import it directly and had to derive it via `ComponentProps`. This brings it in line with `ToastNotification` and other components that re-export their shared `types` module.

--- a/packages/components/src/Notification/index.ts
+++ b/packages/components/src/Notification/index.ts
@@ -1,3 +1,4 @@
 export * from './InlineNotification'
 export * from './GlobalNotification'
 export * from './ToastNotification'
+export * from './types'


### PR DESCRIPTION
## Why

`NotificationVariant` (`'cautionary' | 'informative' | 'success' | 'security' | 'warning'`) is declared and exported in [`Notification/types.ts`](packages/components/src/Notification/types.ts), but [`Notification/index.ts`](packages/components/src/Notification/index.ts) never re-exported that module, so the type never reached the package root.

This means consumers cannot import it directly:

```ts
import { type NotificationVariant } from "@kaizen/components" // ❌ not exported
```

The only workaround was deriving it indirectly, which is more fragile — if the prop is renamed or restructured, the derived type silently changes:

```ts
type NotificationVariant = ComponentProps<typeof InlineNotification>["variant"]
```

## What

Adds `export * from './types'` to `Notification/index.ts` so `NotificationVariant` is reachable from `@kaizen/components`.

This follows the convention already used elsewhere in the codebase — the direct sibling `ToastNotification/index.ts` already does `export * from './types'`, as do `Button`, `Calendar` and `TitleBlock` etc. `Notification` was the only component with a shared `types.ts` whose index didn't forward it.

- Purely additive — no existing exports change.
- Changeset included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)