### PR TITLE
fix: propose span as the default tag for the focusable component wrap…

### DIFF
--- a/.changeset/few-squids-guess.md
+++ b/.changeset/few-squids-guess.md
@@ -1,0 +1,5 @@
+---
+'@kaizen/components': patch
+---
+
+Updated the tooltip Focusable tag to accept an optional tag prop that determines the html element wrapping the passed in children

--- a/packages/components/src/Focusable/Focusable.tsx
+++ b/packages/components/src/Focusable/Focusable.tsx
@@ -1,33 +1,41 @@
-import React, { useRef, type HTMLAttributes, type ReactNode } from 'react'
+import React, { useRef, type ElementType, type HTMLAttributes, type ReactNode } from 'react'
 import classnames from 'classnames'
 import { useFocusable, type FocusableOptions } from 'react-aria'
 import styles from './Focusable.module.css'
 
-export type FocusableProps = {
+export type FocusableProps<T extends ElementType = 'span'> = {
   children: ReactNode
+  /**
+   * The HTML element to render as. Defaults to `span` to avoid block-in-inline
+   * hydration errors when Focusable wraps content inside a `<p>` or other inline context.
+   */
+  as?: T
 } & FocusableOptions &
-  HTMLAttributes<HTMLDivElement>
+  HTMLAttributes<HTMLElement>
 
-export const Focusable = ({ children, className, ...props }: FocusableProps): JSX.Element => {
-  const ref = useRef<HTMLDivElement>(null)
+export const Focusable = <T extends ElementType = 'span'>({
+  children,
+  className,
+  as,
+  ...props
+}: FocusableProps<T>): JSX.Element => {
+  const ref = useRef<HTMLElement>(null)
   const { focusableProps } = useFocusable(props, ref)
+  const Element = as ?? 'span'
 
   return (
-    <div
+    <Element
       ref={ref}
       className={classnames(styles.focusableWrapper, className)}
       {...focusableProps}
       data-inline-hidden-content
-      // We want the div to be focusable for keyboard users,
-      // but screen readers will have the VisuallyHidden content
       // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
       tabIndex={0}
-      // aria-describedby on div doesn't do anthing so we instead render the content in VisuallyHidden from tooltip
-      // but because RAC adds it as it assumes it's interactive element we remove it here
+      // aria-describedby on this element does nothing — tooltip renders VisuallyHidden content instead
       aria-describedby={undefined}
       {...props}
     >
       {children}
-    </div>
+    </Element>
   )
 }

--- a/packages/components/src/Focusable/Focusable.tsx
+++ b/packages/components/src/Focusable/Focusable.tsx
@@ -29,8 +29,11 @@ export const Focusable = <T extends ElementType = 'div'>({
       className={classnames(styles.focusableWrapper, className)}
       {...focusableProps}
       data-inline-hidden-content
+      // We want the element to be focusable for keyboard users,
+      // but screen readers will have the VisuallyHidden content
       tabIndex={0}
-      // aria-describedby on this element does nothing — tooltip renders VisuallyHidden content instead
+      // aria-describedby on div doesn't do anthing so we instead render the content in VisuallyHidden from tooltip
+      // but because RAC adds it as it assumes it's interactive element we remove it here
       aria-describedby={undefined}
       {...props}
     >

--- a/packages/components/src/Focusable/Focusable.tsx
+++ b/packages/components/src/Focusable/Focusable.tsx
@@ -3,25 +3,25 @@ import classnames from 'classnames'
 import { useFocusable, type FocusableOptions } from 'react-aria'
 import styles from './Focusable.module.css'
 
-export type FocusableProps<T extends ElementType = 'span'> = {
+export type FocusableProps<T extends ElementType = 'div'> = {
   children: ReactNode
   /**
-   * The HTML element to render as. Defaults to `span` to avoid block-in-inline
-   * hydration errors when Focusable wraps content inside a `<p>` or other inline context.
+   * The HTML element to render as. Defaults to `div` to avoid an api change
+   * but should be set to 'span' if rendering within something like a 'p' tag to avoid invalid HTML.
    */
-  as?: T
+  tag?: T
 } & FocusableOptions &
-  HTMLAttributes<HTMLElement>
+  HTMLAttributes<HTMLDivElement>
 
-export const Focusable = <T extends ElementType = 'span'>({
+export const Focusable = <T extends ElementType = 'div'>({
   children,
   className,
-  as,
+  tag,
   ...props
 }: FocusableProps<T>): JSX.Element => {
-  const ref = useRef<HTMLElement>(null)
+  const ref = useRef<HTMLDivElement>(null)
   const { focusableProps } = useFocusable(props, ref)
-  const Element = as ?? 'span'
+  const Element = tag ?? 'div'
 
   return (
     <Element

--- a/packages/components/src/Focusable/Focusable.tsx
+++ b/packages/components/src/Focusable/Focusable.tsx
@@ -29,7 +29,6 @@ export const Focusable = <T extends ElementType = 'span'>({
       className={classnames(styles.focusableWrapper, className)}
       {...focusableProps}
       data-inline-hidden-content
-      // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
       tabIndex={0}
       // aria-describedby on this element does nothing — tooltip renders VisuallyHidden content instead
       aria-describedby={undefined}


### PR DESCRIPTION
…per, with an optional polymorphic as prop

## Important: Request PR reviews on Slack

Please reach out to the design system team on Slack in `#help_design_system` for PR reviews. GitHub notifications (e.g. from tagging a person) are not actively monitored.

## Why
Fixes a component tree error caused when using Focusable to render tooltips on an inline, non interactable component.

## What
Swaps the default tag for the Focusable element to span, so it's more semantic inline.
Added optional `as` prop to the component in case the consumer prefers a different tag.

### Notes
One thing to call out is that span as the default changes the component tree for all consumers from div > span.
I think that's correct, but open to setting the default to div for now, and I as the downstream consumer can implement span
