### PR TITLE
fix(Avatar): Fix continued Chromatic flakiness on Avatar

### DIFF
--- a/.changeset/kind-avatars-flake.md
+++ b/.changeset/kind-avatars-flake.md
@@ -1,0 +1,5 @@
+---
+'@kaizen/components': patch
+---
+
+Fix continued Chromatic flakiness on Avatar with long initials. The previous `data-chromatic="ignore"` fix was applied to an element whose size changes with the non-deterministic dynamic font size, and consequently has continued to trigger Chromatic diffs. This change promotes that fix to the parent `abbr`, which has a fixed size, as recommended by Chromatic support to resolve the flakiness.

--- a/packages/components/src/Avatar/Avatar.tsx
+++ b/packages/components/src/Avatar/Avatar.tsx
@@ -91,21 +91,29 @@ const renderInitials = (
   const isLongName = initials.length > 2 && size !== 'small'
   const renderFallback = disableInitials || initials === ''
 
-  return renderFallback ? (
-    <FallbackIcon alt={alt} />
-  ) : (
-    <abbr className={classnames(styles.initials, isLongName && styles.longName)} title={alt}>
-      {isLongName ? (
-        // Only called if 3 or more initials, fits text width for long names
-        //
+  if (renderFallback) {
+    return <FallbackIcon alt={alt} />
+  }
+
+  if (isLongName) {
+    return (
+      <abbr
+        className={classnames(styles.initials, styles.longName)}
+        title={alt}
         // Ignore Chromatic diffs since the font-size calculation has shown itself to be slightly non-deterministic,
         // causing flaky tests.
-        <Textfit mode="single" max={getMaxFontSizePixels(size)} data-chromatic="ignore">
+        data-chromatic="ignore"
+      >
+        <Textfit mode="single" max={getMaxFontSizePixels(size)}>
           {initials}
         </Textfit>
-      ) : (
-        getInitials(fullName, size === 'small')
-      )}
+      </abbr>
+    )
+  }
+
+  return (
+    <abbr className={styles.initials} title={alt}>
+      {getInitials(fullName, size === 'small')}
     </abbr>
   )
 }


### PR DESCRIPTION
## Why

The previous `data-chromatic="ignore"` fix (#6767) was applied to an element whose size changes with the non-deterministic dynamic font size, and consequently has continued to trigger Chromatic diffs.

## What

This change promotes that fix to the parent `abbr`, which has a fixed size, as recommended by Chromatic support to resolve the flakiness.

This also simplifies the conditionals around the three different renderings for Avatar initials for improved code readability.