### PR TITLE
fix(components): add missing -- prefix to CSS var references

### DIFF
--- a/.changeset/turbopack-invalid-css-var-refs.md
+++ b/.changeset/turbopack-invalid-css-var-refs.md
@@ -1,0 +1,5 @@
+---
+"@kaizen/components": patch
+---
+
+Fix two CSS custom-property references that were missing the `--` prefix (`var(color-purple-800)` and `rgb(var(color-purple-800-rgb), …)`) in ConfirmationModal and the Pagination TruncateIndicator. These were silently invalid — the colours never applied — and also caused strict CSS parsers (e.g. Turbopack) to fail to parse the stylesheet.

--- a/.changeset/turbopack-invalid-css-var-refs.md
+++ b/.changeset/turbopack-invalid-css-var-refs.md
@@ -1,5 +1,5 @@
 ---
-"@kaizen/components": patch
+'@kaizen/components': patch
 ---
 
 Fix two CSS custom-property references that were missing the `--` prefix (`var(color-purple-800)` and `rgb(var(color-purple-800-rgb), …)`) in ConfirmationModal and the Pagination TruncateIndicator. These were silently invalid — the colours never applied — and also caused strict CSS parsers (e.g. Turbopack) to fail to parse the stylesheet.

--- a/packages/components/src/Modal/ConfirmationModal/ConfirmationModal.module.scss
+++ b/packages/components/src/Modal/ConfirmationModal/ConfirmationModal.module.scss
@@ -35,7 +35,7 @@
 
     // override Murmur global styles :(
     h1 {
-      color: var(color-purple-800);
+      color: var(--color-purple-800);
     }
   }
 

--- a/packages/components/src/Pagination/subcomponents/TruncateIndicator/TruncateIndicator.module.css
+++ b/packages/components/src/Pagination/subcomponents/TruncateIndicator/TruncateIndicator.module.css
@@ -5,7 +5,7 @@
     justify-content: center;
     width: 36px;
     background-color: transparent;
-    color: rgb(var(color-purple-800-rgb), 0.7);
+    color: rgb(var(--color-purple-800-rgb), 0.7);
     margin: 0 var(--spacing-4);
   }
 }


### PR DESCRIPTION
## Why

Two CSS custom-property references are missing the `--` prefix:

- `ConfirmationModal.module.scss` — `h1 { color: var(color-purple-800); }`
- `Pagination/.../TruncateIndicator.module.css` — `color: rgb(var(color-purple-800-rgb), 0.7);`

`var(color-purple-800)` references a property named `color-purple-800`, which doesn't exist — only `--color-purple-800` does. So these colours have silently never applied (the elements fall back to inherited colour). The same files use `var(--…)` / `$color-purple-800` correctly elsewhere.

They also block our migration to [Turbopack](https://nextjs.org/docs/app/api-reference/turbopack), a new, faster bundler in Next.js that I'm working on supporting across our front end ecosystem. Turbopack's parser rejects the malformed `var()` (`Parsing CSS source code failed`) rather than ignoring it as the webpack/css-loader pipeline does, which fails the build of any app importing `@kaizen/components/dist/styles.css` under Turbopack.

## Change

Add the missing `--` prefix in both places. This both restores the intended color and makes the stylesheet parse under strict parsers.

Note: this changes rendered output (the affected elements become `--color-purple-800` where they previously inherited), so it'll likely surface as a Chromatic diff for review. Hopefully this is a desired change, but we can delete the styles if it is determined that the previous fallback behavior was actually the desired appearance.