### PR TITLE
feat(TitleBlock): add contentInset prop for aligning with Content

### DIFF
--- a/.changeset/titleblock-content-inset-alignment.md
+++ b/.changeset/titleblock-content-inset-alignment.md
@@ -1,0 +1,17 @@
+---
+'@kaizen/components': minor
+---
+
+Add a `contentInset` prop to `TitleBlock` for aligning its content column with the page content beneath it.
+
+`TitleBlock` insets its content column by a hardcoded 24px above 1080px, while `Content` uses `--layout-content-side-margin` (72px). Any page stacking the two therefore has a 48px edge mismatch between 1080px and 1536px viewport widths, and `TitleBlock` previously had no way for a consumer to influence it.
+
+`contentInset` accepts a CSS length and sets `--titleblock-content-inset`. Pass `var(--layout-content-side-margin)` to line the two up:
+
+```tsx
+<TitleBlock title="Reports" contentInset="var(--layout-content-side-margin)" />
+```
+
+The default is unchanged at 24px, so existing consumers render identically.
+
+Note that `TitleBlock` used `margin: 0 $layout-content-side-margin` until #6352, which replaced it with the hardcoded 24px — the changeset for that PR described tab navigation changes and did not mention insets, so the divergence from `Content` may have been unintended. This change only adds the escape hatch; it does not assume which value is correct.

--- a/packages/components/src/TitleBlock/TitleBlock.module.scss
+++ b/packages/components/src/TitleBlock/TitleBlock.module.scss
@@ -124,7 +124,7 @@
 
     @include title-block-min-media-1080 {
       padding: 0;
-      margin-inline: $title-block-spacing-above-1080;
+      margin-inline: var(--titleblock-content-inset, #{$title-block-spacing-above-1080});
     }
   }
 
@@ -141,7 +141,7 @@
 
     @include title-block-min-media-1080 {
       padding: 0;
-      margin-inline: $title-block-spacing-above-1080;
+      margin-inline: var(--titleblock-content-inset, #{$title-block-spacing-above-1080});
     }
   }
 

--- a/packages/components/src/TitleBlock/TitleBlock.tsx
+++ b/packages/components/src/TitleBlock/TitleBlock.tsx
@@ -249,6 +249,7 @@ export const TitleBlock = ({
   navigationTabs,
   collapseNavigationAreaWhenPossible = false,
   sticky = false,
+  contentInset,
   textDirection,
   surveyStatus,
   id,
@@ -273,6 +274,11 @@ export const TitleBlock = ({
     <>
       <div
         id={id}
+        style={
+          contentInset
+            ? ({ '--titleblock-content-inset': contentInset } as React.CSSProperties)
+            : undefined
+        }
         className={classnames(
           styles.titleBlock,
           styles[`${variant}Variant`],

--- a/packages/components/src/TitleBlock/_docs/TitleBlock.stories.tsx
+++ b/packages/components/src/TitleBlock/_docs/TitleBlock.stories.tsx
@@ -2,6 +2,8 @@ import React from 'react'
 import { type Meta, type StoryObj } from '@storybook/react'
 import { expect, waitFor, within } from '@storybook/test'
 import { Heading } from 'react-aria-components'
+import { Container } from '~components/Container'
+import { Content } from '~components/Content'
 import { Icon } from '~components/Icon'
 import { GlobalNotification } from '~components/Notification'
 import { assetUrl } from '~components/utils/hostedAssets'
@@ -901,6 +903,42 @@ const StickyBannerAboveTitleBlock = (
       <div style={{ height: '600px' }} />
     </div>
   )
+}
+
+const CONTENT_ALIGNMENT_VIEWPORTS = {
+  disable: false,
+  // The inset only applies above 1080px, and TitleBlock clamps to its max-width
+  // from 1440px, so 1200 and 1366 are where a mismatch would show.
+  viewports: [1366, 1200],
+}
+
+/**
+ * `contentInset` lets a page line the TitleBlock's content column up with the
+ * `Content` beneath it. The dashed guides mark `Content`'s edges — with the
+ * default 24px inset the TitleBlock sits outside them.
+ */
+export const WithContentInset: Story = {
+  parameters: {
+    viewport: viewports,
+    chromatic: CONTENT_ALIGNMENT_VIEWPORTS,
+  },
+  args: {
+    contentInset: 'var(--layout-content-side-margin)',
+  },
+  render: (args) => (
+    <>
+      <TitleBlock {...args} />
+      <Container>
+        <Content
+          classNameOverride="border-l-1 border-r-1 border-dashed border-purple-400"
+          style={{ paddingTop: 'var(--spacing-24)', paddingBottom: 'var(--spacing-24)' }}
+        >
+          Page content, inset by <code>--layout-content-side-margin</code>. Its edges should line up
+          with the TitleBlock title and actions above.
+        </Content>
+      </Container>
+    </>
+  ),
 }
 
 export const WithGlobalNotificationAbove: Story = {

--- a/packages/components/src/TitleBlock/types.ts
+++ b/packages/components/src/TitleBlock/types.ts
@@ -43,6 +43,14 @@ export type TitleBlockProps = {
    * collapsed hamburger nav.
    */
   sticky?: boolean
+  /**
+   * Horizontal inset of the TitleBlock's content column above 1080px, as a CSS
+   * length. Defaults to `24px`. Pass `var(--layout-content-side-margin)` to line
+   * the TitleBlock up with a `Content` beneath it, which uses that token for its
+   * own gutter. Sets `--titleblock-content-inset`; below 1080px the collapsed
+   * paddings apply instead and this is ignored.
+   */
+  contentInset?: string
   textDirection?: TextDirection
   surveyStatus?: SurveyStatus
   id?: string


### PR DESCRIPTION
## Objective

Gives consumers a way to align `TitleBlock`'s content column with the `Content` beneath it. Default unchanged.

### Context

- `TitleBlock` insets its content column by a hardcoded 24px above 1080px; `Content` uses `--layout-content-side-margin` (72px). Pages stacking the two are misaligned by 48px per side between 1080px and 1536px — invisible above 1536px, where both clamp to 1392px and centre.
- `TitleBlock` has no escape hatch at all: no `className`, `classNameOverride` or `style` prop. Consumers can only override `Content` instead, which pulls their page out of line with the 72px the rest of the product uses.
- Real case: [survey-reporting-ui#3777](https://github.com/cultureamp/survey-reporting-ui/pull/3777) is shipping exactly that workaround, and will swap to this prop once it's released.

### Changes

- 🆕 `contentInset` prop — a CSS length that sets `--titleblock-content-inset`, read by both the title row and the row below the separator, so one prop moves both. Defaults to the existing 24px.
- 🆕 `WithContentInset` story, snapshotted at 1200 and 1366 (the widths where a mismatch shows) with dashed guides on a `Content` beneath.

```tsx
<TitleBlock title="Reports" contentInset="var(--layout-content-side-margin)" />
```

### Notes

- **The 24px looks like an unintended regression, and if you agree the better fix is one line, not this prop.** `%titleBlockInner` used `margin: 0 $layout-content-side-margin` until [#6352](https://github.com/cultureamp/kaizen-design-system/pull/6352) (UUXP-169, Jan 2026) replaced it with the hardcoded value. That changeset described tab navigation and AppChrome compatibility and never mentioned insets. Happy to switch this PR to restoring the token instead — say the word.
- Corroborating that 72px was the original intent: the breadcrumb overhang sets `inset-inline-start: calc(-#{$breadcrumb-circle-width} - #{$ca-grid})` = **-72px**, sized against a 72px gutter. It's also dead — `display: none` unless a container query re-enables it in-flow at `start: 0`. `$breadcrumb-breakpoint-width` appears vestigial too (its only use resolves to the same 24px as the branch it overrides).
- Deliberately **not** touching the sub-1080 paddings (20px / 4px / 12px). Line 409's `padding-inline-end: 8px; // 20 take 12 result in 8 extra padding needed` depends on the 20px, so that's separate, fiddlier work.
- Latent issue found but left alone: `title-block-min-media-1080` is a `@media` query where nearly every other TitleBlock breakpoint is `@container`. Currently masked by `container-type: inline-size` on `body`; a consumer establishing a nearer container would get the inset switching on viewport while everything else switches on container. The `title-block-media-mixed-width` comment about "a diff of 15px between the media and container query" already papers over this.

### Verification

- ✅ Default renders identically — the prop only emits a custom property when passed, and the SCSS falls back to the existing 24px.
- ✅ TitleBlock tests 25/25; `tsc --noEmit` clean; stylelint, prettier, eslint clean.
- ✅ No existing test or snapshot asserted the 24px, so nothing needed updating.
- ⚠️ Not visually reviewed in Kaizen's Storybook beyond the new story — the 20 existing TitleBlock stories will re-snapshot in Chromatic and I haven't eyeballed them.
