### PR TITLE
chore(deps): set automerge to false for react-aria group

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -28,6 +28,7 @@
         "react-aria{/,}**",
         "react-aria-components{/,}**",
       ],
+      automerge: false,
     },
     {
       groupName: "prosemirror",

--- a/renovate.json5
+++ b/renovate.json5
@@ -28,6 +28,8 @@
         "react-aria{/,}**",
         "react-aria-components{/,}**",
       ],
+      // react-aria deps bundle causes frontend diffs which should be
+      // resolved separately rather than merging into rollup PR
       automerge: false,
     },
     {


### PR DESCRIPTION
## Why
`react-aria` deps bundle will cause a lot of chromatic frontend deps which is not ideal to be automerged and handle by Pip the concierge. These deps should be handled manually or separately at least. Because of this reason, automerge option is disabled.

## What
`renovate.json5`: set automerge as false
