### PR TITLE
fix: only notify Slack when a publish was attempted [agent-managed]

### DIFF
--- a/.github/workflows/changeset.yaml
+++ b/.github/workflows/changeset.yaml
@@ -38,20 +38,30 @@ jobs:
           published_packages: ${{ steps.changesets.outputs.publishedPackages }}
           buildkite_webhook_url: ${{ secrets.ENCHIRIDION_BUILDKITE_WEBHOOK_URL }}
 
-  notify-slack:
+  notify-slack-success:
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    needs:
-      version
-      # We only trigger this flow if the publish is happening, inferred by not having a changeset.
-    if: needs.version.outputs.hasChangesets == 'false'
-    env:
-      PUBLISHED: ${{ needs.version.outputs.hasPublished }}
+    needs: version
+    if: needs.version.outputs.hasPublished == 'true'
     steps:
       - name: Send
         uses: slackapi/slack-github-action@v1.24.0
         with:
           channel-id: 'C02NUQ27G56'
-          slack-message: ${{ env.PUBLISHED == 'true' && 'Packages have been published' || 'Publishing failed' }}
+          slack-message: 'Packages have been published'
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+
+  notify-slack-failure:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    needs: version
+    if: ${{ always() && needs.version.result == 'failure' }}
+    steps:
+      - name: Send
+        uses: slackapi/slack-github-action@v1.24.0
+        with:
+          channel-id: 'C02NUQ27G56'
+          slack-message: 'Publishing failed'
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}


### PR DESCRIPTION
## Objective

Merging without a changeset currently posts "Publishing failed" to Slack, even when nothing was meant to publish (renovate config, workflow files). Split the notify job in two: post on an actual publish, post on an actual `version` job failure, and stay quiet otherwise.

Extracted from #7019 (left open for the tarball-check discussion), cut back to the shape Ryan suggested in [thread](https://cultureamp.slack.com/archives/C05D8V4GALX/p1786406395166749?thread_ts=1786404600.505419&cid=C05D8V4GALX).
